### PR TITLE
OADP-648 Don't set default pod resource limits

### DIFF
--- a/controllers/restic_test.go
+++ b/controllers/restic_test.go
@@ -3,10 +3,11 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"os"
 	"reflect"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 
@@ -213,10 +214,6 @@ func TestDPAReconciler_buildResticDaemonset(t *testing.T) {
 										},
 									},
 									Resources: corev1.ResourceRequirements{
-										Limits: corev1.ResourceList{
-											corev1.ResourceCPU:    resource.MustParse("1"),
-											corev1.ResourceMemory: resource.MustParse("512Mi"),
-										},
 										Requests: corev1.ResourceList{
 											corev1.ResourceCPU:    resource.MustParse("500m"),
 											corev1.ResourceMemory: resource.MustParse("128Mi"),
@@ -359,10 +356,6 @@ func TestDPAReconciler_buildResticDaemonset(t *testing.T) {
 										},
 									},
 									Resources: corev1.ResourceRequirements{
-										Limits: corev1.ResourceList{
-											corev1.ResourceCPU:    resource.MustParse("1"),
-											corev1.ResourceMemory: resource.MustParse("512Mi"),
-										},
 										Requests: corev1.ResourceList{
 											corev1.ResourceCPU:    resource.MustParse("500m"),
 											corev1.ResourceMemory: resource.MustParse("128Mi"),
@@ -546,10 +539,6 @@ func TestDPAReconciler_buildResticDaemonset(t *testing.T) {
 										},
 									},
 									Resources: corev1.ResourceRequirements{
-										Limits: corev1.ResourceList{
-											corev1.ResourceCPU:    resource.MustParse("1"),
-											corev1.ResourceMemory: resource.MustParse("512Mi"),
-										},
 										Requests: corev1.ResourceList{
 											corev1.ResourceCPU:    resource.MustParse("500m"),
 											corev1.ResourceMemory: resource.MustParse("128Mi"),
@@ -886,8 +875,7 @@ func TestDPAReconciler_buildResticDaemonset(t *testing.T) {
 									},
 									Resources: corev1.ResourceRequirements{
 										Limits: corev1.ResourceList{
-											corev1.ResourceCPU:    resource.MustParse("2"),
-											corev1.ResourceMemory: resource.MustParse("512Mi"),
+											corev1.ResourceCPU: resource.MustParse("2"),
 										},
 										Requests: corev1.ResourceList{
 											corev1.ResourceCPU:    resource.MustParse("500m"),
@@ -1052,10 +1040,6 @@ func TestDPAReconciler_buildResticDaemonset(t *testing.T) {
 										},
 									},
 									Resources: corev1.ResourceRequirements{
-										Limits: corev1.ResourceList{
-											corev1.ResourceCPU:    resource.MustParse("1"),
-											corev1.ResourceMemory: resource.MustParse("512Mi"),
-										},
 										Requests: corev1.ResourceList{
 											corev1.ResourceCPU:    resource.MustParse("2"),
 											corev1.ResourceMemory: resource.MustParse("128Mi"),
@@ -1220,7 +1204,6 @@ func TestDPAReconciler_buildResticDaemonset(t *testing.T) {
 									},
 									Resources: corev1.ResourceRequirements{
 										Limits: corev1.ResourceList{
-											corev1.ResourceCPU:    resource.MustParse("1"),
 											corev1.ResourceMemory: resource.MustParse("256Mi"),
 										},
 										Requests: corev1.ResourceList{
@@ -1386,10 +1369,6 @@ func TestDPAReconciler_buildResticDaemonset(t *testing.T) {
 										},
 									},
 									Resources: corev1.ResourceRequirements{
-										Limits: corev1.ResourceList{
-											corev1.ResourceCPU:    resource.MustParse("1"),
-											corev1.ResourceMemory: resource.MustParse("512Mi"),
-										},
 										Requests: corev1.ResourceList{
 											corev1.ResourceCPU:    resource.MustParse("500m"),
 											corev1.ResourceMemory: resource.MustParse("256Mi"),
@@ -1557,10 +1536,6 @@ func TestDPAReconciler_buildResticDaemonset(t *testing.T) {
 										},
 									},
 									Resources: corev1.ResourceRequirements{
-										Limits: corev1.ResourceList{
-											corev1.ResourceCPU:    resource.MustParse("1"),
-											corev1.ResourceMemory: resource.MustParse("512Mi"),
-										},
 										Requests: corev1.ResourceList{
 											corev1.ResourceCPU:    resource.MustParse("500m"),
 											corev1.ResourceMemory: resource.MustParse("128Mi"),
@@ -1713,10 +1688,6 @@ func TestDPAReconciler_buildResticDaemonset(t *testing.T) {
 										},
 									},
 									Resources: corev1.ResourceRequirements{
-										Limits: corev1.ResourceList{
-											corev1.ResourceCPU:    resource.MustParse("1"),
-											corev1.ResourceMemory: resource.MustParse("512Mi"),
-										},
 										Requests: corev1.ResourceList{
 											corev1.ResourceCPU:    resource.MustParse("500m"),
 											corev1.ResourceMemory: resource.MustParse("128Mi"),
@@ -1882,10 +1853,6 @@ func TestDPAReconciler_buildResticDaemonset(t *testing.T) {
 										},
 									},
 									Resources: corev1.ResourceRequirements{
-										Limits: corev1.ResourceList{
-											corev1.ResourceCPU:    resource.MustParse("1"),
-											corev1.ResourceMemory: resource.MustParse("512Mi"),
-										},
 										Requests: corev1.ResourceList{
 											corev1.ResourceCPU:    resource.MustParse("500m"),
 											corev1.ResourceMemory: resource.MustParse("128Mi"),
@@ -2086,10 +2053,6 @@ func TestDPAReconciler_buildResticDaemonset(t *testing.T) {
 										},
 									},
 									Resources: corev1.ResourceRequirements{
-										Limits: corev1.ResourceList{
-											corev1.ResourceCPU:    resource.MustParse("1"),
-											corev1.ResourceMemory: resource.MustParse("512Mi"),
-										},
 										Requests: corev1.ResourceList{
 											corev1.ResourceCPU:    resource.MustParse("500m"),
 											corev1.ResourceMemory: resource.MustParse("128Mi"),

--- a/controllers/velero.go
+++ b/controllers/velero.go
@@ -668,10 +668,6 @@ func (r *DPAReconciler) getVeleroResourceReqs(dpa *oadpv1alpha1.DataProtectionAp
 
 	// Set default values
 	ResourcesReqs := corev1.ResourceRequirements{
-		Limits: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("1"),
-			corev1.ResourceMemory: resource.MustParse("512Mi"),
-		},
 		Requests: corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("500m"),
 			corev1.ResourceMemory: resource.MustParse("128Mi"),
@@ -697,6 +693,9 @@ func (r *DPAReconciler) getVeleroResourceReqs(dpa *oadpv1alpha1.DataProtectionAp
 		}
 
 		if dpa.Spec.Configuration.Velero.PodConfig.ResourceAllocations.Limits.Cpu() != nil && dpa.Spec.Configuration.Velero.PodConfig.ResourceAllocations.Limits.Cpu().Value() != 0 {
+			if ResourcesReqs.Limits == nil {
+				ResourcesReqs.Limits = corev1.ResourceList{}
+			}
 			parsedQuantity, err := resource.ParseQuantity(dpa.Spec.Configuration.Velero.PodConfig.ResourceAllocations.Limits.Cpu().String())
 			ResourcesReqs.Limits[corev1.ResourceCPU] = parsedQuantity
 			if err != nil {
@@ -705,6 +704,9 @@ func (r *DPAReconciler) getVeleroResourceReqs(dpa *oadpv1alpha1.DataProtectionAp
 		}
 
 		if dpa.Spec.Configuration.Velero.PodConfig.ResourceAllocations.Limits.Memory() != nil && dpa.Spec.Configuration.Velero.PodConfig.ResourceAllocations.Limits.Memory().Value() != 0 {
+			if ResourcesReqs.Limits == nil {
+				ResourcesReqs.Limits = corev1.ResourceList{}
+			}
 			parsedQuantiy, err := resource.ParseQuantity(dpa.Spec.Configuration.Velero.PodConfig.ResourceAllocations.Limits.Memory().String())
 			ResourcesReqs.Limits[corev1.ResourceMemory] = parsedQuantiy
 			if err != nil {
@@ -722,10 +724,6 @@ func (r *DPAReconciler) getResticResourceReqs(dpa *oadpv1alpha1.DataProtectionAp
 
 	// Set default values
 	ResourcesReqs := corev1.ResourceRequirements{
-		Limits: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("1"),
-			corev1.ResourceMemory: resource.MustParse("512Mi"),
-		},
 		Requests: corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("500m"),
 			corev1.ResourceMemory: resource.MustParse("128Mi"),
@@ -751,6 +749,9 @@ func (r *DPAReconciler) getResticResourceReqs(dpa *oadpv1alpha1.DataProtectionAp
 		}
 
 		if dpa.Spec.Configuration.Restic.PodConfig.ResourceAllocations.Limits.Cpu() != nil && dpa.Spec.Configuration.Restic.PodConfig.ResourceAllocations.Limits.Cpu().Value() != 0 {
+			if ResourcesReqs.Limits == nil {
+				ResourcesReqs.Limits = corev1.ResourceList{}
+			}
 			parsedQuantity, err := resource.ParseQuantity(dpa.Spec.Configuration.Restic.PodConfig.ResourceAllocations.Limits.Cpu().String())
 			ResourcesReqs.Limits[corev1.ResourceCPU] = parsedQuantity
 			if err != nil {
@@ -759,6 +760,9 @@ func (r *DPAReconciler) getResticResourceReqs(dpa *oadpv1alpha1.DataProtectionAp
 		}
 
 		if dpa.Spec.Configuration.Restic.PodConfig.ResourceAllocations.Limits.Memory() != nil && dpa.Spec.Configuration.Restic.PodConfig.ResourceAllocations.Limits.Memory().Value() != 0 {
+			if ResourcesReqs.Limits == nil {
+				ResourcesReqs.Limits = corev1.ResourceList{}
+			}
 			parsedQuantiy, err := resource.ParseQuantity(dpa.Spec.Configuration.Restic.PodConfig.ResourceAllocations.Limits.Memory().String())
 			ResourcesReqs.Limits[corev1.ResourceMemory] = parsedQuantiy
 			if err != nil {

--- a/controllers/velero_test.go
+++ b/controllers/velero_test.go
@@ -172,10 +172,6 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 										},
 									},
 									Resources: corev1.ResourceRequirements{
-										Limits: corev1.ResourceList{
-											corev1.ResourceCPU:    resource.MustParse("1"),
-											corev1.ResourceMemory: resource.MustParse("512Mi"),
-										},
 										Requests: corev1.ResourceList{
 											corev1.ResourceCPU:    resource.MustParse("500m"),
 											corev1.ResourceMemory: resource.MustParse("128Mi"),
@@ -351,10 +347,6 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 										},
 									},
 									Resources: corev1.ResourceRequirements{
-										Limits: corev1.ResourceList{
-											corev1.ResourceCPU:    resource.MustParse("1"),
-											corev1.ResourceMemory: resource.MustParse("512Mi"),
-										},
 										Requests: corev1.ResourceList{
 											corev1.ResourceCPU:    resource.MustParse("500m"),
 											corev1.ResourceMemory: resource.MustParse("128Mi"),
@@ -659,10 +651,6 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 										},
 									},
 									Resources: corev1.ResourceRequirements{
-										Limits: corev1.ResourceList{
-											corev1.ResourceCPU:    resource.MustParse("1"),
-											corev1.ResourceMemory: resource.MustParse("512Mi"),
-										},
 										Requests: corev1.ResourceList{
 											corev1.ResourceCPU:    resource.MustParse("500m"),
 											corev1.ResourceMemory: resource.MustParse("128Mi"),
@@ -848,10 +836,6 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 										},
 									},
 									Resources: corev1.ResourceRequirements{
-										Limits: corev1.ResourceList{
-											corev1.ResourceCPU:    resource.MustParse("1"),
-											corev1.ResourceMemory: resource.MustParse("512Mi"),
-										},
 										Requests: corev1.ResourceList{
 											corev1.ResourceCPU:    resource.MustParse("500m"),
 											corev1.ResourceMemory: resource.MustParse("128Mi"),
@@ -1064,10 +1048,6 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 										},
 									},
 									Resources: corev1.ResourceRequirements{
-										Limits: corev1.ResourceList{
-											corev1.ResourceCPU:    resource.MustParse("1"),
-											corev1.ResourceMemory: resource.MustParse("512Mi"),
-										},
 										Requests: corev1.ResourceList{
 											corev1.ResourceCPU:    resource.MustParse("500m"),
 											corev1.ResourceMemory: resource.MustParse("128Mi"),
@@ -1479,8 +1459,7 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 									},
 									Resources: corev1.ResourceRequirements{
 										Limits: corev1.ResourceList{
-											corev1.ResourceCPU:    resource.MustParse("2"),
-											corev1.ResourceMemory: resource.MustParse("512Mi"),
+											corev1.ResourceCPU: resource.MustParse("2"),
 										},
 										Requests: corev1.ResourceList{
 											corev1.ResourceCPU:    resource.MustParse("500m"),
@@ -1663,10 +1642,6 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 										},
 									},
 									Resources: corev1.ResourceRequirements{
-										Limits: corev1.ResourceList{
-											corev1.ResourceCPU:    resource.MustParse("1"),
-											corev1.ResourceMemory: resource.MustParse("512Mi"),
-										},
 										Requests: corev1.ResourceList{
 											corev1.ResourceCPU:    resource.MustParse("2"),
 											corev1.ResourceMemory: resource.MustParse("128Mi"),
@@ -1848,10 +1823,6 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 										},
 									},
 									Resources: corev1.ResourceRequirements{
-										Limits: corev1.ResourceList{
-											corev1.ResourceCPU:    resource.MustParse("1"),
-											corev1.ResourceMemory: resource.MustParse("512Mi"),
-										},
 										Requests: corev1.ResourceList{
 											corev1.ResourceCPU:    resource.MustParse("500m"),
 											corev1.ResourceMemory: resource.MustParse("256Mi"),
@@ -2034,7 +2005,6 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 									},
 									Resources: corev1.ResourceRequirements{
 										Limits: corev1.ResourceList{
-											corev1.ResourceCPU:    resource.MustParse("1"),
 											corev1.ResourceMemory: resource.MustParse("128Mi"),
 										},
 										Requests: corev1.ResourceList{
@@ -2612,10 +2582,6 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 										},
 									},
 									Resources: corev1.ResourceRequirements{
-										Limits: corev1.ResourceList{
-											corev1.ResourceCPU:    resource.MustParse("1"),
-											corev1.ResourceMemory: resource.MustParse("512Mi"),
-										},
 										Requests: corev1.ResourceList{
 											corev1.ResourceCPU:    resource.MustParse("500m"),
 											corev1.ResourceMemory: resource.MustParse("128Mi"),
@@ -2821,10 +2787,6 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 										},
 									},
 									Resources: corev1.ResourceRequirements{
-										Limits: corev1.ResourceList{
-											corev1.ResourceCPU:    resource.MustParse("1"),
-											corev1.ResourceMemory: resource.MustParse("512Mi"),
-										},
 										Requests: corev1.ResourceList{
 											corev1.ResourceCPU:    resource.MustParse("500m"),
 											corev1.ResourceMemory: resource.MustParse("128Mi"),
@@ -3047,10 +3009,6 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 										},
 									},
 									Resources: corev1.ResourceRequirements{
-										Limits: corev1.ResourceList{
-											corev1.ResourceCPU:    resource.MustParse("1"),
-											corev1.ResourceMemory: resource.MustParse("512Mi"),
-										},
 										Requests: corev1.ResourceList{
 											corev1.ResourceCPU:    resource.MustParse("500m"),
 											corev1.ResourceMemory: resource.MustParse("128Mi"),
@@ -3291,10 +3249,6 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 										},
 									},
 									Resources: corev1.ResourceRequirements{
-										Limits: corev1.ResourceList{
-											corev1.ResourceCPU:    resource.MustParse("1"),
-											corev1.ResourceMemory: resource.MustParse("512Mi"),
-										},
 										Requests: corev1.ResourceList{
 											corev1.ResourceCPU:    resource.MustParse("500m"),
 											corev1.ResourceMemory: resource.MustParse("128Mi"),
@@ -3517,10 +3471,6 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 										},
 									},
 									Resources: corev1.ResourceRequirements{
-										Limits: corev1.ResourceList{
-											corev1.ResourceCPU:    resource.MustParse("1"),
-											corev1.ResourceMemory: resource.MustParse("512Mi"),
-										},
 										Requests: corev1.ResourceList{
 											corev1.ResourceCPU:    resource.MustParse("500m"),
 											corev1.ResourceMemory: resource.MustParse("128Mi"),

--- a/docs/config/resource_req_limits.md
+++ b/docs/config/resource_req_limits.md
@@ -48,10 +48,9 @@ pod(s) is:
 
   ```
   resources:
-    limits:
-      cpu: "1"
-      memory: 256Mi
     requests:
       cpu: 500m
       memory: 128Mi
   ```
+
+This differs from upstream Velero/Restic pod(s) in that the default resources which [has resource limits as well as resource requests](https://velero.io/docs/v1.9/customize-installation/#customize-resource-requests-and-limits).


### PR DESCRIPTION
[OADP-648](https://issues.redhat.com//browse/OADP-648)

We want to leave empty the resource limits to prevent a user from failing backups/restores due to these limits and they can always adjust as necessary.