### PR TITLE
move registry container inside velero pod

### DIFF
--- a/controllers/registry.go
+++ b/controllers/registry.go
@@ -396,12 +396,6 @@ func (r *DPAReconciler) buildRegistryContainer(bsl *velerov1.BackupStorageLocati
 		{
 			Image: getRegistryImage(dpa),
 			Name:  registryName(bsl) + "-container",
-			Ports: []corev1.ContainerPort{
-				{
-					ContainerPort: *containerPort,
-					Protocol:      corev1.ProtocolTCP,
-				},
-			},
 			Env: envVars,
 			LivenessProbe: &probe,
 			ReadinessProbe: &probe,

--- a/controllers/registry_test.go
+++ b/controllers/registry_test.go
@@ -722,7 +722,7 @@ func TestDPAReconciler_buildRegistryContainer(t *testing.T) {
 				},
 			}
 
-			gotRegistryContainer, gotErr := r.buildRegistryContainer(tt.bsl, tt.dpa)
+			gotRegistryContainer, gotErr := r.buildRegistryContainer(tt.bsl, tt.dpa, nil)
 
 			if (gotErr != nil) != tt.wantErr {
 				t.Errorf("ValidateBackupStorageLocations() gotErr = %v, wantErr %v", gotErr, tt.wantErr)

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	github.com/aws/aws-sdk-go v1.28.2
 	github.com/go-logr/logr v0.4.0
+	github.com/google/go-cmp v0.5.6 // indirect
 	github.com/google/uuid v1.1.2
 	github.com/kubernetes-csi/external-snapshotter/client/v4 v4.2.0
 	github.com/onsi/ginkgo v1.16.4


### PR DESCRIPTION
corresponding openshift-velero-plugin image `ghcr.io/kaovilai/openshift-velero-plugin:veleroPodRegistry`
```yaml
apiVersion: oadp.openshift.io/v1alpha1
kind: DataProtectionApplication
metadata:
  name: dpa-sample
spec:
  unsupportedOverrides:
    openshiftPluginImageFqin: ghcr.io/kaovilai/openshift-velero-plugin:veleroPodRegistry
```

blocked by https://github.com/openshift/openshift-velero-plugin/pull/142

Caveats: when you add a new BSL to DPA or outside, velero pod restarts to add additional bsl registry containers.