### PR TITLE
OADP-1224: restic node-agent refactor label

### DIFF
--- a/controllers/restic_test.go
+++ b/controllers/restic_test.go
@@ -130,12 +130,12 @@ func TestDPAReconciler_buildResticDaemonset(t *testing.T) {
 						},
 					},
 				}, &appsv1.DaemonSet{
-					ObjectMeta: getResticObjectMeta(r),
+					ObjectMeta: getNodeAgentObjectMeta(r),
 				},
 			},
 			wantErr: false,
 			want: &appsv1.DaemonSet{
-				ObjectMeta: getResticObjectMeta(r),
+				ObjectMeta: getNodeAgentObjectMeta(r),
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "DaemonSet",
 					APIVersion: appsv1.SchemeGroupVersion.String(),
@@ -144,7 +144,7 @@ func TestDPAReconciler_buildResticDaemonset(t *testing.T) {
 					UpdateStrategy: appsv1.DaemonSetUpdateStrategy{
 						Type: appsv1.RollingUpdateDaemonSetStrategyType,
 					},
-					Selector: resticLabelSelector,
+					Selector: nodeAgentLabelSelector,
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
@@ -271,12 +271,12 @@ func TestDPAReconciler_buildResticDaemonset(t *testing.T) {
 						},
 					},
 				}, &appsv1.DaemonSet{
-					ObjectMeta: getResticObjectMeta(r),
+					ObjectMeta: getNodeAgentObjectMeta(r),
 				},
 			},
 			wantErr: false,
 			want: &appsv1.DaemonSet{
-				ObjectMeta: getResticObjectMeta(r),
+				ObjectMeta: getNodeAgentObjectMeta(r),
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "DaemonSet",
 					APIVersion: appsv1.SchemeGroupVersion.String(),
@@ -285,7 +285,7 @@ func TestDPAReconciler_buildResticDaemonset(t *testing.T) {
 					UpdateStrategy: appsv1.DaemonSetUpdateStrategy{
 						Type: appsv1.RollingUpdateDaemonSetStrategyType,
 					},
-					Selector: resticLabelSelector,
+					Selector: nodeAgentLabelSelector,
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
@@ -413,7 +413,7 @@ func TestDPAReconciler_buildResticDaemonset(t *testing.T) {
 						},
 					},
 				}, &appsv1.DaemonSet{
-					ObjectMeta: getResticObjectMeta(r),
+					ObjectMeta: getNodeAgentObjectMeta(r),
 				},
 			},
 			wantErr: true,
@@ -441,12 +441,12 @@ func TestDPAReconciler_buildResticDaemonset(t *testing.T) {
 						},
 					},
 				}, &appsv1.DaemonSet{
-					ObjectMeta: getResticObjectMeta(r),
+					ObjectMeta: getNodeAgentObjectMeta(r),
 				},
 			},
 			wantErr: false,
 			want: &appsv1.DaemonSet{
-				ObjectMeta: getResticObjectMeta(r),
+				ObjectMeta: getNodeAgentObjectMeta(r),
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "DaemonSet",
 					APIVersion: appsv1.SchemeGroupVersion.String(),
@@ -455,7 +455,7 @@ func TestDPAReconciler_buildResticDaemonset(t *testing.T) {
 					UpdateStrategy: appsv1.DaemonSetUpdateStrategy{
 						Type: appsv1.RollingUpdateDaemonSetStrategyType,
 					},
-					Selector: resticLabelSelector,
+					Selector: nodeAgentLabelSelector,
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
@@ -609,12 +609,12 @@ func TestDPAReconciler_buildResticDaemonset(t *testing.T) {
 						},
 					},
 				}, &appsv1.DaemonSet{
-					ObjectMeta: getResticObjectMeta(r),
+					ObjectMeta: getNodeAgentObjectMeta(r),
 				},
 			},
 			wantErr: false,
 			want: &appsv1.DaemonSet{
-				ObjectMeta: getResticObjectMeta(r),
+				ObjectMeta: getNodeAgentObjectMeta(r),
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "DaemonSet",
 					APIVersion: appsv1.SchemeGroupVersion.String(),
@@ -623,7 +623,7 @@ func TestDPAReconciler_buildResticDaemonset(t *testing.T) {
 					UpdateStrategy: appsv1.DaemonSetUpdateStrategy{
 						Type: appsv1.RollingUpdateDaemonSetStrategyType,
 					},
-					Selector: resticLabelSelector,
+					Selector: nodeAgentLabelSelector,
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
@@ -776,12 +776,12 @@ func TestDPAReconciler_buildResticDaemonset(t *testing.T) {
 						},
 					},
 				}, &appsv1.DaemonSet{
-					ObjectMeta: getResticObjectMeta(r),
+					ObjectMeta: getNodeAgentObjectMeta(r),
 				},
 			},
 			wantErr: false,
 			want: &appsv1.DaemonSet{
-				ObjectMeta: getResticObjectMeta(r),
+				ObjectMeta: getNodeAgentObjectMeta(r),
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "DaemonSet",
 					APIVersion: appsv1.SchemeGroupVersion.String(),
@@ -790,7 +790,7 @@ func TestDPAReconciler_buildResticDaemonset(t *testing.T) {
 					UpdateStrategy: appsv1.DaemonSetUpdateStrategy{
 						Type: appsv1.RollingUpdateDaemonSetStrategyType,
 					},
-					Selector: resticLabelSelector,
+					Selector: nodeAgentLabelSelector,
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
@@ -942,12 +942,12 @@ func TestDPAReconciler_buildResticDaemonset(t *testing.T) {
 						},
 					},
 				}, &appsv1.DaemonSet{
-					ObjectMeta: getResticObjectMeta(r),
+					ObjectMeta: getNodeAgentObjectMeta(r),
 				},
 			},
 			wantErr: false,
 			want: &appsv1.DaemonSet{
-				ObjectMeta: getResticObjectMeta(r),
+				ObjectMeta: getNodeAgentObjectMeta(r),
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "DaemonSet",
 					APIVersion: appsv1.SchemeGroupVersion.String(),
@@ -956,7 +956,7 @@ func TestDPAReconciler_buildResticDaemonset(t *testing.T) {
 					UpdateStrategy: appsv1.DaemonSetUpdateStrategy{
 						Type: appsv1.RollingUpdateDaemonSetStrategyType,
 					},
-					Selector: resticLabelSelector,
+					Selector: nodeAgentLabelSelector,
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
@@ -1105,12 +1105,12 @@ func TestDPAReconciler_buildResticDaemonset(t *testing.T) {
 						},
 					},
 				}, &appsv1.DaemonSet{
-					ObjectMeta: getResticObjectMeta(r),
+					ObjectMeta: getNodeAgentObjectMeta(r),
 				},
 			},
 			wantErr: false,
 			want: &appsv1.DaemonSet{
-				ObjectMeta: getResticObjectMeta(r),
+				ObjectMeta: getNodeAgentObjectMeta(r),
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "DaemonSet",
 					APIVersion: appsv1.SchemeGroupVersion.String(),
@@ -1119,7 +1119,7 @@ func TestDPAReconciler_buildResticDaemonset(t *testing.T) {
 					UpdateStrategy: appsv1.DaemonSetUpdateStrategy{
 						Type: appsv1.RollingUpdateDaemonSetStrategyType,
 					},
-					Selector: resticLabelSelector,
+					Selector: nodeAgentLabelSelector,
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
@@ -1271,12 +1271,12 @@ func TestDPAReconciler_buildResticDaemonset(t *testing.T) {
 						},
 					},
 				}, &appsv1.DaemonSet{
-					ObjectMeta: getResticObjectMeta(r),
+					ObjectMeta: getNodeAgentObjectMeta(r),
 				},
 			},
 			wantErr: false,
 			want: &appsv1.DaemonSet{
-				ObjectMeta: getResticObjectMeta(r),
+				ObjectMeta: getNodeAgentObjectMeta(r),
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "DaemonSet",
 					APIVersion: appsv1.SchemeGroupVersion.String(),
@@ -1285,7 +1285,7 @@ func TestDPAReconciler_buildResticDaemonset(t *testing.T) {
 					UpdateStrategy: appsv1.DaemonSetUpdateStrategy{
 						Type: appsv1.RollingUpdateDaemonSetStrategyType,
 					},
-					Selector: resticLabelSelector,
+					Selector: nodeAgentLabelSelector,
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
@@ -1434,12 +1434,12 @@ func TestDPAReconciler_buildResticDaemonset(t *testing.T) {
 						},
 					},
 				}, &appsv1.DaemonSet{
-					ObjectMeta: getResticObjectMeta(r),
+					ObjectMeta: getNodeAgentObjectMeta(r),
 				},
 			},
 			wantErr: false,
 			want: &appsv1.DaemonSet{
-				ObjectMeta: getResticObjectMeta(r),
+				ObjectMeta: getNodeAgentObjectMeta(r),
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "DaemonSet",
 					APIVersion: appsv1.SchemeGroupVersion.String(),
@@ -1448,7 +1448,7 @@ func TestDPAReconciler_buildResticDaemonset(t *testing.T) {
 					UpdateStrategy: appsv1.DaemonSetUpdateStrategy{
 						Type: appsv1.RollingUpdateDaemonSetStrategyType,
 					},
-					Selector: resticLabelSelector,
+					Selector: nodeAgentLabelSelector,
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
@@ -1592,12 +1592,12 @@ func TestDPAReconciler_buildResticDaemonset(t *testing.T) {
 						},
 					},
 				}, &appsv1.DaemonSet{
-					ObjectMeta: getResticObjectMeta(r),
+					ObjectMeta: getNodeAgentObjectMeta(r),
 				},
 			},
 			wantErr: false,
 			want: &appsv1.DaemonSet{
-				ObjectMeta: getResticObjectMeta(r),
+				ObjectMeta: getNodeAgentObjectMeta(r),
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "DaemonSet",
 					APIVersion: appsv1.SchemeGroupVersion.String(),
@@ -1606,7 +1606,7 @@ func TestDPAReconciler_buildResticDaemonset(t *testing.T) {
 					UpdateStrategy: appsv1.DaemonSetUpdateStrategy{
 						Type: appsv1.RollingUpdateDaemonSetStrategyType,
 					},
-					Selector: resticLabelSelector,
+					Selector: nodeAgentLabelSelector,
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
@@ -1766,12 +1766,12 @@ func TestDPAReconciler_buildResticDaemonset(t *testing.T) {
 						},
 					},
 				}, &appsv1.DaemonSet{
-					ObjectMeta: getResticObjectMeta(r),
+					ObjectMeta: getNodeAgentObjectMeta(r),
 				},
 			},
 			wantErr: false,
 			want: &appsv1.DaemonSet{
-				ObjectMeta: getResticObjectMeta(r),
+				ObjectMeta: getNodeAgentObjectMeta(r),
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "DaemonSet",
 					APIVersion: appsv1.SchemeGroupVersion.String(),
@@ -1780,7 +1780,7 @@ func TestDPAReconciler_buildResticDaemonset(t *testing.T) {
 					UpdateStrategy: appsv1.DaemonSetUpdateStrategy{
 						Type: appsv1.RollingUpdateDaemonSetStrategyType,
 					},
-					Selector: resticLabelSelector,
+					Selector: nodeAgentLabelSelector,
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
@@ -1938,12 +1938,12 @@ func TestDPAReconciler_buildResticDaemonset(t *testing.T) {
 						},
 					},
 				}, &appsv1.DaemonSet{
-					ObjectMeta: getResticObjectMeta(r),
+					ObjectMeta: getNodeAgentObjectMeta(r),
 				},
 			},
 			wantErr: false,
 			want: &appsv1.DaemonSet{
-				ObjectMeta: getResticObjectMeta(r),
+				ObjectMeta: getNodeAgentObjectMeta(r),
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "DaemonSet",
 					APIVersion: appsv1.SchemeGroupVersion.String(),
@@ -1952,7 +1952,7 @@ func TestDPAReconciler_buildResticDaemonset(t *testing.T) {
 					UpdateStrategy: appsv1.DaemonSetUpdateStrategy{
 						Type: appsv1.RollingUpdateDaemonSetStrategyType,
 					},
-					Selector: resticLabelSelector,
+					Selector: nodeAgentLabelSelector,
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{

--- a/controllers/velero_test.go
+++ b/controllers/velero_test.go
@@ -944,7 +944,7 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 						Velero: &oadpv1alpha1.VeleroConfig{
 							PodConfig: &oadpv1alpha1.PodConfig{
 								Labels: map[string]string{
-									"component": "restic",
+									"component": common.NodeAgent,
 								},
 							},
 						},

--- a/tests/e2e/backup_restore_suite_test.go
+++ b/tests/e2e/backup_restore_suite_test.go
@@ -138,7 +138,7 @@ var _ = Describe("AWS backup restore tests", func() {
 
 			if brCase.BackupRestoreType == RESTIC {
 				log.Printf("Waiting for restic pods to be running")
-				Eventually(AreResticPodsRunning(namespace), timeoutMultiplier*time.Minute*3, time.Second*5).Should(BeTrue())
+				Eventually(AreNodeAgentPodsRunning(namespace), timeoutMultiplier*time.Minute*3, time.Second*5).Should(BeTrue())
 			}
 			if brCase.BackupRestoreType == CSI {
 				if provider == "aws" || provider == "ibmcloud" || provider == "gcp" || provider == "azure" {

--- a/tests/e2e/dpa_deployment_suite_test.go
+++ b/tests/e2e/dpa_deployment_suite_test.go
@@ -638,7 +638,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 			//restic installation
 			if dpa.Spec.Configuration.Restic != nil && *dpa.Spec.Configuration.Restic.Enable {
 				log.Printf("Waiting for restic pods to be running")
-				Eventually(AreResticPodsRunning(namespace), timeoutMultiplier*time.Minute*3, time.Second*5).Should(BeTrue())
+				Eventually(AreNodeAgentPodsRunning(namespace), timeoutMultiplier*time.Minute*3, time.Second*5).Should(BeTrue())
 			} else {
 				log.Printf("Waiting for restic daemonset to be deleted")
 				Eventually(IsResticDaemonsetDeleted(namespace), timeoutMultiplier*time.Minute*3, time.Second*5).Should(BeTrue())

--- a/tests/e2e/subscription_suite_test.go
+++ b/tests/e2e/subscription_suite_test.go
@@ -67,7 +67,7 @@ var _ = Describe("Subscription Config Suite Test", func() {
 				Eventually(AreVeleroPodsRunning(namespace), timeoutMultiplier*time.Minute*3, time.Second*5).Should(BeTrue())
 				if velero.Spec.Configuration.Restic.Enable != nil && *velero.Spec.Configuration.Restic.Enable {
 					log.Printf("Waiting for restic pods to be running")
-					Eventually(AreResticPodsRunning(namespace), timeoutMultiplier*time.Minute*3, time.Second*5).Should(BeTrue())
+					Eventually(AreNodeAgentPodsRunning(namespace), timeoutMultiplier*time.Minute*3, time.Second*5).Should(BeTrue())
 				}
 				if s.Spec.Config != nil && s.Spec.Config.Env != nil {
 					// get pod env vars


### PR DESCRIPTION
This PR fix add more changes required from https://github.com/openshift/oadp-operator/pull/858
[OADP-1224](https://issues.redhat.com//browse/OADP-1224)

Without this fix velero fails to discover restic, now called node-agent pods.