### PR TITLE
Fix makefile awk err

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ ifneq ($(OC_CLI),)
 	endif
 endif
 ifneq ($(CLUSTER_TYPE),)
-	CLUSTER_TYPE := $(shell echo $(CLUSTER_TYPE) | awk "{print tolower($0)}")
+	CLUSTER_TYPE := $(shell echo $(CLUSTER_TYPE) | awk -v AWKVAR="${0}" '{print tolower(AWKVAR)}')
 endif
 
 ifeq ($(CLUSTER_TYPE), gcp)

--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,12 @@ ifdef CLI_DIR
 	OC_CLI = ${CLI_DIR}/oc
 endif
 
-ifeq ($0,"")
-CLUSTER_TYPE ?= $(shell $(OC_CLI) get infrastructures cluster -o jsonpath='{.status.platform}' | awk '{print tolower($0)}')
+CLUSTER_TYPE ?= ""
+ifdef OC_CLI
+	CLUSTER_TYPE ?= $(shell $(OC_CLI) get infrastructures cluster -o jsonpath='{.status.platform}')
+endif
+ifneq ($(CLUSTER_TYPE), "")
+	CLUSTER_TYPE := $(shell echo $(CLUSTER_TYPE) | awk '{print tolower($0)}')
 endif
 
 ifeq ($(CLUSTER_TYPE), gcp)

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,9 @@ ifdef CLI_DIR
 	OC_CLI = ${CLI_DIR}/oc
 endif
 
+ifeq ($0,"")
 CLUSTER_TYPE ?= $(shell $(OC_CLI) get infrastructures cluster -o jsonpath='{.status.platform}' | awk '{print tolower($0)}')
+endif
 
 ifeq ($(CLUSTER_TYPE), gcp)
 	CI_CRED_FILE = ${CLUSTER_PROFILE_DIR}/gce.json

--- a/Makefile
+++ b/Makefile
@@ -37,11 +37,12 @@ ifdef CLI_DIR
 	OC_CLI = ${CLI_DIR}/oc
 endif
 
-CLUSTER_TYPE ?= ""
-ifdef OC_CLI
-	CLUSTER_TYPE ?= $(shell $(OC_CLI) get infrastructures cluster -o jsonpath='{.status.platform}')
+ifneq ($(OC_CLI),)
+	ifeq ($(CLUSTER_TYPE),)
+		CLUSTER_TYPE := $(shell $(OC_CLI) get infrastructures cluster -o jsonpath='{.status.platform}')
+	endif
 endif
-ifneq ($(CLUSTER_TYPE), "")
+ifneq ($(CLUSTER_TYPE),)
 	CLUSTER_TYPE := $(shell echo $(CLUSTER_TYPE) | awk '{print tolower($0)}')
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ ifneq ($(OC_CLI),)
 	endif
 endif
 ifneq ($(CLUSTER_TYPE),)
-	CLUSTER_TYPE := $(shell echo $(CLUSTER_TYPE) | awk '{print tolower($0)}')
+	CLUSTER_TYPE := $(shell echo $(CLUSTER_TYPE) | awk "{print tolower($0)}")
 endif
 
 ifeq ($(CLUSTER_TYPE), gcp)


### PR DESCRIPTION
Currently when you run `make test` locally you get the following error:
```
awk: cmd. line:1: {print tolower()}                                                                                                                                          
awk: cmd. line:1:                ^ 0 is invalid as number of arguments for tolower  
```
This PR fixes the error