### PR TITLE
Remove BslMountPath from  pluginSpecificMap

### DIFF
--- a/pkg/credentials/credentials.go
+++ b/pkg/credentials/credentials.go
@@ -15,7 +15,6 @@ type DefaultPluginFields struct {
 	IsCloudProvider    bool
 	SecretName         string
 	MountPath          string
-	BslMountPath       string
 	EnvCredentialsFile string
 	PluginImage        string
 	PluginSecretKey    string
@@ -32,7 +31,6 @@ var (
 			IsCloudProvider:    true,
 			SecretName:         "cloud-credentials",
 			MountPath:          "/credentials",
-			BslMountPath:       "/bsl-cloud-credentials-aws",
 			EnvCredentialsFile: common.AWSSharedCredentialsFileEnvKey,
 			PluginName:         common.VeleroPluginForAWS,
 			PluginSecretKey:    "cloud",
@@ -41,7 +39,6 @@ var (
 			IsCloudProvider:    true,
 			SecretName:         "cloud-credentials-gcp",
 			MountPath:          "/credentials-gcp",
-			BslMountPath:       "/bsl-cloud-credentials-gcp",
 			EnvCredentialsFile: common.GCPCredentialsEnvKey,
 			PluginName:         common.VeleroPluginForGCP,
 			PluginSecretKey:    "cloud",
@@ -50,7 +47,6 @@ var (
 			IsCloudProvider:    true,
 			SecretName:         "cloud-credentials-azure",
 			MountPath:          "/credentials-azure",
-			BslMountPath:       "/bsl-cloud-credentials-azure",
 			EnvCredentialsFile: common.AzureCredentialsFileEnvKey,
 			PluginName:         common.VeleroPluginForAzure,
 			PluginSecretKey:    "cloud",
@@ -322,31 +318,6 @@ func AppendPluginSpecificSpecs(dpa *oadpv1alpha1.DataProtectionApplication, vele
 						},
 					},
 				})
-
-			// append bsl volume secret
-			for _, bslSpec := range dpa.Spec.BackupLocations {
-				if _, ok := bslSpec.Velero.Config["credentialsFile"]; ok {
-					if secretName, err := GetSecretNameFromCredentialsFileConfigString(bslSpec.Velero.Config["credentialsFile"]); err == nil {
-						veleroContainer.VolumeMounts = append(
-							veleroContainer.VolumeMounts,
-							corev1.VolumeMount{
-								Name:      secretName,
-								MountPath: pluginSpecificMap.BslMountPath,
-							})
-						veleroDeployment.Spec.Template.Spec.Volumes = append(
-							veleroDeployment.Spec.Template.Spec.Volumes,
-							corev1.Volume{
-								Name: secretName,
-								VolumeSource: corev1.VolumeSource{
-									Secret: &corev1.SecretVolumeSource{
-										SecretName: secretName,
-									},
-								},
-							},
-						)
-					}
-				}
-			}
 		}
 	}
 	// append custom plugin init containers


### PR DESCRIPTION
End user is not supposed to set Config[“credentialsFile”].  Credential file is created and set in bsl config by [velero](https://github.com/vmware-tanzu/velero/blob/74fd158a1ceae44cfe4a3f000e81d84e36ec4906/pkg/restic/common.go#L320-L326). Required BslMountPath in e2e test is removed and replaced in PR #790