### PR TITLE
Fix velero deployment

### DIFF
--- a/oadp-operator/controllers/velero_controller.go
+++ b/oadp-operator/controllers/velero_controller.go
@@ -82,14 +82,15 @@ func (r *VeleroReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return result, client.IgnoreNotFound(err)
 	}
 	_, err := ReconcileBatch(r.Log,
+		r.ReconcileVeleroServiceAccount,
+		r.ReconcileVeleroClusterRoleBinding,
+		r.ReconcileVeleroSecurityContextConstraint,
+		r.ReconcileVeleroCRDs,
 		r.ValidateBackupStorageLocations,
 		r.ReconcileBackupStorageLocations,
 		r.ReconcileRegistries,
 		r.ValidateVolumeSnapshotLocations,
 		r.ReconcileVolumeSnapshotLocations,
-		r.ReconcileVeleroServiceAccount,
-		r.ReconcileVeleroClusterRoleBinding,
-		r.ReconcileVeleroSecurityContextConstraint,
 		r.ReconcileVeleroDeployment,
 		r.ReconcileResticDaemonset,
 	)

--- a/oadp-operator/go.mod
+++ b/oadp-operator/go.mod
@@ -8,9 +8,11 @@ require (
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.13.0
 	github.com/openshift/api v0.0.0-20210729133136-d870cea76006
+	github.com/prometheus/common v0.26.0 // indirect
 	github.com/vmware-tanzu/velero v1.6.1-0.20210806003158-ed5809b7fc22
 	golang.org/x/tools v0.1.2 // indirect
 	k8s.io/api v0.21.2
+	k8s.io/apiextensions-apiserver v0.21.2 // indirect
 	k8s.io/apimachinery v0.21.2
 	k8s.io/client-go v0.21.2
 	k8s.io/utils v0.0.0-20210527160623-6fdb442a123b

--- a/oadp-operator/go.sum
+++ b/oadp-operator/go.sum
@@ -82,9 +82,11 @@ github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdko
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
+github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d h1:UQZhZ2O0vMHr2cI+DC1Mbh0TJxzA3RcLoMsFw+aXw7E=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/alessio/shellescape v1.2.2/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
@@ -992,6 +994,7 @@ google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlba
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0 h1:bxAC2xTBsZGibn2RTntX0oH50xLsqy1OxA9tTL3p/lk=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/oadp-operator/main.go
+++ b/oadp-operator/main.go
@@ -24,17 +24,18 @@ import (
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
+	security "github.com/openshift/api/security/v1"
+	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
+	"github.com/openshift/oadp-operator/controllers"
+	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-
-	security "github.com/openshift/api/security/v1"
-	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
-	"github.com/openshift/oadp-operator/controllers"
-	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -87,6 +88,16 @@ func main() {
 	}
 	if err := velerov1.AddToScheme(mgr.GetScheme()); err != nil {
 		setupLog.Error(err, "unable to add Velero APIs to scheme")
+		os.Exit(1)
+	}
+
+	if err := appsv1.AddToScheme(mgr.GetScheme()); err != nil {
+		setupLog.Error(err, "unable to add Kubernetes APIs to scheme")
+		os.Exit(1)
+	}
+
+	if err := v1.AddToScheme(mgr.GetScheme()); err != nil {
+		setupLog.Error(err, "unable to add Kubernetes API extensions to scheme")
 		os.Exit(1)
 	}
 

--- a/oadp-operator/pkg/credentials/credentials.go
+++ b/oadp-operator/pkg/credentials/credentials.go
@@ -1,16 +1,19 @@
 package credentials
 
 import (
+	"fmt"
 	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
 	"github.com/openshift/oadp-operator/pkg/common"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"os"
 )
 
-type CloudProviderFields struct {
+type DefaultPluginFields struct {
 	secretName         string
 	mountPath          string
 	envCredentialsFile string
+	pluginImage        string
 }
 
 const (
@@ -19,21 +22,31 @@ const (
 
 var (
 	mountPropagationToHostContainer = corev1.MountPropagationHostToContainer
-	cloudProvidersPluginFields      = map[oadpv1alpha1.DefaultPlugin]CloudProviderFields{
+	pluginSpecificFields            = map[oadpv1alpha1.DefaultPlugin]DefaultPluginFields{
 		oadpv1alpha1.DefaultPluginAWS: {
 			secretName:         "cloud-credentials",
 			mountPath:          "/credentials",
 			envCredentialsFile: "AWS_SHARED_CREDENTIALS_FILE",
+			pluginImage:        fmt.Sprintf("%v/%v/%v:%v", os.Getenv("REGISTRY"), os.Getenv("PROJECT"), os.Getenv("VELERO_AWS_PLUGIN_REPO"), os.Getenv("VELERO_AWS_PLUGIN_TAG")),
 		},
 		oadpv1alpha1.DefaultPluginGCP: {
 			secretName:         "cloud-credentials-gcp",
 			mountPath:          "/credentials-gcp",
 			envCredentialsFile: "GOOGLE_APPLICATION_CREDENTIALS",
+			pluginImage:        fmt.Sprintf("%v/%v/%v:%v", os.Getenv("REGISTRY"), os.Getenv("PROJECT"), os.Getenv("VELERO_GCP_PLUGIN_REPO"), os.Getenv("VELERO_GCP_PLUGIN_TAG")),
 		},
 		oadpv1alpha1.DefaultPluginMicrosoftAzure: {
 			secretName:         "cloud-credentials-azure",
 			mountPath:          "/credentials-azure",
 			envCredentialsFile: "AZURE_CREDENTIALS_FILE",
+			pluginImage:        fmt.Sprintf("%v/%v/%v:%v", os.Getenv("REGISTRY"), os.Getenv("PROJECT"), os.Getenv("VELERO_AZURE_PLUGIN_REPO"), os.Getenv("VELERO_AZURE_PLUGIN_TAG")),
+		},
+		oadpv1alpha1.DefaultPluginOpenShift: {
+			pluginImage: fmt.Sprintf("%v/%v/%v:%v", os.Getenv("REGISTRY"), os.Getenv("PROJECT"), os.Getenv("VELERO_OPENSHIFT_PLUGIN_REPO"), os.Getenv("VELERO_OPENSHIFT_PLUGIN_TAG")),
+		},
+		oadpv1alpha1.DefaultPluginCSI: {
+			//TODO: Check if the Registry needs to an upstream one from CSI
+			pluginImage: fmt.Sprintf("%v/%v/%v:%v", os.Getenv("REGISTRY"), os.Getenv("PROJECT"), os.Getenv("VELERO_CSI_PLUGIN_REPO"), os.Getenv("VELERO_CSI_PLUGIN_TAG")),
 		},
 	}
 )
@@ -41,21 +54,21 @@ var (
 func AppendCloudProviderVolumes(velero *oadpv1alpha1.Velero, ds *appsv1.DaemonSet) error {
 	var veleroContainer *corev1.Container
 	// Find Velero container
-	for _, container := range ds.Spec.Template.Spec.Containers {
+	for i, container := range ds.Spec.Template.Spec.Containers {
 		if container.Name == common.Velero {
-			veleroContainer = &container
+			veleroContainer = &ds.Spec.Template.Spec.Containers[i]
 		}
 	}
 	for _, plugin := range velero.Spec.DefaultVeleroPlugins {
 		// Check that this is a cloud provider plugin in the cloud provider map
-		// ok is boolean that will be true if `plugin` is a valid key in `cloudProvidersPluginFields` map
+		// ok is boolean that will be true if `plugin` is a valid key in `pluginSpecificFields` map
 		// pattern from https://golang.org/doc/effective_go#maps
-		// this replaces the need to iterate through the `cloudProvidersPluginFields` O(n) -> O(1)
-		if cloudProviderMap, ok := cloudProvidersPluginFields[plugin]; ok {
+		// this replaces the need to iterate through the `pluginSpecificFields` O(n) -> O(1)
+		if cloudProviderMap, ok := pluginSpecificFields[plugin]; ok {
 			ds.Spec.Template.Spec.Volumes = append(
 				ds.Spec.Template.Spec.Volumes,
 				corev1.Volume{
-					Name: string(plugin),
+					Name: cloudProviderMap.secretName,
 					VolumeSource: corev1.VolumeSource{
 						Secret: &corev1.SecretVolumeSource{
 							SecretName: cloudProviderMap.secretName,
@@ -66,8 +79,9 @@ func AppendCloudProviderVolumes(velero *oadpv1alpha1.Velero, ds *appsv1.DaemonSe
 			veleroContainer.VolumeMounts = append(
 				veleroContainer.VolumeMounts,
 				corev1.VolumeMount{
-					Name:             cloudProviderMap.secretName,
-					MountPath:        cloudProviderMap.mountPath,
+					Name:      cloudProviderMap.secretName,
+					MountPath: cloudProviderMap.mountPath,
+					//TODO: Check if MountPropagation is needed for plugin specific volume mounts
 					MountPropagation: &mountPropagationToHostContainer,
 				},
 			)
@@ -78,6 +92,93 @@ func AppendCloudProviderVolumes(velero *oadpv1alpha1.Velero, ds *appsv1.DaemonSe
 					Value: cloudProviderMap.mountPath + "/" + cloudFieldPath,
 				},
 			)
+		}
+	}
+	return nil
+}
+
+// add plugin specific specs to velero deployment
+func AppendPluginSpecficSpecs(velero *oadpv1alpha1.Velero, veleroDeployment *appsv1.Deployment) error {
+	var veleroContainer *corev1.Container
+
+	for i, container := range veleroDeployment.Spec.Template.Spec.Containers {
+		if container.Name == common.Velero {
+			veleroContainer = &veleroDeployment.Spec.Template.Spec.Containers[i]
+		}
+	}
+
+	for _, plugin := range velero.Spec.DefaultVeleroPlugins {
+		if pluginSpecificMap, ok := pluginSpecificFields[plugin]; ok {
+
+			// append plugin specific volume mounts
+			if veleroContainer != nil {
+				veleroContainer.VolumeMounts = append(
+					veleroContainer.VolumeMounts,
+					corev1.VolumeMount{
+						Name:      pluginSpecificMap.secretName,
+						MountPath: pluginSpecificMap.mountPath,
+					})
+
+				// append plugin specific env vars
+				veleroContainer.Env = append(
+					veleroContainer.Env,
+					corev1.EnvVar{
+						Name:  pluginSpecificMap.envCredentialsFile,
+						Value: pluginSpecificMap.mountPath + "/" + cloudFieldPath,
+					})
+			}
+
+			// append plugin specific volumes
+			veleroDeployment.Spec.Template.Spec.Volumes = append(
+				veleroDeployment.Spec.Template.Spec.Volumes,
+				corev1.Volume{
+					Name: pluginSpecificMap.secretName,
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName: pluginSpecificMap.secretName,
+						},
+					},
+				})
+
+			// append plugin specifc init containers
+			veleroDeployment.Spec.Template.Spec.InitContainers = append(
+				veleroDeployment.Spec.Template.Spec.InitContainers,
+				corev1.Container{
+					Image:                    pluginSpecificMap.pluginImage,
+					Name:                     string(plugin),
+					ImagePullPolicy:          corev1.PullAlways,
+					Resources:                corev1.ResourceRequirements{},
+					TerminationMessagePath:   "/dev/termination-log",
+					TerminationMessagePolicy: "File",
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							MountPath: "/target",
+							Name:      "plugins",
+						},
+					},
+				})
+
+		}
+	}
+	// append custom plugin init containers
+	if velero.Spec.CustomVeleroPlugins != nil {
+		for _, plugin := range velero.Spec.CustomVeleroPlugins {
+			veleroDeployment.Spec.Template.Spec.InitContainers = append(
+				veleroDeployment.Spec.Template.Spec.InitContainers,
+				corev1.Container{
+					Image:                    plugin.Image,
+					Name:                     plugin.Image,
+					ImagePullPolicy:          corev1.PullAlways,
+					Resources:                corev1.ResourceRequirements{},
+					TerminationMessagePath:   "/dev/termination-log",
+					TerminationMessagePolicy: "File",
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							MountPath: "/target",
+							Name:      "plugins",
+						},
+					},
+				})
 		}
 	}
 	return nil


### PR DESCRIPTION
This PR does the following:
- Refactors Velero deployment controller
- Installs CRDs for non-olm installs
- Fixes registry tests
- Fixes Restic plugin specific update bug
- adds missing apis to scheme