### PR TITLE
e2e proxy: fix first test case failure

### DIFF
--- a/tests/e2e/subscription_suite_test.go
+++ b/tests/e2e/subscription_suite_test.go
@@ -16,6 +16,13 @@ import (
 
 var _ = Describe("Subscription Config Suite Test", func() {
 	var _ = BeforeEach(func() {
+		log.Printf("Building veleroSpec")
+		err := vel.Build(csi)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = vel.Delete()
+		Expect(err).ToNot(HaveOccurred())
+
 		testSuiteInstanceName := "ts-" + instanceName
 		vel.Name = testSuiteInstanceName
 
@@ -51,10 +58,6 @@ var _ = Describe("Subscription Config Suite Test", func() {
 				Consistently(s.csvIsReady, time.Minute*2).Should(BeFalse())
 			} else {
 				Eventually(s.csvIsReady, time.Minute*9).Should(BeTrue())
-
-				log.Printf("Building veleroSpec")
-				err = vel.Build(csi)
-				Expect(err).NotTo(HaveOccurred())
 
 				log.Printf("CreatingOrUpdate test Velero")
 				err = vel.CreateOrUpdate(&vel.CustomResource.Spec)

--- a/tests/e2e/subscription_suite_test.go
+++ b/tests/e2e/subscription_suite_test.go
@@ -19,6 +19,8 @@ var _ = Describe("Subscription Config Suite Test", func() {
 		log.Printf("Building veleroSpec")
 		err := vel.Build(csi)
 		Expect(err).NotTo(HaveOccurred())
+		//also test restic
+		vel.CustomResource.Spec.Configuration.Restic.Enable = pointer.BoolPtr(true)
 
 		err = vel.Delete()
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
First test case may fail due to pods containing ENV from prior test suite because other test suite may not have called vel.Delete.

This PR force vel.Delete prior to each entry to ensure that all velero pods running are created using latest CSV env values.