### PR TITLE
OADP-552: Add privileged pod security labels to operator namespace

### DIFF
--- a/bundle/manifests/oadp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/oadp-operator.clusterserviceversion.yaml
@@ -582,6 +582,17 @@ spec:
                 - update
                 - watch
             - apiGroups:
+                - ""
+              resources:
+                - namespaces
+              verbs:
+                - list
+                - get
+                - create
+                - patch
+                - update
+                - watch
+            - apiGroups:
                 - apps
               resources:
                 - deployments

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -161,6 +161,17 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - list
+  - get
+  - create
+  - patch
+  - update
+  - watch
+- apiGroups:
   - apps
   resources:
   - deployments

--- a/main.go
+++ b/main.go
@@ -184,7 +184,12 @@ func getWatchNamespace() (string, error) {
 
 // setting privileged pod security labels to OADP operator namespace
 func addPodSecurityPriviledgedLabels(watchNamespaceName string) error {
-	setupLog.Info("patching namespace with PSA labels")
+	setupLog.Info("patching operator namespace with PSA labels")
+
+	if len(watchNamespaceName) == 0 {
+		return fmt.Errorf("cannot add privileged pod security labels, watchNamespaceName is empty")
+	}
+
 	kubeconf := ctrl.GetConfigOrDie()
 	clientset, err := kubernetes.NewForConfig(kubeconf)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -82,7 +82,7 @@ func main() {
 	}
 
 	// setting privileged pod security labels to operator ns
-	err = addPodSecurityPriviledgedLabels(watchNamespace)
+	err = addPodSecurityPrivilegedLabels(watchNamespace)
 	if err != nil {
 		setupLog.Error(err, "error setting privileged pod security labels to operator namespace")
 		os.Exit(1)
@@ -183,7 +183,7 @@ func getWatchNamespace() (string, error) {
 }
 
 // setting privileged pod security labels to OADP operator namespace
-func addPodSecurityPriviledgedLabels(watchNamespaceName string) error {
+func addPodSecurityPrivilegedLabels(watchNamespaceName string) error {
 	setupLog.Info("patching operator namespace with PSA labels")
 
 	if len(watchNamespaceName) == 0 {


### PR DESCRIPTION
This PR adds the privileged pod security labels to the OADP operator ns, these are need for OADP Operator to work properly on OCP 4.11

Ref PRs: 
https://github.com/konveyor/mig-operator/pull/838
https://github.com/openshift/cluster-kube-apiserver-operator/pull/1234