### PR TITLE
remove VSPHERE env configs for csv

### DIFF
--- a/bundle/manifests/oadp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/oadp-operator.clusterserviceversion.yaml
@@ -468,8 +468,6 @@ spec:
                         value: velero-plugin-for-microsoft-azure
                       - name: VELERO_CSI_PLUGIN_REPO
                         value: velero-plugin-for-csi
-                      - name: VELERO_VSPHERE_PLUGIN_REPO
-                        value: velero-plugin-for-vsphere
                       - name: VELERO_TAG
                         value: latest
                       - name: VELERO_RESTIC_RESTORE_HELPER_TAG
@@ -482,8 +480,6 @@ spec:
                         value: latest
                       - name: VELERO_CSI_PLUGIN_TAG
                         value: latest
-                      - name: VELERO_VSPHERE_PLUGIN_TAG
-                        value: 1.1.0
                     image: quay.io/konveyor/oadp-operator:latest
                     imagePullPolicy: Always
                     livenessProbe:


### PR DESCRIPTION

Wesley Hayutin Today at 9:33 AM
can vsphere be removed? https://github.com/openshift/oadp-operator/blob/oadp-0.5.2/bundle/manifests/oadp-operator.clusterserviceversion.yaml#L471-L472

Dylan Murray  2 hours ago
Ahh yes. I thought I removed that awhile ago