### PR TITLE
Use konveyor CSI image tag latest in osENV

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -65,7 +65,7 @@ spec:
           - name: VELERO_AZURE_PLUGIN_TAG
             value: konveyor-oadp
           - name: VELERO_CSI_PLUGIN_TAG
-            value: main
+            value: latest
           - name: VELERO_VSPHERE_PLUGIN_TAG
             value: 1.1.0
         args:

--- a/deploy/non-olm/operator.yaml
+++ b/deploy/non-olm/operator.yaml
@@ -72,7 +72,7 @@ spec:
             - name: VELERO_AZURE_PLUGIN_TAG
               value: konveyor-oadp
             - name: VELERO_CSI_PLUGIN_TAG
-              value: main
+              value: latest
             - name: VELERO_VSPHERE_PLUGIN_TAG
               value: 1.1.0
       volumes:


### PR DESCRIPTION
This https://github.com/openshift/oadp-operator/blob/a5e286a238139377a7bcf38d254898ee5a9531bc/pkg/credentials/credentials.go#L81 was returning `quay.io/konveyor/velero-plugin-for-csi:main` which as of today cannot be pulled and was causing CSI init container to ErrImagePullBackoff

Switching to `quay.io/konveyor/velero-plugin-for-csi:latest`

closes #301 