### PR TITLE
Enable e2e tests to execute against downstream build

### DIFF
--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 // Common vars obtained from flags passed in ginkgo.
-var bslCredFile, namespace, credSecretRef, instanceName, provider, vslCredFile, settings, artifact_dir, oc_cli string
+var bslCredFile, namespace, credSecretRef, instanceName, provider, vslCredFile, settings, artifact_dir, oc_cli, stream string
 var timeoutMultiplier time.Duration
 
 func init() {
@@ -29,6 +29,7 @@ func init() {
 	flag.StringVar(&vslCredFile, "ci_cred_file", bslCredFile, "Credentials path for for VolumeSnapshotLocation, this credential would have access to cluster volume snapshots (for CI this is not OADP owned credential)")
 	flag.StringVar(&artifact_dir, "artifact_dir", "/tmp", "Directory for storing must gather")
 	flag.StringVar(&oc_cli, "oc_cli", "oc", "OC CLI Client")
+	flag.StringVar(&stream, "stream", "up", "[up, down] upstream or downstream")
 
 	// helps with launching debug sessions from IDE
 	if os.Getenv("E2E_USE_ENV_FLAGS") == "true" {
@@ -37,6 +38,9 @@ func init() {
 		}
 		if os.Getenv("VELERO_NAMESPACE") != "" {
 			namespace = os.Getenv("VELERO_NAMESPACE")
+		}
+		if os.Getenv("OADP_STREAM") != "" {
+			stream = os.Getenv("OADP_STREAM")
 		}
 		if os.Getenv("SETTINGS") != "" {
 			settings = os.Getenv("SETTINGS")

--- a/tests/e2e/lib/subscription_helpers.go
+++ b/tests/e2e/lib/subscription_helpers.go
@@ -16,13 +16,18 @@ type Subscription struct {
 	*operators.Subscription
 }
 
-func (d *DpaCustomResource) GetOperatorSubscription() (*Subscription, error) {
+func (d *DpaCustomResource) GetOperatorSubscription(stream string) (*Subscription, error) {
 	err := d.SetClient()
 	if err != nil {
 		return nil, err
 	}
 	sl := operators.SubscriptionList{}
-	err = d.Client.List(context.Background(), &sl, client.InNamespace(d.Namespace), client.MatchingLabels(map[string]string{"operators.coreos.com/oadp-operator." + d.Namespace: ""}))
+	if stream == "up"{
+		err = d.Client.List(context.Background(), &sl, client.InNamespace(d.Namespace), client.MatchingLabels(map[string]string{"operators.coreos.com/oadp-operator." + d.Namespace: ""}))
+	}
+	if stream == "down"{
+		err = d.Client.List(context.Background(), &sl, client.InNamespace(d.Namespace), client.MatchingLabels(map[string]string{"operators.coreos.com/redhat-oadp-operator." + d.Namespace: ""}))
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/tests/e2e/subscription_suite_test.go
+++ b/tests/e2e/subscription_suite_test.go
@@ -109,7 +109,6 @@ var _ = Describe("Subscription Config Suite Test", func() {
 					},
 				},
 			},
-			stream: stream,
 		}),
 		Entry("NO_PROXY set", SubscriptionConfigTestCase{
 			SubscriptionConfig: operators.SubscriptionConfig{
@@ -120,7 +119,6 @@ var _ = Describe("Subscription Config Suite Test", func() {
 					},
 				},
 			},
-			stream: stream,
 		}),
 		Entry("HTTPS_PROXY set", SubscriptionConfigTestCase{
 			SubscriptionConfig: operators.SubscriptionConfig{
@@ -133,7 +131,6 @@ var _ = Describe("Subscription Config Suite Test", func() {
 			},
 			// Failure is expected because localhost is not a valid https proxy and manager container will fail setup
 			failureExpected: pointer.Bool(true),
-			stream: stream,
 		}),
 		// Leave this as last entry to reset config
 		Entry("Config unset", SubscriptionConfigTestCase{

--- a/tests/e2e/subscription_suite_test.go
+++ b/tests/e2e/subscription_suite_test.go
@@ -36,11 +36,12 @@ var _ = Describe("Subscription Config Suite Test", func() {
 	type SubscriptionConfigTestCase struct {
 		operators.SubscriptionConfig
 		failureExpected *bool
+		stream string
 	}
 	DescribeTable("Proxy test table",
 		func(testCase SubscriptionConfigTestCase) {
 			log.Printf("Getting Operator Subscription")
-			s, err := dpaCR.GetOperatorSubscription()
+			s, err := dpaCR.GetOperatorSubscription(stream)
 			Expect(err).To(BeNil())
 			log.Printf("Setting test case subscription config")
 			s.Spec.Config = &testCase.SubscriptionConfig
@@ -108,6 +109,7 @@ var _ = Describe("Subscription Config Suite Test", func() {
 					},
 				},
 			},
+			stream: stream,
 		}),
 		Entry("NO_PROXY set", SubscriptionConfigTestCase{
 			SubscriptionConfig: operators.SubscriptionConfig{
@@ -118,6 +120,7 @@ var _ = Describe("Subscription Config Suite Test", func() {
 					},
 				},
 			},
+			stream: stream,
 		}),
 		Entry("HTTPS_PROXY set", SubscriptionConfigTestCase{
 			SubscriptionConfig: operators.SubscriptionConfig{
@@ -130,6 +133,7 @@ var _ = Describe("Subscription Config Suite Test", func() {
 			},
 			// Failure is expected because localhost is not a valid https proxy and manager container will fail setup
 			failureExpected: pointer.Bool(true),
+			stream: stream,
 		}),
 		// Leave this as last entry to reset config
 		Entry("Config unset", SubscriptionConfigTestCase{


### PR DESCRIPTION
Reusing the e2e tests across upstream and downstream builds
will benefit the engineering teams by increasing the coverage
across teams.  Additionally this should enable QE to execute
the dev teams e2e tests against a build.

* New Variable = "stream" ( ok name? )
  * allow cli -stream or env var OADP_STREAM to set value [up,down]
* Only change required was the subscription label

Tested and passed on internal build