### PR TITLE
Adding gather_logs_without_zip script for the use case of (#594)

### DIFF
--- a/must-gather/collection-scripts/gather_logs_without_zip
+++ b/must-gather/collection-scripts/gather_logs_without_zip
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# Default to gathering 72h of logs unless specified as var
+logs_since="${logs_since:-72h}"
+request_timeout="${request_timeout:-0s}"
+max_parallelism=10
+unset KUBECONFIG
+
+clusterID=$(oc get clusterversion -o jsonpath='{.items[].spec.clusterID}' | cut -c -8)
+namespaces=()
+for ns in $(oc get dataprotectionapplications.oadp.openshift.io --all-namespaces --no-headers | awk '{print $1}')
+  do
+    echo "[namespace=${ns}] Detected OADP operator installation"
+    namespaces+=(${ns})
+  done
+# Collect all resources in OADP operator namespaces with must-gather
+for ns in ${namespaces[@]}; do
+    echo "[namespace=${ns}] Running oc adm inspect"
+    /usr/bin/oc adm inspect --dest-dir must-gather/clusters/${clusterID} --all-namespaces ns/${ns} &
+done
+
+# Collect the logs"
+for ns in ${namespaces[@]}; do
+    echo "[cluster=${clusterID}] Gathering logs for namespace ${ns}]"
+    /usr/bin/gather_logs_pods ${clusterID} ${ns} ${logs_since} ${max_parallelism} &
+done
+
+# Collect the DPA CR
+for ns in ${namespaces[@]}; do
+  for dpa in $(oc get dpa --namespace ${ns} --no-headers | awk '{print $1}'); do
+    mkdir -p "/must-gather/clusters/${clusterID}/namespaces/${ns}/oadp.openshift.io/dpa-${dpa}"
+    oc get dpa ${dpa} -o yaml --namespace ${ns} &> "/must-gather/clusters/${clusterID}/namespaces/${ns}/oadp.openshift.io/dpa-${dpa}/${dpa}.yml" &
+    pwait $max_parallelism
+  done
+done
+
+# Waits for gather_crs, gather_logs, gather_metrics running in background
+echo "Waiting for background gather tasks to finish"
+wait
+
+# If running essential-only must-gather, delete duplicated logs collected by oc adm inspect
+if [ -z "$essential_only" ]; then
+  echo "Full must-gather was requested. Keeping full log payload from oc adm inspect"
+else
+  echo "Essential-only must-gather was requested. Removing duplicate pod logs from oc adm inspect to reduce must-gather size"
+  find /must-gather/clusters/*/namespaces/*/pods/ -name '*.log' -delete
+fi
+
+echo "Waiting for copy phase..."
+exit 0


### PR DESCRIPTION
- Added gather_logs_without_zip script for must-gather to enable dumping of pod logs and DPA CR instance for each tests.
- Adding this in separate PR to facilitate build and push of oadp-must-gather image for e2e testing of [594](https://github.com/openshift/oadp-operator/pull/594).
- Avoiding dumping of other OADP CRs such as backups, restores etc., as it collects all of them (Including from previous test cases) for each test case.
- The purpose of #599 and #594 is to enable the collection of test logs so that they are easily searchable through our customized [ci-search](https://github.com/weshayutin/ci-search)