### PR TITLE
made tests' structure more generic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -289,11 +289,11 @@ catalog-build: opm ## Build a catalog image.
 catalog-push: ## Push a catalog image.
 	$(MAKE) docker-push IMG=$(CATALOG_IMG)
 
-S3_BUCKET := $(shell cat $(OADP_S3_BUCKET) | awk '/velero-bucket-name/  {gsub(/"/, "", $2); print $2}')
+S3_BUCKET := $(shell cat $(OADP_S3_BUCKET) | awk '/velero-bucket-name/  {gsub(/"/, "", $$2); print $$2}')
 SETTINGS_TMP=/tmp/test-settings
 test-e2e:
 	mkdir -p $(SETTINGS_TMP)
-	$(shell PROVIDER="$(PROVIDER)" BUCKET="$(S3_BUCKET)" REGION="$(REGION)" SECRET="$(CREDS_SECRET_REF)" TMP_DIR=$(SETTINGS_TMP) /bin/bash tests/e2e/scripts/aws_settings.sh)
+	PROVIDER="$(PROVIDER)" BUCKET="$(S3_BUCKET)" REGION="$(REGION)" SECRET="$(CREDS_SECRET_REF)" TMP_DIR=$(SETTINGS_TMP) /bin/bash tests/e2e/scripts/aws_settings.sh
 	ginkgo -mod=mod tests/e2e/ -- -cloud=$(OADP_AWS_CRED_FILE) \
 	-velero_namespace=$(OADP_TEST_NAMESPACE) \
 	-settings=$(SETTINGS_TMP)/awscreds \

--- a/Makefile
+++ b/Makefile
@@ -289,7 +289,7 @@ catalog-build: opm ## Build a catalog image.
 catalog-push: ## Push a catalog image.
 	$(MAKE) docker-push IMG=$(CATALOG_IMG)
 
-S3_BUCKET := $(shell cat $(OADP_S3_BUCKET) | jq  -r '."velero-bucket-name"')
+S3_BUCKET := $(shell cat $(OADP_S3_BUCKET) | awk '/velero-bucket-name/  {gsub(/"/, "", $2); print $2}')
 SETTINGS_TMP=/tmp/test-settings
 test-e2e:
 	mkdir -p $(SETTINGS_TMP)

--- a/Makefile
+++ b/Makefile
@@ -289,12 +289,16 @@ catalog-build: opm ## Build a catalog image.
 catalog-push: ## Push a catalog image.
 	$(MAKE) docker-push IMG=$(CATALOG_IMG)
 
+S3_BUCKET := $(shell cat $(OADP_S3_BUCKET) | jq  -r '."velero-bucket-name"')
+SETTINGS_TMP=/tmp/test-settings
 test-e2e:
+	mkdir -p $(SETTINGS_TMP)
+	$(shell PROVIDER="$(PROVIDER)" BUCKET="$(S3_BUCKET)" REGION="$(REGION)" SECRET="$(CREDS_SECRET_REF)" TMP_DIR=$(SETTINGS_TMP) /bin/bash tests/e2e/scripts/aws_settings.sh)
 	ginkgo -mod=mod tests/e2e/ -- -cloud=$(OADP_AWS_CRED_FILE) \
-	-s3_bucket=$(OADP_S3_BUCKET) -velero_namespace=$(OADP_TEST_NAMESPACE) \
-	-creds_secret_ref=$(CREDS_SECRET_REF) \
+	-velero_namespace=$(OADP_TEST_NAMESPACE) \
+	-settings=$(SETTINGS_TMP)/awscreds \
 	-velero_instance_name=$(VELERO_INSTANCE_NAME) \
-	-region=$(REGION) \
-	-provider=$(PROVIDER) \
-	-clusterProfile=$(CLUSTER_PROFILE) \
 	-timeout_multiplier=$(E2E_TIMEOUT_MULTIPLIER)
+	-cluster_profile=$(CLUSTER_PROFILE)
+test-e2e-cleanup:
+	rm -rf $(SETTINGS_TMP)

--- a/docs/developer/TESTING.md
+++ b/docs/developer/TESTING.md
@@ -82,21 +82,18 @@ Example Configuration: **launch.json**
 * The [e2e_suite_test.go](https://github.com/openshift/oadp-operator/blob/master/tests/e2e/e2e_suite_test.go) file must be overridden with parameters specific to your environment and aws buckets.
     * The critical paramaters to change are under `func init()`:
         * cloud
-        * s3BucketFilePath
+        * settings
         * namespace
-        * region
-        * provider
+        * cluster_profile
 
 Example Configuration: **e2e_suite_test.go**
 ```go=
 func init() {
 	flag.StringVar(&cloud, "cloud", "/home/user/oadp_e2e/aws_credentials", "Cloud Credentials file path location")
-	flag.StringVar(&s3BucketFilePath, "s3_bucket", "/home/user/oadp_e2e/oadp_s3_bucket", "AWS S3 data file path location")
-	flag.StringVar(&namespace, "velero_namespace", "oadp-operator", "Velero Namespace")
-	flag.StringVar(&region, "region", "us-east-1", "BSL region")
-	flag.StringVar(&provider, "provider", "aws", "BSL provider")
-	flag.StringVar(&credSecretRef, "creds_secret_ref", "cloud-credentials", "Credential secret ref for backup storage location")
+	flag.StringVar(&namespace, "velero_namespace", "oadp-operator", "DPA Namespace")
+	flag.StringVar(&settings, "settings", "./templates/default_settings.json", "Settings of the velero instance")
 	flag.StringVar(&instanceName, "velero_instance_name", "example-velero", "Velero Instance Name")
+	flag.StringVar(&clusterProfile, "cluster_profile", "aws", "Cluster profile")
 	timeoutMultiplierInput := flag.Int64("timeout_multiplier", 1, "Customize timeout multiplier from default (1)")
 	timeoutMultiplier = 1
 	if timeoutMultiplierInput != nil && *timeoutMultiplierInput >= 1 {
@@ -105,6 +102,8 @@ func init() {
 }
 
 ```
+Example settings file could be found under oadp-operator/tests/e2e/templates/default_settings.json, and can be overriden used with different providers with similar structure.
+
 
 * Note that your shell overrides documented [here](https://github.com/openshift/oadp-operator/blob/master/docs/developer/TESTING.md) are not accessable to Visual Studio Code.
 

--- a/go.sum
+++ b/go.sum
@@ -1289,7 +1289,6 @@ k8s.io/apiserver v0.22.1/go.mod h1:2mcM6dzSt+XndzVQJX21Gx0/Klo7Aen7i0Ai6tIa400=
 k8s.io/apiserver v0.22.2/go.mod h1:vrpMmbyjWrgdyOvZTSpsusQq5iigKNWv9o9KlDAbBHI=
 k8s.io/cli-runtime v0.19.2/go.mod h1:CMynmJM4Yf02TlkbhKxoSzi4Zf518PukJ5xep/NaNeY=
 k8s.io/cli-runtime v0.20.9/go.mod h1:MjEpWNIcmJL+gANS1+SVfvWpRSQRxOvTcx+vzvDTtTY=
-k8s.io/cli-runtime v0.19.12/go.mod h1:KopjJ53HaHZjG+WhJmH8WxZzxnXVNkxP7GO1QiQJ2uI=
 k8s.io/client-go v0.18.3/go.mod h1:4a/dpQEvzAhT1BbuWW09qvIaGw6Gbu1gZYiQZIi1DMw=
 k8s.io/client-go v0.19.0/go.mod h1:H9E/VT95blcFQnlyShFgnFT9ZnJOAceiUHM3MlRC+mU=
 k8s.io/client-go v0.19.2/go.mod h1:S5wPhCqyDNAlzM9CnEdgTGV4OqhsW3jGO1UM1epwfJA=

--- a/tests/e2e/backup_restore_suite_test.go
+++ b/tests/e2e/backup_restore_suite_test.go
@@ -20,10 +20,9 @@ var _ = Describe("AWS backup restore tests", func() {
 		testSuiteInstanceName := "ts-" + instanceName
 		vel.Name = testSuiteInstanceName
 
-		credData, err := getCredsData(cloud)
+		credData, err := readFile(cloud)
 		Expect(err).NotTo(HaveOccurred())
-
-		err = createCredentialsSecret(credData, namespace, credSecretRef)
+		err = createCredentialsSecret(credData, namespace, getSecretRef(credSecretRef))
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -80,7 +79,7 @@ var _ = Describe("AWS backup restore tests", func() {
 			}
 
 			if brCase.BackupRestoreType == csi {
-				if vel.ClusterProfile == "aws" {
+				if clusterProfile == "aws" {
 					log.Printf("Creating VolumeSnapshot for CSI backuprestore of %s", brCase.Name)
 					err = installApplication(vel.Client, "./sample-applications/gp2-csi/volumeSnapshotClass.yaml")
 					Expect(err).ToNot(HaveOccurred())

--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -83,12 +83,6 @@ func setUpClient() (*kubernetes.Clientset, error) {
 	return clientset, nil
 }
 
-func getJsonData(path string) ([]byte, error) {
-	// Return buffer data for json
-	jsonData, err := ioutil.ReadFile(path)
-	return jsonData, err
-}
-
 func decodeJson(data []byte) (map[string]interface{}, error) {
 	// Return JSON from buffer data
 	var jsonData map[string]interface{}
@@ -97,7 +91,7 @@ func decodeJson(data []byte) (map[string]interface{}, error) {
 	return jsonData, err
 }
 
-// Keeping it for now.
+// FIXME: Remove
 func createOADPTestNamespace(namespace string) error {
 	// default OADP Namespace
 	kubeConf := getKubeConfig()
@@ -118,7 +112,7 @@ func createOADPTestNamespace(namespace string) error {
 	return err
 }
 
-// Keeping it for now.
+// FIXME: Remove
 func deleteOADPTestNamespace(namespace string) error {
 	// default OADP Namespace
 	kubeConf := getKubeConfig()
@@ -135,7 +129,7 @@ func getKubeConfig() *rest.Config {
 	return config.GetConfigOrDie()
 }
 
-// Keeping it for now
+// FIXME: Remove
 func doesNamespaceExist(namespace string) (bool, error) {
 	clientset, err := setUpClient()
 	if err != nil {
@@ -171,15 +165,15 @@ func serverVersion() (*version.Info, error) {
 	return clientset.Discovery().ServerVersion()
 }
 
-func getCredsData(cloud string) ([]byte, error) {
+func readFile(path string) ([]byte, error) {
 	// pass in aws credentials by cli flag
 	// from cli:  -cloud=<"filepath">
 	// go run main.go -cloud="/Users/emilymcmullan/.aws/credentials"
 	// cloud := flag.String("cloud", "", "file path for aws credentials")
 	// flag.Parse()
-	// save passed in cred file as []byte
-	credsFile, err := ioutil.ReadFile(cloud)
-	return credsFile, err
+	// save passed in cred file as []byteq
+	file, err := ioutil.ReadFile(path)
+	return file, err
 }
 
 func createCredentialsSecret(data []byte, namespace string, credSecretRef string) error {
@@ -235,3 +229,4 @@ func isCredentialsSecretDeleted(namespace string, credSecretRef string) wait.Con
 		return false, err
 	}
 }
+

--- a/tests/e2e/scripts/aws_settings.sh
+++ b/tests/e2e/scripts/aws_settings.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+cat > $TMP_DIR/awscreds <<EOF
+{
+  "spec": {
+      "configuration":{
+        "velero":{
+          "defaultPlugins": [
+            "openshift", "$PROVIDER"
+          ]
+        }
+      },
+      "backupLocations": [
+        {
+          "velero": {
+            "provider": "$PROVIDER",
+            "config": {
+              "region": "$REGION"
+            },
+            
+            "objectStorage":{
+              "bucket": "$BUCKET"
+            }
+          }
+        }
+      ]
+#     ,"credential":{
+#       "name": "$SECRET",
+#       "key": "cloud"
+#     },
+#      "snapshotLocations": [
+#        {
+#          "velero": {
+#            "provider": "$PROVIDER",
+#            "config": { 
+#              "profile": "snapshot",
+#              "region": "$REGION"
+#            }
+#          }
+#        }
+#      ]
+  }
+}
+EOF
+
+x=$(cat $TMP_DIR/awscreds); echo "$x" | grep -o '^[^#]*'  > $TMP_DIR/awscreds

--- a/tests/e2e/subscription_helpers.go
+++ b/tests/e2e/subscription_helpers.go
@@ -22,7 +22,7 @@ func (d *dpaCustomResource) getOperatorSubscription() (*Subscription, error) {
 		return nil, err
 	}
 	sl := operators.SubscriptionList{}
-	err = d.Client.List(context.Background(), &sl, client.InNamespace(d.Namespace), client.MatchingLabels(map[string]string{"operators.coreos.com/oadp-operator.openshift-adp": ""}))
+	err = d.Client.List(context.Background(), &sl, client.InNamespace(d.Namespace), client.MatchingLabels(map[string]string{"operators.coreos.com/oadp-operator." + d.Namespace: ""}))
 	if err != nil {
 		return nil, err
 	}

--- a/tests/e2e/subscription_suite_test.go
+++ b/tests/e2e/subscription_suite_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Subscription Config Suite Test", func() {
 		credData, err := readFile(cloud)
 		Expect(err).NotTo(HaveOccurred())
 
-		err = createCredentialsSecret(credData, namespace, vel.CustomResource.Spec.BackupLocations[0].Velero.Credential.Name)
+		err = createCredentialsSecret(credData, namespace, getSecretRef(credSecretRef))
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/tests/e2e/subscription_suite_test.go
+++ b/tests/e2e/subscription_suite_test.go
@@ -29,10 +29,10 @@ var _ = Describe("Subscription Config Suite Test", func() {
 		testSuiteInstanceName := "ts-" + instanceName
 		vel.Name = testSuiteInstanceName
 
-		credData, err := getCredsData(cloud)
+		credData, err := readFile(cloud)
 		Expect(err).NotTo(HaveOccurred())
 
-		err = createCredentialsSecret(credData, namespace, credSecretRef)
+		err = createCredentialsSecret(credData, namespace, vel.CustomResource.Spec.BackupLocations[0].Velero.Credential.Name)
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/tests/e2e/templates/default_settings.json
+++ b/tests/e2e/templates/default_settings.json
@@ -1,0 +1,40 @@
+{
+  "spec": {
+      "configuration":{
+        "velero":{
+          "defaultPlugins": [
+            "openshift", "aws"
+          ]
+        }
+      },
+      "backupLocations": [
+        {
+          "velero": {
+            "provider": "aws",
+            "config": {
+              "profile": "default",
+              "region": "us-east-1"
+            },
+            "objectStorage":{
+              "bucket": "myBucket"
+            },
+            "credential":{
+              "name": "cloud-credentials",
+              "key": "cloud"
+            }
+          }
+        }
+      ],
+      "snapshotLocations": [
+        {
+          "velero": {
+            "provider": "aws",
+            "config": { 
+              "profile": "default",
+              "region": "us-east-1"
+            }
+          }
+        }
+      ]
+  }
+}

--- a/tests/e2e/velero_deployment_suite_test.go
+++ b/tests/e2e/velero_deployment_suite_test.go
@@ -18,6 +18,9 @@ import (
 )
 
 var _ = Describe("Configuration testing for DPA Custom Resource", func() {
+	provider := dpa.Spec.BackupLocations[0].Velero.Provider
+	bucket := dpa.Spec.BackupLocations[0].Velero.ObjectStorage.Bucket
+	bslConfig := dpa.Spec.BackupLocations[0].Velero.Config
 
 	type InstallCase struct {
 		Name         string
@@ -27,6 +30,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 	}
 
 	DescribeTable("Updating custom resource with new configuration",
+
 		func(installCase InstallCase, expectedErr error) {
 			//TODO: Calling vel.build() is the old pattern.
 			//Change it later to make sure all the spec values are passed for every test case,
@@ -123,11 +127,8 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 			DpaSpec: &oadpv1alpha1.DataProtectionApplicationSpec{
 				Configuration: &oadpv1alpha1.ApplicationConfig{
 					Velero: &oadpv1alpha1.VeleroConfig{
-						DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
-							oadpv1alpha1.DefaultPluginOpenShift,
-							oadpv1alpha1.DefaultPluginAWS,
-						},
-						PodConfig: &oadpv1alpha1.PodConfig{},
+						DefaultPlugins: dpa.Spec.Configuration.Velero.DefaultPlugins,
+						PodConfig:      &oadpv1alpha1.PodConfig{},
 					},
 					Restic: &oadpv1alpha1.ResticConfig{
 						PodConfig: &oadpv1alpha1.PodConfig{},
@@ -138,13 +139,11 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 					{
 						Velero: &velero.BackupStorageLocationSpec{
 							Provider: provider,
-							Config: map[string]string{
-								"region": region,
-							},
-							Default: true,
+							Config:   bslConfig,
+							Default:  true,
 							StorageType: velero.StorageType{
 								ObjectStorage: &velero.ObjectStorageLocation{
-									Bucket: s3Bucket,
+									Bucket: bucket,
 									Prefix: veleroPrefix,
 								},
 							},
@@ -161,11 +160,9 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 				Configuration: &oadpv1alpha1.ApplicationConfig{
 					Velero: &oadpv1alpha1.VeleroConfig{
 						PodConfig: &oadpv1alpha1.PodConfig{},
-						DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
+						DefaultPlugins: append([]oadpv1alpha1.DefaultPlugin{
 							oadpv1alpha1.DefaultPluginCSI,
-							oadpv1alpha1.DefaultPluginAWS,
-							oadpv1alpha1.DefaultPluginOpenShift,
-						},
+						}, dpa.Spec.Configuration.Velero.DefaultPlugins...),
 						CustomPlugins: []oadpv1alpha1.CustomPlugin{
 							{
 								Name:  "encryption-plugin",
@@ -183,13 +180,11 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 					{
 						Velero: &velero.BackupStorageLocationSpec{
 							Provider: provider,
-							Config: map[string]string{
-								"region": region,
-							},
-							Default: true,
+							Config:   bslConfig,
+							Default:  true,
 							StorageType: velero.StorageType{
 								ObjectStorage: &velero.ObjectStorageLocation{
-									Bucket: s3Bucket,
+									Bucket: bucket,
 									Prefix: veleroPrefix,
 								},
 							},
@@ -217,11 +212,9 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 								},
 							},
 						},
-						DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
+						DefaultPlugins: append([]oadpv1alpha1.DefaultPlugin{
 							oadpv1alpha1.DefaultPluginCSI,
-							oadpv1alpha1.DefaultPluginAWS,
-							oadpv1alpha1.DefaultPluginOpenShift,
-						},
+						}, dpa.Spec.Configuration.Velero.DefaultPlugins...),
 					},
 					Restic: &oadpv1alpha1.ResticConfig{
 						PodConfig: &oadpv1alpha1.PodConfig{},
@@ -233,13 +226,11 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 					{
 						Velero: &velero.BackupStorageLocationSpec{
 							Provider: provider,
-							Config: map[string]string{
-								"region": region,
-							},
-							Default: true,
+							Config:   bslConfig,
+							Default:  true,
 							StorageType: velero.StorageType{
 								ObjectStorage: &velero.ObjectStorageLocation{
-									Bucket: s3Bucket,
+									Bucket: bucket,
 									Prefix: veleroPrefix,
 								},
 							},
@@ -270,13 +261,11 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 					{
 						Velero: &velero.BackupStorageLocationSpec{
 							Provider: provider,
-							Config: map[string]string{
-								"region": region,
-							},
-							Default: true,
+							Config:   bslConfig,
+							Default:  true,
 							StorageType: velero.StorageType{
 								ObjectStorage: &velero.ObjectStorageLocation{
-									Bucket: s3Bucket,
+									Bucket: bucket,
 									Prefix: veleroPrefix,
 								},
 							},
@@ -292,38 +281,24 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 			DpaSpec: &oadpv1alpha1.DataProtectionApplicationSpec{
 				Configuration: &oadpv1alpha1.ApplicationConfig{
 					Velero: &oadpv1alpha1.VeleroConfig{
-						PodConfig: &oadpv1alpha1.PodConfig{},
-						DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
-							oadpv1alpha1.DefaultPluginOpenShift,
-							oadpv1alpha1.DefaultPluginAWS,
-						},
+						PodConfig:      &oadpv1alpha1.PodConfig{},
+						DefaultPlugins: dpa.Spec.Configuration.Velero.DefaultPlugins,
 					},
 					Restic: &oadpv1alpha1.ResticConfig{
 						PodConfig: &oadpv1alpha1.PodConfig{},
 						Enable:    pointer.Bool(true),
 					},
 				},
-				SnapshotLocations: []oadpv1alpha1.SnapshotLocation{
-					{
-						Velero: &velero.VolumeSnapshotLocationSpec{
-							Provider: "aws",
-							Config: map[string]string{
-								"region": "us-east-1",
-							},
-						},
-					},
-				},
+				SnapshotLocations: dpa.Spec.SnapshotLocations,
 				BackupLocations: []oadpv1alpha1.BackupLocation{
 					{
 						Velero: &velero.BackupStorageLocationSpec{
 							Provider: provider,
-							Config: map[string]string{
-								"region": region,
-							},
-							Default: true,
+							Config:   bslConfig,
+							Default:  true,
 							StorageType: velero.StorageType{
 								ObjectStorage: &velero.ObjectStorageLocation{
-									Bucket: s3Bucket,
+									Bucket: bucket,
 									Prefix: veleroPrefix,
 								},
 							},
@@ -433,11 +408,8 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 			DpaSpec: &oadpv1alpha1.DataProtectionApplicationSpec{
 				Configuration: &oadpv1alpha1.ApplicationConfig{
 					Velero: &oadpv1alpha1.VeleroConfig{
-						PodConfig: &oadpv1alpha1.PodConfig{},
-						DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
-							oadpv1alpha1.DefaultPluginOpenShift,
-							oadpv1alpha1.DefaultPluginAWS,
-						},
+						PodConfig:      &oadpv1alpha1.PodConfig{},
+						DefaultPlugins: dpa.Spec.Configuration.Velero.DefaultPlugins,
 					},
 					Restic: &oadpv1alpha1.ResticConfig{
 						PodConfig: &oadpv1alpha1.PodConfig{},
@@ -448,13 +420,11 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 					{
 						Velero: &velero.BackupStorageLocationSpec{
 							Provider: provider,
-							Config: map[string]string{
-								"region": region,
-							},
-							Default: true,
+							Config:   bslConfig,
+							Default:  true,
 							StorageType: velero.StorageType{
 								ObjectStorage: &velero.ObjectStorageLocation{
-									Bucket: s3Bucket,
+									Bucket: bucket,
 									Prefix: veleroPrefix,
 								},
 							},
@@ -471,11 +441,9 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 				Configuration: &oadpv1alpha1.ApplicationConfig{
 					Velero: &oadpv1alpha1.VeleroConfig{
 						PodConfig: &oadpv1alpha1.PodConfig{},
-						DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
-							oadpv1alpha1.DefaultPluginOpenShift,
+						DefaultPlugins: append([]oadpv1alpha1.DefaultPlugin{
 							oadpv1alpha1.DefaultPluginCSI,
-							oadpv1alpha1.DefaultPluginAWS,
-						},
+						}, dpa.Spec.Configuration.Velero.DefaultPlugins...),
 					},
 					Restic: &oadpv1alpha1.ResticConfig{
 						PodConfig: &oadpv1alpha1.PodConfig{},
@@ -486,13 +454,11 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 					{
 						Velero: &velero.BackupStorageLocationSpec{
 							Provider: provider,
-							Config: map[string]string{
-								"region": region,
-							},
-							Default: true,
+							Config:   bslConfig,
+							Default:  true,
 							StorageType: velero.StorageType{
 								ObjectStorage: &velero.ObjectStorageLocation{
-									Bucket: s3Bucket,
+									Bucket: bucket,
 									Prefix: veleroPrefix,
 								},
 							},
@@ -510,13 +476,11 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 					{
 						Velero: &velero.BackupStorageLocationSpec{
 							Provider: provider,
-							Config: map[string]string{
-								"region": region,
-							},
-							Default: true,
+							Config:   bslConfig,
+							Default:  true,
 							StorageType: velero.StorageType{
 								ObjectStorage: &velero.ObjectStorageLocation{
-									Bucket: s3Bucket,
+									Bucket: bucket,
 									Prefix: veleroPrefix,
 								},
 							},
@@ -525,11 +489,8 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 				},
 				Configuration: &oadpv1alpha1.ApplicationConfig{
 					Velero: &oadpv1alpha1.VeleroConfig{
-						PodConfig: &oadpv1alpha1.PodConfig{},
-						DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
-							oadpv1alpha1.DefaultPluginOpenShift,
-							oadpv1alpha1.DefaultPluginAWS,
-						},
+						PodConfig:      &oadpv1alpha1.PodConfig{},
+						DefaultPlugins: dpa.Spec.Configuration.Velero.DefaultPlugins,
 					},
 					Restic: &oadpv1alpha1.ResticConfig{
 						PodConfig: &oadpv1alpha1.PodConfig{
@@ -551,13 +512,11 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 					{
 						Velero: &velero.BackupStorageLocationSpec{
 							Provider: provider,
-							Config: map[string]string{
-								"region": region,
-							},
-							Default: true,
+							Config:   bslConfig,
+							Default:  true,
 							StorageType: velero.StorageType{
 								ObjectStorage: &velero.ObjectStorageLocation{
-									Bucket: s3Bucket,
+									Bucket: bucket,
 									Prefix: veleroPrefix,
 								},
 							},
@@ -566,11 +525,8 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 				},
 				Configuration: &oadpv1alpha1.ApplicationConfig{
 					Velero: &oadpv1alpha1.VeleroConfig{
-						PodConfig: &oadpv1alpha1.PodConfig{},
-						DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
-							oadpv1alpha1.DefaultPluginOpenShift,
-							oadpv1alpha1.DefaultPluginAWS,
-						},
+						PodConfig:      &oadpv1alpha1.PodConfig{},
+						DefaultPlugins: dpa.Spec.Configuration.Velero.DefaultPlugins,
 					},
 					Restic: &oadpv1alpha1.ResticConfig{
 						PodConfig: &oadpv1alpha1.PodConfig{
@@ -597,10 +553,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 					Velero: &oadpv1alpha1.VeleroConfig{
 						PodConfig:               &oadpv1alpha1.PodConfig{},
 						NoDefaultBackupLocation: true,
-						DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
-							oadpv1alpha1.DefaultPluginOpenShift,
-							oadpv1alpha1.DefaultPluginAWS,
-						},
+						DefaultPlugins:          dpa.Spec.Configuration.Velero.DefaultPlugins,
 					},
 					Restic: &oadpv1alpha1.ResticConfig{
 						PodConfig: &oadpv1alpha1.PodConfig{},
@@ -622,7 +575,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 							Default:  true,
 							StorageType: velero.StorageType{
 								ObjectStorage: &velero.ObjectStorageLocation{
-									Bucket: s3Bucket,
+									Bucket: bucket,
 									Prefix: veleroPrefix,
 								},
 							},
@@ -650,13 +603,13 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 						Velero: &velero.BackupStorageLocationSpec{
 							Provider: provider,
 							Config: map[string]string{
-								"region":           region,
+								"region":           bslConfig["region"],
 								"s3ForcePathStyle": "true",
 							},
 							Default: true,
 							StorageType: velero.StorageType{
 								ObjectStorage: &velero.ObjectStorageLocation{
-									Bucket: s3Bucket,
+									Bucket: bucket,
 									Prefix: veleroPrefix,
 								},
 							},
@@ -689,7 +642,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 							Default: true,
 							StorageType: velero.StorageType{
 								ObjectStorage: &velero.ObjectStorageLocation{
-									Bucket: s3Bucket,
+									Bucket: bucket,
 									Prefix: veleroPrefix,
 								},
 							},

--- a/tests/e2e/velero_helpers.go
+++ b/tests/e2e/velero_helpers.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -38,20 +39,17 @@ type dpaCustomResource struct {
 	Name              string
 	Namespace         string
 	SecretName        string
-	Bucket            string
-	Region            string
-	Provider          string
-	ClusterProfile    string
 	backupRestoreType BackupRestoreType
 	CustomResource    *oadpv1alpha1.DataProtectionApplication
 	Client            client.Client
 }
 
 var veleroPrefix = "velero-e2e-" + string(uuid.NewUUID())
+var dpa *oadpv1alpha1.DataProtectionApplication
 
 func (v *dpaCustomResource) Build(backupRestoreType BackupRestoreType) error {
 	// Velero Instance creation spec with backupstorage location default to AWS. Would need to parameterize this later on to support multiple plugins.
-	dpa := oadpv1alpha1.DataProtectionApplication{
+	dpaInstance := oadpv1alpha1.DataProtectionApplication{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      v.Name,
 			Namespace: v.Namespace,
@@ -59,26 +57,23 @@ func (v *dpaCustomResource) Build(backupRestoreType BackupRestoreType) error {
 		Spec: oadpv1alpha1.DataProtectionApplicationSpec{
 			Configuration: &oadpv1alpha1.ApplicationConfig{
 				Velero: &oadpv1alpha1.VeleroConfig{
-					DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
-						oadpv1alpha1.DefaultPluginOpenShift,
-						oadpv1alpha1.DefaultPluginAWS,
-					},
+					DefaultPlugins: v.CustomResource.Spec.Configuration.Velero.DefaultPlugins,
 				},
 				Restic: &oadpv1alpha1.ResticConfig{
 					PodConfig: &oadpv1alpha1.PodConfig{},
 				},
 			},
+			SnapshotLocations: v.CustomResource.Spec.SnapshotLocations,
 			BackupLocations: []oadpv1alpha1.BackupLocation{
 				{
 					Velero: &velero.BackupStorageLocationSpec{
-						Provider: v.Provider,
-						Config: map[string]string{
-							"region": v.Region,
-						},
-						Default: true,
+						Provider:   v.CustomResource.Spec.BackupLocations[0].Velero.Provider,
+						Default:    true,
+						Config:     v.CustomResource.Spec.BackupLocations[0].Velero.Config,
+						Credential: v.CustomResource.Spec.BackupLocations[0].Velero.Credential,
 						StorageType: velero.StorageType{
 							ObjectStorage: &velero.ObjectStorageLocation{
-								Bucket: v.Bucket,
+								Bucket: v.CustomResource.Spec.BackupLocations[0].Velero.ObjectStorage.Bucket,
 								Prefix: veleroPrefix,
 							},
 						},
@@ -90,13 +85,13 @@ func (v *dpaCustomResource) Build(backupRestoreType BackupRestoreType) error {
 	v.backupRestoreType = backupRestoreType
 	switch backupRestoreType {
 	case restic:
-		dpa.Spec.Configuration.Restic.Enable = pointer.Bool(true)
+		dpaInstance.Spec.Configuration.Restic.Enable = pointer.Bool(true)
 	case csi:
-		dpa.Spec.Configuration.Restic.Enable = pointer.Bool(false)
-		dpa.Spec.Configuration.Velero.DefaultPlugins = append(dpa.Spec.Configuration.Velero.DefaultPlugins, oadpv1alpha1.DefaultPluginCSI)
-		dpa.Spec.Configuration.Velero.FeatureFlags = append(dpa.Spec.Configuration.Velero.FeatureFlags, "EnableCSI")
+		dpaInstance.Spec.Configuration.Restic.Enable = pointer.Bool(false)
+		dpaInstance.Spec.Configuration.Velero.DefaultPlugins = append(dpaInstance.Spec.Configuration.Velero.DefaultPlugins, oadpv1alpha1.DefaultPluginCSI)
+		dpaInstance.Spec.Configuration.Velero.FeatureFlags = append(dpaInstance.Spec.Configuration.Velero.FeatureFlags, "EnableCSI")
 	}
-	v.CustomResource = &dpa
+	v.CustomResource = &dpaInstance
 	return nil
 }
 
@@ -183,7 +178,7 @@ func getVeleroPods(namespace string) (*corev1.PodList, error) {
 	}
 	// select Velero pod with this label
 	veleroOptions := metav1.ListOptions{
-		LabelSelector: "app.kubernetes.io/name=velero",
+		LabelSelector: "deploy=velero",
 	}
 	// get pods in test namespace with labelSelector
 	podList, err := clientset.CoreV1().Pods(namespace).List(context.TODO(), veleroOptions)
@@ -365,5 +360,27 @@ func verifyVeleroResourceLimits(namespace string, limits corev1.ResourceList) wa
 			}
 		}
 		return true, nil
+	}
+}
+
+func loadDpaSettingsFromJson(settings string) string {
+	file, err := readFile(settings)
+	if err != nil {
+		return fmt.Sprintf("Error decoding json file: %v", err)
+	}
+
+	dpa = &oadpv1alpha1.DataProtectionApplication{}
+	err = json.Unmarshal(file, &dpa)
+	if err != nil {
+		return fmt.Sprintf("Error getting settings json file: %v", err)
+	}
+	return ""
+}
+
+func getSecretRef(credSecretRef string) string {
+	if dpa.Spec.BackupLocations[0].Velero.Credential == nil {
+		return credSecretRef
+	} else {
+		return dpa.Spec.BackupLocations[0].Velero.Credential.Name
 	}
 }


### PR DESCRIPTION
Changed the tests so they would use DPA settings from json file (using the json tags of DPA structs/nested structs), like for example:
https://github.com/openshift/oadp-operator/pull/540/files#diff-740eb61cce497a1813e959f31a1b99b40e39e4c0cbf13d001da2360203c139cc
So it would be more generic and flexible and could be used for other cloud providers.


On the makefile the params will be add to this script:
https://github.com/openshift/oadp-operator/pull/540/files#diff-c4c5b54f7d75374a7c6729ede838cd2c5d323a3851db04a30e7b6d2ad503558d
and create a file which will be used as the settings for the DPA.

Updated the doc accordingly:
https://github.com/openshift/oadp-operator/blob/ad53ecfea14bc6caee58655300a35785d1cc5875/docs/developer/TESTING.md#debugging-e2e-tests-with-visual-studio