### PR TITLE
init use same resources as the main container

### DIFF
--- a/controllers/velero_test.go
+++ b/controllers/velero_test.go
@@ -469,10 +469,15 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 							},
 							InitContainers: []corev1.Container{
 								{
-									Image:                    common.AWSPluginImage,
-									Name:                     common.VeleroPluginForAWS,
-									ImagePullPolicy:          corev1.PullAlways,
-									Resources:                corev1.ResourceRequirements{},
+									Image:           common.AWSPluginImage,
+									Name:            common.VeleroPluginForAWS,
+									ImagePullPolicy: corev1.PullAlways,
+									Resources: corev1.ResourceRequirements{
+										Requests: corev1.ResourceList{
+											corev1.ResourceCPU:    resource.MustParse("500m"),
+											corev1.ResourceMemory: resource.MustParse("128Mi"),
+										},
+									},
 									TerminationMessagePath:   "/dev/termination-log",
 									TerminationMessagePolicy: "File",
 									VolumeMounts: []corev1.VolumeMount{
@@ -483,10 +488,15 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 									},
 								},
 								{
-									Image:                    common.GCPPluginImage,
-									Name:                     common.VeleroPluginForGCP,
-									ImagePullPolicy:          corev1.PullAlways,
-									Resources:                corev1.ResourceRequirements{},
+									Image:           common.GCPPluginImage,
+									Name:            common.VeleroPluginForGCP,
+									ImagePullPolicy: corev1.PullAlways,
+									Resources: corev1.ResourceRequirements{
+										Requests: corev1.ResourceList{
+											corev1.ResourceCPU:    resource.MustParse("500m"),
+											corev1.ResourceMemory: resource.MustParse("128Mi"),
+										},
+									},
 									TerminationMessagePath:   "/dev/termination-log",
 									TerminationMessagePolicy: "File",
 									VolumeMounts: []corev1.VolumeMount{
@@ -497,10 +507,15 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 									},
 								},
 								{
-									Image:                    common.AzurePluginImage,
-									Name:                     common.VeleroPluginForAzure,
-									ImagePullPolicy:          corev1.PullAlways,
-									Resources:                corev1.ResourceRequirements{},
+									Image:           common.AzurePluginImage,
+									Name:            common.VeleroPluginForAzure,
+									ImagePullPolicy: corev1.PullAlways,
+									Resources: corev1.ResourceRequirements{
+										Requests: corev1.ResourceList{
+											corev1.ResourceCPU:    resource.MustParse("500m"),
+											corev1.ResourceMemory: resource.MustParse("128Mi"),
+										},
+									},
 									TerminationMessagePath:   "/dev/termination-log",
 									TerminationMessagePolicy: "File",
 									VolumeMounts: []corev1.VolumeMount{
@@ -511,10 +526,15 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 									},
 								},
 								{
-									Image:                    common.KubeVirtPluginImage,
-									Name:                     common.KubeVirtPlugin,
-									ImagePullPolicy:          corev1.PullAlways,
-									Resources:                corev1.ResourceRequirements{},
+									Image:           common.KubeVirtPluginImage,
+									Name:            common.KubeVirtPlugin,
+									ImagePullPolicy: corev1.PullAlways,
+									Resources: corev1.ResourceRequirements{
+										Requests: corev1.ResourceList{
+											corev1.ResourceCPU:    resource.MustParse("500m"),
+											corev1.ResourceMemory: resource.MustParse("128Mi"),
+										},
+									},
 									TerminationMessagePath:   "/dev/termination-log",
 									TerminationMessagePolicy: "File",
 									VolumeMounts: []corev1.VolumeMount{
@@ -525,10 +545,15 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 									},
 								},
 								{
-									Image:                    common.OpenshiftPluginImage,
-									Name:                     common.VeleroPluginForOpenshift,
-									ImagePullPolicy:          corev1.PullAlways,
-									Resources:                corev1.ResourceRequirements{},
+									Image:           common.OpenshiftPluginImage,
+									Name:            common.VeleroPluginForOpenshift,
+									ImagePullPolicy: corev1.PullAlways,
+									Resources: corev1.ResourceRequirements{
+										Requests: corev1.ResourceList{
+											corev1.ResourceCPU:    resource.MustParse("500m"),
+											corev1.ResourceMemory: resource.MustParse("128Mi"),
+										},
+									},
 									TerminationMessagePath:   "/dev/termination-log",
 									TerminationMessagePolicy: "File",
 									VolumeMounts: []corev1.VolumeMount{
@@ -539,10 +564,15 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 									},
 								},
 								{
-									Image:                    common.CSIPluginImage,
-									Name:                     common.VeleroPluginForCSI,
-									ImagePullPolicy:          corev1.PullAlways,
-									Resources:                corev1.ResourceRequirements{},
+									Image:           common.CSIPluginImage,
+									Name:            common.VeleroPluginForCSI,
+									ImagePullPolicy: corev1.PullAlways,
+									Resources: corev1.ResourceRequirements{
+										Requests: corev1.ResourceList{
+											corev1.ResourceCPU:    resource.MustParse("500m"),
+											corev1.ResourceMemory: resource.MustParse("128Mi"),
+										},
+									},
 									TerminationMessagePath:   "/dev/termination-log",
 									TerminationMessagePolicy: "File",
 									VolumeMounts: []corev1.VolumeMount{
@@ -2671,10 +2701,15 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 							},
 							InitContainers: []corev1.Container{
 								{
-									Image:                    common.AWSPluginImage,
-									Name:                     common.VeleroPluginForAWS,
-									ImagePullPolicy:          corev1.PullAlways,
-									Resources:                corev1.ResourceRequirements{},
+									Image:           common.AWSPluginImage,
+									Name:            common.VeleroPluginForAWS,
+									ImagePullPolicy: corev1.PullAlways,
+									Resources: corev1.ResourceRequirements{
+										Requests: corev1.ResourceList{
+											corev1.ResourceCPU:    resource.MustParse("500m"),
+											corev1.ResourceMemory: resource.MustParse("128Mi"),
+										},
+									},
 									TerminationMessagePath:   "/dev/termination-log",
 									TerminationMessagePolicy: "File",
 									VolumeMounts: []corev1.VolumeMount{
@@ -2876,10 +2911,15 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 							},
 							InitContainers: []corev1.Container{
 								{
-									Image:                    common.AWSPluginImage,
-									Name:                     common.VeleroPluginForAWS,
-									ImagePullPolicy:          corev1.PullAlways,
-									Resources:                corev1.ResourceRequirements{},
+									Image:           common.AWSPluginImage,
+									Name:            common.VeleroPluginForAWS,
+									ImagePullPolicy: corev1.PullAlways,
+									Resources: corev1.ResourceRequirements{
+										Requests: corev1.ResourceList{
+											corev1.ResourceCPU:    resource.MustParse("500m"),
+											corev1.ResourceMemory: resource.MustParse("128Mi"),
+										},
+									},
 									TerminationMessagePath:   "/dev/termination-log",
 									TerminationMessagePolicy: "File",
 									VolumeMounts: []corev1.VolumeMount{
@@ -2890,10 +2930,15 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 									},
 								},
 								{
-									Image:                    common.KubeVirtPluginImage,
-									Name:                     common.KubeVirtPlugin,
-									ImagePullPolicy:          corev1.PullAlways,
-									Resources:                corev1.ResourceRequirements{},
+									Image:           common.KubeVirtPluginImage,
+									Name:            common.KubeVirtPlugin,
+									ImagePullPolicy: corev1.PullAlways,
+									Resources: corev1.ResourceRequirements{
+										Requests: corev1.ResourceList{
+											corev1.ResourceCPU:    resource.MustParse("500m"),
+											corev1.ResourceMemory: resource.MustParse("128Mi"),
+										},
+									},
 									TerminationMessagePath:   "/dev/termination-log",
 									TerminationMessagePolicy: "File",
 									VolumeMounts: []corev1.VolumeMount{
@@ -3098,10 +3143,15 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 							},
 							InitContainers: []corev1.Container{
 								{
-									Image:                    common.AWSPluginImage,
-									Name:                     common.VeleroPluginForAWS,
-									ImagePullPolicy:          corev1.PullAlways,
-									Resources:                corev1.ResourceRequirements{},
+									Image:           common.AWSPluginImage,
+									Name:            common.VeleroPluginForAWS,
+									ImagePullPolicy: corev1.PullAlways,
+									Resources: corev1.ResourceRequirements{
+										Requests: corev1.ResourceList{
+											corev1.ResourceCPU:    resource.MustParse("500m"),
+											corev1.ResourceMemory: resource.MustParse("128Mi"),
+										},
+									},
 									TerminationMessagePath:   "/dev/termination-log",
 									TerminationMessagePolicy: "File",
 									VolumeMounts: []corev1.VolumeMount{
@@ -3338,10 +3388,15 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 							},
 							InitContainers: []corev1.Container{
 								{
-									Image:                    common.AWSPluginImage,
-									Name:                     common.VeleroPluginForAWS,
-									ImagePullPolicy:          corev1.PullAlways,
-									Resources:                corev1.ResourceRequirements{},
+									Image:           common.AWSPluginImage,
+									Name:            common.VeleroPluginForAWS,
+									ImagePullPolicy: corev1.PullAlways,
+									Resources: corev1.ResourceRequirements{
+										Requests: corev1.ResourceList{
+											corev1.ResourceCPU:    resource.MustParse("500m"),
+											corev1.ResourceMemory: resource.MustParse("128Mi"),
+										},
+									},
 									TerminationMessagePath:   "/dev/termination-log",
 									TerminationMessagePolicy: "File",
 									VolumeMounts: []corev1.VolumeMount{
@@ -3566,10 +3621,15 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 							},
 							InitContainers: []corev1.Container{
 								{
-									Image:                    common.AWSPluginImage,
-									Name:                     common.VeleroPluginForAWS,
-									ImagePullPolicy:          corev1.PullAlways,
-									Resources:                corev1.ResourceRequirements{},
+									Image:           common.AWSPluginImage,
+									Name:            common.VeleroPluginForAWS,
+									ImagePullPolicy: corev1.PullAlways,
+									Resources: corev1.ResourceRequirements{
+										Requests: corev1.ResourceList{
+											corev1.ResourceCPU:    resource.MustParse("500m"),
+											corev1.ResourceMemory: resource.MustParse("128Mi"),
+										},
+									},
 									TerminationMessagePath:   "/dev/termination-log",
 									TerminationMessagePolicy: "File",
 									VolumeMounts: []corev1.VolumeMount{

--- a/pkg/credentials/credentials.go
+++ b/pkg/credentials/credentials.go
@@ -255,15 +255,7 @@ func AppendCloudProviderVolumes(dpa *oadpv1alpha1.DataProtectionApplication, ds 
 // add plugin specific specs to velero deployment
 func AppendPluginSpecificSpecs(dpa *oadpv1alpha1.DataProtectionApplication, veleroDeployment *appsv1.Deployment, veleroContainer *corev1.Container, providerNeedsDefaultCreds map[string]bool, hasCloudStorage bool) error {
 
-	init_container_resources := corev1.ResourceRequirements{}
-	if len(veleroDeployment.Spec.Template.Spec.Containers) > 0 {
-		for _, container := range veleroDeployment.Spec.Template.Spec.Containers {
-			if container.Name == "velero" {
-				init_container_resources = container.Resources
-				break
-			}
-		}
-	}
+	init_container_resources := veleroContainer.Resources
 
 	for _, plugin := range dpa.Spec.Configuration.Velero.DefaultPlugins {
 		if pluginSpecificMap, ok := PluginSpecificFields[plugin]; ok {


### PR DESCRIPTION
When deploying a velero instance, the initContainer doesnt have any resources defined, instead, use the same resources that have been defined for the main one.

I'd be nice to be able to set resources for each container, meanwhile we can use whatever is defined for the main one