### PR TITLE
E2E: Parks-app nodejs OCP 4.8.0 patch

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -255,6 +255,7 @@ github.com/go-openapi/validate v0.18.0/go.mod h1:Uh4HdOzKt19xGIGm1qHf/ofbX1YQ4Y+
 github.com/go-openapi/validate v0.19.2/go.mod h1:1tRCw7m3jtI8eNWEEliiAqUIcBztB2KDnRCRMUi7GTA=
 github.com/go-openapi/validate v0.19.5/go.mod h1:8DJv2CVJQ6kGNpFW6eV9N3JviE1C85nY1c2z52x1Gk4=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 h1:p104kn46Q8WdvHunIJ9dAyjPVtrBPhSr3KT2yUst43I=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/gobuffalo/flect v0.2.2/go.mod h1:vmkQwuZYhN5Pc4ljYQZzP+1sq+NEkK+lh20jmEmX3jc=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=

--- a/tests/e2e/sample-applications/parks-app/manifest4.8.yaml
+++ b/tests/e2e/sample-applications/parks-app/manifest4.8.yaml
@@ -1,0 +1,232 @@
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: v1
+    kind: Namespace
+    metadata:
+      name: parks-app
+  
+  - kind: ImageStream
+    apiVersion: image.openshift.io/v1
+    metadata:
+      name: restify
+      namespace: parks-app
+      labels:
+        app: restify
+    spec: {}
+    status:
+      dockerImageRepository: ''
+  
+  - kind: BuildConfig
+    apiVersion: build.openshift.io/v1
+    metadata:
+      name: restify
+      namespace: parks-app
+      labels:
+        app: restify
+    spec:
+      triggers:
+      - type: GitHub
+        github:
+          secret: 4Xwu0tyAab90aaoasd88qweAasdaqvjknfrl3qwpo
+      - type: Generic
+        generic:
+          secret: 4Xwu0tyAab90aaoasd88qweAasdaqvjknfrl3qwpo
+      - type: ConfigChange
+      - type: ImageChange
+        imageChange: {}
+      source:
+        type: Git
+        git:
+          uri: https://github.com/ryanj/restify-mongodb-parks
+          ref: master
+      strategy:
+        type: Source
+        sourceStrategy:
+          from:
+            kind: ImageStreamTag
+            namespace: openshift
+            name: nodejs:10-ubi8
+      output:
+        to:
+          kind: ImageStreamTag
+          name: "restify:latest"
+      resources: {}
+    status:
+      lastVersion: 0
+    
+    
+  - kind: DeploymentConfig
+    apiVersion: apps.openshift.io/v1
+    metadata:
+      name: restify
+      namespace: parks-app
+      labels:
+        app: restify
+    spec:
+      strategy:
+        resources: {}
+      triggers:
+      - type: ConfigChange
+      - type: ImageChange
+        imageChangeParams:
+          automatic: true
+          containerNames:
+          - restify
+          from:
+            kind: ImageStreamTag
+            name: "restify:latest"
+      replicas: 1
+      selector:
+        app: restify
+        deploymentconfig: restify
+      template:
+        metadata:
+          creationTimestamp: 
+          labels:
+            e2e-app: "true"
+            app: restify
+            deploymentconfig: restify
+        spec:
+          volumes:
+          - name: "restify-volume-1"
+            emptyDir: {}
+          containers:
+          - name: restify
+            image: library/restify:latest
+            ports:
+            - containerPort: 8080
+              protocol: TCP
+            env:
+            - name: DATABASE_SERVICE_NAME
+              value: mongodb
+            - name: MONGODB_DATABASE
+              value: restify-database
+            - name: MONGODB_PASSWORD
+              value: mongo-user-password
+            - name: MONGODB_USER
+              value: mongo-user-1
+            resources: {}
+            volumeMounts:
+            - name: "restify-volume-1"
+              mountPath: "/run"
+    status: {}
+    
+  - kind: Route
+    apiVersion: route.openshift.io/v1
+    metadata:
+      name: restify
+      namespace: parks-app
+      labels:
+        app: restify
+    spec:
+      to:
+        kind: Service
+        name: restify
+      port:
+        targetPort: '8080'
+    status: {}
+    
+  - kind: Service
+    apiVersion: v1
+    metadata:
+      name: restify
+      namespace: parks-app
+      labels:
+        app: restify
+    spec:
+      ports:
+      - name: 8080-tcp
+        protocol: TCP
+        port: 8080
+        targetPort: 8080
+      selector:
+        app: restify
+        deploymentconfig: restify
+    status:
+      loadBalancer: {}
+    
+  - kind: DeploymentConfig
+    apiVersion: apps.openshift.io/v1
+    metadata:
+      name: mongodb
+      namespace: parks-app
+    spec:
+      strategy:
+        type: Recreate
+      triggers:
+      - type: ImageChange
+        imageChangeParams:
+          automatic: true
+          containerNames:
+          - mongodb-container
+          from:
+            kind: ImageStreamTag
+            name: mongodb:latest
+            namespace: openshift
+      - type: ConfigChange
+      replicas: 1
+      selector:
+        name: mongodb
+      template:
+        metadata:
+          labels:
+            e2e-app: "true"
+            name: mongodb
+        spec:
+          containers:
+          - name: mongodb-container
+            image: " "
+            ports:
+            - containerPort: 27017
+              protocol: TCP
+            env:
+            - name: MONGODB_USER
+              value: mongo-user-1
+            - name: MONGODB_PASSWORD
+              value: mongo-user-password
+            - name: MONGODB_DATABASE
+              value: restify-database
+            - name: MONGODB_ADMIN_PASSWORD
+              value: moogo-admin-pass
+            volumeMounts:
+            - name: mongodb-data
+              mountPath: /data/db"
+            imagePullPolicy: Always
+          volumes:
+          - name: mongodb-data
+            persistentVolumeClaim:
+              claimName: mongodb-data-claim
+          restartPolicy: Always
+    
+  - kind: Service
+    apiVersion: v1
+    metadata:
+      name: mongodb
+      namespace: parks-app
+    spec:
+      ports:
+      - name: mongo
+        protocol: TCP
+        port: 27017
+        targetPort: 27017
+      selector:
+        name: mongodb
+      portalIP: ''
+      type: ClusterIP
+      sessionAffinity: None
+    status:
+      loadBalancer: {}
+    
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: "mongodb-data-claim"
+      namespace: parks-app
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 10Gi
+    


### PR DESCRIPTION
nodejs:10 did not exist on my ocp 4.8.0 install
quay.io/openshift-release-dev/ocp-release@sha256:56dc7d529400ff7ee2eb1c50f14352fb0773ed9f3a2d24383507188ceb98900a
after some inspection, there is nodejs:10-ubi8