### PR TITLE
AWS plugin config: BSL Region not required when s3ForcePathStyle is false and BackupImages is false

### DIFF
--- a/api/v1alpha1/oadp_types.go
+++ b/api/v1alpha1/oadp_types.go
@@ -202,6 +202,11 @@ type DataProtectionApplicationList struct {
 	Items           []DataProtectionApplication `json:"items"`
 }
 
+// Default BackupImages behavior when nil to true
+func (dpa *DataProtectionApplication) BSLPrefixRequired() bool {
+	return dpa.Spec.BackupImages == nil || *dpa.Spec.BackupImages
+}
+
 func init() {
 	SchemeBuilder.Register(&DataProtectionApplication{}, &DataProtectionApplicationList{}, &CloudStorage{}, &CloudStorageList{})
 }

--- a/api/v1alpha1/oadp_types.go
+++ b/api/v1alpha1/oadp_types.go
@@ -203,7 +203,7 @@ type DataProtectionApplicationList struct {
 }
 
 // Default BackupImages behavior when nil to true
-func (dpa *DataProtectionApplication) BSLPrefixRequired() bool {
+func (dpa *DataProtectionApplication) BackupImages() bool {
 	return dpa.Spec.BackupImages == nil || *dpa.Spec.BackupImages
 }
 

--- a/controllers/bsl.go
+++ b/controllers/bsl.go
@@ -186,7 +186,7 @@ func (r *DPAReconciler) validateAWSBackupStorageLocation(bslSpec velerov1.Backup
 	}
 	// BSL region is required when s3ForcePathStyle is true
 	if len(bslSpec.Config[Region]) == 0 && bslSpec.Config[S3ForcePathStyle] == "true" {
-		return fmt.Errorf("region for AWS backupstoragelocation cannot be empty")
+		return fmt.Errorf("region for AWS backupstoragelocation cannot be empty when s3ForcePathStyle is true")
 	}
 
 	//TODO: Add minio, noobaa, local storage validations

--- a/controllers/bsl.go
+++ b/controllers/bsl.go
@@ -181,12 +181,12 @@ func (r *DPAReconciler) validateAWSBackupStorageLocation(bslSpec velerov1.Backup
 		return fmt.Errorf("bucket name for AWS backupstoragelocation cannot be empty")
 	}
 
-	if len(bslSpec.StorageType.ObjectStorage.Prefix) == 0 && dpa.BSLPrefixRequired() {
+	if len(bslSpec.StorageType.ObjectStorage.Prefix) == 0 && dpa.BackupImages() {
 		return fmt.Errorf("prefix for AWS backupstoragelocation object storage cannot be empty. It is required for backing up images")
 	}
-	// BSL region is required when s3ForcePathStyle is true
-	if len(bslSpec.Config[Region]) == 0 && bslSpec.Config[S3ForcePathStyle] == "true" {
-		return fmt.Errorf("region for AWS backupstoragelocation cannot be empty when s3ForcePathStyle is true")
+	// BSL region is required when s3ForcePathStyle is true AND BackupImages is false
+	if (bslSpec.Config == nil || len(bslSpec.Config[Region]) == 0 && bslSpec.Config[S3ForcePathStyle] == "true") && dpa.BackupImages() {
+		return fmt.Errorf("region for AWS backupstoragelocation cannot be empty when s3ForcePathStyle is true or when backing up images")
 	}
 
 	//TODO: Add minio, noobaa, local storage validations
@@ -218,7 +218,7 @@ func (r *DPAReconciler) validateAzureBackupStorageLocation(bslSpec velerov1.Back
 		return fmt.Errorf("storageAccount for Azure backupstoragelocation config cannot be empty")
 	}
 
-	if len(bslSpec.StorageType.ObjectStorage.Prefix) == 0 && dpa.BSLPrefixRequired() {
+	if len(bslSpec.StorageType.ObjectStorage.Prefix) == 0 && dpa.BackupImages() {
 		return fmt.Errorf("prefix for Azure backupstoragelocation object storage cannot be empty. it is required for backing up images")
 	}
 
@@ -240,7 +240,7 @@ func (r *DPAReconciler) validateGCPBackupStorageLocation(bslSpec velerov1.Backup
 	if len(bslSpec.ObjectStorage.Bucket) == 0 {
 		return fmt.Errorf("bucket name for GCP backupstoragelocation cannot be empty")
 	}
-	if len(bslSpec.StorageType.ObjectStorage.Prefix) == 0 && dpa.BSLPrefixRequired() {
+	if len(bslSpec.StorageType.ObjectStorage.Prefix) == 0 && dpa.BackupImages() {
 		return fmt.Errorf("prefix for GCP backupstoragelocation object storage cannot be empty. it is required for backing up images")
 	}
 

--- a/controllers/bsl.go
+++ b/controllers/bsl.go
@@ -181,9 +181,12 @@ func (r *DPAReconciler) validateAWSBackupStorageLocation(bslSpec velerov1.Backup
 		return fmt.Errorf("bucket name for AWS backupstoragelocation cannot be empty")
 	}
 
-	if len(bslSpec.StorageType.ObjectStorage.Prefix) == 0 || len(bslSpec.Config[Region]) == 0 &&
-		(dpa.Spec.BackupImages == nil || *dpa.Spec.BackupImages) {
-		return fmt.Errorf("prefix and region for AWS backupstoragelocation object storage cannot be empty. It is required for backing up images")
+	if len(bslSpec.StorageType.ObjectStorage.Prefix) == 0 && dpa.BSLPrefixRequired() {
+		return fmt.Errorf("prefix for AWS backupstoragelocation object storage cannot be empty. It is required for backing up images")
+	}
+	// BSL region is required when s3ForcePathStyle is true
+	if len(bslSpec.Config[Region]) == 0 && bslSpec.Config[S3ForcePathStyle] == "true" {
+		return fmt.Errorf("region for AWS backupstoragelocation cannot be empty")
 	}
 
 	//TODO: Add minio, noobaa, local storage validations
@@ -215,7 +218,7 @@ func (r *DPAReconciler) validateAzureBackupStorageLocation(bslSpec velerov1.Back
 		return fmt.Errorf("storageAccount for Azure backupstoragelocation config cannot be empty")
 	}
 
-	if len(bslSpec.StorageType.ObjectStorage.Prefix) == 0 && (dpa.Spec.BackupImages == nil || *dpa.Spec.BackupImages) {
+	if len(bslSpec.StorageType.ObjectStorage.Prefix) == 0 && dpa.BSLPrefixRequired() {
 		return fmt.Errorf("prefix for Azure backupstoragelocation object storage cannot be empty. it is required for backing up images")
 	}
 
@@ -237,8 +240,7 @@ func (r *DPAReconciler) validateGCPBackupStorageLocation(bslSpec velerov1.Backup
 	if len(bslSpec.ObjectStorage.Bucket) == 0 {
 		return fmt.Errorf("bucket name for GCP backupstoragelocation cannot be empty")
 	}
-
-	if len(bslSpec.StorageType.ObjectStorage.Prefix) == 0 && (dpa.Spec.BackupImages == nil || *dpa.Spec.BackupImages) {
+	if len(bslSpec.StorageType.ObjectStorage.Prefix) == 0 && dpa.BSLPrefixRequired() {
 		return fmt.Errorf("prefix for GCP backupstoragelocation object storage cannot be empty. it is required for backing up images")
 	}
 

--- a/controllers/bsl_test.go
+++ b/controllers/bsl_test.go
@@ -1047,7 +1047,7 @@ func TestDPAReconciler_ValidateBackupStorageLocations(t *testing.T) {
 			},
 		},
 		{
-			name: "BSL Region not set for aws provider without S3ForcePathStyle expect to succeed",
+			name: "BSL Region not set for aws provider without S3ForcePathStyle expect to fail",
 			dpa: &oadpv1alpha1.DataProtectionApplication{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
@@ -1072,23 +1072,17 @@ func TestDPAReconciler_ValidateBackupStorageLocations(t *testing.T) {
 					},
 				},
 			},
-			secret: &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "cloud-credentials",
-					Namespace: "test-ns",
-				},
-			},
-			want:    true,
-			wantErr: false,
+			wantErr: true,
 		},
 		{
-			name: "BSL Region not set for aws provider with S3ForcePathStyle expect to fail",
+			name: "BSL Region not set for aws provider without S3ForcePathStyle with BackupImages false expect to succeed",
 			dpa: &oadpv1alpha1.DataProtectionApplication{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "test-ns",
 				},
 				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					BackupImages: pointer.Bool(false),
 					Configuration: &oadpv1alpha1.ApplicationConfig{
 						Velero: &oadpv1alpha1.VeleroConfig{},
 					},
@@ -1096,9 +1090,6 @@ func TestDPAReconciler_ValidateBackupStorageLocations(t *testing.T) {
 						{
 							Velero: &velerov1.BackupStorageLocationSpec{
 								Provider: "aws",
-								Config: map[string]string{
-									S3ForcePathStyle: "true",
-								},
 								StorageType: velerov1.StorageType{
 									ObjectStorage: &velerov1.ObjectStorageLocation{
 										Bucket: "bucket",
@@ -1157,6 +1148,44 @@ func TestDPAReconciler_ValidateBackupStorageLocations(t *testing.T) {
 			},
 			want:    true,
 			wantErr: false,
+		},
+		{
+			name: "BSL Region not set for aws provider with S3ForcePathStyle expect to fail",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "test-ns",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{},
+					},
+					BackupLocations: []oadpv1alpha1.BackupLocation{
+						{
+							Velero: &velerov1.BackupStorageLocationSpec{
+								Provider: "aws",
+								Config: map[string]string{
+									S3ForcePathStyle: "true",
+								},
+								StorageType: velerov1.StorageType{
+									ObjectStorage: &velerov1.ObjectStorageLocation{
+										Bucket: "bucket",
+										Prefix: "prefix",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cloud-credentials",
+					Namespace: "test-ns",
+				},
+			},
+			want:    false,
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {

--- a/controllers/bsl_test.go
+++ b/controllers/bsl_test.go
@@ -1063,8 +1063,13 @@ func TestDPAReconciler_ValidateBackupStorageLocations(t *testing.T) {
 								Provider: "aws",
 								StorageType: velerov1.StorageType{
 									ObjectStorage: &velerov1.ObjectStorageLocation{
-										Bucket: "bucket",
-										Prefix: "prefix",
+										Bucket: "test-aws-bucket",
+										Prefix: "test-prefix",
+									},
+								},
+								Credential: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "cloud-credentials",
 									},
 								},
 							},
@@ -1072,7 +1077,14 @@ func TestDPAReconciler_ValidateBackupStorageLocations(t *testing.T) {
 					},
 				},
 			},
+			want:    false,
 			wantErr: true,
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cloud-credentials",
+					Namespace: "test-ns",
+				},
+			},
 		},
 		{
 			name: "BSL Region not set for aws provider without S3ForcePathStyle with BackupImages false expect to succeed",
@@ -1107,8 +1119,8 @@ func TestDPAReconciler_ValidateBackupStorageLocations(t *testing.T) {
 					Namespace: "test-ns",
 				},
 			},
-			want:    false,
-			wantErr: true,
+			want:    true,
+			wantErr: false,
 		},
 		{
 			name: "BSL Region set for aws provider with S3ForcePathStyle expect to succeed",

--- a/controllers/bsl_test.go
+++ b/controllers/bsl_test.go
@@ -1046,6 +1046,118 @@ func TestDPAReconciler_ValidateBackupStorageLocations(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "BSL Region not set for aws provider without S3ForcePathStyle expect to succeed",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "test-ns",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{},
+					},
+					BackupLocations: []oadpv1alpha1.BackupLocation{
+						{
+							Velero: &velerov1.BackupStorageLocationSpec{
+								Provider: "aws",
+								StorageType: velerov1.StorageType{
+									ObjectStorage: &velerov1.ObjectStorageLocation{
+										Bucket: "bucket",
+										Prefix: "prefix",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cloud-credentials",
+					Namespace: "test-ns",
+				},
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "BSL Region not set for aws provider with S3ForcePathStyle expect to fail",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "test-ns",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{},
+					},
+					BackupLocations: []oadpv1alpha1.BackupLocation{
+						{
+							Velero: &velerov1.BackupStorageLocationSpec{
+								Provider: "aws",
+								Config: map[string]string{
+									S3ForcePathStyle: "true",
+								},
+								StorageType: velerov1.StorageType{
+									ObjectStorage: &velerov1.ObjectStorageLocation{
+										Bucket: "bucket",
+										Prefix: "prefix",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cloud-credentials",
+					Namespace: "test-ns",
+				},
+			},
+			want:    false,
+			wantErr: true,
+		},
+		{
+			name: "BSL Region set for aws provider with S3ForcePathStyle expect to succeed",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "test-ns",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{},
+					},
+					BackupLocations: []oadpv1alpha1.BackupLocation{
+						{
+							Velero: &velerov1.BackupStorageLocationSpec{
+								Provider: "aws",
+								Config: map[string]string{
+									S3ForcePathStyle: "true",
+									Region:           "noobaa",
+								},
+								StorageType: velerov1.StorageType{
+									ObjectStorage: &velerov1.ObjectStorageLocation{
+										Bucket: "bucket",
+										Prefix: "prefix",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cloud-credentials",
+					Namespace: "test-ns",
+				},
+			},
+			want:    true,
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/controllers/registry.go
+++ b/controllers/registry.go
@@ -67,6 +67,7 @@ const (
 	Region                = "region"
 	Profile               = "profile"
 	S3URL                 = "s3Url"
+	S3ForcePathStyle      = "s3ForcePathStyle"
 	InsecureSkipTLSVerify = "insecureSkipTLSVerify"
 	StorageAccount        = "storageAccount"
 	ResourceGroup         = "resourceGroup"

--- a/controllers/registry.go
+++ b/controllers/registry.go
@@ -192,7 +192,7 @@ func (r *DPAReconciler) ReconcileRegistries(log logr.Logger) (bool, error) {
 			},
 		}
 
-		if dpa.Spec.BackupImages != nil && !*dpa.Spec.BackupImages {
+		if !dpa.BackupImages() {
 			deleteContext := context.Background()
 			if err := r.Get(deleteContext, types.NamespacedName{
 				Name:      registryDeployment.Name,
@@ -438,7 +438,12 @@ func (r *DPAReconciler) getAWSRegistryEnvVars(bsl *velerov1.BackupStorageLocatio
 		}
 
 		if awsEnvVars[i].Name == RegistryStorageS3RegionEnvVarKey {
-			awsEnvVars[i].Value = bsl.Spec.Config[Region]
+			bslSpecRegion, regionInConfig := bsl.Spec.Config[Region]
+			if regionInConfig {
+				awsEnvVars[i].Value = bslSpecRegion
+			} else {
+				r.Log.Info("region not found in backupstoragelocation spec")
+			}
 		}
 
 		if awsEnvVars[i].Name == RegistryStorageS3SecretkeyEnvVarKey {
@@ -778,7 +783,7 @@ func (r *DPAReconciler) ReconcileRegistrySVCs(log logr.Logger) (bool, error) {
 				},
 			}
 
-			if dpa.Spec.BackupImages != nil && !*dpa.Spec.BackupImages {
+			if !dpa.BackupImages() {
 				deleteContext := context.Background()
 				if err := r.Get(deleteContext, types.NamespacedName{
 					Name:      svc.Name,
@@ -887,7 +892,7 @@ func (r *DPAReconciler) ReconcileRegistryRoutes(log logr.Logger) (bool, error) {
 				},
 			}
 
-			if dpa.Spec.BackupImages != nil && !*dpa.Spec.BackupImages {
+			if !dpa.BackupImages() {
 				deleteContext := context.Background()
 				if err := r.Get(deleteContext, types.NamespacedName{
 					Name:      route.Name,
@@ -979,7 +984,7 @@ func (r *DPAReconciler) ReconcileRegistryRouteConfigs(log logr.Logger) (bool, er
 				},
 			}
 
-			if dpa.Spec.BackupImages != nil && !*dpa.Spec.BackupImages {
+			if !dpa.BackupImages() {
 				deleteContext := context.Background()
 				if err := r.Get(deleteContext, types.NamespacedName{
 					Name:      registryRouteCM.Name,

--- a/controllers/restic.go
+++ b/controllers/restic.go
@@ -67,15 +67,12 @@ func (r *DPAReconciler) ReconcileResticDaemonset(log logr.Logger) (bool, error) 
 	if err := r.Get(r.Context, r.NamespacedName, &dpa); err != nil {
 		return false, err
 	}
-	if dpa.Spec.Configuration.Restic == nil {
-		return false, nil
-	}
 
 	// Define "static" portion of daemonset
 	ds := &appsv1.DaemonSet{
 		ObjectMeta: getResticObjectMeta(r),
 	}
-	if dpa.Spec.Configuration.Restic.Enable == nil || !*dpa.Spec.Configuration.Restic.Enable {
+	if dpa.Spec.Configuration.Restic == nil || dpa.Spec.Configuration.Restic != nil && (dpa.Spec.Configuration.Restic.Enable == nil || !*dpa.Spec.Configuration.Restic.Enable) {
 		deleteContext := context.Background()
 		if err := r.Get(deleteContext, types.NamespacedName{
 			Name:      ds.Name,

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -61,10 +61,10 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	vel = &dpaCustomResource{
-		Namespace: namespace,
-		Region:    region,
-		Bucket:    s3Bucket,
-		Provider:  provider,
+		Namespace:      namespace,
+		Region:         region,
+		Bucket:         s3Bucket,
+		Provider:       provider,
 		ClusterProfile: clusterProfile,
 	}
 	testSuiteInstanceName := "ts-" + instanceName

--- a/tests/e2e/velero_deployment_suite_test.go
+++ b/tests/e2e/velero_deployment_suite_test.go
@@ -37,6 +37,8 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 			if installCase.WantError {
 				// Eventually()
 				log.Printf("Test case expected to error. Waiting for the error to show in DPA Status")
+				Eventually(vel.GetNoErr().Status.Conditions[0].Type, timeoutMultiplier*time.Minute*3, time.Second*5).Should(Equal("Reconciled"))
+				Eventually(vel.GetNoErr().Status.Conditions[0].Status, timeoutMultiplier*time.Minute*3, time.Second*5).Should(Equal(v1.ConditionFalse))
 				Eventually(vel.GetNoErr().Status.Conditions[0].Reason, timeoutMultiplier*time.Minute*3, time.Second*5).Should(Equal("Error"))
 				Eventually(vel.GetNoErr().Status.Conditions[0].Message, timeoutMultiplier*time.Minute*3, time.Second*5).Should(Equal(expectedErr.Error()))
 				return
@@ -703,6 +705,6 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 				},
 			},
 			WantError: true,
-		}, fmt.Errorf("region for AWS backupstoragelocation cannot be empty")),
+		}, fmt.Errorf("region for AWS backupstoragelocation cannot be empty when s3ForcePathStyle is true")),
 	)
 })

--- a/tests/e2e/velero_deployment_suite_test.go
+++ b/tests/e2e/velero_deployment_suite_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
@@ -38,7 +39,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 				// Eventually()
 				log.Printf("Test case expected to error. Waiting for the error to show in DPA Status")
 				Eventually(vel.GetNoErr().Status.Conditions[0].Type, timeoutMultiplier*time.Minute*3, time.Second*5).Should(Equal("Reconciled"))
-				Eventually(vel.GetNoErr().Status.Conditions[0].Status, timeoutMultiplier*time.Minute*3, time.Second*5).Should(Equal(v1.ConditionFalse))
+				Eventually(vel.GetNoErr().Status.Conditions[0].Status, timeoutMultiplier*time.Minute*3, time.Second*5).Should(Equal(metav1.ConditionFalse))
 				Eventually(vel.GetNoErr().Status.Conditions[0].Reason, timeoutMultiplier*time.Minute*3, time.Second*5).Should(Equal("Error"))
 				Eventually(vel.GetNoErr().Status.Conditions[0].Message, timeoutMultiplier*time.Minute*3, time.Second*5).Should(Equal(expectedErr.Error()))
 				return

--- a/tests/e2e/velero_deployment_suite_test.go
+++ b/tests/e2e/velero_deployment_suite_test.go
@@ -610,10 +610,11 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 			},
 			WantError: false,
 		}, nil),
-		Entry("AWS Without Region No S3ForcePathStyle should succeed", InstallCase{
+		Entry("AWS Without Region No S3ForcePathStyle with BackupImages false should succeed", InstallCase{
 			Name:         "default-no-region-no-s3forcepathstyle",
 			BRestoreType: restic,
 			DpaSpec: &oadpv1alpha1.DataProtectionApplicationSpec{
+				BackupImages: pointer.Bool(false),
 				BackupLocations: []oadpv1alpha1.BackupLocation{
 					{
 						Velero: &velero.BackupStorageLocationSpec{
@@ -674,7 +675,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 			},
 			WantError: false,
 		}, nil),
-		Entry("AWS Without Region And S3ForcePathStyle should fail", InstallCase{
+		Entry("AWS Without Region And S3ForcePathStyle true should fail", InstallCase{
 			Name:         "default-with-region-and-s3forcepathstyle",
 			BRestoreType: restic,
 			DpaSpec: &oadpv1alpha1.DataProtectionApplicationSpec{
@@ -706,6 +707,6 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 				},
 			},
 			WantError: true,
-		}, fmt.Errorf("region for AWS backupstoragelocation cannot be empty when s3ForcePathStyle is true")),
+		}, fmt.Errorf("region for AWS backupstoragelocation cannot be empty when s3ForcePathStyle is true or when backing up images")),
 	)
 })

--- a/tests/e2e/velero_deployment_suite_test.go
+++ b/tests/e2e/velero_deployment_suite_test.go
@@ -94,9 +94,11 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 				}
 			}
 
-			for key, value := range dpa.Spec.Configuration.Restic.PodConfig.NodeSelector {
-				log.Printf("Waiting for restic daemonset to get node selector")
-				Eventually(resticDaemonSetHasNodeSelector(namespace, key, value), timeoutMultiplier*time.Minute*3, time.Second*5).Should(BeTrue())
+			if dpa.Spec.Configuration.Restic != nil && dpa.Spec.Configuration.Restic.PodConfig != nil {
+				for key, value := range dpa.Spec.Configuration.Restic.PodConfig.NodeSelector {
+					log.Printf("Waiting for restic daemonset to get node selector")
+					Eventually(resticDaemonSetHasNodeSelector(namespace, key, value), timeoutMultiplier*time.Minute*3, time.Second*5).Should(BeTrue())
+				}
 			}
 			if dpa.Spec.BackupImages == nil || *installCase.DpaSpec.BackupImages {
 				log.Printf("Waiting for registry pods to be running")

--- a/tests/e2e/velero_deployment_suite_test.go
+++ b/tests/e2e/velero_deployment_suite_test.go
@@ -143,7 +143,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 		}, nil),
 		Entry("Adding Velero custom plugin", InstallCase{
 			Name:         "default-cr-velero-custom-plugin",
-			BRestoreType: "restic",
+			BRestoreType: restic,
 			DpaSpec: &oadpv1alpha1.DataProtectionApplicationSpec{
 				Configuration: &oadpv1alpha1.ApplicationConfig{
 					Velero: &oadpv1alpha1.VeleroConfig{
@@ -188,7 +188,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 		}, nil),
 		Entry("Adding Velero resource allocations", InstallCase{
 			Name:         "default-cr-velero-resource-alloc",
-			BRestoreType: "restic",
+			BRestoreType: restic,
 			DpaSpec: &oadpv1alpha1.DataProtectionApplicationSpec{
 				Configuration: &oadpv1alpha1.ApplicationConfig{
 					Velero: &oadpv1alpha1.VeleroConfig{
@@ -238,7 +238,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 		}, nil),
 		Entry("Adding AWS plugin", InstallCase{
 			Name:         "default-cr-aws-plugin",
-			BRestoreType: "restic",
+			BRestoreType: restic,
 			DpaSpec: &oadpv1alpha1.DataProtectionApplicationSpec{
 				Configuration: &oadpv1alpha1.ApplicationConfig{
 					Velero: &oadpv1alpha1.VeleroConfig{
@@ -275,7 +275,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 		}, nil),
 		Entry("DPA CR with bsl and vsl", InstallCase{
 			Name:         "default-cr-bsl-vsl",
-			BRestoreType: "restic",
+			BRestoreType: restic,
 			DpaSpec: &oadpv1alpha1.DataProtectionApplicationSpec{
 				Configuration: &oadpv1alpha1.ApplicationConfig{
 					Velero: &oadpv1alpha1.VeleroConfig{
@@ -322,7 +322,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 		}, nil),
 		/*Entry("DPA CR with bsl and multiple vsl", InstallCase{
 			Name:         "default-cr-bsl-vsl",
-			BRestoreType: "restic",
+			BRestoreType: restic,
 			DpaSpec: &oadpv1alpha1.DataProtectionApplicationSpec{
 				Configuration: &oadpv1alpha1.ApplicationConfig{
 					Velero: &oadpv1alpha1.VeleroConfig{
@@ -377,7 +377,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 		}, nil),*/
 		/*Entry("DPA CR with no bsl and multiple vsl", InstallCase{
 			Name:         "default-cr-multiple-vsl",
-			BRestoreType: "restic",
+			BRestoreType: restic,
 			DpaSpec: &oadpv1alpha1.DataProtectionApplicationSpec{
 				Configuration: &oadpv1alpha1.ApplicationConfig{
 					Velero: &oadpv1alpha1.VeleroConfig{
@@ -416,7 +416,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 		}, nil),*/
 		Entry("Default velero CR with restic disabled", InstallCase{
 			Name:         "default-cr-no-restic",
-			BRestoreType: "restic",
+			BRestoreType: restic,
 			DpaSpec: &oadpv1alpha1.DataProtectionApplicationSpec{
 				Configuration: &oadpv1alpha1.ApplicationConfig{
 					Velero: &oadpv1alpha1.VeleroConfig{
@@ -453,7 +453,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 		}, nil),
 		Entry("Adding CSI plugin", InstallCase{
 			Name:         "default-cr-csi",
-			BRestoreType: "restic",
+			BRestoreType: restic,
 			DpaSpec: &oadpv1alpha1.DataProtectionApplicationSpec{
 				Configuration: &oadpv1alpha1.ApplicationConfig{
 					Velero: &oadpv1alpha1.VeleroConfig{
@@ -491,7 +491,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 		}, nil),
 		Entry("Set restic node selector", InstallCase{
 			Name:         "default-cr-node-selector",
-			BRestoreType: "restic",
+			BRestoreType: restic,
 			DpaSpec: &oadpv1alpha1.DataProtectionApplicationSpec{
 				BackupLocations: []oadpv1alpha1.BackupLocation{
 					{
@@ -532,7 +532,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 		}, nil),
 		Entry("Enable tolerations", InstallCase{
 			Name:         "default-cr-tolerations",
-			BRestoreType: "restic",
+			BRestoreType: restic,
 			DpaSpec: &oadpv1alpha1.DataProtectionApplicationSpec{
 				BackupLocations: []oadpv1alpha1.BackupLocation{
 					{
@@ -578,7 +578,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 		}, nil),
 		Entry("NoDefaultBackupLocation", InstallCase{
 			Name:         "default-cr-node-selector",
-			BRestoreType: "restic",
+			BRestoreType: restic,
 			DpaSpec: &oadpv1alpha1.DataProtectionApplicationSpec{
 				Configuration: &oadpv1alpha1.ApplicationConfig{
 					Velero: &oadpv1alpha1.VeleroConfig{
@@ -596,6 +596,103 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 				},
 			},
 			WantError: false,
+		}, nil),
+		Entry("AWS Without Region No S3ForcePathStyle should succeed", InstallCase{
+			Name:         "default-no-region-no-s3forcepathstyle",
+			BRestoreType: restic,
+			DpaSpec: &oadpv1alpha1.DataProtectionApplicationSpec{
+				BackupLocations: []oadpv1alpha1.BackupLocation{
+					{
+						Velero: &velero.BackupStorageLocationSpec{
+							Provider: provider,
+							Default:  true,
+							StorageType: velero.StorageType{
+								ObjectStorage: &velero.ObjectStorageLocation{
+									Bucket: s3Bucket,
+									Prefix: veleroPrefix,
+								},
+							},
+						},
+					},
+				},
+				Configuration: &oadpv1alpha1.ApplicationConfig{
+					Velero: &oadpv1alpha1.VeleroConfig{
+						PodConfig: &oadpv1alpha1.PodConfig{},
+						DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
+							oadpv1alpha1.DefaultPluginOpenShift,
+							oadpv1alpha1.DefaultPluginAWS,
+						},
+					},
+				},
+			},
+			WantError: false,
+		}, nil),
+		Entry("AWS With Region And S3ForcePathStyle should succeed", InstallCase{
+			Name:         "default-with-region-and-s3forcepathstyle",
+			BRestoreType: restic,
+			DpaSpec: &oadpv1alpha1.DataProtectionApplicationSpec{
+				BackupLocations: []oadpv1alpha1.BackupLocation{
+					{
+						Velero: &velero.BackupStorageLocationSpec{
+							Provider: provider,
+							Config: map[string]string{
+								"region":           region,
+								"s3ForcePathStyle": "true",
+							},
+							Default: true,
+							StorageType: velero.StorageType{
+								ObjectStorage: &velero.ObjectStorageLocation{
+									Bucket: s3Bucket,
+									Prefix: veleroPrefix,
+								},
+							},
+						},
+					},
+				},
+				Configuration: &oadpv1alpha1.ApplicationConfig{
+					Velero: &oadpv1alpha1.VeleroConfig{
+						PodConfig: &oadpv1alpha1.PodConfig{},
+						DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
+							oadpv1alpha1.DefaultPluginOpenShift,
+							oadpv1alpha1.DefaultPluginAWS,
+						},
+					},
+				},
+			},
+			WantError: false,
+		}, nil),
+		Entry("AWS Without Region And S3ForcePathStyle should fail", InstallCase{
+			Name:         "default-with-region-and-s3forcepathstyle",
+			BRestoreType: restic,
+			DpaSpec: &oadpv1alpha1.DataProtectionApplicationSpec{
+				BackupLocations: []oadpv1alpha1.BackupLocation{
+					{
+						Velero: &velero.BackupStorageLocationSpec{
+							Provider: provider,
+							Config: map[string]string{
+								"s3ForcePathStyle": "true",
+							},
+							Default: true,
+							StorageType: velero.StorageType{
+								ObjectStorage: &velero.ObjectStorageLocation{
+									Bucket: s3Bucket,
+									Prefix: veleroPrefix,
+								},
+							},
+						},
+					},
+				},
+				Configuration: &oadpv1alpha1.ApplicationConfig{
+					Velero: &oadpv1alpha1.VeleroConfig{
+						PodConfig: &oadpv1alpha1.PodConfig{},
+						DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
+							oadpv1alpha1.DefaultPluginOpenShift,
+							oadpv1alpha1.DefaultPluginAWS,
+						},
+					},
+				},
+			},
+			WantError: true,
 		}, nil),
 	)
 })

--- a/tests/e2e/velero_helpers.go
+++ b/tests/e2e/velero_helpers.go
@@ -130,6 +130,11 @@ func (v *dpaCustomResource) Get() (*oadpv1alpha1.DataProtectionApplication, erro
 	return &vel, nil
 }
 
+func (v *dpaCustomResource) GetNoErr() *oadpv1alpha1.DataProtectionApplication {
+	dpa, _ := v.Get()
+	return dpa
+}
+
 func (v *dpaCustomResource) CreateOrUpdate(spec *oadpv1alpha1.DataProtectionApplicationSpec) error {
 	cr, err := v.Get()
 	if apierrors.IsNotFound(err) {


### PR DESCRIPTION
Closes #424 
Closes [OADP-153](https://issues.redhat.com/browse/OADP-153)

- fix reconciler not deleting restic deamonset when restic config is `nil`