### PR TITLE
Fix registry issues

### DIFF
--- a/controllers/bsl.go
+++ b/controllers/bsl.go
@@ -145,6 +145,10 @@ func (r *VeleroReconciler) validateAWSBackupStorageLocation(bslSpec velerov1.Bac
 		return fmt.Errorf("region for AWS backupstoragelocation config cannot be empty")
 	}
 
+	if len(bslSpec.StorageType.ObjectStorage.Prefix) == 0 && (velero.Spec.BackupImages == nil || *velero.Spec.BackupImages) {
+		return fmt.Errorf("prefix for AWS backupstoragelocation object storage cannot be empty. it is required for backing up images")
+	}
+
 	//TODO: Add minio, noobaa, local storage validations
 
 	return nil
@@ -174,6 +178,10 @@ func (r *VeleroReconciler) validateAzureBackupStorageLocation(bslSpec velerov1.B
 		return fmt.Errorf("storageAccount for Azure backupstoragelocation config cannot be empty")
 	}
 
+	if len(bslSpec.StorageType.ObjectStorage.Prefix) == 0 && (velero.Spec.BackupImages == nil || *velero.Spec.BackupImages) {
+		return fmt.Errorf("prefix for Azure backupstoragelocation object storage cannot be empty. it is required for backing up images")
+	}
+
 	return nil
 }
 
@@ -191,6 +199,10 @@ func (r *VeleroReconciler) validateGCPBackupStorageLocation(bslSpec velerov1.Bac
 
 	if len(bslSpec.ObjectStorage.Bucket) == 0 {
 		return fmt.Errorf("bucket name for GCP backupstoragelocation cannot be empty")
+	}
+
+	if len(bslSpec.StorageType.ObjectStorage.Prefix) == 0 && (velero.Spec.BackupImages == nil || *velero.Spec.BackupImages) {
+		return fmt.Errorf("prefix for GCP backupstoragelocation object storage cannot be empty. it is required for backing up images")
 	}
 
 	return nil

--- a/controllers/bsl_test.go
+++ b/controllers/bsl_test.go
@@ -432,6 +432,115 @@ func TestVeleroReconciler_ValidateBackupStorageLocations(t *testing.T) {
 			},
 		},
 		{
+			name: "test BSLs specified, prefix not present for aws BSL",
+			VeleroCR: &oadpv1alpha1.Velero{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "test-ns",
+				},
+				Spec: oadpv1alpha1.VeleroSpec{
+					BackupStorageLocations: []velerov1.BackupStorageLocationSpec{
+						{
+							Provider: "aws",
+							StorageType: velerov1.StorageType{
+								ObjectStorage: &velerov1.ObjectStorageLocation{
+									Bucket: "test-aws-bucket",
+								},
+							},
+							Config: map[string]string{
+								Region: "test-region",
+							},
+							Credential: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: "cloud-credentials",
+								},
+							},
+						},
+					},
+				},
+			},
+			want:    false,
+			wantErr: true,
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cloud-credentials",
+					Namespace: "test-ns",
+				},
+			},
+		},
+		{
+			name: "test BSLs specified, prefix not present for gcp BSL",
+			VeleroCR: &oadpv1alpha1.Velero{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "test-ns",
+				},
+				Spec: oadpv1alpha1.VeleroSpec{
+					BackupStorageLocations: []velerov1.BackupStorageLocationSpec{
+						{
+							Provider: "gcp",
+							StorageType: velerov1.StorageType{
+								ObjectStorage: &velerov1.ObjectStorageLocation{
+									Bucket: "test-gcp-bucket",
+								},
+							},
+							Credential: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: "cloud-credentials",
+								},
+							},
+						},
+					},
+				},
+			},
+			want:    false,
+			wantErr: true,
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cloud-credentials",
+					Namespace: "test-ns",
+				},
+			},
+		},
+		{
+			name: "test BSLs specified, prefix not present for azure BSL",
+			VeleroCR: &oadpv1alpha1.Velero{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "test-ns",
+				},
+				Spec: oadpv1alpha1.VeleroSpec{
+					BackupStorageLocations: []velerov1.BackupStorageLocationSpec{
+						{
+							Provider: "azure",
+							StorageType: velerov1.StorageType{
+								ObjectStorage: &velerov1.ObjectStorageLocation{
+									Bucket: "test-azure-bucket",
+								},
+							},
+							Config: map[string]string{
+								ResourceGroup:  "test-rg",
+								StorageAccount: "test-sa",
+							},
+							Credential: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: "cloud-credentials",
+								},
+							},
+						},
+					},
+				},
+			},
+			want:    false,
+			wantErr: true,
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cloud-credentials",
+					Namespace: "test-ns",
+				},
+			},
+		},
+		{
 			name: "test BSLs specified, multiple appropriate BSLs configured, no error case",
 			VeleroCR: &oadpv1alpha1.Velero{
 				ObjectMeta: metav1.ObjectMeta{

--- a/controllers/bsl_test.go
+++ b/controllers/bsl_test.go
@@ -407,6 +407,7 @@ func TestVeleroReconciler_ValidateBackupStorageLocations(t *testing.T) {
 							StorageType: velerov1.StorageType{
 								ObjectStorage: &velerov1.ObjectStorageLocation{
 									Bucket: "test-aws-bucket",
+									Prefix: "velero",
 								},
 							},
 							Config: map[string]string{
@@ -444,6 +445,7 @@ func TestVeleroReconciler_ValidateBackupStorageLocations(t *testing.T) {
 							StorageType: velerov1.StorageType{
 								ObjectStorage: &velerov1.ObjectStorageLocation{
 									Bucket: "test-aws-bucket",
+									Prefix: "velero",
 								},
 							},
 							Config: map[string]string{
@@ -460,6 +462,7 @@ func TestVeleroReconciler_ValidateBackupStorageLocations(t *testing.T) {
 							StorageType: velerov1.StorageType{
 								ObjectStorage: &velerov1.ObjectStorageLocation{
 									Bucket: "test-azure-bucket",
+									Prefix: "velero",
 								},
 							},
 							Config: map[string]string{
@@ -477,6 +480,7 @@ func TestVeleroReconciler_ValidateBackupStorageLocations(t *testing.T) {
 							StorageType: velerov1.StorageType{
 								ObjectStorage: &velerov1.ObjectStorageLocation{
 									Bucket: "test-gcp-bucket",
+									Prefix: "velero",
 								},
 							},
 							Credential: &corev1.SecretKeySelector{

--- a/controllers/registry.go
+++ b/controllers/registry.go
@@ -60,7 +60,6 @@ const (
 	GCPProvider           = "gcp"
 	Region                = "region"
 	S3URL                 = "s3Url"
-	RootDirectory         = "rootDirectory"
 	InsecureSkipTLSVerify = "insecureSkipTLSVerify"
 	StorageAccount        = "storageAccount"
 	ResourceGroup         = "resourceGroup"
@@ -91,10 +90,6 @@ var cloudProviderEnvVarMap = map[string][]corev1.EnvVar{
 		},
 		{
 			Name:  RegistryStorageS3RegionendpointEnvVarKey,
-			Value: "",
-		},
-		{
-			Name:  RegistryStorageS3RootdirectoryEnvVarKey,
 			Value: "",
 		},
 		{
@@ -131,10 +126,6 @@ var cloudProviderEnvVarMap = map[string][]corev1.EnvVar{
 		},
 		{
 			Name:  RegistryStorageGCSKeyfile,
-			Value: "",
-		},
-		{
-			Name:  RegistryStorageGCSRootdirectory,
 			Value: "",
 		},
 	},
@@ -409,10 +400,6 @@ func (r *VeleroReconciler) getAWSRegistryEnvVars(bsl *velerov1.BackupStorageLoca
 			awsEnvVars[i].Value = bsl.Spec.Config[S3URL]
 		}
 
-		if awsEnvVars[i].Name == RegistryStorageS3RootdirectoryEnvVarKey && bsl.Spec.Config[RootDirectory] != "" {
-			awsEnvVars[i].Value = bsl.Spec.Config[RootDirectory]
-		}
-
 		if awsEnvVars[i].Name == RegistryStorageS3SkipverifyEnvVarKey && bsl.Spec.Config[InsecureSkipTLSVerify] != "" {
 			awsEnvVars[i].Value = bsl.Spec.Config[InsecureSkipTLSVerify]
 		}
@@ -464,9 +451,6 @@ func (r *VeleroReconciler) getGCPRegistryEnvVars(bsl *velerov1.BackupStorageLoca
 
 		if gcpEnvVars[i].Name == RegistryStorageGCSKeyfile {
 			gcpEnvVars[i].Value = credentials.PluginSpecificFields[oadpv1alpha1.DefaultPluginGCP].MountPath + "/" + credentials.PluginSpecificFields[oadpv1alpha1.DefaultPluginGCP].PluginSecretKey
-		}
-		if gcpEnvVars[i].Name == RegistryStorageGCSRootdirectory && bsl.Spec.Config[RootDirectory] != "" {
-			gcpEnvVars[i].Value = bsl.Spec.Config[RootDirectory]
 		}
 	}
 	return gcpEnvVars, nil
@@ -875,7 +859,6 @@ func (r *VeleroReconciler) ReconcileRegistryRouteConfigs(log logr.Logger) (bool,
 
 				return true, nil
 			}
-
 
 			op, err := controllerutil.CreateOrUpdate(r.Context, r.Client, &registryRouteCM, func() error {
 

--- a/controllers/registry_test.go
+++ b/controllers/registry_test.go
@@ -62,7 +62,7 @@ var (
 			"aws_secret_access_key=" + testSecretAccessKey),
 	}
 	secretAzureData = map[string][]byte{
-		"azure": []byte("[default]" + "\n" +
+		"cloud": []byte("[default]" + "\n" +
 			"AZURE_STORAGE_ACCOUNT_ACCESS_KEY=" + testStoragekey + "\n" +
 			"AZURE_CLOUD_NAME=" + testCloudName),
 	}
@@ -107,7 +107,6 @@ func TestVeleroReconciler_buildRegistryDeployment(t *testing.T) {
 					Config: map[string]string{
 						Region:                "aws-region",
 						S3URL:                 "https://sr-url-aws-domain.com",
-						RootDirectory:         "/velero-aws",
 						InsecureSkipTLSVerify: "false",
 					},
 				},
@@ -151,7 +150,6 @@ func TestVeleroReconciler_buildRegistryDeployment(t *testing.T) {
 					Config: map[string]string{
 						Region:                "aws-region",
 						S3URL:                 "https://sr-url-aws-domain.com",
-						RootDirectory:         "/velero-aws",
 						InsecureSkipTLSVerify: "false",
 					},
 				},
@@ -201,7 +199,6 @@ func TestVeleroReconciler_buildRegistryDeployment(t *testing.T) {
 					Config: map[string]string{
 						Region:                "aws-region",
 						S3URL:                 "https://sr-url-aws-domain.com",
-						RootDirectory:         "/velero-aws",
 						InsecureSkipTLSVerify: "false",
 					},
 				},
@@ -328,10 +325,6 @@ func TestVeleroReconciler_buildRegistryDeployment(t *testing.T) {
 										{
 											Name:  RegistryStorageS3RegionendpointEnvVarKey,
 											Value: "https://sr-url-aws-domain.com",
-										},
-										{
-											Name:  RegistryStorageS3RootdirectoryEnvVarKey,
-											Value: "/velero-aws",
 										},
 										{
 											Name:  RegistryStorageS3SkipverifyEnvVarKey,
@@ -498,7 +491,6 @@ func TestVeleroReconciler_getAWSRegistryEnvVars(t *testing.T) {
 					Config: map[string]string{
 						Region:                "aws-region",
 						S3URL:                 "https://sr-url-aws-domain.com",
-						RootDirectory:         "/velero-aws",
 						InsecureSkipTLSVerify: "false",
 					},
 				},
@@ -553,10 +545,6 @@ func TestVeleroReconciler_getAWSRegistryEnvVars(t *testing.T) {
 				{
 					Name:  RegistryStorageS3RegionendpointEnvVarKey,
 					Value: "https://sr-url-aws-domain.com",
-				},
-				{
-					Name:  RegistryStorageS3RootdirectoryEnvVarKey,
-					Value: "/velero-aws",
 				},
 				{
 					Name:  RegistryStorageS3SkipverifyEnvVarKey,
@@ -688,9 +676,7 @@ func TestVeleroReconciler_getGCPRegistryEnvVars(t *testing.T) {
 							Bucket: "gcp-bucket",
 						},
 					},
-					Config: map[string]string{
-						RootDirectory: "/velero-gcp",
-					},
+					Config: map[string]string{},
 				},
 			},
 			secret: &corev1.Secret{
@@ -731,10 +717,6 @@ func TestVeleroReconciler_getGCPRegistryEnvVars(t *testing.T) {
 				{
 					Name:  RegistryStorageGCSKeyfile,
 					Value: "/credentials-gcp/cloud",
-				},
-				{
-					Name:  RegistryStorageGCSRootdirectory,
-					Value: "/velero-gcp",
 				},
 			}
 

--- a/controllers/restic_test.go
+++ b/controllers/restic_test.go
@@ -405,7 +405,6 @@ func TestVeleroReconciler_buildResticDaemonset(t *testing.T) {
 								Config: map[string]string{
 									Region:                "aws-region",
 									S3URL:                 "https://sr-url-aws-domain.com",
-									RootDirectory:         "/velero-aws",
 									InsecureSkipTLSVerify: "false",
 								},
 								Credential: &corev1.SecretKeySelector{
@@ -577,7 +576,6 @@ func TestVeleroReconciler_buildResticDaemonset(t *testing.T) {
 								Config: map[string]string{
 									Region:                "aws-region",
 									S3URL:                 "https://sr-url-aws-domain.com",
-									RootDirectory:         "/velero-aws",
 									InsecureSkipTLSVerify: "false",
 								},
 								Credential: &corev1.SecretKeySelector{
@@ -755,7 +753,6 @@ func TestVeleroReconciler_buildResticDaemonset(t *testing.T) {
 								Config: map[string]string{
 									Region:                "aws-region",
 									S3URL:                 "https://sr-url-aws-domain.com",
-									RootDirectory:         "/velero-aws",
 									InsecureSkipTLSVerify: "false",
 								},
 								Credential: &corev1.SecretKeySelector{

--- a/controllers/velero_controller.go
+++ b/controllers/velero_controller.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	routev1 "github.com/openshift/api/route/v1"
+	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 
 	security "github.com/openshift/api/security/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -125,6 +126,8 @@ func (r *VeleroReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&oadpv1alpha1.Velero{}).
 		Owns(&appsv1.Deployment{}).
+		Owns(&velerov1.BackupStorageLocation{}).
+		Owns(&velerov1.VolumeSnapshotLocation{}).
 		Owns(&appsv1.DaemonSet{}).
 		Owns(&security.SecurityContextConstraints{}).
 		Owns(&corev1.Secret{}).

--- a/pkg/credentials/credentials.go
+++ b/pkg/credentials/credentials.go
@@ -49,7 +49,7 @@ var (
 			MountPath:          "/credentials-azure",
 			EnvCredentialsFile: common.AzureCredentialsFileEnvKey,
 			PluginName:         common.VeleroPluginForAzure,
-			PluginSecretKey:    "azure",
+			PluginSecretKey:    "cloud",
 		},
 		oadpv1alpha1.DefaultPluginOpenShift: {
 			IsCloudProvider: false,


### PR DESCRIPTION
This PR does the following:
- Fixes registry issues for AWS/GCP/Azure
- Adds the validation that `prefix` is needed under `objectStorage` spec of BSL for B/R of Images
- Removes `rootDirectory` support for image registry env var as it invalidates the image backup path in object storage
- Adds BSL and VSL to operator watchlist
- updates the default secret key for azure provider