### PR TITLE
NIT submitcoverage -> submit-coverage, removed test_submitcoverage, codecov....wait_for_ci:no

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -14,6 +14,7 @@ on:
       - '.github/workflows/go-tests.yml'
       - '**/Dockerfile'
       - 'Makefile'
+  workflow_dispatch
 jobs:
   make-test_submitcoverage: #test and submit coverage to codecov on pushes
     runs-on: ubuntu-latest

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -24,7 +24,7 @@ jobs:
       with:
         go-version: '^1.16.6' # The Go version to download (if necessary) and use.
     - run: go version
-    - run: make test submitcoverage
+    - run: make test submit-coverage
   podman-build:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -24,7 +24,7 @@ jobs:
       with:
         go-version: '^1.16.6' # The Go version to download (if necessary) and use.
     - run: go version
-    - run: make test_submitcoverage
+    - run: make test submitcoverage
   podman-build:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -14,7 +14,7 @@ on:
       - '.github/workflows/go-tests.yml'
       - '**/Dockerfile'
       - 'Makefile'
-  workflow_dispatch
+  workflow_dispatch:
 jobs:
   make-test_submitcoverage: #test and submit coverage to codecov on pushes
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,6 @@ submitcoverage:
 	./codecov
 	rm -f ./codecov
 
-test_submitcoverage: test submitcoverage
 # go-get-tool will 'go get' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 define go-get-tool

--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ else
         OS_String = macos
     endif
 endif
-submitcoverage:
+submit-coverage:
 	curl -Os https://uploader.codecov.io/latest/$(OS_String)/codecov
 	chmod +x codecov
 	./codecov

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,5 @@
 codecov:
   token: 4dd31179-e303-41af-96b5-8e434a1d0134
   require_ci_to_pass: no
+  notify:
+      wait_for_ci: no

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,3 @@
 codecov:
   token: 4dd31179-e303-41af-96b5-8e434a1d0134
+  require_ci_to_pass: no


### PR DESCRIPTION
`test_submitcoverage` contains an `_` whereas the rest of the targets have `-` which is inconsistent.
This PR removes `test_submitcoverage` entirely to keep the Makefile clean.