### PR TITLE
e2e: Cherry-pick #790, #801 to oadp-1.1 - enable restic data verification, tuning timeouts, reliability

### DIFF
--- a/tests/e2e/backup_restore_suite_test.go
+++ b/tests/e2e/backup_restore_suite_test.go
@@ -10,7 +10,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/openshift/oadp-operator/tests/e2e/lib"
-	utils "github.com/openshift/oadp-operator/tests/e2e/utils"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -53,11 +52,6 @@ var _ = Describe("AWS backup restore tests", func() {
 	var _ = BeforeEach(func() {
 		testSuiteInstanceName := "ts-" + instanceName
 		dpaCR.Name = testSuiteInstanceName
-
-		credData, err := utils.ReadFile(credFile)
-		Expect(err).NotTo(HaveOccurred())
-		err = CreateCredentialsSecret(credData, namespace, GetSecretRef(credSecretRef))
-		Expect(err).NotTo(HaveOccurred())
 	})
 
 	var _ = AfterEach(func() {
@@ -172,7 +166,7 @@ var _ = Describe("AWS backup restore tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 			// create backup
 			log.Printf("Creating backup %s for case %s", backupName, brCase.Name)
-			backup, err := CreateBackupForNamespaces(dpaCR.Client, namespace, backupName, []string{brCase.ApplicationNamespace})
+			backup, err := CreateBackupForNamespaces(dpaCR.Client, namespace, backupName, []string{brCase.ApplicationNamespace}, brCase.BackupRestoreType == RESTIC)
 			Expect(err).ToNot(HaveOccurred())
 
 			// wait for backup to not be running
@@ -200,52 +194,24 @@ var _ = Describe("AWS backup restore tests", func() {
 			Eventually(IsNamespaceDeleted(brCase.ApplicationNamespace), timeoutMultiplier*time.Minute*2, time.Second*5).Should(BeTrue())
 
 			updateLastInstallingNamespace(brCase.ApplicationNamespace)
-			// Check if backup needs restic deploymentconfig workaround. https://github.com/openshift/oadp-operator/blob/master/docs/TROUBLESHOOTING.md#deployconfig
+			// run restore
+			log.Printf("Creating restore %s for case %s", restoreName, brCase.Name)
+			restore, err := CreateRestoreFromBackup(dpaCR.Client, namespace, backupName, restoreName)
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(IsRestoreDone(dpaCR.Client, namespace, restoreName), timeoutMultiplier*time.Minute*4, time.Second*10).Should(BeTrue())
+			GinkgoWriter.Println(DescribeRestore(dpaCR.Client, restore))
+			Expect(RestoreErrorLogs(dpaCR.Client, restore)).To(Equal([]string{}))
+
+			// Check if restore succeeded
+			succeeded, err = IsRestoreCompletedSuccessfully(dpaCR.Client, namespace, restoreName)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(succeeded).To(Equal(true))
+
 			if brCase.BackupRestoreType == RESTIC && nsRequiresResticDCWorkaround {
-				log.Printf("DC found in backup namespace, using DC restic workaround")
-				var dcWorkaroundResources = []string{"replicationcontroller", "deploymentconfig", "templateinstances.template.openshift.io"}
-				// run restore
-				log.Printf("Creating restore %s excluding DC workaround resources for case %s", restoreName, brCase.Name)
-				noDcDrestoreName := fmt.Sprintf("%s-no-dc-workaround", restoreName)
-				restore, err := CreateRestoreFromBackup(dpaCR.Client, namespace, backupName, noDcDrestoreName, WithExcludedResources(dcWorkaroundResources))
+				// run the restic post restore script if restore type is RESTIC
+				log.Printf("Running restic post restore script for case %s", brCase.Name)
+				err = RunResticPostRestoreScript(restoreName)
 				Expect(err).ToNot(HaveOccurred())
-				Eventually(IsRestoreDone(dpaCR.Client, namespace, noDcDrestoreName), timeoutMultiplier*time.Minute*4, time.Second*10).Should(BeTrue())
-				GinkgoWriter.Println(DescribeRestore(dpaCR.Client, restore))
-				Expect(RestoreErrorLogs(dpaCR.Client, restore)).To(Equal([]string{}))
-
-				// Check if restore succeeded
-				succeeded, err = IsRestoreCompletedSuccessfully(dpaCR.Client, namespace, noDcDrestoreName)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(succeeded).To(Equal(true))
-				Eventually(AreAppBuildsReady(dpaCR.Client, brCase.ApplicationNamespace), timeoutMultiplier*time.Minute*3, time.Second*5).Should(BeTrue())
-
-				// run restore
-				log.Printf("Creating restore %s including DC workaround resources for case %s", restoreName, brCase.Name)
-				withDcRestoreName := fmt.Sprintf("%s-with-dc-workaround", restoreName)
-				restore, err = CreateRestoreFromBackup(dpaCR.Client, namespace, backupName, withDcRestoreName, WithIncludedResources(dcWorkaroundResources))
-				Expect(err).ToNot(HaveOccurred())
-				Eventually(IsRestoreDone(dpaCR.Client, namespace, withDcRestoreName), timeoutMultiplier*time.Minute*4, time.Second*10).Should(BeTrue())
-				GinkgoWriter.Println(DescribeRestore(dpaCR.Client, restore))
-				Expect(RestoreErrorLogs(dpaCR.Client, restore)).To(Equal([]string{}))
-
-				// Check if restore succeeded
-				succeeded, err = IsRestoreCompletedSuccessfully(dpaCR.Client, namespace, withDcRestoreName)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(succeeded).To(Equal(true))
-
-			} else {
-				// run restore
-				log.Printf("Creating restore %s for case %s", restoreName, brCase.Name)
-				restore, err := CreateRestoreFromBackup(dpaCR.Client, namespace, backupName, restoreName)
-				Expect(err).ToNot(HaveOccurred())
-				Eventually(IsRestoreDone(dpaCR.Client, namespace, restoreName), timeoutMultiplier*time.Minute*4, time.Second*10).Should(BeTrue())
-				GinkgoWriter.Println(DescribeRestore(dpaCR.Client, restore))
-				Expect(RestoreErrorLogs(dpaCR.Client, restore)).To(Equal([]string{}))
-
-				// Check if restore succeeded
-				succeeded, err = IsRestoreCompletedSuccessfully(dpaCR.Client, namespace, restoreName)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(succeeded).To(Equal(true))
 			}
 
 			// verify app is running
@@ -294,7 +260,7 @@ var _ = Describe("AWS backup restore tests", func() {
 			ApplicationNamespace: "mongo-persistent",
 			Name:                 "mongo-restic-e2e",
 			BackupRestoreType:    RESTIC,
-			PreBackupVerify:      mongoready(false, RESTIC),
+			PreBackupVerify:      mongoready(true, RESTIC),
 			PostRestoreVerify:    mongoready(false, RESTIC),
 		}, nil),
 		Entry("MySQL application RESTIC", BackupRestoreCase{
@@ -302,7 +268,7 @@ var _ = Describe("AWS backup restore tests", func() {
 			ApplicationNamespace: "mysql-persistent",
 			Name:                 "mysql-restic-e2e",
 			BackupRestoreType:    RESTIC,
-			PreBackupVerify:      mysqlReady(false, RESTIC),
+			PreBackupVerify:      mysqlReady(true, RESTIC),
 			PostRestoreVerify:    mysqlReady(false, RESTIC),
 		}, nil),
 	)

--- a/tests/e2e/lib/apps.go
+++ b/tests/e2e/lib/apps.go
@@ -386,6 +386,10 @@ func VerifyBackupRestoreData(artifact_dir string, namespace string, routeName st
 	//if this is prebackstate = true, add items via makeRequest function. We only want to make request before backup
 	//and ignore post restore checks.
 	if prebackupState {
+		// delete backupFile if it exists
+		if _, err := os.Stat(backupFile); err == nil {
+			os.Remove(backupFile)
+		}
 		//data before curl request
 		dataBeforeCurl, err := getResponseData(appApi + "/todo-incomplete")
 		if err != nil {
@@ -412,7 +416,7 @@ func VerifyBackupRestoreData(artifact_dir string, namespace string, routeName st
 		return err
 	}
 	//Verifying backup-restore data only for CSI as of now.
-	if backupRestoretype == CSI {
+	if backupRestoretype == CSI || backupRestoretype == RESTIC {
 		//check if backupfile exists. If true { compare data response with data from file} (post restore step)
 		//else write data to backup-data.txt (prebackup step)
 		if _, err := os.Stat(backupFile); err == nil {

--- a/tests/e2e/lib/backup.go
+++ b/tests/e2e/lib/backup.go
@@ -11,7 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func CreateBackupForNamespaces(ocClient client.Client, veleroNamespace, backupName string, namespaces []string) (velero.Backup, error) {
+func CreateBackupForNamespaces(ocClient client.Client, veleroNamespace, backupName string, namespaces []string, defaultVolumesToRestic bool) (velero.Backup, error) {
 
 	backup := velero.Backup{
 		ObjectMeta: metav1.ObjectMeta{
@@ -19,7 +19,8 @@ func CreateBackupForNamespaces(ocClient client.Client, veleroNamespace, backupNa
 			Namespace: veleroNamespace,
 		},
 		Spec: velero.BackupSpec{
-			IncludedNamespaces: namespaces,
+			IncludedNamespaces:     namespaces,
+			DefaultVolumesToRestic: &defaultVolumesToRestic,
 		},
 	}
 	err := ocClient.Create(context.Background(), &backup)

--- a/tests/e2e/lib/velero_helpers.go
+++ b/tests/e2e/lib/velero_helpers.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
+	"os/exec"
 	"regexp"
 	"strings"
 	"time"
@@ -230,4 +232,23 @@ func GetVeleroDeploymentList(namespace string) (*appsv1.DeploymentList, error) {
 		return nil, err
 	}
 	return deploymentList, nil
+}
+
+func RunResticPostRestoreScript(dcRestoreName string) error {
+	logger := log.Default()
+	logger.Printf("Running post restore script for %s", dcRestoreName)
+	// get current directory
+	currentDir, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	currentDir = strings.TrimSuffix(currentDir, "/tests/e2e")
+	command := exec.Command("bash", currentDir+"/docs/scripts/dc-restic-post-restore.sh", dcRestoreName)
+	stdOut, err := command.Output()
+	logger.Printf("command: %s", command.String())
+	logger.Printf("stdout: %s", stdOut)
+	logger.Printf("stderr: %s", command.Stderr)
+	logger.Printf("err: %s", err)
+	return err
+	// return exec.Command("bash", "./docs/scripts/dc-restic-post-restore.sh", dcRestoreName).Run()
 }

--- a/tests/e2e/sample-applications/mongo-persistent/pvc/ibmcloud.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/pvc/ibmcloud.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: mongo
+      namespace: mongo-persistent
+      labels:
+        app: mongo
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      storageClassName: ocs-storagecluster-cephfs
+      resources:
+        requests:
+          storage: 1Gi

--- a/tests/e2e/subscription_suite_test.go
+++ b/tests/e2e/subscription_suite_test.go
@@ -8,7 +8,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/openshift/oadp-operator/tests/e2e/lib"
-	utils "github.com/openshift/oadp-operator/tests/e2e/utils"
 	operators "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/pointer"
@@ -28,12 +27,6 @@ var _ = Describe("Subscription Config Suite Test", func() {
 
 		testSuiteInstanceName := "ts-" + instanceName
 		dpaCR.Name = testSuiteInstanceName
-
-		credData, err := utils.ReadFile(credFile)
-		Expect(err).NotTo(HaveOccurred())
-
-		err = CreateCredentialsSecret(credData, namespace, GetSecretRef(credSecretRef))
-		Expect(err).NotTo(HaveOccurred())
 	})
 
 	var _ = AfterEach(func() {


### PR DESCRIPTION
Cherry-pick of #801 and #790

801
- remove velero pod logging when test entry is skipped.
- resolve build timing outs while waiting for CSI PVC to bound with current 3 minutes in CI.
- resolve using incorrect pvc spec if previous test entry fail.
- added missing ibm pvc template
- backup timeout increase to 12 minutes
- resolve pvc create failure if previous test fail and did not uninstall app namespace

790
- Currently restic backup cases are not setting this value and thus we have not actually verified restic backup of pod volumes are working.
- This PR enables restic backup and enable restic restore data verification.
- Stopped setting bsl.spec.config["credentialsFile"] to avoid https://github.com/vmware-tanzu/velero/issues/5228

This replaces #797

Unblocks https://github.com/openshift/release/pull/31533 aws CSI e2e timeout failure
```
  Timed out after 240.004s.
  Expected
      <bool>: false
  to be true
  In [It] at: /go/src/github.com/openshift/oadp-operator/tests/e2e/backup_restore_suite_test.go:179
```