### PR TITLE
Registry credentials can use different secret names when using config["credentialsFile"]

### DIFF
--- a/controllers/registry.go
+++ b/controllers/registry.go
@@ -285,14 +285,14 @@ func (r *DPAReconciler) buildRegistryDeployment(registryDeployment *appsv1.Deplo
 
 	// attach secret volume for cloud providers
 	if _, ok := bsl.Spec.Config["credentialsFile"]; ok {
-		if cloudProviderMap, bslCredOk := credentials.PluginSpecificFields[oadpv1alpha1.DefaultPlugin(bsl.Spec.Provider)]; bslCredOk {
+		if secretName, err := credentials.GetSecretNameFromCredentialsFileConfigString(bsl.Spec.Config["credentialsFile"]); err == nil {
 			registryDeployment.Spec.Template.Spec.Volumes = append(
 				registryDeployment.Spec.Template.Spec.Volumes,
 				corev1.Volume{
-					Name: cloudProviderMap.BslSecretName,
+					Name: secretName,
 					VolumeSource: corev1.VolumeSource{
 						Secret: &corev1.SecretVolumeSource{
-							SecretName: cloudProviderMap.BslSecretName,
+							SecretName: secretName,
 						},
 					},
 				},
@@ -388,12 +388,14 @@ func (r *DPAReconciler) buildRegistryContainer(bsl *velerov1.BackupStorageLocati
 
 	// check for secret name
 	if _, ok := bsl.Spec.Config["credentialsFile"]; ok { // If credentialsFile config is used, then mount the bsl secret
-		if _, bslCredOk := credentials.PluginSpecificFields[oadpv1alpha1.DefaultPlugin(bsl.Spec.Provider)]; bslCredOk {
-			containers[0].VolumeMounts = []corev1.VolumeMount{
-				{
-					Name:      credentials.PluginSpecificFields[oadpv1alpha1.DefaultPlugin(bsl.Spec.Provider)].BslSecretName,
-					MountPath: credentials.PluginSpecificFields[oadpv1alpha1.DefaultPlugin(bsl.Spec.Provider)].BslMountPath,
-				},
+		if secretName, err := credentials.GetSecretNameFromCredentialsFileConfigString(bsl.Spec.Config["credentialsFile"]); err == nil {
+			if _, bslCredOk := credentials.PluginSpecificFields[oadpv1alpha1.DefaultPlugin(bsl.Spec.Provider)]; bslCredOk {
+				containers[0].VolumeMounts = []corev1.VolumeMount{
+					{
+						Name:      secretName,
+						MountPath: credentials.PluginSpecificFields[oadpv1alpha1.DefaultPlugin(bsl.Spec.Provider)].BslMountPath,
+					},
+				}
 			}
 		}
 	} else if bsl.Spec.Provider == GCPProvider { // append secret volumes if the BSL provider is GCP
@@ -579,11 +581,12 @@ func (r *DPAReconciler) getSecretNameAndKey(bslSpec *velerov1.BackupStorageLocat
 	secretName := credentials.PluginSpecificFields[plugin].SecretName
 	secretKey := credentials.PluginSpecificFields[plugin].PluginSecretKey
 	if _, ok := bslSpec.Config["credentialsFile"]; ok {
-		secretName = credentials.PluginSpecificFields[plugin].BslSecretName
-		secretKey = credentials.PluginSpecificFields[plugin].PluginSecretKey
+		if secretName, secretKey, err :=
+			credentials.GetSecretNameKeyFromCredentialsFileConfigString(bslSpec.Config["credentialsFile"]); err == nil {
+			r.Log.Info(fmt.Sprintf("credentialsFile secret: %s, key: %s", secretName, secretKey))
+			return secretName, secretKey
+		}
 	}
-	r.Log.Info(fmt.Sprintf("secret: %s", secretName))
-	r.Log.Info(fmt.Sprintf("key: %s", secretKey))
 	// check if user specified the Credential Name and Key
 	credential := bslSpec.Credential
 	if credential != nil {


### PR DESCRIPTION
[OADP-477](https://issues.redhat.com//browse/OADP-477)