### PR TITLE
Docs typo snapshotLocations

### DIFF
--- a/docs/config/bsl_and_vsl.md
+++ b/docs/config/bsl_and_vsl.md
@@ -4,7 +4,7 @@
 ### Configure Backup Storage Locations and Volume Snapshot Locations
 
 For configuring the `backupStorageLocations` and the `volumeSnapshotLocations` 
-we will be using the `backupLocations.Velero` and the `volumeSnapshots.Velero` 
+we will be using the `backupLocations.Velero` and the `snapshotLocations.Velero` 
 specs respectively in the `oadp_v1alpha1_dpa.yaml` file during the deployment. 
 
 For instance, If we want to configure `aws` for `backupStorageLocations` as 
@@ -38,7 +38,7 @@ spec:
         credential:
           name: cloud-credentials
           key: cloud
-  volumeSnapshots:
+  snapshotLocations:
     - name: default
       velero:
         provider: aws

--- a/docs/config/custom_plugin_images.md
+++ b/docs/config/custom_plugin_images.md
@@ -43,7 +43,7 @@ spec:
         credential:
           name: cloud-credentials
           key: cloud
-  volumeSnapshots:
+  snapshotLocations:
     - name: default
       velero:
         provider: aws

--- a/docs/config/self_signed_certs.md
+++ b/docs/config/self_signed_certs.md
@@ -45,7 +45,7 @@ spec:
         credential:
           name: cloud-credentials
           key: cloud
-  volumeSnapshots:
+  snapshotLocations:
     - name: default
       velero:
         provider: aws

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -79,7 +79,7 @@ your `BackupStorageLocation` must provide a custom secret name.
             credential:
               name: cloud-credentials
               key: cloud
-      volumeSnapshots:
+      snapshotLocations:
         - name: default
           velero:
             provider: aws
@@ -115,7 +115,7 @@ spec:
         credential:
           name: cloud-credentials
           key: cloud
-  volumeSnapshots:
+  snapshotLocations:
     - name: default
       velero:
         provider: aws
@@ -160,7 +160,7 @@ spec:
         credential:
           name: my-custom-name
           key: cloud
-  volumeSnapshots:
+  snapshotLocations:
     - name: default
       velero:
         provider: aws

--- a/docs/examples/stateful.md
+++ b/docs/examples/stateful.md
@@ -40,7 +40,7 @@
             credential:
               name: cloud-credentials
               key: cloud
-      volumeSnapshots:
+      snapshotLocations:
         - name: default
           velero:
             provider: aws

--- a/docs/install_olm.md
+++ b/docs/install_olm.md
@@ -74,7 +74,7 @@ spec:
         credential:
           name: cloud-credentials
           key: cloud
-  volumeSnapshots:
+  snapshotLocations:
     - name: default
       velero:
         provider: aws

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -131,7 +131,7 @@ spec:
         credential:
           name: cloud-credentials
           key: cloud
-  volumeSnapshots:
+  snapshotLocations:
     - name: default
       velero:
         provider: aws


### PR DESCRIPTION
Uses regex `volumeSnapshots([:\.]+)` replace with `snapshotLocations$1`
closes #551 