### PR TITLE
cherry-pick 1.0 OADP-380+kubevirt-upstream-tag-cp

### DIFF
--- a/bundle/manifests/oadp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/oadp-operator.clusterserviceversion.yaml
@@ -2,7 +2,6 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
-    operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift Platform Plus"]'
     alm-examples: |-
       [
         {
@@ -169,7 +168,8 @@ metadata:
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-adp
     operators.openshift.io/infrastructure-features: '["Disconnected"]'
-    operators.operatorframework.io/builder: operator-sdk-v1.18.0+git
+    operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift Platform Plus"]'
+    operators.operatorframework.io/builder: operator-sdk-v1.14.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/openshift/oadp-operator
     support: Red Hat
@@ -498,7 +498,7 @@ spec:
                       - name: VELERO_CSI_PLUGIN_TAG
                         value: latest
                       - name: VELERO_KUBEVIRT_PLUGIN_TAG
-                        value: 0.2.0
+                        value: v0.2.0
                     image: quay.io/konveyor/oadp-operator:latest
                     imagePullPolicy: Always
                     livenessProbe:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -76,7 +76,7 @@ spec:
           - name: VELERO_CSI_PLUGIN_TAG
             value: latest
           - name: VELERO_KUBEVIRT_PLUGIN_TAG
-            value: 0.2.0
+            value: v0.2.0
         args:
         - --leader-elect
         image: controller:latest

--- a/config/manifests/bases/oadp-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/oadp-operator.clusterserviceversion.yaml
@@ -14,6 +14,8 @@ metadata:
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-adp
     operators.openshift.io/infrastructure-features: '["Disconnected"]'
+    operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift
+      Platform Plus"]'
     repository: https://github.com/openshift/oadp-operator
     support: Red Hat
   labels:
@@ -124,7 +126,7 @@ spec:
   - oadp
   links:
   - name: OADP Operator
-    url: https://oadp.konveyor.io/
+    url: https://github.com/openshift/oadp-operator
   maintainers:
   - email: dymurray@redhat.com
     name: Dylan Murray


### PR DESCRIPTION
* Preserve #611 bundle changes in config manifests

* prefix `v` to upstream oadp-operator kubevirt plugin tag