### PR TITLE
OADP-145: post-restore script for restores with DCs and defaultVolumesToRestic

### DIFF
--- a/docs/scripts/dc-restic-post-restore.sh
+++ b/docs/scripts/dc-restic-post-restore.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -e
+
+OADP_NAMESPACE=${OADP_NAMESPACE:=openshift-adp}
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: ${BASH_SOURCE} restore-name"
+  exit 1
+fi
+
+echo using OADP Namespace $OADP_NAMESPACE
+echo restore $1
+
+echo Deleting disconnected restore pods
+oc delete pods -l oadp.openshift.io/disconnected-from-dc=$1
+
+for dc in $(oc get dc --all-namespaces -l oadp.openshift.io/replicas-modified=$1 -o jsonpath='{range .items[*]}{.metadata.namespace}{","}{.metadata.name}{","}{.metadata.annotations.oadp\.openshift\.io/original-replicas}{","}{.metadata.annotations.oadp\.openshift\.io/original-paused}{"\n"}')
+do
+    IFS=',' read -ra dc_arr <<< "$dc"
+    echo Found deployment ${dc_arr[0]}/${dc_arr[1]}, setting replicas: ${dc_arr[2]}, paused: ${dc_arr[3]}
+
+    cat <<EOF | oc patch dc  -n ${dc_arr[0]} ${dc_arr[1]} --patch-file /dev/stdin
+spec:
+  replicas: ${dc_arr[2]}
+  paused: ${dc_arr[3]}
+EOF
+
+done


### PR DESCRIPTION
When restoring a backup with defaultVolumesToRestic=true and
DeploymentConfigs in the backup, this script must be run after the
completion of the restore to clean up the restic restore actions.

The openshift plugins will disconnect DC pods from the ReplicationController
when defaultVolumesToRestic is true and set DC replicas to 0.
This script will remove the restore pods and reset DC replicas so that
new pods will be created that are properly reconnected to the DC.