### PR TITLE
Add a way to override velero/datamover replicas for debug purposes.

### DIFF
--- a/controllers/datamover.go
+++ b/controllers/datamover.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -19,7 +20,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -276,10 +276,17 @@ func (r *DPAReconciler) buildDataMoverDeployment(dataMoverDeployment *appsv1.Dep
 		},
 	}
 
+	replicas := int32(1)
+	if value, present := os.LookupEnv("DATAMOVER_DEBUG_REPLICAS_OVERRIDE"); present {
+		if converted, err := strconv.Atoi(value); err == nil {
+			replicas = int32(converted)
+		}
+	}
+
 	dataMoverDeployment.Labels = r.getDataMoverLabels()
 	dataMoverDeployment.Spec = appsv1.DeploymentSpec{
 		Selector: dataMoverDeployment.Spec.Selector,
-		Replicas: pointer.Int32(1),
+		Replicas: &replicas,
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{

--- a/controllers/datamover.go
+++ b/controllers/datamover.go
@@ -58,6 +58,8 @@ const (
 	SnapshotRetainPolicyMonthly = "SnapshotRetainPolicyMonthly"
 	SnapshotRetainPolicyYearly  = "SnapshotRetainPolicyYearly"
 	SnapshotRetainPolicyWithin  = "SnapshotRetainPolicyWithin"
+
+	DataMoverReplicaOverride = "DATAMOVER_DEBUG_REPLICAS_OVERRIDE"
 )
 
 type gcpCredentials struct {
@@ -277,7 +279,7 @@ func (r *DPAReconciler) buildDataMoverDeployment(dataMoverDeployment *appsv1.Dep
 	}
 
 	replicas := int32(1)
-	if value, present := os.LookupEnv("DATAMOVER_DEBUG_REPLICAS_OVERRIDE"); present {
+	if value, present := os.LookupEnv(DataMoverReplicaOverride); present {
 		if converted, err := strconv.Atoi(value); err == nil {
 			replicas = int32(converted)
 		}

--- a/controllers/velero.go
+++ b/controllers/velero.go
@@ -224,7 +224,13 @@ func (r *DPAReconciler) customizeVeleroDeployment(dpa *oadpv1alpha1.DataProtecti
 	isSTSNeeded := r.isSTSTokenNeeded(dpa.Spec.BackupLocations, dpa.Namespace)
 
 	// Selector: veleroDeployment.Spec.Selector,
-	veleroDeployment.Spec.Replicas = pointer.Int32(1)
+	replicas := int32(1)
+	if value, present := os.LookupEnv("VELERO_DEBUG_REPLICAS_OVERRIDE"); present {
+		if converted, err := strconv.Atoi(value); err == nil {
+			replicas = int32(converted)
+		}
+	}
+	veleroDeployment.Spec.Replicas = &replicas
 	if dpa.Spec.Configuration.Velero.PodConfig != nil {
 		veleroDeployment.Spec.Template.Spec.Tolerations = dpa.Spec.Configuration.Velero.PodConfig.Tolerations
 		veleroDeployment.Spec.Template.Spec.NodeSelector = dpa.Spec.Configuration.Velero.PodConfig.NodeSelector

--- a/controllers/velero.go
+++ b/controllers/velero.go
@@ -41,6 +41,8 @@ const (
 	VeleroGCPSecretName   = "cloud-credentials-gcp"
 	enableCSIFeatureFlag  = "EnableCSI"
 	veleroIOPrefix        = "velero.io/"
+
+	VeleroReplicaOverride = "VELERO_DEBUG_REPLICAS_OVERRIDE"
 )
 
 var (
@@ -225,7 +227,7 @@ func (r *DPAReconciler) customizeVeleroDeployment(dpa *oadpv1alpha1.DataProtecti
 
 	// Selector: veleroDeployment.Spec.Selector,
 	replicas := int32(1)
-	if value, present := os.LookupEnv("VELERO_DEBUG_REPLICAS_OVERRIDE"); present {
+	if value, present := os.LookupEnv(VeleroReplicaOverride); present {
 		if converted, err := strconv.Atoi(value); err == nil {
 			replicas = int32(converted)
 		}

--- a/controllers/velero_test.go
+++ b/controllers/velero_test.go
@@ -2838,7 +2838,7 @@ func TestDPAReconciler_noDefaultCredentials(t *testing.T) {
 	}
 }
 
-func TestDPAReconciler_DebugEnvironment(t *testing.T) {
+func TestDPAReconciler_VeleroDebugEnvironment(t *testing.T) {
 	tests := []struct {
 		name     string
 		replicas *int
@@ -2868,7 +2868,7 @@ func TestDPAReconciler_DebugEnvironment(t *testing.T) {
 			err = os.Unsetenv(VeleroReplicaOverride)
 		}
 		if err != nil {
-			t.Errorf("DPAReconciler.DebugEnvironment failed to set debug override: %v", err)
+			t.Errorf("DPAReconciler.VeleroDebugEnvironment failed to set debug override: %v", err)
 			return
 		}
 
@@ -2904,7 +2904,7 @@ func TestDPAReconciler_DebugEnvironment(t *testing.T) {
 			}
 			err = r.buildVeleroDeployment(deployment, dpa)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("DPAReconciler.DebugEnvironment error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("DPAReconciler.VeleroDebugEnvironment error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if deployment.Spec.Replicas == nil {

--- a/controllers/velero_test.go
+++ b/controllers/velero_test.go
@@ -2837,3 +2837,91 @@ func TestDPAReconciler_noDefaultCredentials(t *testing.T) {
 		})
 	}
 }
+
+func TestDPAReconciler_DebugEnvironment(t *testing.T) {
+	tests := []struct {
+		name     string
+		replicas *int
+		wantErr  bool
+	}{
+		{
+			name:     "debug replica override not set",
+			replicas: nil,
+			wantErr:  false,
+		},
+		{
+			name:     "debug replica override set to 1",
+			replicas: pointer.Int(1),
+			wantErr:  false,
+		},
+		{
+			name:     "debug replica override set to 0",
+			replicas: pointer.Int(0),
+			wantErr:  false,
+		},
+	}
+	for _, tt := range tests {
+		var err error
+		if tt.replicas != nil {
+			err = os.Setenv(VeleroReplicaOverride, strconv.Itoa(*tt.replicas))
+		} else {
+			err = os.Unsetenv(VeleroReplicaOverride)
+		}
+		if err != nil {
+			t.Errorf("DPAReconciler.DebugEnvironment failed to set debug override: %v", err)
+			return
+		}
+
+		dpa := &oadpv1alpha1.DataProtectionApplication{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-Velero-CR",
+				Namespace: "test-ns",
+			},
+			Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+				Configuration: &oadpv1alpha1.ApplicationConfig{
+					Velero: &oadpv1alpha1.VeleroConfig{
+						DefaultPlugins:          allDefaultPluginsList,
+						NoDefaultBackupLocation: true,
+					},
+				},
+			},
+		}
+
+		deployment := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      common.Velero,
+				Namespace: dpa.Namespace,
+			},
+		}
+
+		t.Run(tt.name, func(t *testing.T) {
+			fakeClient, err := getFakeClientFromObjects(dpa)
+			if err != nil {
+				t.Errorf("error in creating fake client, likely programmer error")
+			}
+			r := DPAReconciler{
+				Client: fakeClient,
+			}
+			err = r.buildVeleroDeployment(deployment, dpa)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("DPAReconciler.DebugEnvironment error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if deployment.Spec.Replicas == nil {
+				t.Error("deployment replicas not set")
+				return
+			}
+			if tt.replicas == nil {
+				if *deployment.Spec.Replicas != 1 {
+					t.Errorf("unexpected deployment replica count: %d", *deployment.Spec.Replicas)
+					return
+				}
+			} else {
+				if *deployment.Spec.Replicas != int32(*tt.replicas) {
+					t.Error("debug replica override did not apply")
+					return
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
For local debugging, I need a way to avoid starting the velero and volume-snapshot-mover pods. This pull request adds two environment variables to control the respective deployment replicas, which seems like the simplest way to get this to work. There should be no change in behavior when they are not set.