### PR TITLE
Removing centos mirror for must-gather image

### DIFF
--- a/must-gather/Dockerfile
+++ b/must-gather/Dockerfile
@@ -5,7 +5,6 @@ RUN go get github.com/google/pprof
 FROM quay.io/openshift/origin-must-gather:4.7 as builder
 
 FROM registry.access.redhat.com/ubi8-minimal:latest
-RUN echo -ne "[centos-8-appstream]\nname = CentOS 8 (RPMs) - AppStream\nbaseurl = http://mirror.centos.org/centos-8/8/AppStream/x86_64/os/\nenabled = 1\ngpgcheck = 0" > /etc/yum.repos.d/centos.repo
 
 RUN microdnf -y install rsync tar gzip graphviz findutils
 


### PR DESCRIPTION
- centos appstream repo mirror gives 404: http://mirror.centos.org/centos-8/8/AppStream/
- [http://mirror.centos.org/centos-8/8/AppStream/x86_64/](http://mirror.centos.org/centos-8/8/AppStream/x86_64/os/)
- Unable to build must-gather image locally as it fails with the 404 error.
- Was able to build successfully without the above source as it seemed to have changed.