### PR TITLE
OADP-2045: Remove the unused dataMover.timeout field

### DIFF
--- a/api/v1alpha1/oadp_types.go
+++ b/api/v1alpha1/oadp_types.go
@@ -202,9 +202,6 @@ type DataMover struct {
 	CredentialName string `json:"credentialName,omitempty"`
 	// User supplied timeout to be used for VolumeSnapshotBackup and VolumeSnapshotRestore to complete, default value is 10m
 	// +optional
-	Timeout string `json:"timeout,omitempty"`
-	// the number of batched volumeSnapshotBackups that can be inProgress at once, default value is 10
-	// +optional
 	MaxConcurrentBackupVolumes string `json:"maxConcurrentBackupVolumes,omitempty"`
 	// the number of batched volumeSnapshotRestores that can be inProgress at once, default value is 10
 	// +optional

--- a/api/v1alpha1/oadp_types.go
+++ b/api/v1alpha1/oadp_types.go
@@ -200,7 +200,7 @@ type DataMover struct {
 	// User supplied Restic Secret name
 	// +optional
 	CredentialName string `json:"credentialName,omitempty"`
-	// User supplied timeout to be used for VolumeSnapshotBackup and VolumeSnapshotRestore to complete, default value is 10m
+	// the number of batched volumeSnapshotBackups that can be inProgress at once, default value is 10
 	// +optional
 	MaxConcurrentBackupVolumes string `json:"maxConcurrentBackupVolumes,omitempty"`
 	// the number of batched volumeSnapshotRestores that can be inProgress at once, default value is 10

--- a/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
@@ -718,9 +718,6 @@ spec:
                               description: Yearly defines the number of snapshots to be kept yearly
                               type: string
                           type: object
-                        timeout:
-                          description: User supplied timeout to be used for VolumeSnapshotBackup and VolumeSnapshotRestore to complete, default value is 10m
-                          type: string
                         volumeOptionsForStorageClasses:
                           additionalProperties:
                             properties:

--- a/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
@@ -718,9 +718,6 @@ spec:
                               description: Yearly defines the number of snapshots to be kept yearly
                               type: string
                           type: object
-                        timeout:
-                          description: User supplied timeout to be used for VolumeSnapshotBackup and VolumeSnapshotRestore to complete, default value is 10m
-                          type: string
                         volumeOptionsForStorageClasses:
                           additionalProperties:
                             properties:

--- a/controllers/validator.go
+++ b/controllers/validator.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"time"
-
 	mapset "github.com/deckarep/golang-set/v2"
 
 	"github.com/go-logr/logr"
@@ -63,13 +61,6 @@ func (r *DPAReconciler) ValidateDataProtectionCR(log logr.Logger) (bool, error) 
 	}
 
 	if r.checkIfDataMoverIsEnabled(&dpa) {
-		// parse for timeout if specified and see if there are no errors
-		if len(dpa.Spec.Features.DataMover.Timeout) > 0 {
-			_, err := time.ParseDuration(dpa.Spec.Features.DataMover.Timeout)
-			if err != nil {
-				return false, err
-			}
-		}
 
 		if !VSMPluginPresent {
 			return false, errors.New("datamover is enabled, specify vsm as a default plugin")

--- a/controllers/velero.go
+++ b/controllers/velero.go
@@ -416,12 +416,6 @@ func (r *DPAReconciler) customizeVeleroContainer(dpa *oadpv1alpha1.DataProtectio
 			Value: "true",
 		}})
 
-		if len(dpa.Spec.Features.DataMover.Timeout) > 0 {
-			veleroContainer.Env = common.AppendUniqueEnvVars(veleroContainer.Env, []corev1.EnvVar{{
-				Name:  "DATAMOVER_TIMEOUT",
-				Value: dpa.Spec.Features.DataMover.Timeout,
-			}})
-		}
 	}
 
 	// Enable user to specify --fs-backup-timeout (defaults to 1h)

--- a/tests/e2e/lib/dpa_helpers.go
+++ b/tests/e2e/lib/dpa_helpers.go
@@ -134,7 +134,6 @@ func (v *DpaCustomResource) Build(backupRestoreType BackupRestoreType) error {
 		veleroFeatureFlags["EnableCSI"] = emptyStruct{}
 		dpaInstance.Spec.Features.DataMover.Enable = true
 		dpaInstance.Spec.Features.DataMover.CredentialName = controllers.ResticsecretName
-		dpaInstance.Spec.Features.DataMover.Timeout = "40m"
 		scName, err := v.ProviderStorageClassName(".")
 		if err != nil {
 			return err


### PR DESCRIPTION
dpa.spec.features.dataMover.timeout was never used in OADP-1.2.x and is left over from OADP-1.1.x.

How to test:
Before installing this patch on a oadp-1.2
oc explain dataprotectionapplications.oadp.openshift.io.spec.features.dataMover | grep -i timeout
result: found

Install patch, make deploy-olm
oc explain dataprotectionapplications.oadp.openshift.io.spec.features.dataMover 
result: timeout field is not present
