### PR TITLE
OADP-535 allow for nullable resource allocations

### DIFF
--- a/api/v1alpha1/oadp_types.go
+++ b/api/v1alpha1/oadp_types.go
@@ -96,6 +96,7 @@ type PodConfig struct {
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 	// ResourceAllocations defines the CPU and Memory resource allocations for the restic Pod
 	// +optional
+	// +nullable
 	ResourceAllocations corev1.ResourceRequirements `json:"resourceAllocations,omitempty"`
 }
 

--- a/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
@@ -213,6 +213,7 @@ spec:
                                   anyOf:
                                   - type: integer
                                   - type: string
+                                  nullable: true
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 description: 'Limits describes the maximum amount
@@ -224,6 +225,7 @@ spec:
                                   anyOf:
                                   - type: integer
                                   - type: string
+                                  nullable: true
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 description: 'Requests describes the minimum amount
@@ -359,6 +361,7 @@ spec:
                                   anyOf:
                                   - type: integer
                                   - type: string
+                                  nullable: true
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 description: 'Limits describes the maximum amount
@@ -370,6 +373,7 @@ spec:
                                   anyOf:
                                   - type: integer
                                   - type: string
+                                  nullable: true
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 description: 'Requests describes the minimum amount

--- a/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
@@ -216,6 +216,7 @@ spec:
                                   x-kubernetes-int-or-string: true
                                 description: 'Limits describes the maximum amount
                                   of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                nullable: true
                                 type: object
                               requests:
                                 additionalProperties:
@@ -229,6 +230,7 @@ spec:
                                   for a container, it defaults to Limits if that is
                                   explicitly specified, otherwise to an implementation-defined
                                   value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                nullable: true
                                 type: object
                             type: object
                           tolerations:
@@ -359,6 +361,7 @@ spec:
                                   x-kubernetes-int-or-string: true
                                 description: 'Limits describes the maximum amount
                                   of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                nullable: true
                                 type: object
                               requests:
                                 additionalProperties:
@@ -372,6 +375,7 @@ spec:
                                   for a container, it defaults to Limits if that is
                                   explicitly specified, otherwise to an implementation-defined
                                   value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                nullable: true
                                 type: object
                             type: object
                           tolerations:

--- a/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
@@ -206,6 +206,7 @@ spec:
                           resourceAllocations:
                             description: ResourceAllocations defines the CPU and Memory
                               resource allocations for the restic Pod
+                            nullable: true
                             properties:
                               limits:
                                 additionalProperties:
@@ -351,6 +352,7 @@ spec:
                           resourceAllocations:
                             description: ResourceAllocations defines the CPU and Memory
                               resource allocations for the restic Pod
+                            nullable: true
                             properties:
                               limits:
                                 additionalProperties:

--- a/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
@@ -208,6 +208,7 @@ spec:
                           resourceAllocations:
                             description: ResourceAllocations defines the CPU and Memory
                               resource allocations for the restic Pod
+                            nullable: true
                             properties:
                               limits:
                                 additionalProperties:
@@ -351,6 +352,7 @@ spec:
                           resourceAllocations:
                             description: ResourceAllocations defines the CPU and Memory
                               resource allocations for the restic Pod
+                            nullable: true
                             properties:
                               limits:
                                 additionalProperties:

--- a/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
@@ -219,6 +219,7 @@ spec:
                                   x-kubernetes-int-or-string: true
                                 description: 'Limits describes the maximum amount
                                   of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                nullable: true
                                 type: object
                               requests:
                                 additionalProperties:
@@ -232,6 +233,7 @@ spec:
                                   for a container, it defaults to Limits if that is
                                   explicitly specified, otherwise to an implementation-defined
                                   value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                nullable: true
                                 type: object
                             type: object
                           tolerations:
@@ -363,6 +365,7 @@ spec:
                                   x-kubernetes-int-or-string: true
                                 description: 'Limits describes the maximum amount
                                   of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                nullable: true
                                 type: object
                               requests:
                                 additionalProperties:
@@ -376,6 +379,7 @@ spec:
                                   for a container, it defaults to Limits if that is
                                   explicitly specified, otherwise to an implementation-defined
                                   value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                nullable: true
                                 type: object
                             type: object
                           tolerations:

--- a/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
@@ -215,6 +215,7 @@ spec:
                                   anyOf:
                                   - type: integer
                                   - type: string
+                                  nullable: true
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 description: 'Limits describes the maximum amount
@@ -226,6 +227,7 @@ spec:
                                   anyOf:
                                   - type: integer
                                   - type: string
+                                  nullable: true
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 description: 'Requests describes the minimum amount
@@ -361,6 +363,7 @@ spec:
                                   anyOf:
                                   - type: integer
                                   - type: string
+                                  nullable: true
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 description: 'Limits describes the maximum amount
@@ -372,6 +375,7 @@ spec:
                                   anyOf:
                                   - type: integer
                                   - type: string
+                                  nullable: true
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 description: 'Requests describes the minimum amount


### PR DESCRIPTION
This change allows for null resource allocations fields.

**NOTE** this includes a manual update to the DPA CRD to allow for `null` requests and allocations fields. This means that `make manifests` will no longer give us exactly what we need and will require folks to constantly add it back in. We need to figure out a better path forward for this.
[OADP-535](https://issues.redhat.com//browse/OADP-535)