### PR TITLE
SubscriptionSuiteTest check deployment/deamonset ENV instead of pods in namespace.

### DIFF
--- a/tests/e2e/lib/registry_helpers.go
+++ b/tests/e2e/lib/registry_helpers.go
@@ -14,17 +14,9 @@ import (
 func AreRegistryDeploymentsAvailable(namespace string) wait.ConditionFunc {
 	log.Printf("Checking for available registry deployments")
 	return func() (bool, error) {
-		client, err := setUpClient()
+		deploymentList, err := GetRegistryDeploymentList(namespace)
 		if err != nil {
 			return false, err
-		}
-		registryListOptions := metav1.ListOptions{
-			LabelSelector: "app.kubernetes.io/component=Registry",
-		}
-		// get pods in the oadp-operator-e2e namespace with label selector
-		deploymentList, err := client.AppsV1().Deployments(namespace).List(context.TODO(), registryListOptions)
-		if err != nil {
-			return false, nil
 		}
 		if len(deploymentList.Items) == 0 {
 			return false, fmt.Errorf("registry deployment is not yet created")
@@ -39,4 +31,20 @@ func AreRegistryDeploymentsAvailable(namespace string) wait.ConditionFunc {
 		}
 		return true, nil
 	}
+}
+
+func GetRegistryDeploymentList(namespace string) (*appsv1.DeploymentList, error) {
+	client, err := setUpClient()
+	if err != nil {
+		return nil, err
+	}
+	registryListOptions := metav1.ListOptions{
+		LabelSelector: "app.kubernetes.io/component=Registry",
+	}
+	// get pods in the oadp-operator-e2e namespace with label selector
+	deploymentList, err := client.AppsV1().Deployments(namespace).List(context.TODO(), registryListOptions)
+	if err != nil {
+		return nil, err
+	}
+	return deploymentList, nil
 }

--- a/tests/e2e/lib/restic_helpers.go
+++ b/tests/e2e/lib/restic_helpers.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -176,4 +177,20 @@ func ResticDaemonSetHasNodeSelector(namespace, key, value string) wait.Condition
 		}
 		return false, err
 	}
+}
+
+func GetResticDaemonsetList(namespace string) (*appsv1.DaemonSetList, error) {
+	client, err := setUpClient()
+	if err != nil {
+		return nil, err
+	}
+	registryListOptions := metav1.ListOptions{
+		LabelSelector: "component=velero",
+	}
+	// get pods in the oadp-operator-e2e namespace with label selector
+	deploymentList, err := client.AppsV1().DaemonSets(namespace).List(context.TODO(), registryListOptions)
+	if err != nil {
+		return nil, err
+	}
+	return deploymentList, nil
 }

--- a/tests/e2e/lib/velero_helpers.go
+++ b/tests/e2e/lib/velero_helpers.go
@@ -19,6 +19,8 @@ import (
 	veleroClientset "github.com/vmware-tanzu/velero/pkg/generated/clientset/versioned"
 	"github.com/vmware-tanzu/velero/pkg/label"
 	"github.com/vmware-tanzu/velero/pkg/restic"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -154,4 +156,20 @@ func RestoreErrorLogs(ocClient client.Client, restore velero.Restore) []string {
 		}
 	}
 	return logLines
+}
+
+func GetVeleroDeploymentList(namespace string) (*appsv1.DeploymentList, error) {
+	client, err := setUpClient()
+	if err != nil {
+		return nil, err
+	}
+	registryListOptions := metav1.ListOptions{
+		LabelSelector: "component=velero",
+	}
+	// get pods in the oadp-operator-e2e namespace with label selector
+	deploymentList, err := client.AppsV1().Deployments(namespace).List(context.TODO(), registryListOptions)
+	if err != nil {
+		return nil, err
+	}
+	return deploymentList, nil
 }


### PR DESCRIPTION
Reduce terminating pods from a previous deployment related flakes which does not have latest ENV as specified in latest deployment.