### PR TITLE
Add Cluster Profile argument for CSI test case

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 OADP_TEST_NAMESPACE ?= openshift-adp
 REGION ?= us-east-1
 PROVIDER ?= aws
+CLUSTER_PROFILE ?= aws
 CREDS_SECRET_REF ?= cloud-credentials
 OADP_AWS_CRED_FILE ?= /var/run/oadp-credentials/aws-credentials
 OADP_S3_BUCKET ?= /var/run/oadp-credentials/velero-bucket-name
@@ -282,4 +283,5 @@ test-e2e:
 	-velero_instance_name=$(VELERO_INSTANCE_NAME) \
 	-region=$(REGION) \
 	-provider=$(PROVIDER) \
+	-clusterProfile=$(CLUSTER_PROFILE) \
 	-timeout_multiplier=$(E2E_TIMEOUT_MULTIPLIER)

--- a/tests/e2e/backup_restore_suite_test.go
+++ b/tests/e2e/backup_restore_suite_test.go
@@ -78,10 +78,15 @@ var _ = Describe("AWS backup restore tests", func() {
 				log.Printf("Waiting for restic pods to be running")
 				Eventually(areResticPodsRunning(namespace), timeoutMultiplier*time.Minute*3, time.Second*5).Should(BeTrue())
 			}
+
 			if brCase.BackupRestoreType == csi {
-				log.Printf("Creating VolumeSnapshot for CSI backuprestore of %s", brCase.Name)
-				err = installApplication(vel.Client, "./sample-applications/gp2-csi/volumeSnapshotClass.yaml")
-				Expect(err).ToNot(HaveOccurred())
+				if vel.ClusterProfile == "aws" {
+					log.Printf("Creating VolumeSnapshot for CSI backuprestore of %s", brCase.Name)
+					err = installApplication(vel.Client, "./sample-applications/gp2-csi/volumeSnapshotClass.yaml")
+					Expect(err).ToNot(HaveOccurred())
+				} else {
+					Skip("CSI testing is not provided for this cluster provider.")
+				}
 			}
 
 			if vel.CustomResource.Spec.BackupImages == nil || *vel.CustomResource.Spec.BackupImages {

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Common vars obtained from flags passed in ginkgo.
-var cloud, namespace, s3Bucket, s3BucketFilePath, credSecretRef, instanceName, region, provider string
+var cloud, namespace, s3Bucket, s3BucketFilePath, credSecretRef, instanceName, region, provider, clusterProfile string
 var timeoutMultiplier time.Duration
 
 func init() {
@@ -20,6 +20,7 @@ func init() {
 	flag.StringVar(&namespace, "velero_namespace", "oadp-operator", "Velero Namespace")
 	flag.StringVar(&region, "region", "us-east-1", "BSL region")
 	flag.StringVar(&provider, "provider", "aws", "BSL provider")
+	flag.StringVar(&clusterProfile, "clusterProfile", "aws", "Cluster Profile")
 	flag.StringVar(&credSecretRef, "creds_secret_ref", "cloud-credentials", "Credential secret ref for backup storage location")
 	flag.StringVar(&instanceName, "velero_instance_name", "example-velero", "Velero Instance Name")
 	timeoutMultiplierInput := flag.Int64("timeout_multiplier", 1, "Customize timeout multiplier from default (1)")
@@ -64,6 +65,7 @@ var _ = BeforeSuite(func() {
 		Region:    region,
 		Bucket:    s3Bucket,
 		Provider:  provider,
+		ClusterProfile: clusterProfile,
 	}
 	testSuiteInstanceName := "ts-" + instanceName
 	vel.Name = testSuiteInstanceName

--- a/tests/e2e/velero_helpers.go
+++ b/tests/e2e/velero_helpers.go
@@ -41,6 +41,7 @@ type dpaCustomResource struct {
 	Bucket            string
 	Region            string
 	Provider          string
+	ClusterProfile    string
 	backupRestoreType BackupRestoreType
 	CustomResource    *oadpv1alpha1.DataProtectionApplication
 	Client            client.Client


### PR DESCRIPTION
Cluster Profile defines which cloud provider the cluster is running on. This determines the storage drivers defined in volumesnapshotclass object which is unique to the cluster's cloud provider.

Provider flag is Object Storage provider and is not always the cloud provider that the e2e cluster is running on.