### PR TITLE
Add tolerations support for Velero and Restic

### DIFF
--- a/roles/velero/defaults/main.yml
+++ b/roles/velero/defaults/main.yml
@@ -48,6 +48,8 @@ velero_azure_plugin_version: "{{ lookup( 'env', 'VELERO_AZURE_PLUGIN_TAG') }}"
 velero_registry_tag: "{{ lookup( 'env', 'VELERO_REGISTRY_TAG') }}"
 velero_registry_repo: "{{ lookup( 'env', 'VELERO_REGISTRY_REPO') }}"
 velero_registry_image: "{{ registry }}/{{ project }}/{{ velero_registry_repo }}"
+velero_tolerations: []
+restic_tolerations: []
 restic_pv_host_path: /var/lib/kubelet/pods
 restic_timeout: 1h
 size: 1

--- a/roles/velero/templates/restic.yml.j2
+++ b/roles/velero/templates/restic.yml.j2
@@ -50,6 +50,26 @@ spec:
           emptyDir: {}
         - name: certs
           emptyDir: {}
+{% if restic_tolerations | length > 0 %}
+      tolerations:
+{% for tol in restic_tolerations %}
+{% if tol.key is defined %}
+      - key: {{ tol.key }}
+{% endif %}
+{% if tol.operator is defined %}
+        operator: {{ tol.operator }}
+{% endif %}
+{% if tol.value is defined %}
+        value: {{ tol.value }}
+{% endif %}
+{% if tol.effect is defined %}
+        effect: {{ tol.effect }}
+{% endif %}
+{% if tol.toleration_seconds is defined %}
+        tolerationSeconds: {{ tol.toleration_seconds }}
+{% endif %} 
+{% endfor %}
+{% endif %}
       containers:
         - name: velero
           securityContext:

--- a/roles/velero/templates/velero.yml.j2
+++ b/roles/velero/templates/velero.yml.j2
@@ -20,6 +20,11 @@ metadata:
   namespace: {{ velero_namespace }}
   name: velero
 spec:
+{% if velero_node_selector is defined %}
+  nodeSelector: {{ velero_node_selector }}
+{% else %}
+  nodeSelector: null
+{% endif %}
   selector:
     matchLabels:
       component: velero
@@ -35,6 +40,26 @@ spec:
     spec:
       restartPolicy: Always
       serviceAccountName: velero
+{% if velero_tolerations | length > 0 %}
+      tolerations:
+{% for tol in velero_tolerations %}
+{% if tol.key is defined %}
+      - key: {{ tol.key }}
+{% endif %}
+{% if tol.operator is defined %}
+        operator: {{ tol.operator }}
+{% endif %}
+{% if tol.value is defined %}
+        value: {{ tol.value }}
+{% endif %}
+{% if tol.effect is defined %}
+        effect: {{ tol.effect }}
+{% endif %}
+{% if tol.toleration_seconds is defined %}
+        tolerationSeconds: {{ tol.toleration_seconds }}
+{% endif %} 
+{% endfor %}
+{% endif %}
       containers:
         - name: velero
           image: {{ velero_image_fqin }}


### PR DESCRIPTION
This PR does the following:
- Adds `tolerations` support for Velero Deployment
- Adds `tolerations` support for Restic DS
- Adds `nodeSelector` support for Velero Deployment