### PR TITLE
Update CSI doc 

### DIFF
--- a/docs/examples/CSI/csi_example.md
+++ b/docs/examples/CSI/csi_example.md
@@ -104,6 +104,7 @@ allowVolumeExpansion: true
 ### Create the Mssql deployment config:
 
 `oc create -f docs/examples/manifests/mysql/mysql-persistent-csi-template.yaml`
+`oc create -f docs/examples/manifests/mysql/pvc/aws.yaml`
 
 This example will create the following resources:
 * **Namespace**


### PR DESCRIPTION
Mysql deployment config (mysql-persistent-csi-template.yaml) does not create pvc. 
PVC is created separately in e2e test suite according to cluster-profile of the test. 