### PR TITLE
OADP-200: Limit velero servicemonitor to keep bounded cardinality

### DIFF
--- a/controllers/monitor.go
+++ b/controllers/monitor.go
@@ -99,6 +99,15 @@ func (r *DPAReconciler) buildVeleroServiceMonitor(serviceMonitor *monitor.Servic
 		{
 			Interval: "30s",
 			Port:     "monitoring",
+			MetricRelabelConfigs: []*monitor.RelabelConfig{
+				{
+					Action: "keep",
+					Regex:  ("velero_backup_total|velero_restore_total"),
+					SourceLabels: []string{
+						"__name__",
+					},
+				},
+			},
 		},
 	}
 

--- a/controllers/monitor_test.go
+++ b/controllers/monitor_test.go
@@ -140,6 +140,15 @@ func TestDPAReconciler_buildVeleroServiceMonitor(t *testing.T) {
 						{
 							Interval: "30s",
 							Port:     "monitoring",
+							MetricRelabelConfigs: []*monitor.RelabelConfig{
+								{
+									Action: "keep",
+									Regex:  ("velero_backup_total|velero_restore_total"),
+									SourceLabels: []string{
+										"__name__",
+									},
+								},
+							},
 						},
 					},
 					NamespaceSelector: monitor.NamespaceSelector{


### PR DESCRIPTION
This PR limits the metrics scraped by the velero service monitor to only `velero_backup_total` and `velero_restore_total` (both have bounded cardinality, collectively `2`), thus fixing the concerns related to openshift's in-cluster monitoring stack being affected with metrics having unbounded cardinality.