### PR TITLE
OADP-1987: Correctly get backup/restore logs in must-gather.

### DIFF
--- a/must-gather/collection-scripts/logs/gather_logs_backup
+++ b/must-gather/collection-scripts/logs/gather_logs_backup
@@ -15,11 +15,11 @@ skip_tls=$8
 mkdir -p "${object_collection_path}"
 echo "[cluster=${cluster}][ns=${ns}] Gathering 'velero backup describe ${backup}'"
 if [ "$timeout" = "0s" ]; then
-    timeout 30s velero describe backup ${backup} --insecure-skip-tls-verify=${skip_tls} --details &> "${object_collection_path}/backup-describe-${backup}.txt" &
+    timeout 30s velero describe backup ${backup} --namespace ${ns} --insecure-skip-tls-verify=${skip_tls} --details &> "${object_collection_path}/backup-describe-${backup}.txt" &
 else
-    timeout ${timeout} velero describe backup ${backup} --insecure-skip-tls-verify=${skip_tls} --details &> "${object_collection_path}/backup-describe-${backup}.txt" &
+    timeout ${timeout} velero describe backup ${backup} --namespace ${ns} --insecure-skip-tls-verify=${skip_tls} --details &> "${object_collection_path}/backup-describe-${backup}.txt" &
 fi
 echo "[cluster=${cluster}][ns=${ns}] Gathering 'velero backup logs ${backup}'"
-timeout 30s velero backup logs ${backup} --insecure-skip-tls-verify=${skip_tls} --timeout=30s &> "${object_collection_path}/backup-${backup}.log" &
+timeout 30s velero backup logs ${backup} --namespace ${ns} --insecure-skip-tls-verify=${skip_tls} --timeout=30s &> "${object_collection_path}/backup-${backup}.log" &
 
 wait

--- a/must-gather/collection-scripts/logs/gather_logs_restore
+++ b/must-gather/collection-scripts/logs/gather_logs_restore
@@ -15,11 +15,11 @@ skip_tls=$8
 mkdir -p "${object_collection_path}"
 echo "[cluster=${cluster}][ns=${ns}] Gathering 'velero restore describe ${restore}'"
 if [ "$timeout" = "0s" ]; then
-    timeout 30s velero describe restore ${restore} --insecure-skip-tls-verify=${skip_tls} --details &> "${object_collection_path}/restore-describe-${restore}.txt" &
+    timeout 30s velero describe restore ${restore} --namespace ${ns} --insecure-skip-tls-verify=${skip_tls} --details &> "${object_collection_path}/restore-describe-${restore}.txt" &
 else
-    timeout ${timeout} velero describe restore ${restore} --insecure-skip-tls-verify=${skip_tls} --details &> "${object_collection_path}/restore-describe-${restore}.txt" &
+    timeout ${timeout} velero describe restore ${restore} --namespace ${ns} --insecure-skip-tls-verify=${skip_tls} --details &> "${object_collection_path}/restore-describe-${restore}.txt" &
 fi
 echo "[cluster=${cluster}][ns=${ns}] Gathering 'velero restore logs ${restore}'"
-timeout 30s velero restore logs ${restore} --insecure-skip-tls-verify=${skip_tls} --timeout=30s &> "${object_collection_path}/restore-${restore}.log" &
+timeout 30s velero restore logs ${restore} --namespace ${ns} --insecure-skip-tls-verify=${skip_tls} --timeout=30s &> "${object_collection_path}/restore-${restore}.log" &
 
 wait


### PR DESCRIPTION
In must-gather's gather_logs scripts, the velero command needs a namespace to be able to find the requested backup or restore.