### PR TITLE
Fix OADP-487

### DIFF
--- a/controllers/registry_test.go
+++ b/controllers/registry_test.go
@@ -1938,7 +1938,7 @@ func Test_replaceCarriageReturn(t *testing.T) {
 		{
 			name: "Given secret data with carriage return, carriage return is replaced with new line",
 			args: args{
-				data: secretDataWithCarriageReturnInSecret,
+				data:   secretDataWithCarriageReturnInSecret,
 				logger: logr.FromContextOrDiscard(context.TODO()),
 			},
 			want: secretDataWithEqualInSecret,

--- a/controllers/velero.go
+++ b/controllers/velero.go
@@ -441,11 +441,11 @@ func (r *DPAReconciler) customizeVeleroDeployment(dpa *oadpv1alpha1.DataProtecti
 
 	isSTSNeeded := r.isSTSTokenNeeded(dpa.Spec.BackupLocations, dpa.Namespace)
 
-	//TODO: add velero nodeselector, needs to be added to the VELERO CR first
 	// Selector: veleroDeployment.Spec.Selector,
 	veleroDeployment.Spec.Replicas = pointer.Int32(1)
 	if dpa.Spec.Configuration.Velero.PodConfig != nil {
 		veleroDeployment.Spec.Template.Spec.Tolerations = dpa.Spec.Configuration.Velero.PodConfig.Tolerations
+		veleroDeployment.Spec.Template.Spec.NodeSelector = dpa.Spec.Configuration.Velero.PodConfig.NodeSelector
 	}
 	veleroDeployment.Spec.Template.Spec.Volumes = append(veleroDeployment.Spec.Template.Spec.Volumes,
 		corev1.Volume{

--- a/controllers/velero_test.go
+++ b/controllers/velero_test.go
@@ -646,6 +646,7 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 							"app.kubernetes.io/managed-by": common.OADPOperator,
 							"app.kubernetes.io/component":  Server,
 							oadpv1alpha1.OadpOperatorLabel: "True",
+							"component":                    "velero",
 						},
 					},
 				},
@@ -693,6 +694,7 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 						"app.kubernetes.io/managed-by": common.OADPOperator,
 						"app.kubernetes.io/component":  Server,
 						oadpv1alpha1.OadpOperatorLabel: "True",
+						"component":                    "velero",
 					},
 				},
 				TypeMeta: metav1.TypeMeta{
@@ -707,6 +709,7 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 							"app.kubernetes.io/managed-by": common.OADPOperator,
 							"app.kubernetes.io/component":  Server,
 							oadpv1alpha1.OadpOperatorLabel: "True",
+							"component":                    "velero",
 						},
 					},
 					Replicas: pointer.Int32(1),
@@ -718,6 +721,7 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 								"app.kubernetes.io/managed-by": common.OADPOperator,
 								"app.kubernetes.io/component":  Server,
 								oadpv1alpha1.OadpOperatorLabel: "True",
+								"component":                    "velero",
 							},
 							Annotations: map[string]string{
 								"prometheus.io/scrape": "true",
@@ -841,6 +845,7 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 							"app.kubernetes.io/managed-by": common.OADPOperator,
 							"app.kubernetes.io/component":  Server,
 							oadpv1alpha1.OadpOperatorLabel: "True",
+							"component":                    "velero",
 						},
 					},
 				},
@@ -883,6 +888,7 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 						"app.kubernetes.io/managed-by": common.OADPOperator,
 						"app.kubernetes.io/component":  Server,
 						oadpv1alpha1.OadpOperatorLabel: "True",
+						"component":                    "velero",
 					},
 				},
 				TypeMeta: metav1.TypeMeta{
@@ -897,6 +903,7 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 							"app.kubernetes.io/managed-by": common.OADPOperator,
 							"app.kubernetes.io/component":  Server,
 							oadpv1alpha1.OadpOperatorLabel: "True",
+							"component":                    "velero",
 						},
 					},
 					Replicas: pointer.Int32(1),
@@ -908,6 +915,7 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 								"app.kubernetes.io/managed-by": common.OADPOperator,
 								"app.kubernetes.io/component":  Server,
 								oadpv1alpha1.OadpOperatorLabel: "True",
+								"component":                    "velero",
 							},
 							Annotations: map[string]string{
 								"prometheus.io/scrape": "true",

--- a/controllers/velero_test.go
+++ b/controllers/velero_test.go
@@ -628,6 +628,386 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 			},
 		},
 		{
+			name: "given valid DPA CR, velero deployment tolerations",
+			veleroDeployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-velero-deployment",
+					Namespace: "test-ns",
+				},
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Deployment",
+					APIVersion: appsv1.SchemeGroupVersion.String(),
+				},
+				Spec: appsv1.DeploymentSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app.kubernetes.io/name":       common.Velero,
+							"app.kubernetes.io/instance":   "test-Velero-CR",
+							"app.kubernetes.io/managed-by": common.OADPOperator,
+							"app.kubernetes.io/component":  Server,
+							oadpv1alpha1.OadpOperatorLabel: "True",
+						},
+					},
+				},
+			},
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-Velero-CR",
+					Namespace: "test-ns",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{
+							PodConfig: &oadpv1alpha1.PodConfig{
+								ResourceAllocations: corev1.ResourceRequirements{
+									Limits: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("2"),
+										corev1.ResourceMemory: resource.MustParse("700Mi"),
+									},
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("1"),
+										corev1.ResourceMemory: resource.MustParse("256Mi"),
+									},
+								},
+								Tolerations: []corev1.Toleration{
+									{
+										Key:      "key1",
+										Operator: "Equal",
+										Value:    "value1",
+										Effect:   "NoSchedule",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+			wantVeleroDeployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-velero-deployment",
+					Namespace: "test-ns",
+					Labels: map[string]string{
+						"app.kubernetes.io/name":       common.Velero,
+						"app.kubernetes.io/instance":   "test-Velero-CR",
+						"app.kubernetes.io/managed-by": common.OADPOperator,
+						"app.kubernetes.io/component":  Server,
+						oadpv1alpha1.OadpOperatorLabel: "True",
+					},
+				},
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Deployment",
+					APIVersion: appsv1.SchemeGroupVersion.String(),
+				},
+				Spec: appsv1.DeploymentSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app.kubernetes.io/name":       common.Velero,
+							"app.kubernetes.io/instance":   "test-Velero-CR",
+							"app.kubernetes.io/managed-by": common.OADPOperator,
+							"app.kubernetes.io/component":  Server,
+							oadpv1alpha1.OadpOperatorLabel: "True",
+						},
+					},
+					Replicas: pointer.Int32(1),
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								"app.kubernetes.io/name":       common.Velero,
+								"app.kubernetes.io/instance":   "test-Velero-CR",
+								"app.kubernetes.io/managed-by": common.OADPOperator,
+								"app.kubernetes.io/component":  Server,
+								oadpv1alpha1.OadpOperatorLabel: "True",
+							},
+							Annotations: map[string]string{
+								"prometheus.io/scrape": "true",
+								"prometheus.io/port":   "8085",
+								"prometheus.io/path":   "/metrics",
+							},
+						},
+						Spec: corev1.PodSpec{
+							RestartPolicy:      corev1.RestartPolicyAlways,
+							ServiceAccountName: common.Velero,
+							Tolerations: []corev1.Toleration{
+								{
+									Key:      "key1",
+									Operator: "Equal",
+									Value:    "value1",
+									Effect:   "NoSchedule",
+								},
+							},
+							Containers: []corev1.Container{
+								{
+									Name:            common.Velero,
+									Image:           common.VeleroImage,
+									ImagePullPolicy: corev1.PullAlways,
+									Ports: []corev1.ContainerPort{
+										{
+											Name:          "metrics",
+											ContainerPort: 8085,
+										},
+									},
+									Resources: corev1.ResourceRequirements{
+										Limits: corev1.ResourceList{
+											corev1.ResourceCPU:    resource.MustParse("2"),
+											corev1.ResourceMemory: resource.MustParse("700Mi"),
+										},
+										Requests: corev1.ResourceList{
+											corev1.ResourceCPU:    resource.MustParse("1"),
+											corev1.ResourceMemory: resource.MustParse("256Mi"),
+										},
+									},
+									Command: []string{"/velero"},
+									Args: []string{
+										"server",
+										"--restic-timeout=1h",
+									},
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      "plugins",
+											MountPath: "/plugins",
+										},
+										{
+											Name:      "scratch",
+											MountPath: "/scratch",
+										},
+										{
+											Name:      "certs",
+											MountPath: "/etc/ssl/certs",
+										},
+									},
+									Env: []corev1.EnvVar{
+										{
+											Name:  common.VeleroScratchDirEnvKey,
+											Value: "/scratch",
+										},
+										{
+											Name: common.VeleroNamespaceEnvKey,
+											ValueFrom: &corev1.EnvVarSource{
+												FieldRef: &corev1.ObjectFieldSelector{
+													FieldPath: "metadata.namespace",
+												},
+											},
+										},
+										{
+											Name:  common.LDLibraryPathEnvKey,
+											Value: "/plugins",
+										},
+									},
+								},
+							},
+							Volumes: []corev1.Volume{
+								{
+									Name: "plugins",
+									VolumeSource: corev1.VolumeSource{
+										EmptyDir: &corev1.EmptyDirVolumeSource{},
+									},
+								},
+								{
+									Name: "scratch",
+									VolumeSource: corev1.VolumeSource{
+										EmptyDir: &corev1.EmptyDirVolumeSource{},
+									},
+								},
+								{
+									Name: "certs",
+									VolumeSource: corev1.VolumeSource{
+										EmptyDir: &corev1.EmptyDirVolumeSource{},
+									},
+								},
+							},
+							InitContainers: []corev1.Container{},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "given valid DPA CR, velero deployment nodeselector",
+			veleroDeployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-velero-deployment",
+					Namespace: "test-ns",
+				},
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Deployment",
+					APIVersion: appsv1.SchemeGroupVersion.String(),
+				},
+				Spec: appsv1.DeploymentSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app.kubernetes.io/name":       common.Velero,
+							"app.kubernetes.io/instance":   "test-Velero-CR",
+							"app.kubernetes.io/managed-by": common.OADPOperator,
+							"app.kubernetes.io/component":  Server,
+							oadpv1alpha1.OadpOperatorLabel: "True",
+						},
+					},
+				},
+			},
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-Velero-CR",
+					Namespace: "test-ns",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{
+							PodConfig: &oadpv1alpha1.PodConfig{
+								ResourceAllocations: corev1.ResourceRequirements{
+									Limits: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("2"),
+										corev1.ResourceMemory: resource.MustParse("700Mi"),
+									},
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("1"),
+										corev1.ResourceMemory: resource.MustParse("256Mi"),
+									},
+								},
+								NodeSelector: map[string]string{
+									"foo": "bar",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+			wantVeleroDeployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-velero-deployment",
+					Namespace: "test-ns",
+					Labels: map[string]string{
+						"app.kubernetes.io/name":       common.Velero,
+						"app.kubernetes.io/instance":   "test-Velero-CR",
+						"app.kubernetes.io/managed-by": common.OADPOperator,
+						"app.kubernetes.io/component":  Server,
+						oadpv1alpha1.OadpOperatorLabel: "True",
+					},
+				},
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Deployment",
+					APIVersion: appsv1.SchemeGroupVersion.String(),
+				},
+				Spec: appsv1.DeploymentSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app.kubernetes.io/name":       common.Velero,
+							"app.kubernetes.io/instance":   "test-Velero-CR",
+							"app.kubernetes.io/managed-by": common.OADPOperator,
+							"app.kubernetes.io/component":  Server,
+							oadpv1alpha1.OadpOperatorLabel: "True",
+						},
+					},
+					Replicas: pointer.Int32(1),
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								"app.kubernetes.io/name":       common.Velero,
+								"app.kubernetes.io/instance":   "test-Velero-CR",
+								"app.kubernetes.io/managed-by": common.OADPOperator,
+								"app.kubernetes.io/component":  Server,
+								oadpv1alpha1.OadpOperatorLabel: "True",
+							},
+							Annotations: map[string]string{
+								"prometheus.io/scrape": "true",
+								"prometheus.io/port":   "8085",
+								"prometheus.io/path":   "/metrics",
+							},
+						},
+						Spec: corev1.PodSpec{
+							RestartPolicy:      corev1.RestartPolicyAlways,
+							ServiceAccountName: common.Velero,
+							NodeSelector: map[string]string{
+								"foo": "bar",
+							},
+							Containers: []corev1.Container{
+								{
+									Name:            common.Velero,
+									Image:           common.VeleroImage,
+									ImagePullPolicy: corev1.PullAlways,
+									Ports: []corev1.ContainerPort{
+										{
+											Name:          "metrics",
+											ContainerPort: 8085,
+										},
+									},
+									Resources: corev1.ResourceRequirements{
+										Limits: corev1.ResourceList{
+											corev1.ResourceCPU:    resource.MustParse("2"),
+											corev1.ResourceMemory: resource.MustParse("700Mi"),
+										},
+										Requests: corev1.ResourceList{
+											corev1.ResourceCPU:    resource.MustParse("1"),
+											corev1.ResourceMemory: resource.MustParse("256Mi"),
+										},
+									},
+									Command: []string{"/velero"},
+									Args: []string{
+										"server",
+										"--restic-timeout=1h",
+									},
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      "plugins",
+											MountPath: "/plugins",
+										},
+										{
+											Name:      "scratch",
+											MountPath: "/scratch",
+										},
+										{
+											Name:      "certs",
+											MountPath: "/etc/ssl/certs",
+										},
+									},
+									Env: []corev1.EnvVar{
+										{
+											Name:  common.VeleroScratchDirEnvKey,
+											Value: "/scratch",
+										},
+										{
+											Name: common.VeleroNamespaceEnvKey,
+											ValueFrom: &corev1.EnvVarSource{
+												FieldRef: &corev1.ObjectFieldSelector{
+													FieldPath: "metadata.namespace",
+												},
+											},
+										},
+										{
+											Name:  common.LDLibraryPathEnvKey,
+											Value: "/plugins",
+										},
+									},
+								},
+							},
+							Volumes: []corev1.Volume{
+								{
+									Name: "plugins",
+									VolumeSource: corev1.VolumeSource{
+										EmptyDir: &corev1.EmptyDirVolumeSource{},
+									},
+								},
+								{
+									Name: "scratch",
+									VolumeSource: corev1.VolumeSource{
+										EmptyDir: &corev1.EmptyDirVolumeSource{},
+									},
+								},
+								{
+									Name: "certs",
+									VolumeSource: corev1.VolumeSource{
+										EmptyDir: &corev1.EmptyDirVolumeSource{},
+									},
+								},
+							},
+							InitContainers: []corev1.Container{},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "given valid DPA CR, appropriate velero deployment is build with aws plugin specific specs",
 			veleroDeployment: &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{

--- a/tests/e2e/dpa_deployment_suite_test.go
+++ b/tests/e2e/dpa_deployment_suite_test.go
@@ -23,11 +23,11 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 	bslConfig := Dpa.Spec.BackupLocations[0].Velero.Config
 
 	type InstallCase struct {
-		Name         string
-		BRestoreType BackupRestoreType
-		DpaSpec      *oadpv1alpha1.DataProtectionApplicationSpec
+		Name               string
+		BRestoreType       BackupRestoreType
+		DpaSpec            *oadpv1alpha1.DataProtectionApplicationSpec
 		TestCarriageReturn bool
-		WantError    bool
+		WantError          bool
 	}
 
 	genericTests := []TableEntry{
@@ -64,8 +64,8 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 			WantError: false,
 		}, nil),
 		Entry("Default velero CR, test carriage return", InstallCase{
-			Name:         "default-cr",
-			BRestoreType: RESTIC,
+			Name:               "default-cr",
+			BRestoreType:       RESTIC,
 			TestCarriageReturn: true,
 			DpaSpec: &oadpv1alpha1.DataProtectionApplicationSpec{
 				Configuration: &oadpv1alpha1.ApplicationConfig{

--- a/tests/e2e/lib/dpa_helpers.go
+++ b/tests/e2e/lib/dpa_helpers.go
@@ -148,7 +148,7 @@ func (v *DpaCustomResource) CreateOrUpdate(spec *oadpv1alpha1.DataProtectionAppl
 func (v *DpaCustomResource) CreateOrUpdateWithRetries(spec *oadpv1alpha1.DataProtectionApplicationSpec, retries int) error {
 	var (
 		err error
-		cr *oadpv1alpha1.DataProtectionApplication
+		cr  *oadpv1alpha1.DataProtectionApplication
 	)
 	for i := 0; i < retries; i++ {
 		if cr, err = v.Get(); apierrors.IsNotFound(err) {
@@ -159,9 +159,9 @@ func (v *DpaCustomResource) CreateOrUpdateWithRetries(spec *oadpv1alpha1.DataPro
 			return err
 		}
 		cr.Spec = *spec
-		if err = v.Client.Update(context.Background(), cr); err != nil{
+		if err = v.Client.Update(context.Background(), cr); err != nil {
 			if apierrors.IsConflict(err) && i < retries-1 {
-				log.Println("conflict detected during DPA CreateOrUpdate, retrying for ", retries - i - 1 , " more times")
+				log.Println("conflict detected during DPA CreateOrUpdate, retrying for ", retries-i-1, " more times")
 				time.Sleep(time.Second * 2)
 				continue
 			}


### PR DESCRIPTION
- Fixes https://issues.redhat.com/browse/OADP-487 
- Adds unit tests for `nodeselector` and `tolerations` for velero and restic.