### PR TITLE
make bundle related images fix

### DIFF
--- a/bundle/manifests/oadp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/oadp-operator.clusterserviceversion.yaml
@@ -698,6 +698,24 @@ spec:
                         value: latest
                       - name: VELERO_KUBEVIRT_PLUGIN_TAG
                         value: v0.2.0
+                      - name: RELATED_IMAGE_velero
+                        value: quay.io/konveyor/velero:latest
+                      - name: RELATED_IMAGE_velero_restic_restore_helper
+                        value: quay.io/konveyor/velero-restic-restore-helper:latest
+                      - name: RELATED_IMAGE_openshift_plugin
+                        value: quay.io/konveyor/openshift-velero-plugin:latest
+                      - name: RELATED_IMAGE_aws_plugin
+                        value: quay.io/konveyor/velero-plugin-for-aws:latest
+                      - name: RELATED_IMAGE_azure_plugin
+                        value: quay.io/konveyor/velero-plugin-for-microsoft-azure:latest
+                      - name: RELATED_IMAGE_gcp_plugin
+                        value: quay.io/konveyor/velero-plugin-for-gcp:latest
+                      - name: RELATED_IMAGE_csi_plugin
+                        value: quay.io/konveyor/velero-plugin-for-csi:latest
+                      - name: RELATED_IMAGE_registry
+                        value: quay.io/konveyor/registry:latest
+                      - name: RELATED_IMAGE_kubevirt_plugin
+                        value: quay.io/konveyor/kubevirt-velero-plugin:v0.2.0
                     image: quay.io/konveyor/oadp-operator:latest
                     imagePullPolicy: Always
                     livenessProbe:
@@ -807,19 +825,19 @@ spec:
     - image: quay.io/konveyor/velero:latest
       name: velero
     - image: quay.io/konveyor/velero-restic-restore-helper:latest
-      name: velero_restic_restore_helper
+      name: velero-restic-restore-helper
     - image: quay.io/konveyor/openshift-velero-plugin:latest
-      name: openshift_plugin
+      name: openshift-plugin
     - image: quay.io/konveyor/velero-plugin-for-aws:latest
-      name: aws_plugin
+      name: aws-plugin
     - image: quay.io/konveyor/velero-plugin-for-microsoft-azure:latest
-      name: azure_plugin
+      name: azure-plugin
     - image: quay.io/konveyor/velero-plugin-for-gcp:latest
-      name: gcp_plugin
+      name: gcp-plugin
     - image: quay.io/konveyor/velero-plugin-for-csi:latest
-      name: csi_plugin
+      name: csi-plugin
     - image: quay.io/konveyor/registry:latest
       name: registry
     - image: quay.io/konveyor/kubevirt-velero-plugin:v0.2.0
-      name: kubevirt_plugin
+      name: kubevirt-plugin
   version: 99.0.0

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -77,6 +77,24 @@ spec:
             value: latest
           - name: VELERO_KUBEVIRT_PLUGIN_TAG
             value: v0.2.0
+          - value: quay.io/konveyor/velero:latest
+            name: RELATED_IMAGE_velero
+          - value: quay.io/konveyor/velero-restic-restore-helper:latest
+            name: RELATED_IMAGE_velero_restic_restore_helper
+          - value: quay.io/konveyor/openshift-velero-plugin:latest
+            name: RELATED_IMAGE_openshift_plugin
+          - value: quay.io/konveyor/velero-plugin-for-aws:latest
+            name: RELATED_IMAGE_aws_plugin
+          - value: quay.io/konveyor/velero-plugin-for-microsoft-azure:latest
+            name: RELATED_IMAGE_azure_plugin
+          - value: quay.io/konveyor/velero-plugin-for-gcp:latest
+            name: RELATED_IMAGE_gcp_plugin
+          - value: quay.io/konveyor/velero-plugin-for-csi:latest
+            name: RELATED_IMAGE_csi_plugin
+          - value: quay.io/konveyor/registry:latest
+            name: RELATED_IMAGE_registry
+          - value: quay.io/konveyor/kubevirt-velero-plugin:v0.2.0
+            name: RELATED_IMAGE_kubevirt_plugin
         args:
         - --leader-elect
         image: controller:latest

--- a/config/manifests/bases/oadp-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/oadp-operator.clusterserviceversion.yaml
@@ -340,23 +340,4 @@ spec:
   maturity: stable
   provider:
     name: Red Hat
-  relatedImages:
-  - image: quay.io/konveyor/velero:latest
-    name: velero
-  - image: quay.io/konveyor/velero-restic-restore-helper:latest
-    name: velero_restic_restore_helper
-  - image: quay.io/konveyor/openshift-velero-plugin:latest
-    name: openshift_plugin
-  - image: quay.io/konveyor/velero-plugin-for-aws:latest
-    name: aws_plugin
-  - image: quay.io/konveyor/velero-plugin-for-microsoft-azure:latest
-    name: azure_plugin
-  - image: quay.io/konveyor/velero-plugin-for-gcp:latest
-    name: gcp_plugin
-  - image: quay.io/konveyor/velero-plugin-for-csi:latest
-    name: csi_plugin
-  - image: quay.io/konveyor/registry:latest
-    name: registry
-  - image: quay.io/konveyor/kubevirt-velero-plugin:v0.2.0
-    name: kubevirt_plugin
   version: 99.0.0


### PR DESCRIPTION
Looks like `operator-sdk generate bundle` gets Related images from [FindRelatedImages](https://github.dev/operator-framework/operator-sdk/blob/fb15b62e9c0defee208086ccab79112c68843454/internal/cmd/operator-sdk/generate/internal/relatedimages.go#L29) which iterate over manifests of type deployment. It then check that the container has env RELATED_IMAGE_

Looks like a regression with operator-sdk that appeared around [v1.19.1 release](https://github.com/operator-framework/operator-sdk/releases/tag/v1.19.1)

Edit: submitted a fix to operator-sdk https://github.com/operator-framework/operator-sdk/pull/5765 is approved, this will close.