### PR TITLE
Add regsitry kill switch

### DIFF
--- a/api/v1alpha1/velero_types.go
+++ b/api/v1alpha1/velero_types.go
@@ -112,6 +112,9 @@ type VeleroSpec struct {
 	// Defining this field automatically add EnableAPIGroupVersions to the velero server feature flag
 	// +optional
 	RestoreResourcesVersionPriority string `json:"restoreResourcesVersionPriority,omitempty"`
+	// BackupImages is used to specify whether you want to deploy a registry for enabling backup and restore of images
+	// +optional
+	BackupImages *bool `json:"backupImages,omitempty"`
 }
 
 // VeleroStatus defines the observed state of Velero

--- a/config/crd/bases/oadp.openshift.io_veleroes.yaml
+++ b/config/crd/bases/oadp.openshift.io_veleroes.yaml
@@ -36,6 +36,10 @@ spec:
           spec:
             description: VeleroSpec defines the desired state of Velero
             properties:
+              backupImages:
+                description: BackupImages is used to specify whether you want to deploy
+                  a registry for enabling backup and restore of images
+                type: boolean
               backupStorageLocations:
                 description: Velero configuration
                 items:


### PR DESCRIPTION
This PR adds a Velero CR spec `backupImages` which acts as a switch to enable/disable resources needed for backup and restore of images.