### PR TITLE
e2e: print container logs on failure only, increase app build timeouts

### DIFF
--- a/tests/e2e/backup_restore_suite_test.go
+++ b/tests/e2e/backup_restore_suite_test.go
@@ -180,7 +180,7 @@ var _ = Describe("AWS backup restore tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// wait for backup to not be running
-			Eventually(IsBackupDone(dpaCR.Client, namespace, backupName), timeoutMultiplier*time.Minute*4, time.Second*10).Should(BeTrue())
+			Eventually(IsBackupDone(dpaCR.Client, namespace, backupName), timeoutMultiplier*time.Minute*12, time.Second*10).Should(BeTrue())
 			GinkgoWriter.Println(DescribeBackup(dpaCR.Client, backup))
 			Expect(BackupErrorLogs(dpaCR.Client, backup)).To(Equal([]string{}))
 

--- a/tests/e2e/backup_restore_suite_test.go
+++ b/tests/e2e/backup_restore_suite_test.go
@@ -126,6 +126,10 @@ var _ = Describe("AWS backup restore tests", func() {
 					snapshotClassPath := fmt.Sprintf("./sample-applications/snapclass-csi/%s.yaml", provider)
 					err = InstallApplication(dpaCR.Client, snapshotClassPath)
 					Expect(err).ToNot(HaveOccurred())
+					log.Printf("Creating pvc for case %s", brCase.Name)
+					pvcPath := fmt.Sprintf("./sample-applications/%s/pvc/%s.yaml", brCase.ApplicationNamespace, provider)
+					err = InstallApplication(dpaCR.Client, pvcPath)
+					Expect(err).ToNot(HaveOccurred())
 				}
 
 			}
@@ -140,15 +144,10 @@ var _ = Describe("AWS backup restore tests", func() {
 
 			// install app
 			updateLastInstallingNamespace(brCase.ApplicationNamespace)
+
 			log.Printf("Installing application for case %s", brCase.Name)
 			err = InstallApplication(dpaCR.Client, brCase.ApplicationTemplate)
 			Expect(err).ToNot(HaveOccurred())
-			if brCase.BackupRestoreType == CSI {
-				log.Printf("Creating pvc for case %s", brCase.Name)
-				pvcPath := fmt.Sprintf("./sample-applications/%s/pvc/%s.yaml", brCase.ApplicationNamespace, provider)
-				err = InstallApplication(dpaCR.Client, pvcPath)
-				Expect(err).ToNot(HaveOccurred())
-			}
 
 			// wait for pods to be running
 			Eventually(AreAppBuildsReady(dpaCR.Client, brCase.ApplicationNamespace), timeoutMultiplier*time.Minute*5, time.Second*5).Should(BeTrue())

--- a/tests/e2e/backup_restore_suite_test.go
+++ b/tests/e2e/backup_restore_suite_test.go
@@ -151,7 +151,7 @@ var _ = Describe("AWS backup restore tests", func() {
 			}
 
 			// wait for pods to be running
-			Eventually(AreAppBuildsReady(dpaCR.Client, brCase.ApplicationNamespace), timeoutMultiplier*time.Minute*3, time.Second*5).Should(BeTrue())
+			Eventually(AreAppBuildsReady(dpaCR.Client, brCase.ApplicationNamespace), timeoutMultiplier*time.Minute*5, time.Second*5).Should(BeTrue())
 			Eventually(AreApplicationPodsRunning(brCase.ApplicationNamespace), timeoutMultiplier*time.Minute*9, time.Second*5).Should(BeTrue())
 
 			// Run optional custom verification

--- a/tests/e2e/backup_restore_suite_test.go
+++ b/tests/e2e/backup_restore_suite_test.go
@@ -126,10 +126,6 @@ var _ = Describe("AWS backup restore tests", func() {
 					snapshotClassPath := fmt.Sprintf("./sample-applications/snapclass-csi/%s.yaml", provider)
 					err = InstallApplication(dpaCR.Client, snapshotClassPath)
 					Expect(err).ToNot(HaveOccurred())
-					log.Printf("Creating pvc for case %s", brCase.Name)
-					pvcPath := fmt.Sprintf("./sample-applications/%s/pvc/%s.yaml", brCase.ApplicationNamespace, provider)
-					err = InstallApplication(dpaCR.Client, pvcPath)
-					Expect(err).ToNot(HaveOccurred())
 				}
 
 			}
@@ -144,10 +140,15 @@ var _ = Describe("AWS backup restore tests", func() {
 
 			// install app
 			updateLastInstallingNamespace(brCase.ApplicationNamespace)
-
 			log.Printf("Installing application for case %s", brCase.Name)
 			err = InstallApplication(dpaCR.Client, brCase.ApplicationTemplate)
 			Expect(err).ToNot(HaveOccurred())
+			if brCase.BackupRestoreType == CSI {
+				log.Printf("Creating pvc for case %s", brCase.Name)
+				pvcPath := fmt.Sprintf("./sample-applications/%s/pvc/%s.yaml", brCase.ApplicationNamespace, provider)
+				err = InstallApplication(dpaCR.Client, pvcPath)
+				Expect(err).ToNot(HaveOccurred())
+			}
 
 			// wait for pods to be running
 			Eventually(AreAppBuildsReady(dpaCR.Client, brCase.ApplicationNamespace), timeoutMultiplier*time.Minute*5, time.Second*5).Should(BeTrue())

--- a/tests/e2e/backup_restore_suite_test.go
+++ b/tests/e2e/backup_restore_suite_test.go
@@ -54,16 +54,6 @@ var _ = Describe("AWS backup restore tests", func() {
 		dpaCR.Name = testSuiteInstanceName
 	})
 
-	var _ = AfterEach(func() {
-		GinkgoWriter.Println("Printing velero deployment pod logs")
-		logs, err := GetVeleroContainerLogs(namespace)
-		Expect(err).NotTo(HaveOccurred())
-		GinkgoWriter.Println(logs)
-		GinkgoWriter.Println("End of velero deployment pod logs")
-		err = dpaCR.Delete()
-		Expect(err).ToNot(HaveOccurred())
-
-	})
 	var lastInstallingApplicationNamespace string
 	var lastInstallTime time.Time
 	var _ = ReportAfterEach(func(report SpecReport) {
@@ -72,7 +62,14 @@ var _ = Describe("AWS backup restore tests", func() {
 			if lastInstallingApplicationNamespace != "" {
 				PrintNamespaceEventsAfterTime(lastInstallingApplicationNamespace, lastInstallTime)
 			}
+			GinkgoWriter.Println("Printing velero deployment pod logs")
+			logs, err := GetVeleroContainerLogs(namespace)
+			Expect(err).NotTo(HaveOccurred())
+			GinkgoWriter.Println(logs)
+			GinkgoWriter.Println("End of velero deployment pod logs")
 		}
+		err := dpaCR.Delete()
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	type BackupRestoreCase struct {

--- a/tests/e2e/backup_restore_suite_test.go
+++ b/tests/e2e/backup_restore_suite_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/ginkgo/v2/types"
 	. "github.com/onsi/gomega"
 	. "github.com/openshift/oadp-operator/tests/e2e/lib"
 	corev1 "k8s.io/api/core/v1"
@@ -61,6 +62,11 @@ var _ = Describe("AWS backup restore tests", func() {
 	var lastInstallingApplicationNamespace string
 	var lastInstallTime time.Time
 	var _ = ReportAfterEach(func(report SpecReport) {
+		if report.State == types.SpecStateSkipped {
+			// do not run if the test is skipped
+			return
+		}
+		GinkgoWriter.Println("Report after each: state: ", report.State.String())
 		if report.Failed() {
 			// print namespace error events for app namespace
 			if lastInstallingApplicationNamespace != "" {

--- a/tests/e2e/lib/apps.go
+++ b/tests/e2e/lib/apps.go
@@ -11,10 +11,12 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"reflect"
 	"sort"
 	"strings"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
 	"github.com/onsi/ginkgo/v2"
 	ocpappsv1 "github.com/openshift/api/apps/v1"
@@ -74,15 +76,33 @@ func InstallApplication(ocClient client.Client, file string) error {
 			if err != nil {
 				return err
 			}
-			if resource.Object["kind"] == "VolumeSnapshotClass" {
-				clusterResource.Object["driver"] = resource.Object["driver"]
-				clusterResource.Object["parameters"] = resource.Object["parameters"]
-			} else {
-				clusterResource.Object["spec"] = resource.Object["spec"]
+			if _, metadataExists := clusterResource.Object["metadata"]; metadataExists {
+				// copy generation, resourceVersion, and annotations from the existing resource
+				resource.SetGeneration(clusterResource.GetGeneration())
+				resource.SetResourceVersion(clusterResource.GetResourceVersion())
+				resource.SetUID(clusterResource.GetUID())
+				resource.SetManagedFields(clusterResource.GetManagedFields())
+				resource.SetCreationTimestamp(clusterResource.GetCreationTimestamp())
+				resource.SetDeletionTimestamp(clusterResource.GetDeletionTimestamp())
 			}
-			err = ocClient.Update(context.Background(), &clusterResource)
-			if err != nil {
-				return err
+			needsUpdate := false
+			for key := range clusterResource.Object {
+				if key == "status" {
+					continue
+				}
+				if !reflect.DeepEqual(clusterResource.Object[key], resource.Object[key]) {
+					fmt.Println("diff found for key:", key)
+					ginkgo.GinkgoWriter.Println(cmp.Diff(clusterResource.Object[key], resource.Object[key]))
+					needsUpdate = true
+					clusterResource.Object[key] = resource.Object[key]
+				}
+			}
+			if needsUpdate {
+				fmt.Printf("updating resource: %s; name: %s\n", resource.GetKind(), resource.GetName())
+				err = ocClient.Update(context.Background(), &clusterResource)
+				if err != nil {
+					return err
+				}
 			}
 		} else if err != nil {
 			return err

--- a/tests/e2e/sample-applications/mongo-persistent/pvc/ibmcloud.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/pvc/ibmcloud.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: mongo
+      namespace: mongo-persistent
+      labels:
+        app: mongo
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      storageClassName: ocs-storagecluster-cephfs
+      resources:
+        requests:
+          storage: 1Gi


### PR DESCRIPTION
- remove unnecessary velero container log printing when test entry is skipped.
- resolve build timing outs while waiting for CSI PVC to bound with current 3 minutes in CI.
- resolve using incorrect pvc spec if previous test entry fail.
- added missing ibm pvc template
- backup timeout increase to 12 minutes
- resolve pvc create failure if previous test fail and did not uninstall app namespace