### PR TITLE
oadp-1.0: stop changing go.mod in ci-Dockerfile

### DIFF
--- a/build/ci-Dockerfile
+++ b/build/ci-Dockerfile
@@ -5,10 +5,7 @@ WORKDIR /go/src/github.com/openshift/oadp-operator
 
 COPY ./ .
 
-RUN go get -d -u github.com/onsi/ginkgo/ginkgo && \
- go get -d -u github.com/onsi/ginkgo/v2/ginkgo && \
- go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo@latest
-RUN go get github.com/onsi/gomega/...
+RUN go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo
 RUN chmod -R 777 ./
 RUN chmod -R 777 /go/
 RUN go mod download


### PR DESCRIPTION
Signed-off-by: Tiger Kaovilai <tkaovila@redhat.com>

Validated that e2e compile errors in [e2e in prow](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/38198/rehearse-38198-periodic-ci-openshift-oadp-operator-oadp-1.0-4.7-operator-e2e-aws-periodic-slack/1646319660976574464#1:build-log.txt%3A133-141)
are caused by `go get` in ci-Dockerfile.

Confirmed locally with results from
```
❯ docker run --rm -it \
    registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.12 sh -c ' \
    git clone https://github.com/openshift/oadp-operator.git --single-branch --branch oadp-1.0 && \
    cd oadp-operator && \
    export GOFLAGS=-mod=mod && \
    go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo@latest && \
    go get -d -u github.com/onsi/ginkgo/ginkgo && \
    go get -d -u github.com/onsi/ginkgo/v2/ginkgo && \
    go mod download && \
    ginkgo build tests/e2e'
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
Cloning into 'oadp-operator'...
remote: Enumerating objects: 6779, done.
...
go: upgraded github.com/onsi/ginkgo/v2 v2.1.1 => v2.9.2
go: upgraded github.com/onsi/gomega v1.17.0 => v1.27.4
Failed to compile e2e:

# sigs.k8s.io/controller-runtime/pkg/log
/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.10.3/pkg/log/log.go:67:16: cannot use NullLogger{} (value of type NullLogger) as type logr.Logger in argument to Log.Fulfill
/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.10.3/pkg/log/log.go:82:31: cannot use NullLogger{} (value of type NullLogger) as type logr.Logger in argument to NewDelegatingLogger
/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.10.3/pkg/log/log.go:86:24: cannot use Log (variable of type *DelegatingLogger) as type logr.Logger in variable declaration
/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.10.3/pkg/log/log.go:88:16: assignment mismatch: 1 variable but logr.FromContext returns 2 values
/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.10.3/pkg/log/null.go:30:21: cannot use NullLogger{} (value of type NullLogger) as type logr.Logger in variable declaration
/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.10.3/pkg/log/null.go:49:9: cannot use log (variable of type NullLogger) as type logr.Logger in return statement
/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.10.3/pkg/log/deleg.go:79:17: undefined: logr.WithCallDepth
/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.10.3/pkg/log/deleg.go:163:9: cannot use res (variable of type *DelegatingLogger) as type logr.Logger in return statement
/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.10.3/pkg/log/deleg.go:179:9: cannot use res (variable of type *DelegatingLogger) as type logr.Logger in return statement
/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.10.3/pkg/log/deleg.go:195:9: cannot use res (variable of type *DelegatingLogger) as type logr.Logger in return statement
/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.10.3/pkg/log/null.go:49:9: too many errors
# k8s.io/klog/v2
/go/pkg/mod/k8s.io/klog/v2@v2.9.0/klog.go:705:13: invalid operation: logr != nil (mismatched types logr.Logger and untyped nil)
/go/pkg/mod/k8s.io/klog/v2@v2.9.0/klog.go:724:13: invalid operation: logr != nil (mismatched types logr.Logger and untyped nil)
/go/pkg/mod/k8s.io/klog/v2@v2.9.0/klog.go:742:13: invalid operation: logr != nil (mismatched types logr.Logger and untyped nil)
/go/pkg/mod/k8s.io/klog/v2@v2.9.0/klog.go:763:13: invalid operation: logr != nil (mismatched types logr.Logger and untyped nil)
/go/pkg/mod/k8s.io/klog/v2@v2.9.0/klog.go:782:14: invalid operation: loggr != nil (mismatched types logr.Logger and untyped nil)
/go/pkg/mod/k8s.io/klog/v2@v2.9.0/klog.go:783:8: undefined: logr.WithCallDepth
/go/pkg/mod/k8s.io/klog/v2@v2.9.0/klog.go:794:14: invalid operation: loggr != nil (mismatched types logr.Logger and untyped nil)
/go/pkg/mod/k8s.io/klog/v2@v2.9.0/klog.go:795:8: undefined: logr.WithCallDepth
/go/pkg/mod/k8s.io/klog/v2@v2.9.0/klog.go:915:12: invalid operation: log != nil (mismatched types logr.Logger and untyped nil)
/go/pkg/mod/k8s.io/klog/v2@v2.9.0/klog.go:919:9: undefined: logr.WithCallDepth
/go/pkg/mod/k8s.io/klog/v2@v2.9.0/klog.go:919:9: too many errors
```

vs removing `go get` resulting in "Compiled e2e.test"

```
docker run --rm -it \
    registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.12 sh -c ' \
    git clone https://github.com/openshift/oadp-operator.git --single-branch --branch oadp-1.0 && \
    cd oadp-operator && \
    export GOFLAGS=-mod=mod && \
    go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo@latest && \
    ginkgo build tests/e2e'
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
Cloning into 'oadp-operator'...
remote: Enumerating objects: 6779, done.
remote: Counting objects: 100% (159/159), done.
remote: Compressing objects: 100% (96/96), done.
remote: Total 6779 (delta 111), reused 66 (delta 63), pack-reused 6620
Receiving objects: 100% (6779/6779), 42.67 MiB | 11.22 MiB/s, done.
Resolving deltas: 100% (3421/3421), done.
go: downloading github.com/onsi/ginkgo v1.16.5
go: downloading github.com/onsi/ginkgo/v2 v2.9.2
...
go: downloading github.com/onsi/gomega v1.17.0
...
go: downloading github.com/Azure/go-autorest/autorest/validation v0.2.0
go: downloading github.com/Azure/go-autorest/autorest/to v0.3.0

Compiled e2e.test
```