### PR TITLE
master: ci: Ensure go mod matches ginkgo bin installed

### DIFF
--- a/build/ci-Dockerfile
+++ b/build/ci-Dockerfile
@@ -5,8 +5,8 @@ WORKDIR /go/src/github.com/openshift/oadp-operator
 
 COPY ./ .
 
-RUN go get -u github.com/onsi/ginkgo/ginkgo && \
- go get -u github.com/onsi/ginkgo/v2/ginkgo && \
+RUN go get -d -u github.com/onsi/ginkgo/ginkgo && \
+ go get -d -u github.com/onsi/ginkgo/v2/ginkgo && \
  go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo@latest
 RUN go get github.com/onsi/gomega/...
 RUN chmod -R 777 ./

--- a/build/ci-Dockerfile
+++ b/build/ci-Dockerfile
@@ -1,13 +1,13 @@
 # Build the manager binary
 FROM quay.io/konveyor/builder:v1.17.2 AS builder
 
-RUN go get -u github.com/onsi/ginkgo/ginkgo && \
- go get -u github.com/onsi/ginkgo/v2/ginkgo
-RUN go get github.com/onsi/gomega/...
-
 WORKDIR /go/src/github.com/openshift/oadp-operator
 
 COPY ./ .
 
+RUN go get -u github.com/onsi/ginkgo/ginkgo && \
+ go get -u github.com/onsi/ginkgo/v2/ginkgo && \
+ go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo@latest
+RUN go get github.com/onsi/gomega/...
 RUN chmod -R 777 ./
 RUN go mod download


### PR DESCRIPTION
Verify in gitpod environment. https://gitpod.io/#https://github.com/kaovilai/oadp-operator/tree/master-ginkgo-ciDockerfile-graceperiod
```
gitpod /workspace/oadp-operator (master-ginkgo-ciDockerfile-graceperiod) $ docker build -f build/ci-Dockerfile . -t cidockerfile
Sending build context to Docker daemon  67.31MB
gitpod /workspace/oadp-operator (master-ginkgo-ciDockerfile-graceperiod) $ docker run -it --rm cidockerfile
[root@f3ec4e0f5fa0 oadp-operator]# /root/go/bin/ginkgo version
Ginkgo Version 2.3.0
[root@f3ec4e0f5fa0 oadp-operator]# cat go.mod | grep ginkgo/v2
        github.com/onsi/ginkgo/v2 v2.3.0
```

Per https://github.com/onsi/ginkgo/issues/1055

Fixes https://github.com/openshift/oadp-operator/pull/851#issuecomment-1276087522