### PR TITLE
OADP-521 set controller reference after modifying objectmeta

### DIFF
--- a/controllers/restic.go
+++ b/controllers/restic.go
@@ -119,10 +119,10 @@ func (r *DPAReconciler) ReconcileResticDaemonset(log logr.Logger) (bool, error) 
 			}
 		}
 
-		if err := controllerutil.SetControllerReference(&dpa, ds, r.Scheme); err != nil {
+		if _, err := r.buildResticDaemonset(&dpa, ds); err != nil {
 			return err
 		}
-		if _, err := r.buildResticDaemonset(&dpa, ds); err != nil {
+		if err := controllerutil.SetControllerReference(&dpa, ds, r.Scheme); err != nil {
 			return err
 		}
 		return nil

--- a/controllers/velero.go
+++ b/controllers/velero.go
@@ -272,13 +272,14 @@ func (r *DPAReconciler) ReconcileVeleroDeployment(log logr.Logger) (bool, error)
 			}
 		}
 
-		// Setting controller owner reference on the velero deployment
-		err := controllerutil.SetControllerReference(&dpa, veleroDeployment, r.Scheme)
+		// update the Deployment template
+		err := r.buildVeleroDeployment(veleroDeployment, &dpa)
 		if err != nil {
 			return err
 		}
-		// update the Deployment template
-		return r.buildVeleroDeployment(veleroDeployment, &dpa)
+
+		// Setting controller owner reference on the velero deployment
+		return controllerutil.SetControllerReference(&dpa, veleroDeployment, r.Scheme)
 	})
 
 	if err != nil {

--- a/tests/e2e/dpa_deployment_suite_test.go
+++ b/tests/e2e/dpa_deployment_suite_test.go
@@ -630,4 +630,36 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 
 		}, genericTests,
 	)
+	
+	type deletionCase struct {
+		WantError bool
+	}
+	DescribeTable("DPA Deletion test", 
+		func(installCase deletionCase) {
+			log.Printf("Building dpa")
+			err := dpaCR.Build(RESTIC)
+			Expect(err).NotTo(HaveOccurred())
+			log.Printf("Creating dpa")
+			err = dpaCR.CreateOrUpdate(&dpaCR.CustomResource.Spec)
+			Expect(err).NotTo(HaveOccurred())
+			log.Printf("Waiting for velero pod to be running")
+			Eventually(AreVeleroPodsRunning(namespace), timeoutMultiplier*time.Minute*3, time.Second*5).Should(BeTrue())
+			if dpaCR.CustomResource.BackupImages() {
+				log.Printf("Waiting for registry pods to be running")
+				Eventually(AreRegistryDeploymentsAvailable(namespace), timeoutMultiplier*time.Minute*3, time.Second*5).Should(BeTrue())
+			}
+			log.Printf("Deleting dpa")
+			err = dpaCR.Delete()
+			if installCase.WantError {
+				Expect(err).To(HaveOccurred())
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+				log.Printf("Checking no velero pods are running")
+				Eventually(AreVeleroPodsRunning(namespace), timeoutMultiplier*time.Minute*3, time.Second*5).ShouldNot(BeTrue())
+				log.Printf("Checking no registry deployment available")
+				Eventually(AreRegistryDeploymentsNotAvailable(namespace), timeoutMultiplier*time.Minute*3, time.Second*5).Should(BeTrue())
+			}
+		},
+		Entry("Should succeed", deletionCase{WantError: false}),
+    )
 })

--- a/tests/e2e/lib/registry_helpers.go
+++ b/tests/e2e/lib/registry_helpers.go
@@ -14,6 +14,7 @@ import (
 func AreRegistryDeploymentsAvailable(namespace string) wait.ConditionFunc {
 	log.Printf("Checking for available registry deployments")
 	return func() (bool, error) {
+		// get pods in the oadp-operator-e2e namespace with label selector
 		deploymentList, err := GetRegistryDeploymentList(namespace)
 		if err != nil {
 			return false, err
@@ -47,4 +48,24 @@ func GetRegistryDeploymentList(namespace string) (*appsv1.DeploymentList, error)
 		return nil, err
 	}
 	return deploymentList, nil
+}
+
+func AreRegistryDeploymentsNotAvailable(namespace string) wait.ConditionFunc {
+	log.Printf("Checking for unavailable registry deployments")
+	return func() (bool, error) {
+		// get pods in the oadp-operator-e2e namespace with label selector
+		deploymentList, err := GetRegistryDeploymentList(namespace)
+		if err != nil {
+			return false, err
+		}
+		// loop until deployment status is 'Running' or timeout
+		for _, deploymentInfo := range deploymentList.Items {
+			for _, conditions := range deploymentInfo.Status.Conditions {
+				if conditions.Type == appsv1.DeploymentAvailable && conditions.Status == corev1.ConditionTrue {
+					return false, fmt.Errorf("registry deployment is still available.\nconditions: %v", deploymentInfo.Status.Conditions)
+				}
+			}
+		}
+		return true, nil
+	}
 }


### PR DESCRIPTION
Fix regression introduced in #668 where ownerReference were removed.
Closes [OADP-521](https://issues.redhat.com//browse/OADP-521)