### PR TITLE
Create docs-actions link checker

### DIFF
--- a/.github/workflows/docs-actions.yml
+++ b/.github/workflows/docs-actions.yml
@@ -1,0 +1,16 @@
+name: docs-actions
+on:
+  pull_request:
+    paths:
+      - '**/**.md'
+jobs:
+  link-checker:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Link Checker
+      uses: lycheeverse/lychee-action@v1.0.8
+      with:
+        args: --verbose --no-progress **/*.md
+    - run: if grep 'Errors in' ./lychee/out.md; then fail; fi


### PR DESCRIPTION
This PR introduces GIthub Action that run with every pull requests on `.md` files.

It checks if links in docs are valid and accessible.

Potential issues with this PR are errors like `HTTP status client error (429 Too Many Requests)` which can come up if the actions are run too frequently or a site is heavily referenced.