### PR TITLE
Update storageclass apigroup in csv

### DIFF
--- a/bundle/manifests/oadp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/oadp-operator.clusterserviceversion.yaml
@@ -469,6 +469,16 @@ spec:
                 - snapshot.storage.k8s.io
               resources:
                 - volumesnapshotclasses
+              verbs:
+                - create
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - storage.k8s.io
+              resources:
                 - storageclasses
               verbs:
                 - create

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -45,17 +45,27 @@ rules:
   - watch
   - deletecollection
 - apiGroups:
-    - snapshot.storage.k8s.io
+  - snapshot.storage.k8s.io
   resources:
-    - volumesnapshotclasses
-    - storageclasses
+  - volumesnapshotclasses
   verbs:
-    - create
-    - get
-    - list
-    - patch
-    - update
-    - watch
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - coordination.k8s.io
   - corev1


### PR DESCRIPTION
Fixes the Failed to watch error logs
```
Failed to watch *v1.StorageClass: unknown (get storageclasses.storage.k8s.io)
```
Fixes https://github.com/konveyor/volume-snapshot-mover/issues/120