### PR TITLE
Only `cat /var/run/oadp-credentials/new-velero-bucket-name` when needed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -330,7 +330,7 @@ catalog-build: opm ## Build a catalog image.
 catalog-push: ## Push a catalog image.
 	$(MAKE) docker-push IMG=$(CATALOG_IMG)
 
-OADP_BUCKET := $(shell cat $(OADP_BUCKET_FILE))
+OADP_BUCKET = $(shell cat $(OADP_BUCKET_FILE))
 TEST_FILTER := $(shell echo '! aws && ! gcp && ! azure' | sed -r "s/[&]* [!] $(CLUSTER_TYPE)|[!] $(CLUSTER_TYPE) [&]*//")
 SETTINGS_TMP=/tmp/test-settings
 


### PR DESCRIPTION
Change
- Don't use "simply expanded variables" for every target

Prevent cat errs on non dependent targets
```sh
cat: /var/run/oadp-credentials/new-velero-bucket-name: No such file or directory
```
unless var is being used by target in e2e.