### PR TITLE
Enable e2e tests to execute against downstream build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 OADP_TEST_NAMESPACE ?= openshift-adp
 CLUSTER_TYPE ?= aws
+OADP_STREAM ?= up
 
 # CONFIGS FOR CLOUD
 # bsl / blob storage cred dir
@@ -353,6 +354,7 @@ test-e2e: test-e2e-setup
 	--ginkgo.label-filter="$(TEST_FILTER)" \
 	-ci_cred_file=$(CI_CRED_FILE) \
 	-provider=$(CLUSTER_TYPE) \
+	-stream=$(OADP_STREAM) \
 	-creds_secret_ref=$(CREDS_SECRET_REF)
 
 test-e2e-cleanup:

--- a/tests/e2e/backup_restore_suite_test.go
+++ b/tests/e2e/backup_restore_suite_test.go
@@ -94,11 +94,11 @@ var _ = Describe("AWS backup restore tests", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			log.Printf("Waiting for velero pod to be running")
-			Eventually(AreVeleroPodsRunning(namespace), timeoutMultiplier*time.Minute*3, time.Second*5).Should(BeTrue())
+			Eventually(AreVeleroPodsRunning(namespace), timeoutMultiplier*time.Minute*4, time.Second*5).Should(BeTrue())
 
 			if brCase.BackupRestoreType == RESTIC {
 				log.Printf("Waiting for restic pods to be running")
-				Eventually(AreResticPodsRunning(namespace), timeoutMultiplier*time.Minute*3, time.Second*5).Should(BeTrue())
+				Eventually(AreResticPodsRunning(namespace), timeoutMultiplier*time.Minute*4, time.Second*5).Should(BeTrue())
 			}
 			if brCase.BackupRestoreType == CSI {
 				log.Printf("Creating VolumeSnapshotClass for CSI backuprestore of %s", brCase.Name)
@@ -122,7 +122,7 @@ var _ = Describe("AWS backup restore tests", func() {
 			err = InstallApplication(dpaCR.Client, brCase.ApplicationTemplate)
 			Expect(err).ToNot(HaveOccurred())
 			// wait for pods to be running
-			Eventually(AreAppBuildsReady(dpaCR.Client, brCase.ApplicationNamespace), timeoutMultiplier*time.Minute*3, time.Second*5).Should(BeTrue())
+			Eventually(AreAppBuildsReady(dpaCR.Client, brCase.ApplicationNamespace), timeoutMultiplier*time.Minute*5, time.Second*5).Should(BeTrue())
 			Eventually(AreApplicationPodsRunning(brCase.ApplicationNamespace), timeoutMultiplier*time.Minute*9, time.Second*5).Should(BeTrue())
 
 			// Run optional custom verification

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 // Common vars obtained from flags passed in ginkgo.
-var credFile, namespace, credSecretRef, instanceName, provider, ci_cred_file, settings, artifact_dir, oc_cli string
+var credFile, namespace, credSecretRef, instanceName, provider, ci_cred_file, settings, artifact_dir, oc_cli, stream string
 var timeoutMultiplier time.Duration
 
 func init() {

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -28,6 +28,7 @@ func init() {
 	flag.StringVar(&ci_cred_file, "ci_cred_file", credFile, "CI Cloud Cred File")
 	flag.StringVar(&artifact_dir, "artifact_dir", "/tmp", "Directory for storing must gather")
 	flag.StringVar(&oc_cli, "oc_cli", "oc", "OC CLI Client")
+	flag.StringVar(&stream, "stream", "up", "[up, down] upstream or downstream")
 
 	// helps with launching debug sessions from IDE
 	if os.Getenv("E2E_USE_ENV_FLAGS") == "true" {
@@ -36,6 +37,9 @@ func init() {
 		}
 		if os.Getenv("VELERO_NAMESPACE") != "" {
 			namespace = os.Getenv("VELERO_NAMESPACE")
+		}
+		if os.Getenv("OADP_STREAM") != "" {
+			stream = os.Getenv("OADP_STREAM")
 		}
 		if os.Getenv("SETTINGS") != "" {
 			settings = os.Getenv("SETTINGS")

--- a/tests/e2e/lib/subscription_helpers.go
+++ b/tests/e2e/lib/subscription_helpers.go
@@ -16,13 +16,18 @@ type Subscription struct {
 	*operators.Subscription
 }
 
-func (d *DpaCustomResource) GetOperatorSubscription() (*Subscription, error) {
+func (d *DpaCustomResource) GetOperatorSubscription(stream string) (*Subscription, error) {
 	err := d.SetClient()
 	if err != nil {
 		return nil, err
 	}
 	sl := operators.SubscriptionList{}
-	err = d.Client.List(context.Background(), &sl, client.InNamespace(d.Namespace), client.MatchingLabels(map[string]string{"operators.coreos.com/oadp-operator." + d.Namespace: ""}))
+	if stream == "up"{
+		err = d.Client.List(context.Background(), &sl, client.InNamespace(d.Namespace), client.MatchingLabels(map[string]string{"operators.coreos.com/oadp-operator." + d.Namespace: ""}))
+	}
+	if stream == "down"{
+		err = d.Client.List(context.Background(), &sl, client.InNamespace(d.Namespace), client.MatchingLabels(map[string]string{"operators.coreos.com/redhat-oadp-operator." + d.Namespace: ""}))
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/tests/e2e/subscription_suite_test.go
+++ b/tests/e2e/subscription_suite_test.go
@@ -44,11 +44,12 @@ var _ = Describe("Subscription Config Suite Test", func() {
 	type SubscriptionConfigTestCase struct {
 		operators.SubscriptionConfig
 		failureExpected *bool
+		stream string
 	}
 	DescribeTable("Proxy test table",
 		func(testCase SubscriptionConfigTestCase) {
 			log.Printf("Getting Operator Subscription")
-			s, err := dpaCR.GetOperatorSubscription()
+			s, err := dpaCR.GetOperatorSubscription(stream)
 			Expect(err).To(BeNil())
 			log.Printf("Setting test case subscription config")
 			s.Spec.Config = &testCase.SubscriptionConfig

--- a/tests/e2e/subscription_suite_test.go
+++ b/tests/e2e/subscription_suite_test.go
@@ -44,11 +44,12 @@ var _ = Describe("Subscription Config Suite Test", func() {
 	type SubscriptionConfigTestCase struct {
 		operators.SubscriptionConfig
 		failureExpected *bool
-		stream string
+		stream          string
 	}
 	DescribeTable("Proxy test table",
 		func(testCase SubscriptionConfigTestCase) {
 			log.Printf("Getting Operator Subscription")
+			log.Printf(stream)
 			s, err := dpaCR.GetOperatorSubscription(stream)
 			Expect(err).To(BeNil())
 			log.Printf("Setting test case subscription config")


### PR DESCRIPTION
Cherry-pick: [811](https://github.com/openshift/oadp-operator/commit/dd82e43487240b7a14b97f44481733b0d78cebf0) Enable e2e tests to execute against downstream build 