### PR TITLE
Remove reference to unknown revision `github.com/openshift/api v3.9.0`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -160,3 +160,5 @@ require (
 )
 
 replace github.com/vmware-tanzu/velero => github.com/openshift/velero v0.10.2-0.20230518025540-34ab2a01f0e3
+
+replace github.com/openshift/api => github.com/openshift/api v0.0.0-20230414143018-3367bc7e6ac7 // release-4.13

--- a/go.sum
+++ b/go.sum
@@ -666,8 +666,8 @@ github.com/onsi/gomega v1.14.0/go.mod h1:cIuvLEne0aoVhAgh/O6ac0Op8WWw9H6eYCriF+t
 github.com/onsi/gomega v1.15.0/go.mod h1:cIuvLEne0aoVhAgh/O6ac0Op8WWw9H6eYCriF+tEHG0=
 github.com/onsi/gomega v1.27.2 h1:SKU0CXeKE/WVgIV1T61kSa3+IRE8Ekrv9rdXDwwTqnY=
 github.com/onsi/gomega v1.27.2/go.mod h1:5mR3phAHpkAVIDkHEUBY6HGVsU+cpcEscrGPB4oPlZI=
-github.com/openshift/api v3.9.0+incompatible h1:fJ/KsefYuZAjmrr3+5U9yZIZbTOpVkDDLDLFresAeYs=
-github.com/openshift/api v3.9.0+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
+github.com/openshift/api v0.0.0-20230414143018-3367bc7e6ac7 h1:rncLxJBpFGqBztyxCMwNRnMjhhIDOWHJowi6q8G6koI=
+github.com/openshift/api v0.0.0-20230414143018-3367bc7e6ac7/go.mod h1:ctXNyWanKEjGj8sss1KjjHQ3ENKFm33FFnS5BKaIPh4=
 github.com/openshift/velero v0.10.2-0.20230518025540-34ab2a01f0e3 h1:zMVfoOJH/tOijj06o+pth75QRizB5spYXBPxQabs98I=
 github.com/openshift/velero v0.10.2-0.20230518025540-34ab2a01f0e3/go.mod h1:EBv9g8EJDkTr/5lwtn2cfOb7DIJUca7lXbnD8sM4Pxw=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=


### PR DESCRIPTION
fix `main.go:32:2: reading github.com/openshift/api/go.mod at revision v3.9.0: unknown revision v3.9.0`

Fix @weshayutin's https://github.com/openshift/oadp-operator/pull/1024#issuecomment-1555913026