### PR TITLE
Add Velero metrics recording rule

### DIFF
--- a/bundle/manifests/oadp-metrics-recording-rule.yaml
+++ b/bundle/manifests/oadp-metrics-recording-rule.yaml
@@ -1,0 +1,12 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: oadp-operator
+spec:
+  groups:
+  - name: oadp-operator.rules
+    rules:
+    - expr: max without(instance) (velero_restore_total)
+      record: cluster:velero_restore_total:max
+    - expr: max without(instance) (velero_backup_total)
+      record: cluster:velero_backup_total:max


### PR DESCRIPTION
This PR adds a `PrometheusRule` which removes the `instance` label from the metrics and restricts the cardinality.