### PR TITLE
manual sha and slug specification for openshift prow ci

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,8 +167,15 @@ endif
 submit-coverage:
 	curl -Os https://uploader.codecov.io/latest/$(OS_String)/codecov
 	chmod +x codecov
-	./codecov
-	rm -f ./codecov
+	./codecov > tmp.results 2> tmp.err
+	cat tmp.results || echo "tmp.results not found"
+	cat tmp.err || echo "tmp.err not found"
+	@echo $$(cat tmp.results | grep 'resultURL' -c)
+	@echo $$(cat tmp.err | grep 'please specify sha and slug manually' -c)
+	if [ $$(cat tmp.err | grep 'please specify sha and slug manually' -c) == 1 ]; then \
+		echo "specifying sha and slug manually" && ./codecov -C $(shell git rev-parse HEAD) -r openshift/oadp-operator; \
+	fi
+	rm -f codecov tmp.*
 
 # go-get-tool will 'go get' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))


### PR DESCRIPTION
In the prow environment
`make submit-coverage` would fail with [error](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/branch-ci-openshift-oadp-operator-master-operator-unit-test-coverage/1438945851526352896/artifacts/operator-unit-test-coverage/unit-coverage/build-log.txt)
```bash
Unable to detect service, please specify sha and slug manually.
```

This PR ensures that sha and slug information are passed in manually.