### PR TITLE
OADP-708/OADP-1526: Validation for BSL/VSL credentials secrets

### DIFF
--- a/api/v1alpha1/oadp_types.go
+++ b/api/v1alpha1/oadp_types.go
@@ -317,6 +317,15 @@ func (dpa *DataProtectionApplication) BackupImages() bool {
 	return dpa.Spec.BackupImages == nil || *dpa.Spec.BackupImages
 }
 
+func (veleroConfig *VeleroConfig) HasFeatureFlag(flag string) bool {
+	for _, featureFlag := range veleroConfig.FeatureFlags {
+		if featureFlag == flag {
+			return true
+		}
+	}
+	return false
+}
+
 func init() {
 	SchemeBuilder.Register(&DataProtectionApplication{}, &DataProtectionApplicationList{}, &CloudStorage{}, &CloudStorageList{})
 }

--- a/controllers/validator.go
+++ b/controllers/validator.go
@@ -125,7 +125,7 @@ func (r *DPAReconciler) ValidateVeleroPlugins(log logr.Logger) (bool, error) {
 		if !foundInBSLorVSL && !hasCloudStorage {
 			pluginNeedsCheck = true
 		}
-		if ok && pluginSpecificMap.IsCloudProvider && pluginNeedsCheck && !dpa.Spec.Configuration.Velero.NoDefaultBackupLocation {
+		if ok && pluginSpecificMap.IsCloudProvider && pluginNeedsCheck && !dpa.Spec.Configuration.Velero.NoDefaultBackupLocation && !dpa.Spec.Configuration.Velero.HasFeatureFlag("no-secret") {
 			secretNamesToValidate := make(map[string]empty)
 			// check specified credentials in backup locations exists in the cluster
 			for _, location := range dpa.Spec.BackupLocations {

--- a/controllers/validator.go
+++ b/controllers/validator.go
@@ -7,6 +7,7 @@ import (
 
 	"time"
 
+	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/go-logr/logr"
 	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
 	"github.com/openshift/oadp-operator/pkg/credentials"
@@ -126,25 +127,25 @@ func (r *DPAReconciler) ValidateVeleroPlugins(log logr.Logger) (bool, error) {
 			pluginNeedsCheck = true
 		}
 		if ok && pluginSpecificMap.IsCloudProvider && pluginNeedsCheck && !dpa.Spec.Configuration.Velero.NoDefaultBackupLocation && !dpa.Spec.Configuration.Velero.HasFeatureFlag("no-secret") {
-			secretNamesToValidate := make(map[string]empty)
+			secretNamesToValidate := mapset.NewSet[string]()
 			// check specified credentials in backup locations exists in the cluster
 			for _, location := range dpa.Spec.BackupLocations {
 				if location.Velero != nil {
 					provider := strings.TrimPrefix(location.Velero.Provider, veleroIOPrefix)
 					if provider == string(plugin) && location.Velero != nil {
 						if location.Velero.Credential != nil {
-							secretNamesToValidate[location.Velero.Credential.Name] = empty{}
+							secretNamesToValidate.Add(location.Velero.Credential.Name)
 						} else {
-							secretNamesToValidate[pluginSpecificMap.SecretName] = empty{}
+							secretNamesToValidate.Add(pluginSpecificMap.SecretName)
 						}
 					}
 				}
 			}
 			// check for default secret name if dpa has snapshotLocations
 			if foundInVSL := snapshotLocationsProviders[string(plugin)]; foundInVSL {
-				secretNamesToValidate[pluginSpecificMap.SecretName] = empty{}
+				secretNamesToValidate.Add(pluginSpecificMap.SecretName)
 			}
-			for secretName, _ := range secretNamesToValidate {
+			for _, secretName := range secretNamesToValidate.ToSlice() {
 				_, err := r.getProviderSecret(secretName)
 				if err != nil {
 					r.Log.Info(fmt.Sprintf("error validating %s provider secret:  %s/%s", string(plugin), r.NamespacedName.Namespace, secretName))

--- a/controllers/validator_test.go
+++ b/controllers/validator_test.go
@@ -1,8 +1,9 @@
 package controllers
 
 import (
-	"k8s.io/apimachinery/pkg/api/resource"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/go-logr/logr"
 	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
@@ -515,8 +516,8 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 				},
 			},
 			objects: []client.Object{},
-			wantErr: true,
-			want:    false,
+			wantErr: false,
+			want:    true,
 		},
 		{
 			name: "given valid DPA CR VSL configured and GCP Default Plugin without secret",
@@ -622,7 +623,56 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 			want:    false,
 		},
 		{
-			name: "given valid DPA CR AWS Default Plugin with credentials and a VSL",
+			name: "given valid DPA CR AWS Default Plugin with credentials and a VSL, and default secret specified, passes",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-DPA-CR",
+					Namespace: "test-ns",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					BackupLocations: []oadpv1alpha1.BackupLocation{
+						{
+							Velero: &v1.BackupStorageLocationSpec{
+								Provider: "velero.io/aws",
+								Credential: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "cloud-credentials",
+									},
+									Key:      "cloud",
+									Optional: new(bool),
+								},
+							},
+						},
+					},
+					SnapshotLocations: []oadpv1alpha1.SnapshotLocation{
+						{
+							Velero: &v1.VolumeSnapshotLocationSpec{
+								Provider: "velero.io/aws",
+							},
+						},
+					},
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{
+							DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
+								oadpv1alpha1.DefaultPluginAWS,
+							},
+						},
+					},
+				},
+			},
+			objects: []client.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cloud-credentials",
+						Namespace: "test-ns",
+					},
+				},
+			},
+			wantErr: false,
+			want:    true,
+		},
+		{
+			name: "given valid DPA CR AWS Default Plugin with credentials and a VSL, and without secret in cluster, fails",
 			dpa: &oadpv1alpha1.DataProtectionApplication{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-DPA-CR",
@@ -660,8 +710,8 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 				},
 			},
 			objects: []client.Object{},
-			wantErr: false,
-			want:    true,
+			wantErr: true,
+			want:    false,
 		},
 		{
 			name: "given valid DPA CR, datamover enabled, vsm plugin not specified, error case",

--- a/controllers/validator_test.go
+++ b/controllers/validator_test.go
@@ -515,7 +515,14 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 					},
 				},
 			},
-			objects: []client.Object{},
+			objects: []client.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cloud-credentials-gcp",
+						Namespace: "test-ns",
+					},
+				},
+			},
 			wantErr: false,
 			want:    true,
 		},

--- a/controllers/validator_test.go
+++ b/controllers/validator_test.go
@@ -492,7 +492,7 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 			want:    true,
 		},
 		{
-			name: "given valid DPA CR BSL configured and GCP Default Plugin without secret",
+			name: "given valid DPA CR BSL configured and GCP Default Plugin with secret",
 			dpa: &oadpv1alpha1.DataProtectionApplication{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-DPA-CR",
@@ -525,6 +525,64 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 			},
 			wantErr: false,
 			want:    true,
+		},
+		{
+			name: "given valid DPA CR BSL configured and GCP Default Plugin without secret with no-secret feature flag",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-DPA-CR",
+					Namespace: "test-ns",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					BackupLocations: []oadpv1alpha1.BackupLocation{
+						{
+							Velero: &v1.BackupStorageLocationSpec{
+								Provider: "velero.io/gcp",
+							},
+						},
+					},
+
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{
+							DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
+								oadpv1alpha1.DefaultPluginGCP,
+							},
+							FeatureFlags: []string{"no-secret"},
+						},
+					},
+				},
+			},
+			objects: []client.Object{},
+			wantErr: false,
+			want:    true,
+		},
+		{
+			name: "should error: given valid DPA CR BSL configured and GCP Default Plugin without secret without no-secret feature flag",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-DPA-CR",
+					Namespace: "test-ns",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					BackupLocations: []oadpv1alpha1.BackupLocation{
+						{
+							Velero: &v1.BackupStorageLocationSpec{
+								Provider: "velero.io/gcp",
+							},
+						},
+					},
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{
+							DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
+								oadpv1alpha1.DefaultPluginGCP,
+							},
+						},
+					},
+				},
+			},
+			objects: []client.Object{},
+			wantErr: true,
+			want:    false,
 		},
 		{
 			name: "given valid DPA CR VSL configured and GCP Default Plugin without secret",

--- a/controllers/velero.go
+++ b/controllers/velero.go
@@ -41,6 +41,7 @@ const (
 	VeleroAzureSecretName = "cloud-credentials-azure"
 	VeleroGCPSecretName   = "cloud-credentials-gcp"
 	enableCSIFeatureFlag  = "EnableCSI"
+	veleroIOPrefix        = "velero.io/"
 )
 
 var (
@@ -757,11 +758,11 @@ func (r DPAReconciler) noDefaultCredentials(dpa oadpv1alpha1.DataProtectionAppli
 	} else {
 		for _, bsl := range dpa.Spec.BackupLocations {
 			if bsl.Velero != nil && bsl.Velero.Credential == nil {
-				bslProvider := strings.TrimPrefix(bsl.Velero.Provider, "velero.io/")
+				bslProvider := strings.TrimPrefix(bsl.Velero.Provider, veleroIOPrefix)
 				providerNeedsDefaultCreds[bslProvider] = true
 			}
 			if bsl.Velero != nil && bsl.Velero.Credential != nil {
-				bslProvider := strings.TrimPrefix(bsl.Velero.Provider, "velero.io/")
+				bslProvider := strings.TrimPrefix(bsl.Velero.Provider, veleroIOPrefix)
 				if found := providerNeedsDefaultCreds[bslProvider]; !found {
 					providerNeedsDefaultCreds[bslProvider] = false
 				}
@@ -784,7 +785,7 @@ func (r DPAReconciler) noDefaultCredentials(dpa oadpv1alpha1.DataProtectionAppli
 		if vsl.Velero != nil {
 			// To handle the case where we want to manually hand the credentials for a cloud storage created
 			// Bucket credentials via configuration. Only AWS is supported
-			provider := strings.TrimPrefix(vsl.Velero.Provider, "velero.io")
+			provider := strings.TrimPrefix(vsl.Velero.Provider, veleroIOPrefix)
 			if vsl.Velero.Credential != nil || provider == string(oadpv1alpha1.AWSBucketProvider) && hasCloudStorage {
 				providerNeedsDefaultCreds[provider] = false
 			} else {

--- a/controllers/velero_test.go
+++ b/controllers/velero_test.go
@@ -4613,7 +4613,7 @@ func Test_validateVeleroPlugins(t *testing.T) {
 			want:    true,
 		},
 		{
-			name: "given invalid Velero secret, the validplugin check fails",
+			name: "given aws default plugin without bsl, the valid plugin check passes",
 			dpa: &oadpv1alpha1.DataProtectionApplication{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-Velero-CR",
@@ -4630,8 +4630,8 @@ func Test_validateVeleroPlugins(t *testing.T) {
 				},
 			},
 			secret:  &corev1.Secret{},
-			wantErr: true,
-			want:    false,
+			wantErr: false,
+			want:    true,
 		},
 	}
 	for _, tt := range tests {

--- a/controllers/vsl.go
+++ b/controllers/vsl.go
@@ -54,7 +54,7 @@ func (r *DPAReconciler) LabelVSLSecrets(log logr.Logger) (bool, error) {
 	}
 
 	for _, vsl := range dpa.Spec.SnapshotLocations {
-		provider := strings.TrimPrefix(vsl.Velero.Provider, "velero.io")
+		provider := strings.TrimPrefix(vsl.Velero.Provider, veleroIOPrefix)
 		switch provider {
 		case "aws":
 			secretName := credentials.PluginSpecificFields[oadpv1alpha1.DefaultPluginAWS].SecretName

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,11 @@ require (
 )
 
 require (
+	github.com/deckarep/golang-set/v2 v2.1.0
+	github.com/google/go-cmp v0.5.9
+)
+
+require (
 	cloud.google.com/go v0.100.2 // indirect
 	cloud.google.com/go/compute v1.5.0 // indirect
 	cloud.google.com/go/iam v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -211,6 +211,8 @@ github.com/dave/rebecca v0.9.1/go.mod h1:N6XYdMD/OKw3lkF3ywh8Z6wPGuwNFDNtWYEMFWE
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/deckarep/golang-set/v2 v2.1.0 h1:g47V4Or+DUdzbs8FxCCmgb6VYd+ptPAngjM6dtGktsI=
+github.com/deckarep/golang-set/v2 v2.1.0/go.mod h1:VAky9rY/yGXJOLEDv3OMci+7wtDpOF4IN+y82NBOac4=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dimchansky/utfbom v1.1.0/go.mod h1:rO41eb7gLfo8SF1jd9F8HplJm1Fewwi4mQvIirEdv+8=


### PR DESCRIPTION
[OADP-708](https://issues.redhat.com//browse/OADP-708): validate secret names in BSL and VSL, remove required default VSL secret if no VSL.
[OADP-1526](https://issues.redhat.com//browse/OADP-1526): Validate existence of VSL credentials.

This includes a rebase of #784, and adds an extra commit on top. I'm not sure if it's better to rebase and merge #784 separately and use this just for the [OADP-1526](https://issues.redhat.com//browse/OADP-1526) work, but the changes in this combined pull request are working as far as I can tell.