### PR TITLE
ci-Dockerfile: `git config core.filemode false`

### DIFF
--- a/build/ci-Dockerfile
+++ b/build/ci-Dockerfile
@@ -9,6 +9,7 @@ RUN go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo
 RUN go mod download
 
 FROM builder AS test
+RUN git config core.fileMode false
 RUN chmod -R 777 ./
 RUN chmod -R 777 $(go env GOPATH)
 RUN mkdir -p $(go env GOCACHE) && chmod -R 777 $(go env GOCACHE)


### PR DESCRIPTION
Fix `git diff` due to chmod
```
old mode 100644
new mode 100755
```

https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/41430/rehearse-41430-pull-ci-openshift-oadp-operator-velero-datamover-4.10-operator-unit-test/1681721009402548224#1:build-log.txt%3A289