### PR TITLE
e2e: Don't create default VolumeSnapshotClass

### DIFF
--- a/tests/e2e/sample-applications/snapclass-csi/aws.yaml
+++ b/tests/e2e/sample-applications/snapclass-csi/aws.yaml
@@ -7,7 +7,5 @@ items:
       name: oadp-example-snapclass
       labels:
         velero.io/csi-volumesnapshot-class: 'true'
-      annotations:
-        snapshot.storage.kubernetes.io/is-default-class: 'true'
     driver: ebs.csi.aws.com
     deletionPolicy: Retain

--- a/tests/e2e/sample-applications/snapclass-csi/azure.yaml
+++ b/tests/e2e/sample-applications/snapclass-csi/azure.yaml
@@ -7,7 +7,5 @@ items:
       name: oadp-example-snapclass
       labels:
         velero.io/csi-volumesnapshot-class: 'true'
-      annotations:
-        snapshot.storage.kubernetes.io/is-default-class: 'true'
     driver: disk.csi.azure.com
     deletionPolicy: Retain

--- a/tests/e2e/sample-applications/snapclass-csi/gcp.yaml
+++ b/tests/e2e/sample-applications/snapclass-csi/gcp.yaml
@@ -7,7 +7,5 @@ items:
       name: oadp-example-snapclass
       labels:
         velero.io/csi-volumesnapshot-class: 'true'
-      annotations:
-        snapshot.storage.kubernetes.io/is-default-class: 'true'
     driver: pd.csi.storage.gke.io
     deletionPolicy: Retain

--- a/tests/e2e/sample-applications/snapclass-csi/ibmcloud.yaml
+++ b/tests/e2e/sample-applications/snapclass-csi/ibmcloud.yaml
@@ -7,8 +7,6 @@ items:
       name: oadp-example-snapclass
       labels:
         velero.io/csi-volumesnapshot-class: 'true'
-      annotations:
-        snapshot.storage.kubernetes.io/is-default-class: 'true'
     driver: openshift-storage.cephfs.csi.ceph.com
     deletionPolicy: Retain
     parameters:


### PR DESCRIPTION
This PR avoids creating duplicate default VolumeSnapshotClass for the purpose of creating Velero CSI snapshots.

VolumeSnapshotClass with a velero label is needed for a target storage driver but it does not need to be default.

Resolves 4.11 VSC create issue.
Unblock https://github.com/openshift/release/pull/31340/