### PR TITLE
add golangci linters to github actions ci

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,34 @@
+name: golangci-lint
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - master
+      - main
+  pull_request:
+jobs:
+  golangci:
+    strategy:
+      matrix:
+        go-version: [1.15.x]
+        os: [ubuntu-latest] #[macos-latest]
+    name: lint
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
+          version: v1.29
+          # Optional: working directory, useful for monorepos
+          # working-directory: somedir
+
+          # Optional: golangci-lint command line arguments.
+          # args: --issues-exit-code=0
+
+          # Optional: show only new issues if it's a pull request. The default value is `false`.
+          # When executed locally, review oadp-operator oadp-operator/.golangci.yml -> new-from-rev
+          only-new-issues: true
+

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,35 @@
+run:
+  timeout: 5m
+  #  modules-download-mode: readonly|vendor|mod
+  # modules-download-mode: vendor
+
+linters-settings:
+  govet:
+    # report about shadowed variables
+    check-shadowing: true
+    enable-all: true
+
+output:
+  sort-results: true
+
+linters:
+  disable-all: true
+  # https://golangci-lint.run/usage/linters/
+  enable:
+    - deadcode
+    - gofmt
+    - gosimple
+    - govet
+    - ineffassign
+    - structcheck
+    - unconvert
+    - unused
+    - varcheck
+
+# similar to .github/workflows/golangci-lint.yml --> only-new-issues:true
+issues:
+  # lint from a specific git hash
+  # new-from-rev: bdbdc9b9436b3cb6aef8882fe8435f78f450cd5e
+  # lint only the pull request
+  new-from-rev: HEAD~1
+

--- a/docs/developer/linter.md
+++ b/docs/developer/linter.md
@@ -1,0 +1,17 @@
+<h1 align="center">E2E Testing</h1>
+
+## Prerequisites:
+
+### Install golangci-lint
+```bash
+go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+golangci-lint version
+golangci-lint help linters
+```
+
+### Execute golangci-lint
+```bash
+golangci-lint run
+```
+### golangci-lint Documentation
+https://golangci-lint.run/usage/configuration/


### PR DESCRIPTION
Information re: golangci
https://golangci-lint.run/

The configuration is set to only lint
new code atm.  Let's not fail jobs on unrelated
old code until this is well socialized. See
inline comments in config files.

Test execution in github:
https://github.com/weshayutin/oadp-operator/pull/4/checks?check_run_id=3860994813

To view lint issues in code base
remove param, "new-from-rev: HEAD~1"
from .golangci.yml and execute locally