### PR TITLE
Update travis goproxy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
   - DEFAULT_BRANCH: master
   - DOCKERFILE: Dockerfile
   - DOCKER_CLI_EXPERIMENTAL: enabled
-  - GOPROXY: https://goproxy.io,direct
+  - GOPROXY: https://proxy.golang.org,https://goproxy.io,direct
 
 before_install:
 - |


### PR DESCRIPTION
@dymurray @sseago this might be worth a shot. I believe `https://proxy.golang.org,direct` is default and if this works it might be just as well unsetting it completely. If I recall I was still getting a grip on the failures when I added this. It ended up being unrelated and due to log output timeouts, which just happened to usually happen while downloading deps without `-v`...