### PR TITLE
[e2e] 4.9 mongodb image parks-app fix

### DIFF
--- a/tests/e2e/sample-applications/parks-app/manifest4.8.yaml
+++ b/tests/e2e/sample-applications/parks-app/manifest4.8.yaml
@@ -154,15 +154,6 @@ items:
       strategy:
         type: Recreate
       triggers:
-      - type: ImageChange
-        imageChangeParams:
-          automatic: true
-          containerNames:
-          - mongodb-container
-          from:
-            kind: ImageStreamTag
-            name: mongodb:latest
-            namespace: openshift
       - type: ConfigChange
       replicas: 1
       selector:
@@ -175,7 +166,8 @@ items:
         spec:
           containers:
           - name: mongodb-container
-            image: " "
+            image: >-
+              registry.redhat.io/rhscl/mongodb-36-rhel7:latest
             ports:
             - containerPort: 27017
               protocol: TCP


### PR DESCRIPTION
OCP 4.9 do not contain built in image streams for mongodb.