### PR TITLE
OADP-708, OADP-1526 validate secret names in BSL and VSL, remove required default VSL secret if no VSL.

### DIFF
--- a/api/v1alpha1/oadp_types.go
+++ b/api/v1alpha1/oadp_types.go
@@ -267,6 +267,15 @@ func (dpa *DataProtectionApplication) BackupImages() bool {
 	return dpa.Spec.BackupImages == nil || *dpa.Spec.BackupImages
 }
 
+func (veleroConfig *VeleroConfig) HasFeatureFlag(flag string) bool {
+	for _, featureFlag := range veleroConfig.FeatureFlags {
+		if featureFlag == flag {
+			return true
+		}
+	}
+	return false
+}
+
 func init() {
 	SchemeBuilder.Register(&DataProtectionApplication{}, &DataProtectionApplicationList{}, &CloudStorage{}, &CloudStorageList{})
 }

--- a/controllers/validator.go
+++ b/controllers/validator.go
@@ -3,10 +3,13 @@ package controllers
 import (
 	"errors"
 	"fmt"
+	"strings"
+
+	"time"
+
 	"github.com/go-logr/logr"
 	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
 	"github.com/openshift/oadp-operator/pkg/credentials"
-	"time"
 )
 
 func (r *DPAReconciler) ValidateDataProtectionCR(log logr.Logger) (bool, error) {
@@ -92,22 +95,42 @@ func (r *DPAReconciler) ValidateVeleroPlugins(log logr.Logger) (bool, error) {
 		return false, err
 	}
 
-	var defaultPlugin oadpv1alpha1.DefaultPlugin
-	for _, plugin := range dpa.Spec.Configuration.Velero.DefaultPlugins {
+	snapshotLocationsProviders := make(map[string]bool)
+	for _, location := range dpa.Spec.SnapshotLocations {
+		if location.Velero != nil {
+			provider := strings.TrimPrefix(location.Velero.Provider, veleroIOPrefix)
+			snapshotLocationsProviders[provider] = true
+		}
+	}
 
+	for _, plugin := range dpa.Spec.Configuration.Velero.DefaultPlugins {
 		pluginSpecificMap, ok := credentials.PluginSpecificFields[plugin]
 		pluginNeedsCheck, foundInBSLorVSL := providerNeedsDefaultCreds[string(plugin)]
 
 		if !foundInBSLorVSL && !hasCloudStorage {
 			pluginNeedsCheck = true
 		}
-
 		if ok && pluginSpecificMap.IsCloudProvider && pluginNeedsCheck && !dpa.Spec.Configuration.Velero.NoDefaultBackupLocation {
-			secretName := pluginSpecificMap.SecretName
-			_, err := r.getProviderSecret(secretName)
-			if err != nil {
-				r.Log.Info(fmt.Sprintf("error validating %s provider secret:  %s/%s", defaultPlugin, r.NamespacedName.Namespace, secretName))
-				return false, err
+			secretNamesToValidate := []string{}
+			// check specified credentials in backup locations exists in the cluster
+			for _, location := range dpa.Spec.BackupLocations {
+				if location.Velero != nil {
+					provider := strings.TrimPrefix(location.Velero.Provider, veleroIOPrefix)
+					if provider == string(plugin) && location.Velero != nil && location.Velero.Credential != nil {
+						secretNamesToValidate = append(secretNamesToValidate, location.Velero.Credential.Name)
+					}
+				}
+			}
+			// check for default secret name if dpa has snapshotLocations
+			if foundInVSL := snapshotLocationsProviders[string(plugin)]; foundInVSL {
+				secretNamesToValidate = append(secretNamesToValidate, pluginSpecificMap.SecretName)
+			}
+			for _, secretName := range secretNamesToValidate {
+				_, err := r.getProviderSecret(secretName)
+				if err != nil {
+					r.Log.Info(fmt.Sprintf("error validating %s provider secret:  %s/%s", string(plugin), r.NamespacedName.Namespace, secretName))
+					return false, err
+				}
 			}
 		}
 	}

--- a/controllers/validator.go
+++ b/controllers/validator.go
@@ -81,6 +81,9 @@ func (r *DPAReconciler) ValidateDataProtectionCR(log logr.Logger) (bool, error) 
 	return true, nil
 }
 
+// empty struct to use as map value
+type empty struct{}
+
 // For later: Move this code into validator.go when more need for validation arises
 // TODO: if multiple default plugins exist, ensure we validate all of them.
 // Right now its sequential validation
@@ -111,21 +114,25 @@ func (r *DPAReconciler) ValidateVeleroPlugins(log logr.Logger) (bool, error) {
 			pluginNeedsCheck = true
 		}
 		if ok && pluginSpecificMap.IsCloudProvider && pluginNeedsCheck && !dpa.Spec.Configuration.Velero.NoDefaultBackupLocation {
-			secretNamesToValidate := []string{}
+			secretNamesToValidate := make(map[string]empty)
 			// check specified credentials in backup locations exists in the cluster
 			for _, location := range dpa.Spec.BackupLocations {
 				if location.Velero != nil {
 					provider := strings.TrimPrefix(location.Velero.Provider, veleroIOPrefix)
-					if provider == string(plugin) && location.Velero != nil && location.Velero.Credential != nil {
-						secretNamesToValidate = append(secretNamesToValidate, location.Velero.Credential.Name)
+					if provider == string(plugin) && location.Velero != nil {
+						if location.Velero.Credential != nil {
+							secretNamesToValidate[location.Velero.Credential.Name] = empty{}
+						} else {
+							secretNamesToValidate[pluginSpecificMap.SecretName] = empty{}
+						}
 					}
 				}
 			}
 			// check for default secret name if dpa has snapshotLocations
 			if foundInVSL := snapshotLocationsProviders[string(plugin)]; foundInVSL {
-				secretNamesToValidate = append(secretNamesToValidate, pluginSpecificMap.SecretName)
+				secretNamesToValidate[pluginSpecificMap.SecretName] = empty{}
 			}
-			for _, secretName := range secretNamesToValidate {
+			for secretName, _ := range secretNamesToValidate {
 				_, err := r.getProviderSecret(secretName)
 				if err != nil {
 					r.Log.Info(fmt.Sprintf("error validating %s provider secret:  %s/%s", string(plugin), r.NamespacedName.Namespace, secretName))

--- a/controllers/validator.go
+++ b/controllers/validator.go
@@ -113,7 +113,7 @@ func (r *DPAReconciler) ValidateVeleroPlugins(log logr.Logger) (bool, error) {
 		if !foundInBSLorVSL && !hasCloudStorage {
 			pluginNeedsCheck = true
 		}
-		if ok && pluginSpecificMap.IsCloudProvider && pluginNeedsCheck && !dpa.Spec.Configuration.Velero.NoDefaultBackupLocation {
+		if ok && pluginSpecificMap.IsCloudProvider && pluginNeedsCheck && !dpa.Spec.Configuration.Velero.NoDefaultBackupLocation && !dpa.Spec.Configuration.Velero.HasFeatureFlag("no-secret") {
 			secretNamesToValidate := make(map[string]empty)
 			// check specified credentials in backup locations exists in the cluster
 			for _, location := range dpa.Spec.BackupLocations {

--- a/controllers/validator_test.go
+++ b/controllers/validator_test.go
@@ -1,8 +1,9 @@
 package controllers
 
 import (
-	"k8s.io/apimachinery/pkg/api/resource"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/go-logr/logr"
 	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
@@ -515,8 +516,8 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 				},
 			},
 			objects: []client.Object{},
-			wantErr: true,
-			want:    false,
+			wantErr: false,
+			want:    true,
 		},
 		{
 			name: "given valid DPA CR VSL configured and GCP Default Plugin without secret",
@@ -622,7 +623,56 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 			want:    false,
 		},
 		{
-			name: "given valid DPA CR AWS Default Plugin with credentials and a VSL",
+			name: "given valid DPA CR AWS Default Plugin with credentials and a VSL, and default secret specified, passes",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-DPA-CR",
+					Namespace: "test-ns",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					BackupLocations: []oadpv1alpha1.BackupLocation{
+						{
+							Velero: &v1.BackupStorageLocationSpec{
+								Provider: "velero.io/aws",
+								Credential: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "cloud-credentials",
+									},
+									Key:      "cloud",
+									Optional: new(bool),
+								},
+							},
+						},
+					},
+					SnapshotLocations: []oadpv1alpha1.SnapshotLocation{
+						{
+							Velero: &v1.VolumeSnapshotLocationSpec{
+								Provider: "velero.io/aws",
+							},
+						},
+					},
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{
+							DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
+								oadpv1alpha1.DefaultPluginAWS,
+							},
+						},
+					},
+				},
+			},
+			objects: []client.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cloud-credentials",
+						Namespace: "test-ns",
+					},
+				},
+			},
+			wantErr: false,
+			want:    true,
+		},
+		{
+			name: "given valid DPA CR AWS Default Plugin with credentials and a VSL, and without secret in cluster, fails",
 			dpa: &oadpv1alpha1.DataProtectionApplication{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-DPA-CR",
@@ -660,8 +710,8 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 				},
 			},
 			objects: []client.Object{},
-			wantErr: false,
-			want:    true,
+			wantErr: true,
+			want:    false,
 		},
 	}
 	for _, tt := range tests {

--- a/controllers/validator_test.go
+++ b/controllers/validator_test.go
@@ -515,7 +515,14 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 					},
 				},
 			},
-			objects: []client.Object{},
+			objects: []client.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cloud-credentials-gcp",
+						Namespace: "test-ns",
+					},
+				},
+			},
 			wantErr: false,
 			want:    true,
 		},

--- a/controllers/validator_test.go
+++ b/controllers/validator_test.go
@@ -492,7 +492,7 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 			want:    true,
 		},
 		{
-			name: "given valid DPA CR BSL configured and GCP Default Plugin without secret",
+			name: "given valid DPA CR BSL configured and GCP Default Plugin with secret",
 			dpa: &oadpv1alpha1.DataProtectionApplication{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-DPA-CR",
@@ -525,6 +525,64 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 			},
 			wantErr: false,
 			want:    true,
+		},
+		{
+			name: "given valid DPA CR BSL configured and GCP Default Plugin without secret with no-secret feature flag",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-DPA-CR",
+					Namespace: "test-ns",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					BackupLocations: []oadpv1alpha1.BackupLocation{
+						{
+							Velero: &v1.BackupStorageLocationSpec{
+								Provider: "velero.io/gcp",
+							},
+						},
+					},
+
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{
+							DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
+								oadpv1alpha1.DefaultPluginGCP,
+							},
+							FeatureFlags: []string{"no-secret"},
+						},
+					},
+				},
+			},
+			objects: []client.Object{},
+			wantErr: false,
+			want:    true,
+		},
+		{
+			name: "should error: given valid DPA CR BSL configured and GCP Default Plugin without secret without no-secret feature flag",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-DPA-CR",
+					Namespace: "test-ns",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					BackupLocations: []oadpv1alpha1.BackupLocation{
+						{
+							Velero: &v1.BackupStorageLocationSpec{
+								Provider: "velero.io/gcp",
+							},
+						},
+					},
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{
+							DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
+								oadpv1alpha1.DefaultPluginGCP,
+							},
+						},
+					},
+				},
+			},
+			objects: []client.Object{},
+			wantErr: true,
+			want:    false,
 		},
 		{
 			name: "given valid DPA CR VSL configured and GCP Default Plugin without secret",

--- a/controllers/velero.go
+++ b/controllers/velero.go
@@ -41,6 +41,7 @@ const (
 	VeleroAzureSecretName = "cloud-credentials-azure"
 	VeleroGCPSecretName   = "cloud-credentials-gcp"
 	enableCSIFeatureFlag  = "EnableCSI"
+	veleroIOPrefix        = "velero.io/"
 )
 
 var (
@@ -726,11 +727,11 @@ func (r DPAReconciler) noDefaultCredentials(dpa oadpv1alpha1.DataProtectionAppli
 	} else {
 		for _, bsl := range dpa.Spec.BackupLocations {
 			if bsl.Velero != nil && bsl.Velero.Credential == nil {
-				bslProvider := strings.TrimPrefix(bsl.Velero.Provider, "velero.io/")
+				bslProvider := strings.TrimPrefix(bsl.Velero.Provider, veleroIOPrefix)
 				providerNeedsDefaultCreds[bslProvider] = true
 			}
 			if bsl.Velero != nil && bsl.Velero.Credential != nil {
-				bslProvider := strings.TrimPrefix(bsl.Velero.Provider, "velero.io/")
+				bslProvider := strings.TrimPrefix(bsl.Velero.Provider, veleroIOPrefix)
 				if found := providerNeedsDefaultCreds[bslProvider]; !found {
 					providerNeedsDefaultCreds[bslProvider] = false
 				}
@@ -753,7 +754,7 @@ func (r DPAReconciler) noDefaultCredentials(dpa oadpv1alpha1.DataProtectionAppli
 		if vsl.Velero != nil {
 			// To handle the case where we want to manually hand the credentials for a cloud storage created
 			// Bucket credentials via configuration. Only AWS is supported
-			provider := strings.TrimPrefix(vsl.Velero.Provider, "velero.io")
+			provider := strings.TrimPrefix(vsl.Velero.Provider, veleroIOPrefix)
 			if vsl.Velero.Credential != nil || provider == string(oadpv1alpha1.AWSBucketProvider) && hasCloudStorage {
 				providerNeedsDefaultCreds[provider] = false
 			} else {

--- a/controllers/velero_test.go
+++ b/controllers/velero_test.go
@@ -3844,7 +3844,7 @@ func Test_validateVeleroPlugins(t *testing.T) {
 			want:    true,
 		},
 		{
-			name: "given invalid Velero secret, the validplugin check fails",
+			name: "given aws default plugin without bsl, the valid plugin check passes",
 			dpa: &oadpv1alpha1.DataProtectionApplication{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-Velero-CR",
@@ -3861,8 +3861,8 @@ func Test_validateVeleroPlugins(t *testing.T) {
 				},
 			},
 			secret:  &corev1.Secret{},
-			wantErr: true,
-			want:    false,
+			wantErr: false,
+			want:    true,
 		},
 	}
 	for _, tt := range tests {

--- a/controllers/vsl.go
+++ b/controllers/vsl.go
@@ -54,7 +54,7 @@ func (r *DPAReconciler) LabelVSLSecrets(log logr.Logger) (bool, error) {
 	}
 
 	for _, vsl := range dpa.Spec.SnapshotLocations {
-		provider := strings.TrimPrefix(vsl.Velero.Provider, "velero.io")
+		provider := strings.TrimPrefix(vsl.Velero.Provider, veleroIOPrefix)
 		switch provider {
 		case "aws":
 			secretName := credentials.PluginSpecificFields[oadpv1alpha1.DefaultPluginAWS].SecretName

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,10 @@ require (
 	sigs.k8s.io/controller-runtime v0.12.2
 )
 
-require github.com/google/go-cmp v0.5.9
+require (
+	github.com/deckarep/golang-set/v2 v2.1.0
+	github.com/google/go-cmp v0.5.9
+)
 
 require (
 	cloud.google.com/go v0.100.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -208,6 +208,8 @@ github.com/dave/rebecca v0.9.1/go.mod h1:N6XYdMD/OKw3lkF3ywh8Z6wPGuwNFDNtWYEMFWE
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/deckarep/golang-set/v2 v2.1.0 h1:g47V4Or+DUdzbs8FxCCmgb6VYd+ptPAngjM6dtGktsI=
+github.com/deckarep/golang-set/v2 v2.1.0/go.mod h1:VAky9rY/yGXJOLEDv3OMci+7wtDpOF4IN+y82NBOac4=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dimchansky/utfbom v1.1.0/go.mod h1:rO41eb7gLfo8SF1jd9F8HplJm1Fewwi4mQvIirEdv+8=


### PR DESCRIPTION
[OADP-708](https://issues.redhat.com//browse/OADP-708)

additionally defined `veleroIOPrefix` const which fixes some typos in TrimPrefixes.

TODO: remove required default secrets validation for VSL, they are now optional.
If secret is defined, check secret exists in cluster during validation