### PR TITLE
build/ci-Dockerfile `chmod -R 777 /go/`

### DIFF
--- a/build/ci-Dockerfile
+++ b/build/ci-Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM quay.io/konveyor/builder:v1.17.2 AS builder
+FROM quay.io/konveyor/builder:v1.18 AS builder
 
 WORKDIR /go/src/github.com/openshift/oadp-operator
 
@@ -11,4 +11,5 @@ RUN go get -d -u github.com/onsi/ginkgo/ginkgo && \
 # pin v1.22 as latest requires go 1.18
 RUN go get -d -u github.com/onsi/gomega@v1.22
 RUN chmod -R 777 ./
+RUN chmod -R 777 /go/
 RUN go mod download


### PR DESCRIPTION
We want to make /go/ writable for all users to resolve [CI permission issue](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/35643/rehearse-35643-pull-ci-openshift-oadp-operator-master-4.9-operator-e2e-aws/1617908146062233600#1:build-log.txt%3A135)