### PR TITLE
OADP-1934: Remove hard-coded namespace from debug example.

### DIFF
--- a/must-gather/collection-scripts/debug/tail_failed_pods
+++ b/must-gather/collection-scripts/debug/tail_failed_pods
@@ -1,10 +1,11 @@
 #!/bin/bash
 
-skip_tls="${1:-false}"
+namespace="${1:-openshift-adp}"
+skip_tls="${2:-false}"
 
-for pod in $(oc get pods --insecure-skip-tls-verify=${skip_tls} -n openshift-adp -o jsonpath='{.items[?(.status.containerStatuses[0].lastState.terminated.reason=="Error")].metadata.name}'); do
+for pod in $(oc get pods --insecure-skip-tls-verify=${skip_tls} -n ${namespace} -o jsonpath='{.items[?(.status.containerStatuses[0].lastState.terminated.reason=="Error")].metadata.name}'); do
     echo "***"
-    echo "* Last logs from failed pod openshift-adp/${pod}:"
-    oc logs -n openshift-adp --insecure-skip-tls-verify=${skip_tls} $pod --tail=10
+    echo "* Last logs from failed pod ${namespace}/${pod}:"
+    oc logs -n ${namespace} --insecure-skip-tls-verify=${skip_tls} $pod --tail=10
     echo -e "\n\n\n"
 done


### PR DESCRIPTION
The must-gather debug directory example script had the "openshift-adp" namespace hard-coded, this pull request adds a quick command line option and leaves "openshift-adp" as the default.