### PR TITLE
OADP 486 - Update velero service account permissions (#673)

### DIFF
--- a/bundle/manifests/oadp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/oadp-operator.clusterserviceversion.yaml
@@ -421,8 +421,41 @@ spec:
           serviceAccountName: openshift-adp-controller-manager
         - rules:
             - apiGroups:
+                - build.openshift.io
+                - migration.openshift.io
+                - rbac.authorization.k8s.io
+                - velero.io
+              resources:
+                - '*'
+              verbs:
+                - '*'
+            - apiGroups:
+                - ""
+              resources:
+                - serviceaccounts
+              verbs:
+                - '*'
+            - apiGroups:
+                - packages.operators.coreos.com
+              resources:
+                - packagemanifests
+              verbs:
+                - '*'
+            - apiGroups:
                 - '*'
               resources:
+                - '*'
+              verbs:
+                - get
+                - watch
+                - list
+                - update
+                - patch
+                - create
+                - delete
+                - assign
+                - deletecollection
+            - nonResourceURLs:
                 - '*'
               verbs:
                 - '*'

--- a/config/velero/velero-role.yaml
+++ b/config/velero/velero-role.yaml
@@ -7,8 +7,41 @@ metadata:
   name: velero-role
 rules:
 - apiGroups:
+  - build.openshift.io
+  - migration.openshift.io
+  - rbac.authorization.k8s.io
+  - velero.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - '*'
+- apiGroups:
+  - packages.operators.coreos.com
+  resources:
+  - packagemanifests
+  verbs:
+  - '*'
+- apiGroups:
   - '*'
   resources:
+  - '*'
+  verbs:
+  - get
+  - watch
+  - list
+  - update
+  - patch
+  - create
+  - delete
+  - assign
+  - deletecollection
+- nonResourceURLs:
   - '*'
   verbs:
   - '*'
@@ -16,7 +49,6 @@ rules:
   - security.openshift.io
   resourceNames:
   - privileged
-  - velero-privileged
   resources:
   - securitycontextconstraints
   verbs:


### PR DESCRIPTION
* OADP 486 - Update velero service account permissions

* Add back velero-privileged

(cherry picked from commit 3612b14bf724c2743388fb4d62529ce0c81eed1d)