### PR TITLE
OADP-521 1.0 cp: set controller reference after modifying objectmeta

### DIFF
--- a/controllers/restic.go
+++ b/controllers/restic.go
@@ -119,10 +119,10 @@ func (r *DPAReconciler) ReconcileResticDaemonset(log logr.Logger) (bool, error) 
 			}
 		}
 
-		if err := controllerutil.SetControllerReference(&dpa, ds, r.Scheme); err != nil {
+		if _, err := r.buildResticDaemonset(&dpa, ds); err != nil {
 			return err
 		}
-		if _, err := r.buildResticDaemonset(&dpa, ds); err != nil {
+		if err := controllerutil.SetControllerReference(&dpa, ds, r.Scheme); err != nil {
 			return err
 		}
 		return nil

--- a/controllers/velero.go
+++ b/controllers/velero.go
@@ -272,13 +272,14 @@ func (r *DPAReconciler) ReconcileVeleroDeployment(log logr.Logger) (bool, error)
 			}
 		}
 
-		// Setting controller owner reference on the velero deployment
-		err := controllerutil.SetControllerReference(&dpa, veleroDeployment, r.Scheme)
+		// update the Deployment template
+		err := r.buildVeleroDeployment(veleroDeployment, &dpa)
 		if err != nil {
 			return err
 		}
-		// update the Deployment template
-		return r.buildVeleroDeployment(veleroDeployment, &dpa)
+
+		// Setting controller owner reference on the velero deployment
+		return controllerutil.SetControllerReference(&dpa, veleroDeployment, r.Scheme)
 	})
 
 	if err != nil {

--- a/tests/e2e/lib/registry_helpers.go
+++ b/tests/e2e/lib/registry_helpers.go
@@ -14,15 +14,8 @@ import (
 func AreRegistryDeploymentsAvailable(namespace string) wait.ConditionFunc {
 	log.Printf("Checking for available registry deployments")
 	return func() (bool, error) {
-		client, err := setUpClient()
-		if err != nil {
-			return false, err
-		}
-		registryListOptions := metav1.ListOptions{
-			LabelSelector: "app.kubernetes.io/component=Registry",
-		}
 		// get pods in the oadp-operator-e2e namespace with label selector
-		deploymentList, err := client.AppsV1().Deployments(namespace).List(context.TODO(), registryListOptions)
+		deploymentList, err := GetRegistryDeploymentList(namespace)
 		if err != nil {
 			return false, nil
 		}
@@ -34,6 +27,42 @@ func AreRegistryDeploymentsAvailable(namespace string) wait.ConditionFunc {
 			for _, conditions := range deploymentInfo.Status.Conditions {
 				if conditions.Type == appsv1.DeploymentAvailable && conditions.Status != corev1.ConditionTrue {
 					return false, fmt.Errorf("registry deployment is not yet available.\nconditions: %v", deploymentInfo.Status.Conditions)
+				}
+			}
+		}
+		return true, nil
+	}
+}
+
+func GetRegistryDeploymentList(namespace string) (*appsv1.DeploymentList, error) {
+	client, err := setUpClient()
+	if err != nil {
+		return nil, err
+	}
+	registryListOptions := metav1.ListOptions{
+		LabelSelector: "app.kubernetes.io/component=Registry",
+	}
+	// get pods in the oadp-operator-e2e namespace with label selector
+	deploymentList, err := client.AppsV1().Deployments(namespace).List(context.TODO(), registryListOptions)
+	if err != nil {
+		return nil, err
+	}
+	return deploymentList, nil
+}
+
+func AreRegistryDeploymentsNotAvailable(namespace string) wait.ConditionFunc {
+	log.Printf("Checking for unavailable registry deployments")
+	return func() (bool, error) {
+		// get pods in the oadp-operator-e2e namespace with label selector
+		deploymentList, err := GetRegistryDeploymentList(namespace)
+		if err != nil {
+			return false, err
+		}
+		// loop until deployment status is 'Running' or timeout
+		for _, deploymentInfo := range deploymentList.Items {
+			for _, conditions := range deploymentInfo.Status.Conditions {
+				if conditions.Type == appsv1.DeploymentAvailable && conditions.Status == corev1.ConditionTrue {
+					return false, fmt.Errorf("registry deployment is still available.\nconditions: %v", deploymentInfo.Status.Conditions)
 				}
 			}
 		}


### PR DESCRIPTION
Fix regression introduced in https://github.com/openshift/oadp-operator/pull/668 where ownerReference were removed.
Closes [OADP-521](https://issues.redhat.com//browse/OADP-521)

Verification: Metadata of Velero deployment and restic daemonset contains controller reference to the DPA CR that created it.

Further, the deletion od DPA should delete these (owned by DPA) child resources.