### PR TITLE
Update vsb and vsr crds with status field updates

### DIFF
--- a/bundle/manifests/datamover.oadp.openshift.io_volumesnapshotbackups.yaml
+++ b/bundle/manifests/datamover.oadp.openshift.io_volumesnapshotbackups.yaml
@@ -44,33 +44,35 @@ spec:
                 description: Restic Secret reference for given BSL
                 properties:
                   name:
-                    description: Name of the BSL specific restic secret
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
                     type: string
                 type: object
               volumeSnapshotContent:
-                description: 'ObjectReference contains enough information to let you
+                description: "ObjectReference contains enough information to let you
                   inspect or modify the referred object. --- New uses of this type
                   are discouraged because of difficulty describing its usage when
                   embedded in APIs. 1. Ignored fields.  It includes many fields which
                   are not generally honored.  For instance, ResourceVersion and FieldPath
-                  are both very rarely valid in actual usage. 2. Invalid usage help.  It
-                  is impossible to add specific help for individual usage.  In most
-                  embedded usages, there are particular restrictions like, "must refer
-                  only to types A and B" or "UID not honored" or "name must be restricted".
-                  Those cannot be well described when embedded. 3. Inconsistent validation.  Because
-                  the usages are different, the validation rules are different by
-                  usage, which makes it hard for users to predict what will happen.
-                  4. The fields are both imprecise and overly precise.  Kind is not
-                  a precise mapping to a URL. This can produce ambiguity during interpretation
-                  and require a REST mapping.  In most cases, the dependency is on
-                  the group,resource tuple and the version of the actual struct is
-                  irrelevant. 5. We cannot easily change it.  Because this type is
-                  embedded in many locations, updates to this type will affect numerous
-                  schemas.  Don''t make new APIs embed an underspecified API type
-                  they do not control. Instead of using this type, create a locally
-                  provided and used type that is well-focused on your reference. For
-                  example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
-                  .'
+                  are both very rarely valid in actual usage. 2. Invalid usage help.
+                  \ It is impossible to add specific help for individual usage.  In
+                  most embedded usages, there are particular restrictions like, \"must
+                  refer only to types A and B\" or \"UID not honored\" or \"name must
+                  be restricted\". Those cannot be well described when embedded. 3.
+                  Inconsistent validation.  Because the usages are different, the
+                  validation rules are different by usage, which makes it hard for
+                  users to predict what will happen. 4. The fields are both imprecise
+                  and overly precise.  Kind is not a precise mapping to a URL. This
+                  can produce ambiguity during interpretation and require a REST mapping.
+                  \ In most cases, the dependency is on the group,resource tuple and
+                  the version of the actual struct is irrelevant. 5. We cannot easily
+                  change it.  Because this type is embedded in many locations, updates
+                  to this type will affect numerous schemas.  Don't make new APIs
+                  embed an underspecified API type they do not control. \n Instead
+                  of using this type, create a locally provided and used type that
+                  is well-focused on your reference. For example, ServiceReferences
+                  for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                  ."
                 properties:
                   apiVersion:
                     description: API version of the referent.
@@ -112,6 +114,11 @@ spec:
             properties:
               completed:
                 type: boolean
+              completionTimestamp:
+                description: CompletionTimestamp records the time a volumesnapshotbackup
+                  reached a terminal state.
+                format: date-time
+                type: string
               conditions:
                 description: Include references to the volsync CRs and their state
                   as they are running
@@ -119,8 +126,8 @@ spec:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    type FooStatus struct{ // Represents the observations of a foo's
-                    current state. // Known .status.conditions.type are: \"Available\",
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
                     \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
                     // +listType=map // +listMapKey=type Conditions []metav1.Condition
                     `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
@@ -185,6 +192,25 @@ spec:
               phase:
                 description: volumesnapshot backup phase status
                 type: string
+              replicationSourceData:
+                description: Includes information pertaining to Volsync ReplicationSource
+                  CR
+                properties:
+                  completionTimestamp:
+                    description: CompletionTimestamp records the time a ReplicationSource
+                      reached a terminal state.
+                    format: date-time
+                    type: string
+                  name:
+                    description: name of the ReplicationSource associated with the
+                      volumesnapshotbackup
+                    type: string
+                  startTimestamp:
+                    description: StartTimestamp records the time a ReplicationSource
+                      was started.
+                    format: date-time
+                    type: string
+                type: object
               resticrepository:
                 description: Includes restic repository path
                 type: string
@@ -201,6 +227,11 @@ spec:
                     description: name of the StorageClass
                     type: string
                 type: object
+              startTimestamp:
+                description: StartTimestamp records the time a volsumesnapshotbackup
+                  was started.
+                format: date-time
+                type: string
               volumeSnapshotClassName:
                 description: name of the VolumeSnapshotClass
                 type: string

--- a/bundle/manifests/datamover.oadp.openshift.io_volumesnapshotrestores.yaml
+++ b/bundle/manifests/datamover.oadp.openshift.io_volumesnapshotrestores.yaml
@@ -77,13 +77,18 @@ spec:
             description: VolumeSnapshotRestoreStatus defines the observed state of
               VolumeSnapshotRestore
             properties:
+              completionTimestamp:
+                description: CompletionTimestamp records the time a volumesnapshotrestore
+                  reached a terminal state.
+                format: date-time
+                type: string
               conditions:
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    type FooStatus struct{ // Represents the observations of a foo's
-                    current state. // Known .status.conditions.type are: \"Available\",
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
                     \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
                     // +listType=map // +listMapKey=type Conditions []metav1.Condition
                     `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
@@ -148,7 +153,33 @@ spec:
               phase:
                 description: volumesnapshot restore phase status
                 type: string
+              replicationDestinationData:
+                description: Includes information pertaining to Volsync ReplicationDestination
+                  CR
+                properties:
+                  completionTimestamp:
+                    description: CompletionTimestamp records the time a ReplicationDestination
+                      reached a terminal state.
+                    format: date-time
+                    type: string
+                  name:
+                    description: name of the ReplicationDestination associated with
+                      the volumesnapshotrestore
+                    type: string
+                  startTimestamp:
+                    description: StartTimestamp records the time a ReplicationDestination
+                      was started.
+                    format: date-time
+                    type: string
+                type: object
               snapshotHandle:
+                description: name of the volumesnapshot snaphandle that is backed
+                  up
+                type: string
+              startTimestamp:
+                description: StartTimestamp records the time a volsumesnapshotrestore
+                  was started.
+                format: date-time
                 type: string
             type: object
         type: object

--- a/config/crd/bases/datamover.oadp.openshift.io_volumesnapshotbackups.yaml
+++ b/config/crd/bases/datamover.oadp.openshift.io_volumesnapshotbackups.yaml
@@ -193,9 +193,25 @@ spec:
               phase:
                 description: volumesnapshot backup phase status
                 type: string
-              replicationSourceName:
-                description: name of the ReplicationSource associated with the volumesnapshotbackup
-                type: string
+              replicationSourceData:
+                description: Includes information pertaining to Volsync ReplicationSource
+                  CR
+                properties:
+                  completionTimestamp:
+                    description: CompletionTimestamp records the time a ReplicationSource
+                      reached a terminal state.
+                    format: date-time
+                    type: string
+                  name:
+                    description: name of the ReplicationSource associated with the
+                      volumesnapshotbackup
+                    type: string
+                  startTimestamp:
+                    description: StartTimestamp records the time a ReplicationSource
+                      was started.
+                    format: date-time
+                    type: string
+                type: object
               resticrepository:
                 description: Includes restic repository path
                 type: string

--- a/config/crd/bases/datamover.oadp.openshift.io_volumesnapshotbackups.yaml
+++ b/config/crd/bases/datamover.oadp.openshift.io_volumesnapshotbackups.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -44,33 +45,35 @@ spec:
                 description: Restic Secret reference for given BSL
                 properties:
                   name:
-                    description: Name of the BSL specific restic secret
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
                     type: string
                 type: object
               volumeSnapshotContent:
-                description: 'ObjectReference contains enough information to let you
+                description: "ObjectReference contains enough information to let you
                   inspect or modify the referred object. --- New uses of this type
                   are discouraged because of difficulty describing its usage when
                   embedded in APIs. 1. Ignored fields.  It includes many fields which
                   are not generally honored.  For instance, ResourceVersion and FieldPath
-                  are both very rarely valid in actual usage. 2. Invalid usage help.  It
-                  is impossible to add specific help for individual usage.  In most
-                  embedded usages, there are particular restrictions like, "must refer
-                  only to types A and B" or "UID not honored" or "name must be restricted".
-                  Those cannot be well described when embedded. 3. Inconsistent validation.  Because
-                  the usages are different, the validation rules are different by
-                  usage, which makes it hard for users to predict what will happen.
-                  4. The fields are both imprecise and overly precise.  Kind is not
-                  a precise mapping to a URL. This can produce ambiguity during interpretation
-                  and require a REST mapping.  In most cases, the dependency is on
-                  the group,resource tuple and the version of the actual struct is
-                  irrelevant. 5. We cannot easily change it.  Because this type is
-                  embedded in many locations, updates to this type will affect numerous
-                  schemas.  Don''t make new APIs embed an underspecified API type
-                  they do not control. Instead of using this type, create a locally
-                  provided and used type that is well-focused on your reference. For
-                  example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
-                  .'
+                  are both very rarely valid in actual usage. 2. Invalid usage help.
+                  \ It is impossible to add specific help for individual usage.  In
+                  most embedded usages, there are particular restrictions like, \"must
+                  refer only to types A and B\" or \"UID not honored\" or \"name must
+                  be restricted\". Those cannot be well described when embedded. 3.
+                  Inconsistent validation.  Because the usages are different, the
+                  validation rules are different by usage, which makes it hard for
+                  users to predict what will happen. 4. The fields are both imprecise
+                  and overly precise.  Kind is not a precise mapping to a URL. This
+                  can produce ambiguity during interpretation and require a REST mapping.
+                  \ In most cases, the dependency is on the group,resource tuple and
+                  the version of the actual struct is irrelevant. 5. We cannot easily
+                  change it.  Because this type is embedded in many locations, updates
+                  to this type will affect numerous schemas.  Don't make new APIs
+                  embed an underspecified API type they do not control. \n Instead
+                  of using this type, create a locally provided and used type that
+                  is well-focused on your reference. For example, ServiceReferences
+                  for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                  ."
                 properties:
                   apiVersion:
                     description: API version of the referent.
@@ -112,6 +115,11 @@ spec:
             properties:
               completed:
                 type: boolean
+              completionTimestamp:
+                description: CompletionTimestamp records the time a volumesnapshotbackup
+                  reached a terminal state.
+                format: date-time
+                type: string
               conditions:
                 description: Include references to the volsync CRs and their state
                   as they are running
@@ -119,8 +127,8 @@ spec:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    type FooStatus struct{ // Represents the observations of a foo's
-                    current state. // Known .status.conditions.type are: \"Available\",
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
                     \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
                     // +listType=map // +listMapKey=type Conditions []metav1.Condition
                     `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
@@ -185,6 +193,9 @@ spec:
               phase:
                 description: volumesnapshot backup phase status
                 type: string
+              replicationSourceName:
+                description: name of the ReplicationSource associated with the volumesnapshotbackup
+                type: string
               resticrepository:
                 description: Includes restic repository path
                 type: string
@@ -201,6 +212,11 @@ spec:
                     description: name of the StorageClass
                     type: string
                 type: object
+              startTimestamp:
+                description: StartTimestamp records the time a volsumesnapshotbackup
+                  was started.
+                format: date-time
+                type: string
               volumeSnapshotClassName:
                 description: name of the VolumeSnapshotClass
                 type: string

--- a/config/crd/bases/datamover.oadp.openshift.io_volumesnapshotrestores.yaml
+++ b/config/crd/bases/datamover.oadp.openshift.io_volumesnapshotrestores.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -77,13 +78,18 @@ spec:
             description: VolumeSnapshotRestoreStatus defines the observed state of
               VolumeSnapshotRestore
             properties:
+              completionTimestamp:
+                description: CompletionTimestamp records the time a volumesnapshotrestore
+                  reached a terminal state.
+                format: date-time
+                type: string
               conditions:
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    type FooStatus struct{ // Represents the observations of a foo's
-                    current state. // Known .status.conditions.type are: \"Available\",
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
                     \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
                     // +listType=map // +listMapKey=type Conditions []metav1.Condition
                     `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
@@ -148,7 +154,18 @@ spec:
               phase:
                 description: volumesnapshot restore phase status
                 type: string
+              replicationDestinationName:
+                description: name of the ReplicationDestination associated with the
+                  volumesnapshotrestore
+                type: string
               snapshotHandle:
+                description: name of the volumesnapshot snaphandle that is backed
+                  up
+                type: string
+              startTimestamp:
+                description: StartTimestamp records the time a volsumesnapshotrestore
+                  was started.
+                format: date-time
                 type: string
             type: object
         type: object

--- a/config/crd/bases/datamover.oadp.openshift.io_volumesnapshotrestores.yaml
+++ b/config/crd/bases/datamover.oadp.openshift.io_volumesnapshotrestores.yaml
@@ -154,10 +154,25 @@ spec:
               phase:
                 description: volumesnapshot restore phase status
                 type: string
-              replicationDestinationName:
-                description: name of the ReplicationDestination associated with the
-                  volumesnapshotrestore
-                type: string
+              replicationDestinationData:
+                description: Includes information pertaining to Volsync ReplicationDestination
+                  CR
+                properties:
+                  completionTimestamp:
+                    description: CompletionTimestamp records the time a ReplicationDestination
+                      reached a terminal state.
+                    format: date-time
+                    type: string
+                  name:
+                    description: name of the ReplicationDestination associated with
+                      the volumesnapshotrestore
+                    type: string
+                  startTimestamp:
+                    description: StartTimestamp records the time a ReplicationDestination
+                      was started.
+                    format: date-time
+                    type: string
+                type: object
               snapshotHandle:
                 description: name of the volumesnapshot snaphandle that is backed
                   up


### PR DESCRIPTION
This PR updates the VSB and VSR CRDs with the following additions to the status:
- Adds `StartTimestamp` and `CompletionTimeStamp` to VSB and VSR status
- Adds Volsync `ReplicationSource` name, `StartTimestamp` and `CompletionTimeStamp` to VSB status
- Adds Volsync `ReplicationDestination` name, `StartTimestamp` and `CompletionTimeStamp` to VSR status

Related volume-snapshot-mover controller PR: https://github.com/migtools/volume-snapshot-mover/pull/181