### PR TITLE
OADP-607: Rectify operator permissions

### DIFF
--- a/bundle/manifests/oadp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/oadp-operator.clusterserviceversion.yaml
@@ -464,6 +464,7 @@ spec:
                 - patch
                 - update
                 - watch
+                - deletecollection
             - apiGroups:
                 - snapshot.storage.k8s.io
               resources:
@@ -476,7 +477,6 @@ spec:
                 - patch
                 - update
                 - watch
-                - deletecollection
             - apiGroups:
                 - coordination.k8s.io
                 - corev1


### PR DESCRIPTION
The permissions in CSV did not match the permissions specified in role.yaml, this PR rectifies the issue.