### PR TITLE
fix(CSV): remove maxOpenShiftVersion restriction

### DIFF
--- a/deploy/olm-catalog/bundle/manifests/oadp-operator.v99.0.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/bundle/manifests/oadp-operator.v99.0.0.clusterserviceversion.yaml
@@ -4,14 +4,6 @@ metadata:
   name: oadp-operator.v99.0.0
   namespace: oadp-operator
   annotations:
-    # Setting olm.maxOpenShiftVersion automatically
-    # This property was added via an automatic process since it was possible to identify that this distribution uses API(s),
-    # which will be removed in the k8s version 1.22 and OpenShift version OCP 4.9. Then, it will prevent OCP users to
-    # upgrade their cluster to 4.9 before they have installed in their current clusters a version of your operator that
-    # is compatible with it. Please, ensure that your project is no longer using these API(s) and that you start to
-    # distribute solutions which is compatible with Openshift 4.9.
-    # For further information, check the README of this repository.
-    olm.properties: '[{"type": "olm.maxOpenShiftVersion", "value": "4.8"}]'
     olm.skipRange: '>=0.0.0 <99.0.0'
     containerImage: "quay.io/konveyor/oadp-operator:latest"
     alm-examples: |-


### PR DESCRIPTION
OADP no longer uses any v1beta1 API(s) which would preclude it from use
on an OCP version 4.9 cluster.