### PR TITLE
upgraded ginkgo on tests to ginkgo 2.0

### DIFF
--- a/build/ci-Dockerfile
+++ b/build/ci-Dockerfile
@@ -2,7 +2,8 @@
 # TODO! Find a real ubi8 image for golang 1.16
 FROM quay.io/app-sre/boilerplate:image-v2.1.0 as builder
 
-RUN go get -u github.com/onsi/ginkgo/ginkgo
+RUN go get -u github.com/onsi/ginkgo/ginkgo && \
+ go get -u github.com/onsi/ginkgo/v2/ginkgo
 RUN go get github.com/onsi/gomega/...
 
 WORKDIR /go/src/github.com/openshift/oadp-operator

--- a/build/custom-ci-Dockerfile
+++ b/build/custom-ci-Dockerfile
@@ -1,7 +1,8 @@
 FROM openshift/origin-release:golang-1.16
 RUN yum -y install epel-release --disablerepo=epel && yum clean all
 RUN yum -y install make
-RUN go get -u github.com/onsi/ginkgo/ginkgo
+RUN go get -u github.com/onsi/ginkgo/ginkgo && \
+ go get -u github.com/onsi/ginkgo/v2/ginkgo
 RUN go get github.com/onsi/gomega/...
 RUN chmod g+rw /etc/passwd
 ENV LC_ALL=en_US.utf-8 LANG=en_US.utf-8

--- a/docs/developer/TESTING.md
+++ b/docs/developer/TESTING.md
@@ -4,7 +4,7 @@
 
 ### Install Ginkgo
 ```bash
-$ go get -u github.com/onsi/ginkgo/ginkgo
+$ go get -u github.com/onsi/ginkgo/v2/ginkgo
 ```
 
 ### Setup backup storage configuration

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,8 @@ require (
 	github.com/go-logr/logr v0.4.0
 	github.com/google/uuid v1.1.2
 	github.com/onsi/ginkgo v1.16.4
-	github.com/onsi/gomega v1.16.0
+	github.com/onsi/ginkgo/v2 v2.1.1
+	github.com/onsi/gomega v1.17.0
 	github.com/openshift/api v0.0.0-20210805075156-d8fab4513288
 	github.com/operator-framework/api v0.10.7
 	github.com/operator-framework/operator-lib v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -383,6 +383,7 @@ github.com/google/pprof v0.0.0-20201023163331-3e6fc7fc9c4c/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20201203190320-1bf35d6f28c2/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210122040257-d980be63207e/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210226084205-cbba55b83ad5/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
+github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -571,6 +572,8 @@ github.com/onsi/ginkgo v1.14.1/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9k
 github.com/onsi/ginkgo v1.16.2/go.mod h1:CObGmKUOKaSC0RjmoAK7tKyn4Azo5P2IWuoMnvwxz1E=
 github.com/onsi/ginkgo v1.16.4 h1:29JGrr5oVBm5ulCWet69zQkzWipVXIol6ygQUe/EzNc=
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
+github.com/onsi/ginkgo/v2 v2.1.1 h1:LCnPB85AvFNr91s0B2aDzEiiIg6MUwLYbryC1NSlWi8=
+github.com/onsi/ginkgo/v2 v2.1.1/go.mod h1:vw5CSIxN1JObi/U8gcbwft7ZxR2dgaR70JSE3/PpL4c=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
@@ -580,8 +583,8 @@ github.com/onsi/gomega v1.10.2/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1y
 github.com/onsi/gomega v1.13.0/go.mod h1:lRk9szgn8TxENtWd0Tp4c3wjlRfMTMH27I+3Je41yGY=
 github.com/onsi/gomega v1.14.0/go.mod h1:cIuvLEne0aoVhAgh/O6ac0Op8WWw9H6eYCriF+tEHG0=
 github.com/onsi/gomega v1.15.0/go.mod h1:cIuvLEne0aoVhAgh/O6ac0Op8WWw9H6eYCriF+tEHG0=
-github.com/onsi/gomega v1.16.0 h1:6gjqkI8iiRHMvdccRJM8rVKjCWk6ZIm6FTm3ddIe4/c=
-github.com/onsi/gomega v1.16.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
+github.com/onsi/gomega v1.17.0 h1:9Luw4uT5HTjHTN8+aNcSThgH1vdXnmdJ8xIfZ4wyTRE=
+github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/openshift/api v0.0.0-20210805075156-d8fab4513288 h1:Yw96Z8gygCXxjeMTm55gGsTNxwnJkr6L2Baf3NsUQFU=

--- a/tests/e2e/apps.go
+++ b/tests/e2e/apps.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/v2"
 	ocpappsv1 "github.com/openshift/api/apps/v1"
 	appsv1 "k8s.io/api/apps/v1"
 

--- a/tests/e2e/backup.go
+++ b/tests/e2e/backup.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/v2"
 	velero "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"

--- a/tests/e2e/backup_restore_suite_test.go
+++ b/tests/e2e/backup_restore_suite_test.go
@@ -7,8 +7,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -79,13 +78,9 @@ var _ = Describe("AWS backup restore tests", func() {
 			}
 
 			if brCase.BackupRestoreType == csi {
-				if clusterProfile == "aws" {
-					log.Printf("Creating VolumeSnapshot for CSI backuprestore of %s", brCase.Name)
-					err = installApplication(dpaCR.Client, "./sample-applications/gp2-csi/volumeSnapshotClass.yaml")
-					Expect(err).ToNot(HaveOccurred())
-				} else {
-					Skip("CSI testing is not provided for this cluster provider.")
-				}
+				log.Printf("Creating VolumeSnapshot for CSI backuprestore of %s", brCase.Name)
+				err = installApplication(dpaCR.Client, "./sample-applications/gp2-csi/volumeSnapshotClass.yaml")
+				Expect(err).ToNot(HaveOccurred())
 			}
 
 			if dpaCR.CustomResource.Spec.BackupImages == nil || *dpaCR.CustomResource.Spec.BackupImages {
@@ -170,7 +165,7 @@ var _ = Describe("AWS backup restore tests", func() {
 			}
 
 		},
-		Entry("MSSQL application CSI", BackupRestoreCase{
+		Entry("MSSQL application CSI", Label("aws"), BackupRestoreCase{
 			ApplicationTemplate:  "./sample-applications/mssql-persistent/mssql-persistent-csi-template.yaml",
 			ApplicationNamespace: "mssql-persistent",
 			Name:                 "mssql-e2e",

--- a/tests/e2e/dpa_deployment_suite_test.go
+++ b/tests/e2e/dpa_deployment_suite_test.go
@@ -8,8 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
 	velero "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 

--- a/tests/e2e/restore.go
+++ b/tests/e2e/restore.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/v2"
 	velero "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"

--- a/tests/e2e/subscription_suite_test.go
+++ b/tests/e2e/subscription_suite_test.go
@@ -6,8 +6,7 @@ import (
 	"log"
 	"time"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	operators "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	corev1 "k8s.io/api/core/v1"


### PR DESCRIPTION
Upgraded ginkgo to version 2.0, so it will be possible to use labels in order to filter tests in CI, instead of using conditions within the test logic.
Left ginkgo 1.16 because it's used in controllers/suite_test.go, and it uses timeout as part of BeforeSuite function, which is probably deprecated in ginkgo 2.. 