### PR TITLE
Fix access key value containing `=` edge case

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,7 +243,7 @@ submit-coverage:
 	fi
 	rm -f codecov tmp.*
 
-# go-get-tool will 'go get -d' any package $2 and install it to $1.
+# go-get-tool will 'go get' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 define go-get-tool
 @[ -f $(1) ] || { \
@@ -252,7 +252,7 @@ TMP_DIR=$$(mktemp -d) ;\
 cd $$TMP_DIR ;\
 go mod init tmp ;\
 echo "Downloading $(2)" ;\
-GOBIN=$(PROJECT_DIR)/bin go get -d $(2) ;\
+GOBIN=$(PROJECT_DIR)/bin go get $(2) ;\
 rm -rf $$TMP_DIR ;\
 }
 endef

--- a/Makefile
+++ b/Makefile
@@ -48,9 +48,9 @@ ENVTEST_K8S_VERSION = 1.21
 
 .PHONY:ginkgo
 ginkgo: # Make sure ginkgo is in $GOPATH/bin
-	go get github.com/onsi/ginkgo/ginkgo
-	go get github.com/onsi/ginkgo/v2/ginkgo
-	go get github.com/onsi/gomega/...
+	go get -d github.com/onsi/ginkgo/ginkgo
+	go get -d github.com/onsi/ginkgo/v2/ginkgo
+	go get -d github.com/onsi/gomega/...
 
 # VERSION defines the project version for the bundle.
 # Update this value when you upgrade the version of your project.
@@ -243,7 +243,7 @@ submit-coverage:
 	fi
 	rm -f codecov tmp.*
 
-# go-get-tool will 'go get' any package $2 and install it to $1.
+# go-get-tool will 'go get -d' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 define go-get-tool
 @[ -f $(1) ] || { \
@@ -252,7 +252,7 @@ TMP_DIR=$$(mktemp -d) ;\
 cd $$TMP_DIR ;\
 go mod init tmp ;\
 echo "Downloading $(2)" ;\
-GOBIN=$(PROJECT_DIR)/bin go get $(2) ;\
+GOBIN=$(PROJECT_DIR)/bin go get -d $(2) ;\
 rm -rf $$TMP_DIR ;\
 }
 endef

--- a/controllers/bucket_controller.go
+++ b/controllers/bucket_controller.go
@@ -86,7 +86,7 @@ func (b BucketReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 			b.EventRecorder.Event(&bucket, corev1.EventTypeWarning, "UnableToParseAnnotation", fmt.Sprintf("unable to parse annotation: %v, use \"1\", \"t\", \"T\", \"true\", \"TRUE\", \"True\" or \"0\", \"f\", \"F\", \"false\", \"FALSE\", \"False\"", err))
 			return ctrl.Result{Requeue: true}, nil
 		}
-		if  shouldDelete && bucket.DeletionTimestamp != nil {
+		if shouldDelete && bucket.DeletionTimestamp != nil {
 			deleted, err := clnt.Delete()
 			if err != nil {
 				log.Error(err, "unable to delete bucket")
@@ -100,7 +100,7 @@ func (b BucketReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 			}
 			log.Info("bucket deleted")
 			b.EventRecorder.Event(&bucket, corev1.EventTypeNormal, "BucketDeleted", fmt.Sprintf("bucket %v deleted", bucket.Spec.Name))
-	
+
 			//Removing oadpFinalizerBucket from bucket.Finalizers
 			bucket.Finalizers = removeKey(bucket.Finalizers, oadpFinalizerBucket)
 			err = b.Client.Update(ctx, &bucket, &client.UpdateOptions{})

--- a/controllers/registry.go
+++ b/controllers/registry.go
@@ -590,14 +590,18 @@ func (r *DPAReconciler) parseAWSSecret(secret corev1.Secret, secretKey string, m
 	AWSAccessKey, AWSSecretKey, profile := "", "", ""
 	splitString := strings.Split(string(secret.Data[secretKey]), "\n")
 	keyNameRegex, err := regexp.Compile(`\[.*\]`)
+	const (
+		accessKeyKey = "aws_access_key_id"
+		secretKeyKey = "aws_secret_access_key"
+	)
 	if err != nil {
 		return AWSAccessKey, AWSSecretKey, errors.New("parseAWSSecret faulty regex: keyNameRegex")
 	}
-	awsAccessKeyRegex, err := regexp.Compile(`\baws_access_key_id\b`)
+	awsAccessKeyRegex, err := regexp.Compile(`\b` + accessKeyKey + `\b`)
 	if err != nil {
 		return AWSAccessKey, AWSSecretKey, errors.New("parseAWSSecret faulty regex: awsAccessKeyRegex")
 	}
-	awsSecretKeyRegex, err := regexp.Compile(`\baws_secret_access_key\b`)
+	awsSecretKeyRegex, err := regexp.Compile(`\b` + secretKeyKey + `\b`)
 	if err != nil {
 		return AWSAccessKey, AWSSecretKey, errors.New("parseAWSSecret faulty regex: awsSecretKeyRegex")
 	}
@@ -630,22 +634,18 @@ func (r *DPAReconciler) parseAWSSecret(secret corev1.Secret, secretKey string, m
 						return AWSAccessKey, AWSSecretKey, err
 					}
 					if matchedAccessKey { // check for access key
-						cleanedLine := strings.ReplaceAll(profLine, " ", "")
-						splitLine := strings.Split(cleanedLine, "=")
-						if len(splitLine) != 2 {
-							r.Log.Info("Could not parse secret for AWS Access key")
-							return AWSAccessKey, AWSSecretKey, errors.New("secret parsing error")
+						AWSAccessKey, err = r.getMatchedKeyValue(accessKeyKey, profLine)
+						if err != nil {
+							r.Log.Info("Error processing access key id for the supplied AWS credential")
+							return AWSAccessKey, AWSSecretKey, err
 						}
-						AWSAccessKey = splitLine[1]
 						continue
 					} else if matchedSecretKey { // check for secret key
-						cleanedLine := strings.ReplaceAll(profLine, " ", "")
-						splitLine := strings.Split(cleanedLine, "=")
-						if len(splitLine) != 2 {
-							r.Log.Info("Could not parse secret for AWS Secret key")
-							return AWSAccessKey, AWSSecretKey, errors.New("secret parsing error")
+						AWSSecretKey, err = r.getMatchedKeyValue(secretKeyKey, profLine)
+						if err != nil {
+							r.Log.Info("Error processing secret key id for the supplied AWS credential")
+							return AWSAccessKey, AWSSecretKey, err
 						}
-						AWSSecretKey = splitLine[1]
 						continue
 					} else {
 						break // aws credentials file is only allowed to have profile followed by aws_access_key_id, aws_secret_access_key
@@ -761,15 +761,19 @@ func (r *DPAReconciler) parseAzureSecret(secret corev1.Secret, secretKey string)
 	return azcreds, nil
 }
 
-func (r *DPAReconciler) getMatchedKeyValue(matchedKey string, line string) (string, error) {
-	cleanedLine := strings.ReplaceAll(line, " ", "")
-	cleanedLine = strings.ReplaceAll(cleanedLine, "\"", "")
-	matchedKeyValue := strings.Replace(cleanedLine, matchedKey, "", -1)
-	if len(matchedKeyValue) == 0 {
-		r.Log.Info("Could not parse secret for %s", matchedKey)
-		return matchedKeyValue, errors.New("azure secret parsing error")
+// Return value to the right of = sign
+func (r *DPAReconciler) getMatchedKeyValue(key string, s string) (string, error) {
+	s = strings.ReplaceAll(s, "\"", "")
+	for _, prefix := range []string{key, "="} {
+		s = strings.Trim(s, " ")
+		s = strings.TrimPrefix(s, prefix)
 	}
-	return matchedKeyValue, nil
+	s = strings.Trim(s, " ")
+	if len(s) == 0 {
+		r.Log.Info("Could not parse secret for %s", key)
+		return s, errors.New(key + " secret parsing error")
+	}
+	return s, nil
 }
 
 func (r *DPAReconciler) ReconcileRegistrySVCs(log logr.Logger) (bool, error) {

--- a/controllers/registry.go
+++ b/controllers/registry.go
@@ -721,37 +721,37 @@ func (r *DPAReconciler) parseAzureSecret(secret corev1.Secret, secretKey string)
 
 		switch {
 		case matchedStorageKey:
-			storageKeyValue, err := r.getMatchedKeyValue("AZURE_STORAGE_ACCOUNT_ACCESS_KEY=", line)
+			storageKeyValue, err := r.getMatchedKeyValue("AZURE_STORAGE_ACCOUNT_ACCESS_KEY", line)
 			if err != nil {
 				return azcreds, err
 			}
 			azcreds.strorageAccountKey = storageKeyValue
 		case matchedSubscriptionId:
-			subscriptionIdValue, err := r.getMatchedKeyValue("AZURE_SUBSCRIPTION_ID=", line)
+			subscriptionIdValue, err := r.getMatchedKeyValue("AZURE_SUBSCRIPTION_ID", line)
 			if err != nil {
 				return azcreds, err
 			}
 			azcreds.subscriptionID = subscriptionIdValue
 		case matchedCliendId:
-			clientIdValue, err := r.getMatchedKeyValue("AZURE_CLIENT_ID=", line)
+			clientIdValue, err := r.getMatchedKeyValue("AZURE_CLIENT_ID", line)
 			if err != nil {
 				return azcreds, err
 			}
 			azcreds.clientID = clientIdValue
 		case matchedClientsecret:
-			clientSecretValue, err := r.getMatchedKeyValue("AZURE_CLIENT_SECRET=", line)
+			clientSecretValue, err := r.getMatchedKeyValue("AZURE_CLIENT_SECRET", line)
 			if err != nil {
 				return azcreds, err
 			}
 			azcreds.clientSecret = clientSecretValue
 		case matchedResourceGroup:
-			resourceGroupValue, err := r.getMatchedKeyValue("AZURE_RESOURCE_GROUP=", line)
+			resourceGroupValue, err := r.getMatchedKeyValue("AZURE_RESOURCE_GROUP", line)
 			if err != nil {
 				return azcreds, err
 			}
 			azcreds.resourceGroup = resourceGroupValue
 		case matchedTenantId:
-			tenantIdValue, err := r.getMatchedKeyValue("AZURE_TENANT_ID=", line)
+			tenantIdValue, err := r.getMatchedKeyValue("AZURE_TENANT_ID", line)
 			if err != nil {
 				return azcreds, err
 			}

--- a/controllers/registry.go
+++ b/controllers/registry.go
@@ -763,14 +763,12 @@ func (r *DPAReconciler) parseAzureSecret(secret corev1.Secret, secretKey string)
 
 // Return value to the right of = sign with quotations and spaces removed.
 func (r *DPAReconciler) getMatchedKeyValue(key string, s string) (string, error) {
-	for _, removeChar := range []string{"\"", "'"} {
+	for _, removeChar := range []string{"\"", "'", " "} {
 		s = strings.ReplaceAll(s, removeChar, "")
 	}
 	for _, prefix := range []string{key, "="} {
-		s = strings.Trim(s, " ")
 		s = strings.TrimPrefix(s, prefix)
 	}
-	s = strings.Trim(s, " ")
 	if len(s) == 0 {
 		r.Log.Info("Could not parse secret for %s", key)
 		return s, errors.New(key + " secret parsing error")

--- a/controllers/registry.go
+++ b/controllers/registry.go
@@ -761,9 +761,11 @@ func (r *DPAReconciler) parseAzureSecret(secret corev1.Secret, secretKey string)
 	return azcreds, nil
 }
 
-// Return value to the right of = sign
+// Return value to the right of = sign with quotations and spaces removed.
 func (r *DPAReconciler) getMatchedKeyValue(key string, s string) (string, error) {
-	s = strings.ReplaceAll(s, "\"", "")
+	for _, removeChar := range []string{"\"", "'"} {
+		s = strings.ReplaceAll(s, removeChar, "")
+	}
 	for _, prefix := range []string{key, "="} {
 		s = strings.Trim(s, " ")
 		s = strings.TrimPrefix(s, prefix)

--- a/controllers/registry_test.go
+++ b/controllers/registry_test.go
@@ -78,6 +78,19 @@ var (
 				"aws_secret_access_key=" + testSecretAccessKey,
 		),
 	}
+	secretDataWithEqualInSecret = map[string][]byte{
+		"cloud": []byte(
+			"\n[" + testBslProfile + "]\n" +
+				"aws_access_key_id=" + testBslAccessKey + "\n" +
+				"aws_secret_access_key=" + testBslSecretAccessKey + "=" + testBslSecretAccessKey +
+				"\n[default]" + "\n" +
+				"aws_access_key_id=" + testAccessKey + "\n" +
+				"aws_secret_access_key=" + testSecretAccessKey + "=" + testSecretAccessKey +
+				"\n[test-profile]\n" +
+				"aws_access_key_id=" + testAccessKey + "\n" +
+				"aws_secret_access_key=" + testSecretAccessKey + "=" + testSecretAccessKey,
+		),
+	}
 	awsSecretDataWithMissingProfile = map[string][]byte{
 		"cloud": []byte(
 			"[default]" + "\n" +
@@ -175,6 +188,56 @@ func TestDPAReconciler_buildRegistryDeployment(t *testing.T) {
 					Namespace: "test-ns",
 				},
 				Data: secretData,
+			},
+			registrySecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "oadp-test-bsl-aws-registry-secret",
+					Namespace: "test-ns",
+				},
+				Data: awsRegistrySecretData,
+			},
+			dpa: &oadpv1alpha1.DataProtectionApplication{},
+		},
+		{
+			name: "given a valid bsl with equal in secret val get appropriate registry deployment",
+			registryDeployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-registry",
+					Namespace: "test-ns",
+				},
+				Spec: appsv1.DeploymentSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"component": "oadp-" + "test-bsl" + "-" + "aws" + "-registry",
+						},
+					},
+				},
+			},
+			bsl: &velerov1.BackupStorageLocation{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-bsl",
+					Namespace: "test-ns",
+				},
+				Spec: velerov1.BackupStorageLocationSpec{
+					Provider: AWSProvider,
+					StorageType: velerov1.StorageType{
+						ObjectStorage: &velerov1.ObjectStorageLocation{
+							Bucket: "aws-bucket",
+						},
+					},
+					Config: map[string]string{
+						Region:                "aws-region",
+						S3URL:                 "https://sr-url-aws-domain.com",
+						InsecureSkipTLSVerify: "false",
+					},
+				},
+			},
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cloud-credentials",
+					Namespace: "test-ns",
+				},
+				Data: secretDataWithEqualInSecret,
 			},
 			registrySecret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{

--- a/tests/e2e/backup_restore_suite_test.go
+++ b/tests/e2e/backup_restore_suite_test.go
@@ -173,8 +173,8 @@ var _ = Describe("AWS backup restore tests", func() {
 			ApplicationNamespace: "mysql-persistent",
 			Name:                 "mysql-e2e",
 			BackupRestoreType:    CSI,
-			PreBackupVerify:   mysqlReady,
-			PostRestoreVerify: mysqlReady,
+			PreBackupVerify:      mysqlReady,
+			PostRestoreVerify:    mysqlReady,
 		}, nil),
 		Entry("Parks application <4.8.0", BackupRestoreCase{
 			ApplicationTemplate:  "./sample-applications/parks-app/manifest.yaml",
@@ -190,8 +190,8 @@ var _ = Describe("AWS backup restore tests", func() {
 			ApplicationNamespace: "mysql-persistent",
 			Name:                 "mysql-e2e",
 			BackupRestoreType:    RESTIC,
-			PreBackupVerify:   mysqlReady,
-			PostRestoreVerify: mysqlReady,
+			PreBackupVerify:      mysqlReady,
+			PostRestoreVerify:    mysqlReady,
 		}, nil),
 		Entry("Parks application >=4.8.0", BackupRestoreCase{
 			ApplicationTemplate:  "./sample-applications/parks-app/manifest4.8.yaml",


### PR DESCRIPTION
Close #529 
[OADP-378](https://issues.redhat.com/browse/OADP-378)

PR CatalogSource
```yaml
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: oadp-secretparsing
  namespace: openshift-marketplace
spec:
  sourceType: grpc
  image: ghcr.io/kaovilai/oadp-operator-catalog:secretparsing
  displayName: Tiger's OADP SecretParsing
  publisher: Tiger Kaovilai
  updateStrategy:
    registryPoll:
      interval: 10m
```