### PR TITLE
e2e: set defaultVolumesToRestic for restic backup, enable restic restore data verification, remove two-phase restore.

### DIFF
--- a/tests/e2e/backup_restore_suite_test.go
+++ b/tests/e2e/backup_restore_suite_test.go
@@ -172,7 +172,7 @@ var _ = Describe("AWS backup restore tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 			// create backup
 			log.Printf("Creating backup %s for case %s", backupName, brCase.Name)
-			backup, err := CreateBackupForNamespaces(dpaCR.Client, namespace, backupName, []string{brCase.ApplicationNamespace})
+			backup, err := CreateBackupForNamespaces(dpaCR.Client, namespace, backupName, []string{brCase.ApplicationNamespace}, brCase.BackupRestoreType == RESTIC)
 			Expect(err).ToNot(HaveOccurred())
 
 			// wait for backup to not be running
@@ -294,7 +294,7 @@ var _ = Describe("AWS backup restore tests", func() {
 			ApplicationNamespace: "mongo-persistent",
 			Name:                 "mongo-restic-e2e",
 			BackupRestoreType:    RESTIC,
-			PreBackupVerify:      mongoready(false, RESTIC),
+			PreBackupVerify:      mongoready(true, RESTIC),
 			PostRestoreVerify:    mongoready(false, RESTIC),
 		}, nil),
 		Entry("MySQL application RESTIC", BackupRestoreCase{
@@ -302,7 +302,7 @@ var _ = Describe("AWS backup restore tests", func() {
 			ApplicationNamespace: "mysql-persistent",
 			Name:                 "mysql-restic-e2e",
 			BackupRestoreType:    RESTIC,
-			PreBackupVerify:      mysqlReady(false, RESTIC),
+			PreBackupVerify:      mysqlReady(true, RESTIC),
 			PostRestoreVerify:    mysqlReady(false, RESTIC),
 		}, nil),
 	)

--- a/tests/e2e/dpa_deployment_suite_test.go
+++ b/tests/e2e/dpa_deployment_suite_test.go
@@ -588,13 +588,13 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 				log.Printf("Checking for bsl spec")
 				for _, bsl := range dpa.Spec.BackupLocations {
 					// Check if bsl matches the spec
-					Eventually(DoesBSLExist(namespace, *bsl.Velero, installCase.DpaSpec), timeoutMultiplier*time.Minute*3, time.Second*5).Should(BeTrue())
+					Expect(DoesBSLSpecMatchesDpa(namespace, *bsl.Velero, installCase.DpaSpec)).To(BeTrue())
 				}
 			}
 			if len(dpa.Spec.SnapshotLocations) > 0 {
 				log.Printf("Checking for vsl spec")
 				for _, vsl := range dpa.Spec.SnapshotLocations {
-					Eventually(DoesVSLExist(namespace, *vsl.Velero, installCase.DpaSpec), timeoutMultiplier*time.Minute*3, time.Second*5).Should(BeTrue())
+					Expect(DoesVSLSpecMatchesDpa(namespace, *vsl.Velero, installCase.DpaSpec)).To(BeTrue())
 				}
 			}
 

--- a/tests/e2e/dpa_deployment_suite_test.go
+++ b/tests/e2e/dpa_deployment_suite_test.go
@@ -21,6 +21,12 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 	provider := Dpa.Spec.BackupLocations[0].Velero.Provider
 	bucket := Dpa.Spec.BackupLocations[0].Velero.ObjectStorage.Bucket
 	bslConfig := Dpa.Spec.BackupLocations[0].Velero.Config
+	bslCredential := corev1.SecretKeySelector{
+		LocalObjectReference: corev1.LocalObjectReference{
+			Name: "bsl-cloud-credentials-" + provider,
+		},
+		Key: "cloud",
+	}
 
 	type InstallCase struct {
 		Name               string
@@ -57,6 +63,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 									Prefix: VeleroPrefix,
 								},
 							},
+							Credential: &bslCredential,
 						},
 					},
 				},
@@ -90,6 +97,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 									Prefix: VeleroPrefix,
 								},
 							},
+							Credential: &bslCredential,
 						},
 					},
 				},
@@ -131,6 +139,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 									Prefix: VeleroPrefix,
 								},
 							},
+							Credential: &bslCredential,
 						},
 					},
 				},
@@ -177,6 +186,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 									Prefix: VeleroPrefix,
 								},
 							},
+							Credential: &bslCredential,
 						},
 					},
 				},
@@ -212,6 +222,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 									Prefix: VeleroPrefix,
 								},
 							},
+							Credential: &bslCredential,
 						},
 					},
 				},
@@ -245,6 +256,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 									Prefix: VeleroPrefix,
 								},
 							},
+							Credential: &bslCredential,
 						},
 					},
 				},
@@ -277,6 +289,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 									Prefix: VeleroPrefix,
 								},
 							},
+							Credential: &bslCredential,
 						},
 					},
 				},
@@ -311,6 +324,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 									Prefix: VeleroPrefix,
 								},
 							},
+							Credential: &bslCredential,
 						},
 					},
 				},
@@ -333,6 +347,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 									Prefix: VeleroPrefix,
 								},
 							},
+							Credential: &bslCredential,
 						},
 					},
 				},
@@ -369,6 +384,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 									Prefix: VeleroPrefix,
 								},
 							},
+							Credential: &bslCredential,
 						},
 					},
 				},
@@ -431,6 +447,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 									Prefix: VeleroPrefix,
 								},
 							},
+							Credential: &bslCredential,
 						},
 					},
 				},
@@ -466,6 +483,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 									Prefix: VeleroPrefix,
 								},
 							},
+							Credential: &bslCredential,
 						},
 					},
 				},
@@ -499,6 +517,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 									Prefix: VeleroPrefix,
 								},
 							},
+							Credential: &bslCredential,
 						},
 					},
 				},
@@ -536,10 +555,15 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 			err := dpaCR.Build(installCase.BRestoreType)
 			Expect(err).NotTo(HaveOccurred())
 			if len(installCase.DpaSpec.BackupLocations) > 0 {
-				if installCase.DpaSpec.BackupLocations[0].Velero.Config != nil {
-					installCase.DpaSpec.BackupLocations[0].Velero.Config["credentialsFile"] = "bsl-cloud-credentials-" + dpaCR.Provider + "/cloud"
-					if installCase.TestCarriageReturn {
-						installCase.DpaSpec.BackupLocations[0].Velero.Config["credentialsFile"] = "bsl-cloud-credentials-" + dpaCR.Provider + "-with-carriage-return/cloud"
+				if installCase.DpaSpec.BackupLocations[0].Velero.Credential == nil {
+					installCase.DpaSpec.BackupLocations[0].Velero.Credential = &bslCredential
+				}
+				if installCase.TestCarriageReturn {
+					installCase.DpaSpec.BackupLocations[0].Velero.Credential = &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "bsl-cloud-credentials-" + dpaCR.Provider + "-with-carriage-return",
+						},
+						Key: bslCredential.Key,
 					}
 				}
 			}

--- a/tests/e2e/lib/apps.go
+++ b/tests/e2e/lib/apps.go
@@ -386,6 +386,10 @@ func VerifyBackupRestoreData(artifact_dir string, namespace string, routeName st
 	//if this is prebackstate = true, add items via makeRequest function. We only want to make request before backup
 	//and ignore post restore checks.
 	if prebackupState {
+		// delete backupFile if it exists
+		if _, err := os.Stat(backupFile); err == nil {
+			os.Remove(backupFile)
+		}
 		//data before curl request
 		dataBeforeCurl, err := getResponseData(appApi + "/todo-incomplete")
 		if err != nil {
@@ -412,7 +416,7 @@ func VerifyBackupRestoreData(artifact_dir string, namespace string, routeName st
 		return err
 	}
 	//Verifying backup-restore data only for CSI as of now.
-	if backupRestoretype == CSI {
+	if backupRestoretype == CSI || backupRestoretype == RESTIC {
 		//check if backupfile exists. If true { compare data response with data from file} (post restore step)
 		//else write data to backup-data.txt (prebackup step)
 		if _, err := os.Stat(backupFile); err == nil {

--- a/tests/e2e/lib/backup.go
+++ b/tests/e2e/lib/backup.go
@@ -11,7 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func CreateBackupForNamespaces(ocClient client.Client, veleroNamespace, backupName string, namespaces []string) (velero.Backup, error) {
+func CreateBackupForNamespaces(ocClient client.Client, veleroNamespace, backupName string, namespaces []string, defaultVolumesToRestic bool) (velero.Backup, error) {
 
 	backup := velero.Backup{
 		ObjectMeta: metav1.ObjectMeta{
@@ -19,7 +19,8 @@ func CreateBackupForNamespaces(ocClient client.Client, veleroNamespace, backupNa
 			Namespace: veleroNamespace,
 		},
 		Spec: velero.BackupSpec{
-			IncludedNamespaces: namespaces,
+			IncludedNamespaces:     namespaces,
+			DefaultVolumesToRestic: &defaultVolumesToRestic,
 		},
 	}
 	err := ocClient.Create(context.Background(), &backup)

--- a/tests/e2e/lib/velero_helpers.go
+++ b/tests/e2e/lib/velero_helpers.go
@@ -243,7 +243,7 @@ func RunResticPostRestoreScript(dcRestoreName string) error {
 		return err
 	}
 	currentDir = strings.TrimSuffix(currentDir, "/tests/e2e")
-	command := exec.Command("bash", currentDir + "/docs/scripts/dc-restic-post-restore.sh", dcRestoreName)
+	command := exec.Command("bash", currentDir+"/docs/scripts/dc-restic-post-restore.sh", dcRestoreName)
 	stdOut, err := command.Output()
 	logger.Printf("command: %s", command.String())
 	logger.Printf("stdout: %s", stdOut)

--- a/tests/e2e/subscription_suite_test.go
+++ b/tests/e2e/subscription_suite_test.go
@@ -8,7 +8,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/openshift/oadp-operator/tests/e2e/lib"
-	utils "github.com/openshift/oadp-operator/tests/e2e/utils"
 	operators "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/pointer"
@@ -28,12 +27,6 @@ var _ = Describe("Subscription Config Suite Test", func() {
 
 		testSuiteInstanceName := "ts-" + instanceName
 		dpaCR.Name = testSuiteInstanceName
-
-		credData, err := utils.ReadFile(credFile)
-		Expect(err).NotTo(HaveOccurred())
-
-		err = CreateCredentialsSecret(credData, namespace, GetSecretRef(credSecretRef))
-		Expect(err).NotTo(HaveOccurred())
 	})
 
 	var _ = AfterEach(func() {


### PR DESCRIPTION
Currently restic backup cases are not setting this value and thus we have not actually verified restic backup of pod volumes are working.

This PR enables restic backup and enable restic restore data verification.
Stopped setting `bsl.spec.config["credentialsFile"]` to avoid https://github.com/vmware-tanzu/velero/issues/5228