### PR TITLE
[OADP-329] mimic velero cli loglevel options

### DIFF
--- a/api/v1alpha1/oadp_types.go
+++ b/api/v1alpha1/oadp_types.go
@@ -76,7 +76,7 @@ type VeleroConfig struct {
 	PodConfig *PodConfig `json:"podConfig,omitempty"`
 	// Velero server’s log level (use debug for the most logging, leave unset for velero default)
 	// +optional
-	// +kubebuilder:validation:Enum=error;warn;warning;info;debug;trace
+	// +kubebuilder:validation:Enum=trace;debug;info;warning;error;fatal;panic
 	LogLevel string `json:"logLevel,omitempty"`
 }
 

--- a/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
@@ -319,12 +319,13 @@ spec:
                         description: Velero server’s log level (use debug for the
                           most logging, leave unset for velero default)
                         enum:
-                        - error
-                        - warn
-                        - warning
-                        - info
-                        - debug
                         - trace
+                        - debug
+                        - info
+                        - warning
+                        - error
+                        - fatal
+                        - panic
                         type: string
                       noDefaultBackupLocation:
                         description: If you need to install Velero without a default

--- a/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
@@ -321,12 +321,13 @@ spec:
                         description: Velero server’s log level (use debug for the
                           most logging, leave unset for velero default)
                         enum:
-                        - error
-                        - warn
-                        - warning
-                        - info
-                        - debug
                         - trace
+                        - debug
+                        - info
+                        - warning
+                        - error
+                        - fatal
+                        - panic
                         type: string
                       noDefaultBackupLocation:
                         description: If you need to install Velero without a default

--- a/controllers/velero.go
+++ b/controllers/velero.go
@@ -544,11 +544,11 @@ func (r *DPAReconciler) customizeVeleroDeployment(dpa *oadpv1alpha1.DataProtecti
 	}
 
 	if dpa.Spec.Configuration.Velero.LogLevel != "" {
-		_, err := veleroLogrusParseLevel(dpa.Spec.Configuration.Velero.LogLevel)
+		logLevel, err := logrus.ParseLevel(dpa.Spec.Configuration.Velero.LogLevel)
 		if err != nil {
-			return fmt.Errorf("invalid log level %s\nallowed: %s", dpa.Spec.Configuration.Velero.LogLevel, "error;warn;warning;info;debug;trace")
+			return fmt.Errorf("invalid log level %s, use: %s", dpa.Spec.Configuration.Velero.LogLevel, "trace, debug, info, warning, error, fatal, or panic")
 		}
-		veleroContainer.Args = append(veleroContainer.Args, "--log-level", dpa.Spec.Configuration.Velero.LogLevel)
+		veleroContainer.Args = append(veleroContainer.Args, "--log-level", logLevel.String())
 	}
 
 	return credentials.AppendPluginSpecificSpecs(dpa, veleroDeployment, veleroContainer, providerNeedsDefaultCreds, hasCloudStorage)
@@ -761,26 +761,3 @@ func (r DPAReconciler) noDefaultCredentials(dpa oadpv1alpha1.DataProtectionAppli
 
 }
 
-// imported from https://github.com/sirupsen/logrus/blob/v1.8.1/logrus.go#L25-L45
-// removes panic and fatal from valid levels.
-func veleroLogrusParseLevel(lvl string) (logrus.Level, error) {
-	switch strings.ToLower(lvl) {
-	// case "panic":
-	// 	return logrus.PanicLevel, nil
-	// case "fatal":
-	// 	return logrus.FatalLevel, nil
-	case "error":
-		return logrus.ErrorLevel, nil
-	case "warn", "warning":
-		return logrus.WarnLevel, nil
-	case "info":
-		return logrus.InfoLevel, nil
-	case "debug":
-		return logrus.DebugLevel, nil
-	case "trace":
-		return logrus.TraceLevel, nil
-	}
-
-	var l logrus.Level
-	return l, fmt.Errorf("not a valid logrus Level: %q", lvl)
-}


### PR DESCRIPTION
[ [OADP-329](https://issues.redhat.com//browse/OADP-329) ] mimic velero cli loglevel options.

`warn` option is blocked in CRD enum to mimic CLI but would no longer cause velero deployment to crashloop if we ever wanted to add it back.

panic and fatal is now valid per velero cli documentation.