### PR TITLE
add a simple golang version check to warn developers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ endif
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.21
 
+
 .PHONY:ginkgo
 ginkgo: # Make sure ginkgo is in $GOPATH/bin
 	go get -d github.com/onsi/ginkgo/ginkgo
@@ -148,6 +149,9 @@ help: ## Display this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
 ##@ Development
+# golang version check
+golang_check: golang_check ## Ensure the golang version meets the requirements
+	./docs/developer/golang_version_check
 
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	# Commenting out default which overwrites scoped config/rbac/role.yaml
@@ -354,6 +358,7 @@ deploy-olm: THIS_OPERATOR_IMAGE?=ttl.sh/oadp-operator-$(GIT_REV):1h # Set target
 deploy-olm: THIS_BUNDLE_IMAGE?=ttl.sh/oadp-operator-bundle-$(GIT_REV):1h # Set target specific variable
 deploy-olm: DEPLOY_TMP:=$(shell mktemp -d)/ # Set target specific variable
 deploy-olm:
+	./docs/developer/golang_version_check
 	oc whoami # Check if logged in
 	oc create namespace $(OADP_TEST_NAMESPACE) # This should error out if namespace already exists, delete namespace (to clear current resources) before proceeding
 	@echo "DEPLOY_TMP: $(DEPLOY_TMP)"

--- a/docs/developer/golang_version_check
+++ b/docs/developer/golang_version_check
@@ -1,0 +1,31 @@
+#!/usr/bin/sh
+MINIMUM_GO_MAJOR_VERSION=1
+MINIMUM_GO_MINOR_VERSION=18
+MINIMUM_GO_RELEASE_VERSION=6
+
+GO_MAJOR_VERSION=`go version | cut -c 14- | cut -d' ' -f1 | cut -d'.' -f1`
+GO_MINOR_VERSION=`go version | cut -c 14- | cut -d' ' -f1 | cut -d'.' -f2`
+GO_RELEASE_VERSION=`go version | cut -c 14- | cut -d' ' -f1 | cut -d'.' -f3`
+
+printf "MINIMUM_ GOLANG Version:  %s.%s.%s\n" $MINIMUM_GO_MAJOR_VERSION $MINIMUM_GO_MINOR_VERSION $MINIMUM_GO_RELEASE_VERSION
+printf "Current GOLANG Version:  %s.%s.%s\n" $GO_MAJOR_VERSION $GO_MINOR_VERSION $GO_RELEASE_VERSION
+
+function check_version ()
+{
+  if [ $1 -ge $2 ]; then
+    printf "version pass\n"
+  else
+    printf "Please check your golang version\n";
+    exit 1 
+  fi
+
+}
+
+check_version $GO_MAJOR_VERSION $MINIMUM_GO_MAJOR_VERSION
+check_version $GO_MINOR_VERSION $MINIMUM_GO_MINOR_VERSION
+check_version $GO_RELEASE_VERSION $MINIMUM_GO_RELEASE_VERSION
+
+exit 0
+
+
+   


### PR DESCRIPTION
For new developers it may not be clear why some of the make commands are not working properly.  For example [1] changed the minimum required golang to successfully use `make deploy-olm`. It was also not 100% clear what golang version would work across platforms.

It may be helpful to specify the required version and expose it via the makefile.

[1]https://github.com/openshift/oadp-operator/pull/809