### PR TITLE
Increase script timeout and other minor Travis fixes

### DIFF
--- a/.travis-build-image.sh
+++ b/.travis-build-image.sh
@@ -9,5 +9,8 @@ fi
 export ARCH=$(uname -m)
 
 docker build -t ${IMAGE}:${TAG}-${ARCH} -f ${DOCKERFILE} .
-docker login quay.io -u "${QUAY_ROBOT}" -p ${QUAY_TOKEN}
-docker push ${IMAGE}:${TAG}-${ARCH}
+
+if [[ -n "${QUAY_ROBOT}" ]]; then
+  docker login quay.io -u "${QUAY_ROBOT}" -p ${QUAY_TOKEN}
+  docker push ${IMAGE}:${TAG}-${ARCH}
+fi

--- a/.travis-push-manifest.sh
+++ b/.travis-push-manifest.sh
@@ -1,28 +1,28 @@
 #!/bin/bash
+if [[ -n "${QUAY_ROBOT}" ]]; then
 
-if [ "${TRAVIS_BRANCH}" == "${DEFAULT_BRANCH}" ]; then
-  export TAG=latest
-else
-  export TAG=${TRAVIS_BRANCH}
+  if [ "${TRAVIS_BRANCH}" == "${DEFAULT_BRANCH}" ]; then
+    export TAG=latest
+  else
+    export TAG=${TRAVIS_BRANCH}
+  fi
+
+  export DOCKER_CLI_EXPERIMENTAL=enabled
+
+  #Without this docker manifest create fails
+  #https://github.com/docker/for-linux/issues/396
+  sudo chmod o+x /etc/docker
+
+  docker manifest create \
+    ${IMAGE}:${TAG} \
+    ${IMAGE}:${TAG}-x86_64 \
+    ${IMAGE}:${TAG}-ppc64le \
+    ${IMAGE}:${TAG}-s390x \
+    ${IMAGE}:${TAG}-aarch64
+
+  docker manifest inspect ${IMAGE}:${TAG}
+
+  docker login quay.io -u "${QUAY_ROBOT}" -p ${QUAY_TOKEN}
+
+  docker manifest push ${IMAGE}:${TAG}
 fi
-
-export DOCKER_CLI_EXPERIMENTAL=enabled
-
-#Without this docker manifest create fails
-#https://github.com/docker/for-linux/issues/396
-sudo chmod o+x /etc/docker
-
-docker manifest create \
-  ${IMAGE}:${TAG} \
-  ${IMAGE}:${TAG}-x86_64 \
-  ${IMAGE}:${TAG}-ppc64le \
-  ${IMAGE}:${TAG}-s390x \
-  ${IMAGE}:${TAG}-aarch64
-echo $?
-
-docker manifest inspect ${IMAGE}:${TAG}
-echo $?
-
-docker login quay.io -u "${QUAY_ROBOT}" -p ${QUAY_TOKEN}
-
-docker manifest push ${IMAGE}:${TAG}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
-language: bash
+language: shell
 os: linux
 services: docker
-sudo: required
 dist: bionic
 
 env:
@@ -13,13 +12,17 @@ jobs:
   include:
    - stage: build image
      arch: ppc64le
-     script: ./.travis-build-image.sh
+     script:
+     - travis_wait 60 ./.travis-build-image.sh
    - arch: amd64
-     script: ./.travis-build-image.sh
+     script:
+     - travis_wait 60 ./.travis-build-image.sh
    - arch: s390x
-     script: ./.travis-build-image.sh
+     script:
+     - travis_wait 60 ./.travis-build-image.sh
    - arch: arm64
-     script: ./.travis-build-image.sh
+     script:
+     - travis_wait 60 ./.travis-build-image.sh
    - stage: push manifest
-     arch: x86_64
+     arch: amd64
      script: ./.travis-push-manifest.sh


### PR DESCRIPTION
Tested in this repo to confirm the options and logic work. https://app.travis-ci.com/github/konveyor/travis-multiarch-test/builds 

Some of these are very minor to clean up warnings. For instance the `sudo` option not longer does anything, `bash` is an alias for `shell`, and `x86_64` is an alias for `amd64` in .travus.yml.

I wrapped the pull/push from quay logic in a check to see if QUAY_ROBOT is set as well. Tiger had jobs running in his fork that were failing on push there, which makes sense, but isn't helpful. With this change it can catch build errors but won't attempt to authenticate and push from someones fork.