### PR TITLE
cherry-pick 1.0 OADP-329 - velero loglevel feature flag (#588)

### DIFF
--- a/api/v1alpha1/oadp_types.go
+++ b/api/v1alpha1/oadp_types.go
@@ -74,6 +74,10 @@ type VeleroConfig struct {
 	NoDefaultBackupLocation bool `json:"noDefaultBackupLocation,omitempty"`
 	// Pod specific configuration
 	PodConfig *PodConfig `json:"podConfig,omitempty"`
+	// Velero server’s log level (use debug for the most logging, leave unset for velero default)
+	// +optional
+	// +kubebuilder:validation:Enum=error;warn;warning;info;debug;trace
+	LogLevel string `json:"logLevel,omitempty"`
 }
 
 // PodConfig defines the pod configuration options

--- a/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
@@ -310,6 +310,17 @@ spec:
                         items:
                           type: string
                         type: array
+                      logLevel:
+                        description: Velero server’s log level (use debug for the
+                          most logging, leave unset for velero default)
+                        enum:
+                        - error
+                        - warn
+                        - warning
+                        - info
+                        - debug
+                        - trace
+                        type: string
                       noDefaultBackupLocation:
                         description: If you need to install Velero without a default
                           backup storage location NoDefaultBackupLocation flag is

--- a/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
@@ -312,6 +312,17 @@ spec:
                         items:
                           type: string
                         type: array
+                      logLevel:
+                        description: Velero server’s log level (use debug for the
+                          most logging, leave unset for velero default)
+                        enum:
+                        - error
+                        - warn
+                        - warning
+                        - info
+                        - debug
+                        - trace
+                        type: string
                       noDefaultBackupLocation:
                         description: If you need to install Velero without a default
                           backup storage location NoDefaultBackupLocation flag is

--- a/controllers/velero.go
+++ b/controllers/velero.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/openshift/oadp-operator/pkg/credentials"
 	"github.com/operator-framework/operator-lib/proxy"
+	"github.com/sirupsen/logrus"
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -515,6 +516,15 @@ func (r *DPAReconciler) customizeVeleroDeployment(dpa *oadpv1alpha1.DataProtecti
 	if err != nil {
 		return err
 	}
+
+	if dpa.Spec.Configuration.Velero.LogLevel != "" {
+		_, err := veleroLogrusParseLevel(dpa.Spec.Configuration.Velero.LogLevel)
+		if err != nil {
+			return fmt.Errorf("invalid log level %s\nallowed: %s", dpa.Spec.Configuration.Velero.LogLevel, "error;warn;warning;info;debug;trace")
+		}
+		veleroContainer.Args = append(veleroContainer.Args, "--log-level", dpa.Spec.Configuration.Velero.LogLevel)
+	}
+
 	return credentials.AppendPluginSpecificSpecs(dpa, veleroDeployment, veleroContainer, providerNeedsDefaultCreds, hasCloudStorage)
 }
 
@@ -706,4 +716,28 @@ func (r DPAReconciler) noDefaultCredentials(dpa oadpv1alpha1.DataProtectionAppli
 
 	return providerNeedsDefaultCreds, hasCloudStorage, nil
 
+}
+
+// imported from https://github.com/sirupsen/logrus/blob/v1.8.1/logrus.go#L25-L45
+// removes panic and fatal from valid levels.
+func veleroLogrusParseLevel(lvl string) (logrus.Level, error) {
+	switch strings.ToLower(lvl) {
+	// case "panic":
+	// 	return logrus.PanicLevel, nil
+	// case "fatal":
+	// 	return logrus.FatalLevel, nil
+	case "error":
+		return logrus.ErrorLevel, nil
+	case "warn", "warning":
+		return logrus.WarnLevel, nil
+	case "info":
+		return logrus.InfoLevel, nil
+	case "debug":
+		return logrus.DebugLevel, nil
+	case "trace":
+		return logrus.TraceLevel, nil
+	}
+
+	var l logrus.Level
+	return l, fmt.Errorf("not a valid logrus Level: %q", lvl)
 }

--- a/docs/API_ref.md
+++ b/docs/API_ref.md
@@ -44,6 +44,7 @@
 | restoreResourcesVersionPriority | string                  | RestoreResourceVersionPriority represents a configmap that will be created if defined for use in conjunction with `EnableAPIGroupVersions` feature flag. Defining this field automatically add EnableAPIGroupVersions to the velero server feature flag  |
 | noDefaultBackupLocation         | bool                    | If you need to install Velero without a default backup storage location NoDefaultBackupLocation flag is required for confirmation                                                                                                                        |
 | podConfig                       | *PodConfig              | Velero Pod specific configuration                                                                                                                                                                                                                        |
+| logLevel                       | string              | Velero server’s log level (default info, use debug for the most logging). Valid options are error, warn, warning, info, debug, trace                                                                                                                                                                                                                        |
 
 ### ResticConfig
 

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/operator-framework/api v0.10.7
 	github.com/operator-framework/operator-lib v0.9.0
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.51.2
+	github.com/sirupsen/logrus v1.8.1
 	github.com/vmware-tanzu/velero v1.7.0 // TODO: Update this to a pinned version
 	k8s.io/api v0.22.2
 	k8s.io/apiextensions-apiserver v0.22.2


### PR DESCRIPTION
* loglevel

Signed-off-by: Tiger Kaovilai <tkaovila@redhat.com>

* Remove panic and fatal

* resolves https://github.com/openshift/oadp-operator/pull/588/files#r823051753, https://github.com/openshift/oadp-operator/pull/588/files#r823050949

* refactor err

* panic fatal removed from error message

* resolves https://github.com/openshift/oadp-operator/pull/588#discussion_r827084018

* make bundle to update crd

* Copy ParseLevel function, use hardcoded error str