### PR TITLE
OADP-413 Update oadp-operator to support VSL credentials

### DIFF
--- a/controllers/velero.go
+++ b/controllers/velero.go
@@ -832,7 +832,7 @@ func (r DPAReconciler) noDefaultCredentials(dpa oadpv1alpha1.DataProtectionAppli
 			// To handle the case where we want to manually hand the credentials for a cloud storage created
 			// Bucket credentials via configuration. Only AWS is supported
 			provider := strings.TrimPrefix(vsl.Velero.Provider, "velero.io")
-			if provider == string(oadpv1alpha1.AWSBucketProvider) && hasCloudStorage {
+			if vsl.Velero.Credential != nil || provider == string(oadpv1alpha1.AWSBucketProvider) && hasCloudStorage {
 				providerNeedsDefaultCreds[provider] = false
 			} else {
 				providerNeedsDefaultCreds[provider] = true


### PR DESCRIPTION
Note: this isn't ready to merge until the upstream PR (#TBD) is
merged, it's pulled back into konveyor-dev, and go.mo is updated here
to point there. Currently this points to my test/dev velero branch for this
functionality.