### PR TITLE
Remove test from docker-build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -211,7 +211,7 @@ run: manifests generate fmt vet ## Run a controller from your host.
 # from: https://github.com/containers/podman/issues/12144#issuecomment-955760527
 # related enhancements that may remove the need to manually install qemu-user-static https://bugzilla.redhat.com/show_bug.cgi?id=2061584
 DOCKER_BUILD_ARGS ?= --platform=linux/amd64
-docker-build: test ## Build docker image with the manager.
+docker-build: ## Build docker image with the manager.
 	docker build -t $(IMG) . $(DOCKER_BUILD_ARGS)
 
 docker-push: ## Push docker image with the manager.


### PR DESCRIPTION
Fix make deploy-olm failing due to unit test finding out about images differences.

Test is still run in CI in PRs so should be fine.