### PR TITLE
Fix typo in CRD description

### DIFF
--- a/api/v1alpha1/oadp_types.go
+++ b/api/v1alpha1/oadp_types.go
@@ -115,13 +115,13 @@ type PodConfig struct {
 	// labels to add to pods
 	// +optional
 	Labels map[string]string `json:"labels,omitempty"`
-	// nodeSelector defines the nodeSelector to be supplied to Restic podSpec
+	// nodeSelector defines the nodeSelector to be supplied to podSpec
 	// +optional
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
-	// tolerations defines the list of tolerations to be applied to Restic daemonset
+	// tolerations defines the list of tolerations to be applied
 	// +optional
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
-	// resourceAllocations defines the CPU and Memory resource allocations for the restic Pod
+	// resourceAllocations defines the CPU and Memory resource allocations for the Pod
 	// +optional
 	// +nullable
 	ResourceAllocations corev1.ResourceRequirements `json:"resourceAllocations,omitempty"`

--- a/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
@@ -246,10 +246,10 @@ spec:
                             nodeSelector:
                               additionalProperties:
                                 type: string
-                              description: nodeSelector defines the nodeSelector to be supplied to Restic podSpec
+                              description: nodeSelector defines the nodeSelector to be supplied to podSpec
                               type: object
                             resourceAllocations:
-                              description: resourceAllocations defines the CPU and Memory resource allocations for the restic Pod
+                              description: resourceAllocations defines the CPU and Memory resource allocations for the Pod
                               nullable: true
                               properties:
                                 claims:
@@ -291,7 +291,7 @@ spec:
                                   nullable: true
                               type: object
                             tolerations:
-                              description: tolerations defines the list of tolerations to be applied to Restic daemonset
+                              description: tolerations defines the list of tolerations to be applied
                               items:
                                 description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
                                 properties:
@@ -595,10 +595,10 @@ spec:
                             nodeSelector:
                               additionalProperties:
                                 type: string
-                              description: nodeSelector defines the nodeSelector to be supplied to Restic podSpec
+                              description: nodeSelector defines the nodeSelector to be supplied to podSpec
                               type: object
                             resourceAllocations:
-                              description: resourceAllocations defines the CPU and Memory resource allocations for the restic Pod
+                              description: resourceAllocations defines the CPU and Memory resource allocations for the Pod
                               nullable: true
                               properties:
                                 claims:
@@ -640,7 +640,7 @@ spec:
                                   nullable: true
                               type: object
                             tolerations:
-                              description: tolerations defines the list of tolerations to be applied to Restic daemonset
+                              description: tolerations defines the list of tolerations to be applied
                               items:
                                 description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
                                 properties:

--- a/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
@@ -1,5 +1,3 @@
-
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -14,1226 +12,893 @@ spec:
     listKind: DataProtectionApplicationList
     plural: dataprotectionapplications
     shortNames:
-    - dpa
+      - dpa
     singular: dataprotectionapplication
   scope: Namespaced
   versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: DataProtectionApplication is the Schema for the dpa API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: DataProtectionApplicationSpec defines the desired state of
-              Velero
-            properties:
-              backupImages:
-                description: backupImages is used to specify whether you want to deploy
-                  a registry for enabling backup and restore of images
-                type: boolean
-              backupLocations:
-                description: backupLocations defines the list of desired configuration
-                  to use for BackupStorageLocations
-                items:
-                  description: BackupLocation defines the configuration for the DPA
-                    backup storage
-                  properties:
-                    bucket:
-                      properties:
-                        backupSyncPeriod:
-                          description: backupSyncPeriod defines how frequently to
-                            sync backup API objects from object storage. A value of
-                            0 disables sync.
-                          nullable: true
-                          type: string
-                        cloudStorageRef:
-                          description: LocalObjectReference contains enough information
-                            to let you locate the referenced object inside the same
-                            namespace.
-                          properties:
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                          type: object
-                        config:
-                          additionalProperties:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: DataProtectionApplication is the Schema for the dpa API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DataProtectionApplicationSpec defines the desired state of Velero
+              properties:
+                backupImages:
+                  description: backupImages is used to specify whether you want to deploy a registry for enabling backup and restore of images
+                  type: boolean
+                backupLocations:
+                  description: backupLocations defines the list of desired configuration to use for BackupStorageLocations
+                  items:
+                    description: BackupLocation defines the configuration for the DPA backup storage
+                    properties:
+                      bucket:
+                        properties:
+                          backupSyncPeriod:
+                            description: backupSyncPeriod defines how frequently to sync backup API objects from object storage. A value of 0 disables sync.
+                            nullable: true
                             type: string
-                          description: config is for provider-specific configuration
-                            fields.
-                          type: object
-                        credential:
-                          description: credential contains the credential information
-                            intended to be used with this location
-                          properties:
-                            key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
+                          cloudStorageRef:
+                            description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                type: string
+                            type: object
+                          config:
+                            additionalProperties:
                               type: string
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                            description: config is for provider-specific configuration fields.
+                            type: object
+                          credential:
+                            description: credential contains the credential information intended to be used with this location
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key must be defined
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                          default:
+                            description: default indicates this location is the default backup storage location.
+                            type: boolean
+                        required:
+                          - cloudStorageRef
+                        type: object
+                      name:
+                        type: string
+                      velero:
+                        description: BackupStorageLocationSpec defines the desired state of a Velero BackupStorageLocation
+                        properties:
+                          accessMode:
+                            description: AccessMode defines the permissions for the backup storage location.
+                            enum:
+                              - ReadOnly
+                              - ReadWrite
+                            type: string
+                          backupSyncPeriod:
+                            description: BackupSyncPeriod defines how frequently to sync backup API objects from object storage. A value of 0 disables sync.
+                            nullable: true
+                            type: string
+                          config:
+                            additionalProperties:
                               type: string
-                            optional:
-                              description: Specify whether the Secret or its key must
-                                be defined
-                              type: boolean
-                          required:
-                          - key
-                          type: object
-                        default:
-                          description: default indicates this location is the default
-                            backup storage location.
-                          type: boolean
-                      required:
-                      - cloudStorageRef
-                      type: object
-                    name:
-                      type: string
-                    velero:
-                      description: BackupStorageLocationSpec defines the desired state
-                        of a Velero BackupStorageLocation
+                            description: Config is for provider-specific configuration fields.
+                            type: object
+                          credential:
+                            description: Credential contains the credential information intended to be used with this location
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key must be defined
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                          default:
+                            description: Default indicates this location is the default backup storage location.
+                            type: boolean
+                          objectStorage:
+                            description: ObjectStorageLocation specifies the settings necessary to connect to a provider's object storage.
+                            properties:
+                              bucket:
+                                description: Bucket is the bucket to use for object storage.
+                                type: string
+                              caCert:
+                                description: CACert defines a CA bundle to use when verifying TLS connections to the provider.
+                                format: byte
+                                type: string
+                              prefix:
+                                description: Prefix is the path inside a bucket to use for Velero storage. Optional.
+                                type: string
+                            required:
+                              - bucket
+                            type: object
+                          provider:
+                            description: Provider is the provider of the backup storage.
+                            type: string
+                          validationFrequency:
+                            description: ValidationFrequency defines how frequently to validate the corresponding object storage. A value of 0 disables validation.
+                            nullable: true
+                            type: string
+                        required:
+                          - objectStorage
+                          - provider
+                        type: object
+                    type: object
+                  type: array
+                configuration:
+                  description: configuration is used to configure the data protection application's server config
+                  properties:
+                    restic:
+                      description: ResticConfig is the configuration for restic server
                       properties:
-                        accessMode:
-                          description: AccessMode defines the permissions for the
-                            backup storage location.
+                        enable:
+                          description: enable defines a boolean pointer whether we want the daemonset to exist or not
+                          type: boolean
+                        podConfig:
+                          description: Pod specific configuration
+                          properties:
+                            env:
+                              description: env defines the list of environment variables to be supplied to podSpec
+                              items:
+                                description: EnvVar represents an environment variable present in a Container.
+                                properties:
+                                  name:
+                                    description: Name of the environment variable. Must be a C_IDENTIFIER.
+                                    type: string
+                                  value:
+                                    description: 'Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
+                                    type: string
+                                  valueFrom:
+                                    description: Source for the environment variable's value. Cannot be used if value is not empty.
+                                    properties:
+                                      configMapKeyRef:
+                                        description: Selects a key of a ConfigMap.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap or its key must be defined
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                      fieldRef:
+                                        description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select in the specified API version.
+                                            type: string
+                                        required:
+                                          - fieldPath
+                                        type: object
+                                      resourceFieldRef:
+                                        description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            description: Specifies the output format of the exposed resources, defaults to "1"
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                          - resource
+                                        type: object
+                                      secretKeyRef:
+                                        description: Selects a key of a secret in the pod's namespace
+                                        properties:
+                                          key:
+                                            description: The key of the secret to select from.  Must be a valid secret key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret or its key must be defined
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                    type: object
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                            labels:
+                              additionalProperties:
+                                type: string
+                              description: labels to add to pods
+                              type: object
+                            nodeSelector:
+                              additionalProperties:
+                                type: string
+                              description: nodeSelector defines the nodeSelector to be supplied to podSpec
+                              type: object
+                            resourceAllocations:
+                              description: resourceAllocations defines the CPU and Memory resource allocations for the Pod
+                              nullable: true
+                              properties:
+                                claims:
+                                  description: "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable."
+                                  items:
+                                    description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                                    properties:
+                                      name:
+                                        description: Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - name
+                                  x-kubernetes-list-type: map
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                    nullable: true
+                                  description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  type: object
+                                  nullable: true
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                    nullable: true
+                                  description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  type: object
+                                  nullable: true
+                              type: object
+                            tolerations:
+                              description: tolerations defines the list of tolerations to be applied
+                              items:
+                                description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                                properties:
+                                  effect:
+                                    description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                    type: string
+                                  key:
+                                    description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                    type: string
+                                  operator:
+                                    description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                    type: string
+                                  tolerationSeconds:
+                                    description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                                    format: int64
+                                    type: integer
+                                  value:
+                                    description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        supplementalGroups:
+                          description: supplementalGroups defines the linux groups to be applied to the Restic Pod
+                          items:
+                            format: int64
+                            type: integer
+                          type: array
+                        timeout:
+                          description: timeout defines the Restic timeout, default value is 1h
+                          type: string
+                      type: object
+                    velero:
+                      properties:
+                        args:
+                          description: Velero args are settings to customize velero server arguments. Overrides values in other fields.
+                          properties:
+                            add_dir_header:
+                              description: If true, adds the file directory to the header of the log messages
+                              type: boolean
+                            alsologtostderr:
+                              description: log to standard error as well as files (no effect when -logtostderr=true)
+                              type: boolean
+                            backup-sync-period:
+                              description: How often to ensure all Velero backups in object storage exist as Backup API objects in the cluster. This is the default sync period if none is explicitly specified for a backup storage location.
+                              format: int64
+                              type: integer
+                            client-burst:
+                              description: Maximum number of requests by the server to the Kubernetes API in a short period of time.
+                              type: integer
+                            client-page-size:
+                              description: Page size of requests by the server to the Kubernetes API when listing objects during a backup. Set to 0 to disable paging.
+                              type: integer
+                            client-qps:
+                              description: Maximum number of requests per second by the server to the Kubernetes API once the burst limit has been reached. this will be validated as a valid float32
+                              type: string
+                            colorized:
+                              description: Show colored output in TTY
+                              type: boolean
+                            default-backup-ttl:
+                              description: default 720h0m0s
+                              format: int64
+                              type: integer
+                            default-item-operation-timeout:
+                              description: How long to wait on asynchronous BackupItemActions and RestoreItemActions to complete before timing out. (default 1h0m0s)
+                              format: int64
+                              type: integer
+                            default-repo-maintain-frequency:
+                              description: How often 'maintain' is run for backup repositories by default.
+                              format: int64
+                              type: integer
+                            default-volumes-to-fs-backup:
+                              description: Backup all volumes with pod volume file system backup by default.
+                              type: boolean
+                            disabled-controllers:
+                              description: List of controllers to disable on startup. Valid values are backup,backup-operations,backup-deletion,backup-finalizer,backup-sync,download-request,gc,backup-repo,restore,restore-operations,schedule,server-status-request
+                              enum:
+                                - backup
+                                - backup-operations
+                                - backup-deletion
+                                - backup-finalizer
+                                - backup-sync
+                                - download-request
+                                - gc
+                                - backup-repo
+                                - restore
+                                - restore-operations
+                                - schedule
+                                - server-status-request
+                              items:
+                                type: string
+                              type: array
+                            fs-backup-timeout:
+                              description: How long pod volume file system backups/restores should be allowed to run before timing out. (default 4h0m0s)
+                              format: int64
+                              type: integer
+                            garbage-collection-frequency:
+                              description: How long to wait by default before backups can be garbage collected. (default 720h0m0s)
+                              format: int64
+                              type: integer
+                            item-operation-sync-frequency:
+                              description: How often to check status on backup/restore operations after backup/restore processing.
+                              format: int64
+                              type: integer
+                            log-format:
+                              description: The format for log output. Valid values are text, json. (default text)
+                              enum:
+                                - text
+                                - json
+                              type: string
+                            log_backtrace_at:
+                              description: when logging hits line file:N, emit a stack trace
+                              type: string
+                            log_dir:
+                              description: If non-empty, write log files in this directory (no effect when -logtostderr=true)
+                              type: string
+                            log_file:
+                              description: If non-empty, use this log file (no effect when -logtostderr=true)
+                              type: string
+                            log_file_max_size:
+                              description: Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
+                              format: int64
+                              minimum: 0
+                              type: integer
+                            logtostderr:
+                              description: 'Boolean flags. Not handled atomically because the flag.Value interface does not let us avoid the =true, and that shorthand is necessary for compatibility. TODO: does this matter enough to fix? Seems unlikely.'
+                              type: boolean
+                            max-concurrent-k8s-connections:
+                              description: Max concurrent connections number that Velero can create with kube-apiserver. Default is 30. (default 30)
+                              type: integer
+                            metrics-address:
+                              description: The address to expose prometheus metrics
+                              type: string
+                            one_output:
+                              description: If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
+                              type: boolean
+                            profiler-address:
+                              description: The address to expose the pprof profiler.
+                              type: string
+                            resource-timeout:
+                              description: How long to wait for resource processes which are not covered by other specific timeout parameters. Default is 10 minutes. (default 10m0s)
+                              format: int64
+                              type: integer
+                            restore-resource-priorities:
+                              description: Desired order of resource restores, the priority list contains two parts which are split by "-" element. The resources before "-" element are restored first as high priorities, the resources after "-" element are restored last as low priorities, and any resource not in the list will be restored alphabetically between the high and low priorities. (default customresourcedefinitions,namespaces,storageclasses,volumesnapshotbackups.datamover.oadp.openshift.io,volumesnapshotclass.snapshot.storage.k8s.io,volumesnapshotcontents.snapshot.storage.k8s.io,volumesnapshots.snapshot.storage.k8s.io,persistentvolumes,persistentvolumeclaims,serviceaccounts,secrets,configmaps,limitranges,pods,replicasets.apps,clusterclasses.cluster.x-k8s.io,services,-,clusterbootstraps.run.tanzu.vmware.com,clusters.cluster.x-k8s.io,clusterresourcesets.addons.cluster.x-k8s.io)
+                              type: string
+                            skip_headers:
+                              description: If true, avoid header prefixes in the log messages
+                              type: boolean
+                            skip_log_headers:
+                              description: If true, avoid headers when opening log files (no effect when -logtostderr=true)
+                              type: boolean
+                            stderrthreshold:
+                              description: logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
+                              type: integer
+                            store-validation-frequency:
+                              description: How often to verify if the storage is valid. Optional. Set this to `0s` to disable sync. Default 1 minute.
+                              format: int64
+                              type: integer
+                            terminating-resource-timeout:
+                              description: How long to wait on persistent volumes and namespaces to terminate during a restore before timing out.
+                              format: int64
+                              type: integer
+                            v:
+                              description: number for the log level verbosity
+                              type: integer
+                            vmodule:
+                              description: comma-separated list of pattern=N settings for file-filtered logging
+                              type: string
+                          type: object
+                        customPlugins:
+                          description: customPlugins defines the custom plugin to be installed with Velero
+                          items:
+                            properties:
+                              image:
+                                type: string
+                              name:
+                                type: string
+                            required:
+                              - image
+                              - name
+                            type: object
+                          type: array
+                        defaultItemOperationTimeout:
+                          description: How long to wait on asynchronous BackupItemActions and RestoreItemActions to complete before timing out. Default value is 1h.
+                          type: string
+                        defaultPlugins:
+                          items:
+                            type: string
+                          type: array
+                        featureFlags:
+                          description: featureFlags defines the list of features to enable for Velero instance
+                          items:
+                            type: string
+                          type: array
+                        itemOperationSyncFrequency:
+                          description: How often to check status on async backup/restore operations after backup processing. Default value is 2m.
+                          type: string
+                        logLevel:
+                          description: Velero server’s log level (use debug for the most logging, leave unset for velero default)
                           enum:
-                          - ReadOnly
-                          - ReadWrite
+                            - trace
+                            - debug
+                            - info
+                            - warning
+                            - error
+                            - fatal
+                            - panic
                           type: string
-                        backupSyncPeriod:
-                          description: BackupSyncPeriod defines how frequently to
-                            sync backup API objects from object storage. A value of
-                            0 disables sync.
-                          nullable: true
-                          type: string
-                        config:
-                          additionalProperties:
-                            type: string
-                          description: Config is for provider-specific configuration
-                            fields.
-                          type: object
-                        credential:
-                          description: Credential contains the credential information
-                            intended to be used with this location
-                          properties:
-                            key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                            optional:
-                              description: Specify whether the Secret or its key must
-                                be defined
-                              type: boolean
-                          required:
-                          - key
-                          type: object
-                        default:
-                          description: Default indicates this location is the default
-                            backup storage location.
+                        noDefaultBackupLocation:
+                          description: If you need to install Velero without a default backup storage location noDefaultBackupLocation flag is required for confirmation
                           type: boolean
-                        objectStorage:
-                          description: ObjectStorageLocation specifies the settings
-                            necessary to connect to a provider's object storage.
+                        podConfig:
+                          description: Pod specific configuration
                           properties:
-                            bucket:
-                              description: Bucket is the bucket to use for object
-                                storage.
-                              type: string
-                            caCert:
-                              description: CACert defines a CA bundle to use when
-                                verifying TLS connections to the provider.
-                              format: byte
-                              type: string
-                            prefix:
-                              description: Prefix is the path inside a bucket to use
-                                for Velero storage. Optional.
-                              type: string
-                          required:
-                          - bucket
+                            env:
+                              description: env defines the list of environment variables to be supplied to podSpec
+                              items:
+                                description: EnvVar represents an environment variable present in a Container.
+                                properties:
+                                  name:
+                                    description: Name of the environment variable. Must be a C_IDENTIFIER.
+                                    type: string
+                                  value:
+                                    description: 'Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
+                                    type: string
+                                  valueFrom:
+                                    description: Source for the environment variable's value. Cannot be used if value is not empty.
+                                    properties:
+                                      configMapKeyRef:
+                                        description: Selects a key of a ConfigMap.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap or its key must be defined
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                      fieldRef:
+                                        description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select in the specified API version.
+                                            type: string
+                                        required:
+                                          - fieldPath
+                                        type: object
+                                      resourceFieldRef:
+                                        description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            description: Specifies the output format of the exposed resources, defaults to "1"
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                          - resource
+                                        type: object
+                                      secretKeyRef:
+                                        description: Selects a key of a secret in the pod's namespace
+                                        properties:
+                                          key:
+                                            description: The key of the secret to select from.  Must be a valid secret key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret or its key must be defined
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                    type: object
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                            labels:
+                              additionalProperties:
+                                type: string
+                              description: labels to add to pods
+                              type: object
+                            nodeSelector:
+                              additionalProperties:
+                                type: string
+                              description: nodeSelector defines the nodeSelector to be supplied to podSpec
+                              type: object
+                            resourceAllocations:
+                              description: resourceAllocations defines the CPU and Memory resource allocations for the Pod
+                              nullable: true
+                              properties:
+                                claims:
+                                  description: "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable."
+                                  items:
+                                    description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                                    properties:
+                                      name:
+                                        description: Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - name
+                                  x-kubernetes-list-type: map
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                    nullable: true
+                                  description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  type: object
+                                  nullable: true
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                    nullable: true
+                                  description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  type: object
+                                  nullable: true
+                              type: object
+                            tolerations:
+                              description: tolerations defines the list of tolerations to be applied
+                              items:
+                                description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                                properties:
+                                  effect:
+                                    description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                    type: string
+                                  key:
+                                    description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                    type: string
+                                  operator:
+                                    description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                    type: string
+                                  tolerationSeconds:
+                                    description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                                    format: int64
+                                    type: integer
+                                  value:
+                                    description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                    type: string
+                                type: object
+                              type: array
                           type: object
-                        provider:
-                          description: Provider is the provider of the backup storage.
+                        resourceTimeout:
+                          description: resourceTimeout defines how long to wait for several Velero resources before timeout occurs, such as Velero CRD availability, volumeSnapshot deletion, and repo availability. Default is 10m
                           type: string
-                        validationFrequency:
-                          description: ValidationFrequency defines how frequently
-                            to validate the corresponding object storage. A value
-                            of 0 disables validation.
-                          nullable: true
+                        restoreResourcesVersionPriority:
+                          description: restoreResourceVersionPriority represents a configmap that will be created if defined for use in conjunction with EnableAPIGroupVersions feature flag Defining this field automatically add EnableAPIGroupVersions to the velero server feature flag
                           type: string
-                      required:
-                      - objectStorage
-                      - provider
                       type: object
                   type: object
-                type: array
-              configuration:
-                description: configuration is used to configure the data protection
-                  application's server config
-                properties:
-                  restic:
-                    description: ResticConfig is the configuration for restic server
-                    properties:
-                      enable:
-                        description: enable defines a boolean pointer whether we want
-                          the daemonset to exist or not
-                        type: boolean
-                      podConfig:
-                        description: Pod specific configuration
-                        properties:
-                          env:
-                            description: env defines the list of environment variables
-                              to be supplied to podSpec
-                            items:
-                              description: EnvVar represents an environment variable
-                                present in a Container.
-                              properties:
-                                name:
-                                  description: Name of the environment variable. Must
-                                    be a C_IDENTIFIER.
-                                  type: string
-                                value:
-                                  description: 'Variable references $(VAR_NAME) are
-                                    expanded using the previously defined environment
-                                    variables in the container and any service environment
-                                    variables. If a variable cannot be resolved, the
-                                    reference in the input string will be unchanged.
-                                    Double $$ are reduced to a single $, which allows
-                                    for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                    will produce the string literal "$(VAR_NAME)".
-                                    Escaped references will never be expanded, regardless
-                                    of whether the variable exists or not. Defaults
-                                    to "".'
-                                  type: string
-                                valueFrom:
-                                  description: Source for the environment variable's
-                                    value. Cannot be used if value is not empty.
-                                  properties:
-                                    configMapKeyRef:
-                                      description: Selects a key of a ConfigMap.
-                                      properties:
-                                        key:
-                                          description: The key to select.
-                                          type: string
-                                        name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
-                                          type: string
-                                        optional:
-                                          description: Specify whether the ConfigMap
-                                            or its key must be defined
-                                          type: boolean
-                                      required:
-                                      - key
-                                      type: object
-                                    fieldRef:
-                                      description: 'Selects a field of the pod: supports
-                                        metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
-                                        `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                        spec.serviceAccountName, status.hostIP, status.podIP,
-                                        status.podIPs.'
-                                      properties:
-                                        apiVersion:
-                                          description: Version of the schema the FieldPath
-                                            is written in terms of, defaults to "v1".
-                                          type: string
-                                        fieldPath:
-                                          description: Path of the field to select
-                                            in the specified API version.
-                                          type: string
-                                      required:
-                                      - fieldPath
-                                      type: object
-                                    resourceFieldRef:
-                                      description: 'Selects a resource of the container:
-                                        only resources limits and requests (limits.cpu,
-                                        limits.memory, limits.ephemeral-storage, requests.cpu,
-                                        requests.memory and requests.ephemeral-storage)
-                                        are currently supported.'
-                                      properties:
-                                        containerName:
-                                          description: 'Container name: required for
-                                            volumes, optional for env vars'
-                                          type: string
-                                        divisor:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          description: Specifies the output format
-                                            of the exposed resources, defaults to
-                                            "1"
-                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                          x-kubernetes-int-or-string: true
-                                        resource:
-                                          description: 'Required: resource to select'
-                                          type: string
-                                      required:
-                                      - resource
-                                      type: object
-                                    secretKeyRef:
-                                      description: Selects a key of a secret in the
-                                        pod's namespace
-                                      properties:
-                                        key:
-                                          description: The key of the secret to select
-                                            from.  Must be a valid secret key.
-                                          type: string
-                                        name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
-                                          type: string
-                                        optional:
-                                          description: Specify whether the Secret
-                                            or its key must be defined
-                                          type: boolean
-                                      required:
-                                      - key
-                                      type: object
-                                  type: object
-                              required:
-                              - name
-                              type: object
-                            type: array
-                          labels:
-                            additionalProperties:
-                              type: string
-                            description: labels to add to pods
-                            type: object
-                          nodeSelector:
-                            additionalProperties:
-                              type: string
-                            description: nodeSelector defines the nodeSelector to
-                              be supplied to podSpec
-                            type: object
-                          resourceAllocations:
-                            description: resourceAllocations defines the CPU and Memory
-                              resource allocations for the Pod
-                            nullable: true
-                            properties:
-                              claims:
-                                description: "Claims lists the names of resources,
-                                  defined in spec.resourceClaims, that are used by
-                                  this container. \n This is an alpha field and requires
-                                  enabling the DynamicResourceAllocation feature gate.
-                                  \n This field is immutable."
-                                items:
-                                  description: ResourceClaim references one entry
-                                    in PodSpec.ResourceClaims.
-                                  properties:
-                                    name:
-                                      description: Name must match the name of one
-                                        entry in pod.spec.resourceClaims of the Pod
-                                        where this field is used. It makes that resource
-                                        available inside a container.
-                                      type: string
-                                  required:
-                                  - name
-                                  type: object
-                                type: array
-                                x-kubernetes-list-map-keys:
-                                - name
-                                x-kubernetes-list-type: map
-                              limits:
-                                additionalProperties:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                                description: 'Limits describes the maximum amount
-                                  of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                                type: object
-                              requests:
-                                additionalProperties:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                                description: 'Requests describes the minimum amount
-                                  of compute resources required. If Requests is omitted
-                                  for a container, it defaults to Limits if that is
-                                  explicitly specified, otherwise to an implementation-defined
-                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                                type: object
-                            type: object
-                          tolerations:
-                            description: tolerations defines the list of tolerations
-                              to be applied
-                            items:
-                              description: The pod this Toleration is attached to
-                                tolerates any taint that matches the triple <key,value,effect>
-                                using the matching operator <operator>.
-                              properties:
-                                effect:
-                                  description: Effect indicates the taint effect to
-                                    match. Empty means match all taint effects. When
-                                    specified, allowed values are NoSchedule, PreferNoSchedule
-                                    and NoExecute.
-                                  type: string
-                                key:
-                                  description: Key is the taint key that the toleration
-                                    applies to. Empty means match all taint keys.
-                                    If the key is empty, operator must be Exists;
-                                    this combination means to match all values and
-                                    all keys.
-                                  type: string
-                                operator:
-                                  description: Operator represents a key's relationship
-                                    to the value. Valid operators are Exists and Equal.
-                                    Defaults to Equal. Exists is equivalent to wildcard
-                                    for value, so that a pod can tolerate all taints
-                                    of a particular category.
-                                  type: string
-                                tolerationSeconds:
-                                  description: TolerationSeconds represents the period
-                                    of time the toleration (which must be of effect
-                                    NoExecute, otherwise this field is ignored) tolerates
-                                    the taint. By default, it is not set, which means
-                                    tolerate the taint forever (do not evict). Zero
-                                    and negative values will be treated as 0 (evict
-                                    immediately) by the system.
-                                  format: int64
-                                  type: integer
-                                value:
-                                  description: Value is the taint value the toleration
-                                    matches to. If the operator is Exists, the value
-                                    should be empty, otherwise just a regular string.
-                                  type: string
-                              type: object
-                            type: array
-                        type: object
-                      supplementalGroups:
-                        description: supplementalGroups defines the linux groups to
-                          be applied to the Restic Pod
-                        items:
-                          format: int64
-                          type: integer
-                        type: array
-                      timeout:
-                        description: timeout defines the Restic timeout, default value
-                          is 1h
-                        type: string
-                    type: object
-                  velero:
-                    properties:
-                      args:
-                        description: Velero args are settings to customize velero
-                          server arguments. Overrides values in other fields.
-                        properties:
-                          add_dir_header:
-                            description: If true, adds the file directory to the header
-                              of the log messages
-                            type: boolean
-                          alsologtostderr:
-                            description: log to standard error as well as files (no
-                              effect when -logtostderr=true)
-                            type: boolean
-                          backup-sync-period:
-                            description: How often to ensure all Velero backups in
-                              object storage exist as Backup API objects in the cluster.
-                              This is the default sync period if none is explicitly
-                              specified for a backup storage location.
-                            format: int64
-                            type: integer
-                          client-burst:
-                            description: Maximum number of requests by the server
-                              to the Kubernetes API in a short period of time.
-                            type: integer
-                          client-page-size:
-                            description: Page size of requests by the server to the
-                              Kubernetes API when listing objects during a backup.
-                              Set to 0 to disable paging.
-                            type: integer
-                          client-qps:
-                            description: Maximum number of requests per second by
-                              the server to the Kubernetes API once the burst limit
-                              has been reached. this will be validated as a valid
-                              float32
-                            type: string
-                          colorized:
-                            description: Show colored output in TTY
-                            type: boolean
-                          default-backup-ttl:
-                            description: default 720h0m0s
-                            format: int64
-                            type: integer
-                          default-item-operation-timeout:
-                            description: How long to wait on asynchronous BackupItemActions
-                              and RestoreItemActions to complete before timing out.
-                              (default 1h0m0s)
-                            format: int64
-                            type: integer
-                          default-repo-maintain-frequency:
-                            description: How often 'maintain' is run for backup repositories
-                              by default.
-                            format: int64
-                            type: integer
-                          default-volumes-to-fs-backup:
-                            description: Backup all volumes with pod volume file system
-                              backup by default.
-                            type: boolean
-                          disabled-controllers:
-                            description: List of controllers to disable on startup.
-                              Valid values are backup,backup-operations,backup-deletion,backup-finalizer,backup-sync,download-request,gc,backup-repo,restore,restore-operations,schedule,server-status-request
-                            enum:
-                            - backup
-                            - backup-operations
-                            - backup-deletion
-                            - backup-finalizer
-                            - backup-sync
-                            - download-request
-                            - gc
-                            - backup-repo
-                            - restore
-                            - restore-operations
-                            - schedule
-                            - server-status-request
-                            items:
-                              type: string
-                            type: array
-                          fs-backup-timeout:
-                            description: How long pod volume file system backups/restores
-                              should be allowed to run before timing out. (default
-                              4h0m0s)
-                            format: int64
-                            type: integer
-                          garbage-collection-frequency:
-                            description: How long to wait by default before backups
-                              can be garbage collected. (default 720h0m0s)
-                            format: int64
-                            type: integer
-                          item-operation-sync-frequency:
-                            description: How often to check status on backup/restore
-                              operations after backup/restore processing.
-                            format: int64
-                            type: integer
-                          log-format:
-                            description: The format for log output. Valid values are
-                              text, json. (default text)
-                            enum:
-                            - text
-                            - json
-                            type: string
-                          log_backtrace_at:
-                            description: when logging hits line file:N, emit a stack
-                              trace
-                            type: string
-                          log_dir:
-                            description: If non-empty, write log files in this directory
-                              (no effect when -logtostderr=true)
-                            type: string
-                          log_file:
-                            description: If non-empty, use this log file (no effect
-                              when -logtostderr=true)
-                            type: string
-                          log_file_max_size:
-                            description: Defines the maximum size a log file can grow
-                              to (no effect when -logtostderr=true). Unit is megabytes.
-                              If the value is 0, the maximum file size is unlimited.
-                              (default 1800)
-                            format: int64
-                            minimum: 0
-                            type: integer
-                          logtostderr:
-                            description: 'Boolean flags. Not handled atomically because
-                              the flag.Value interface does not let us avoid the =true,
-                              and that shorthand is necessary for compatibility. TODO:
-                              does this matter enough to fix? Seems unlikely.'
-                            type: boolean
-                          max-concurrent-k8s-connections:
-                            description: Max concurrent connections number that Velero
-                              can create with kube-apiserver. Default is 30. (default
-                              30)
-                            type: integer
-                          metrics-address:
-                            description: The address to expose prometheus metrics
-                            type: string
-                          one_output:
-                            description: If true, only write logs to their native
-                              severity level (vs also writing to each lower severity
-                              level; no effect when -logtostderr=true)
-                            type: boolean
-                          profiler-address:
-                            description: The address to expose the pprof profiler.
-                            type: string
-                          resource-timeout:
-                            description: How long to wait for resource processes which
-                              are not covered by other specific timeout parameters.
-                              Default is 10 minutes. (default 10m0s)
-                            format: int64
-                            type: integer
-                          restore-resource-priorities:
-                            description: Desired order of resource restores, the priority
-                              list contains two parts which are split by "-" element.
-                              The resources before "-" element are restored first
-                              as high priorities, the resources after "-" element
-                              are restored last as low priorities, and any resource
-                              not in the list will be restored alphabetically between
-                              the high and low priorities. (default customresourcedefinitions,namespaces,storageclasses,volumesnapshotbackups.datamover.oadp.openshift.io,volumesnapshotclass.snapshot.storage.k8s.io,volumesnapshotcontents.snapshot.storage.k8s.io,volumesnapshots.snapshot.storage.k8s.io,persistentvolumes,persistentvolumeclaims,serviceaccounts,secrets,configmaps,limitranges,pods,replicasets.apps,clusterclasses.cluster.x-k8s.io,services,-,clusterbootstraps.run.tanzu.vmware.com,clusters.cluster.x-k8s.io,clusterresourcesets.addons.cluster.x-k8s.io)
-                            type: string
-                          skip_headers:
-                            description: If true, avoid header prefixes in the log
-                              messages
-                            type: boolean
-                          skip_log_headers:
-                            description: If true, avoid headers when opening log files
-                              (no effect when -logtostderr=true)
-                            type: boolean
-                          stderrthreshold:
-                            description: logs at or above this threshold go to stderr
-                              when writing to files and stderr (no effect when -logtostderr=true
-                              or -alsologtostderr=false) (default 2)
-                            type: integer
-                          store-validation-frequency:
-                            description: How often to verify if the storage is valid.
-                              Optional. Set this to `0s` to disable sync. Default
-                              1 minute.
-                            format: int64
-                            type: integer
-                          terminating-resource-timeout:
-                            description: How long to wait on persistent volumes and
-                              namespaces to terminate during a restore before timing
-                              out.
-                            format: int64
-                            type: integer
-                          v:
-                            description: number for the log level verbosity
-                            type: integer
-                          vmodule:
-                            description: comma-separated list of pattern=N settings
-                              for file-filtered logging
-                            type: string
-                        type: object
-                      customPlugins:
-                        description: customPlugins defines the custom plugin to be
-                          installed with Velero
-                        items:
-                          properties:
-                            image:
-                              type: string
-                            name:
-                              type: string
-                          required:
-                          - image
-                          - name
-                          type: object
-                        type: array
-                      defaultItemOperationTimeout:
-                        description: How long to wait on asynchronous BackupItemActions
-                          and RestoreItemActions to complete before timing out. Default
-                          value is 1h.
-                        type: string
-                      defaultPlugins:
-                        items:
-                          type: string
-                        type: array
-                      featureFlags:
-                        description: featureFlags defines the list of features to
-                          enable for Velero instance
-                        items:
-                          type: string
-                        type: array
-                      itemOperationSyncFrequency:
-                        description: How often to check status on async backup/restore
-                          operations after backup processing. Default value is 2m.
-                        type: string
-                      logLevel:
-                        description: Velero server’s log level (use debug for the
-                          most logging, leave unset for velero default)
-                        enum:
-                        - trace
-                        - debug
-                        - info
-                        - warning
-                        - error
-                        - fatal
-                        - panic
-                        type: string
-                      noDefaultBackupLocation:
-                        description: If you need to install Velero without a default
-                          backup storage location noDefaultBackupLocation flag is
-                          required for confirmation
-                        type: boolean
-                      podConfig:
-                        description: Pod specific configuration
-                        properties:
-                          env:
-                            description: env defines the list of environment variables
-                              to be supplied to podSpec
-                            items:
-                              description: EnvVar represents an environment variable
-                                present in a Container.
-                              properties:
-                                name:
-                                  description: Name of the environment variable. Must
-                                    be a C_IDENTIFIER.
-                                  type: string
-                                value:
-                                  description: 'Variable references $(VAR_NAME) are
-                                    expanded using the previously defined environment
-                                    variables in the container and any service environment
-                                    variables. If a variable cannot be resolved, the
-                                    reference in the input string will be unchanged.
-                                    Double $$ are reduced to a single $, which allows
-                                    for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                    will produce the string literal "$(VAR_NAME)".
-                                    Escaped references will never be expanded, regardless
-                                    of whether the variable exists or not. Defaults
-                                    to "".'
-                                  type: string
-                                valueFrom:
-                                  description: Source for the environment variable's
-                                    value. Cannot be used if value is not empty.
-                                  properties:
-                                    configMapKeyRef:
-                                      description: Selects a key of a ConfigMap.
-                                      properties:
-                                        key:
-                                          description: The key to select.
-                                          type: string
-                                        name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
-                                          type: string
-                                        optional:
-                                          description: Specify whether the ConfigMap
-                                            or its key must be defined
-                                          type: boolean
-                                      required:
-                                      - key
-                                      type: object
-                                    fieldRef:
-                                      description: 'Selects a field of the pod: supports
-                                        metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
-                                        `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                        spec.serviceAccountName, status.hostIP, status.podIP,
-                                        status.podIPs.'
-                                      properties:
-                                        apiVersion:
-                                          description: Version of the schema the FieldPath
-                                            is written in terms of, defaults to "v1".
-                                          type: string
-                                        fieldPath:
-                                          description: Path of the field to select
-                                            in the specified API version.
-                                          type: string
-                                      required:
-                                      - fieldPath
-                                      type: object
-                                    resourceFieldRef:
-                                      description: 'Selects a resource of the container:
-                                        only resources limits and requests (limits.cpu,
-                                        limits.memory, limits.ephemeral-storage, requests.cpu,
-                                        requests.memory and requests.ephemeral-storage)
-                                        are currently supported.'
-                                      properties:
-                                        containerName:
-                                          description: 'Container name: required for
-                                            volumes, optional for env vars'
-                                          type: string
-                                        divisor:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          description: Specifies the output format
-                                            of the exposed resources, defaults to
-                                            "1"
-                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                          x-kubernetes-int-or-string: true
-                                        resource:
-                                          description: 'Required: resource to select'
-                                          type: string
-                                      required:
-                                      - resource
-                                      type: object
-                                    secretKeyRef:
-                                      description: Selects a key of a secret in the
-                                        pod's namespace
-                                      properties:
-                                        key:
-                                          description: The key of the secret to select
-                                            from.  Must be a valid secret key.
-                                          type: string
-                                        name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
-                                          type: string
-                                        optional:
-                                          description: Specify whether the Secret
-                                            or its key must be defined
-                                          type: boolean
-                                      required:
-                                      - key
-                                      type: object
-                                  type: object
-                              required:
-                              - name
-                              type: object
-                            type: array
-                          labels:
-                            additionalProperties:
-                              type: string
-                            description: labels to add to pods
-                            type: object
-                          nodeSelector:
-                            additionalProperties:
-                              type: string
-                            description: nodeSelector defines the nodeSelector to
-                              be supplied to podSpec
-                            type: object
-                          resourceAllocations:
-                            description: resourceAllocations defines the CPU and Memory
-                              resource allocations for the Pod
-                            nullable: true
-                            properties:
-                              claims:
-                                description: "Claims lists the names of resources,
-                                  defined in spec.resourceClaims, that are used by
-                                  this container. \n This is an alpha field and requires
-                                  enabling the DynamicResourceAllocation feature gate.
-                                  \n This field is immutable."
-                                items:
-                                  description: ResourceClaim references one entry
-                                    in PodSpec.ResourceClaims.
-                                  properties:
-                                    name:
-                                      description: Name must match the name of one
-                                        entry in pod.spec.resourceClaims of the Pod
-                                        where this field is used. It makes that resource
-                                        available inside a container.
-                                      type: string
-                                  required:
-                                  - name
-                                  type: object
-                                type: array
-                                x-kubernetes-list-map-keys:
-                                - name
-                                x-kubernetes-list-type: map
-                              limits:
-                                additionalProperties:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                                description: 'Limits describes the maximum amount
-                                  of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                                type: object
-                              requests:
-                                additionalProperties:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                                description: 'Requests describes the minimum amount
-                                  of compute resources required. If Requests is omitted
-                                  for a container, it defaults to Limits if that is
-                                  explicitly specified, otherwise to an implementation-defined
-                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                                type: object
-                            type: object
-                          tolerations:
-                            description: tolerations defines the list of tolerations
-                              to be applied
-                            items:
-                              description: The pod this Toleration is attached to
-                                tolerates any taint that matches the triple <key,value,effect>
-                                using the matching operator <operator>.
-                              properties:
-                                effect:
-                                  description: Effect indicates the taint effect to
-                                    match. Empty means match all taint effects. When
-                                    specified, allowed values are NoSchedule, PreferNoSchedule
-                                    and NoExecute.
-                                  type: string
-                                key:
-                                  description: Key is the taint key that the toleration
-                                    applies to. Empty means match all taint keys.
-                                    If the key is empty, operator must be Exists;
-                                    this combination means to match all values and
-                                    all keys.
-                                  type: string
-                                operator:
-                                  description: Operator represents a key's relationship
-                                    to the value. Valid operators are Exists and Equal.
-                                    Defaults to Equal. Exists is equivalent to wildcard
-                                    for value, so that a pod can tolerate all taints
-                                    of a particular category.
-                                  type: string
-                                tolerationSeconds:
-                                  description: TolerationSeconds represents the period
-                                    of time the toleration (which must be of effect
-                                    NoExecute, otherwise this field is ignored) tolerates
-                                    the taint. By default, it is not set, which means
-                                    tolerate the taint forever (do not evict). Zero
-                                    and negative values will be treated as 0 (evict
-                                    immediately) by the system.
-                                  format: int64
-                                  type: integer
-                                value:
-                                  description: Value is the taint value the toleration
-                                    matches to. If the operator is Exists, the value
-                                    should be empty, otherwise just a regular string.
-                                  type: string
-                              type: object
-                            type: array
-                        type: object
-                      resourceTimeout:
-                        description: resourceTimeout defines how long to wait for
-                          several Velero resources before timeout occurs, such as
-                          Velero CRD availability, volumeSnapshot deletion, and repo
-                          availability. Default is 10m
-                        type: string
-                      restoreResourcesVersionPriority:
-                        description: restoreResourceVersionPriority represents a configmap
-                          that will be created if defined for use in conjunction with
-                          EnableAPIGroupVersions feature flag Defining this field
-                          automatically add EnableAPIGroupVersions to the velero server
-                          feature flag
-                        type: string
-                    type: object
-                type: object
-              features:
-                description: features defines the configuration for the DPA to enable
-                  the OADP tech preview features
-                properties:
-                  dataMover:
-                    description: Contains data mover specific configurations
-                    properties:
-                      credentialName:
-                        description: User supplied Restic Secret name
-                        type: string
-                      enable:
-                        description: enable flag is used to specify whether you want
-                          to deploy the volume snapshot mover controller
-                        type: boolean
-                      maxConcurrentBackupVolumes:
-                        description: the number of batched volumeSnapshotBackups that
-                          can be inProgress at once, default value is 10
-                        type: string
-                      maxConcurrentRestoreVolumes:
-                        description: the number of batched volumeSnapshotRestores
-                          that can be inProgress at once, default value is 10
-                        type: string
-                      pruneInterval:
-                        description: defines how often (in days) to prune the datamover
-                          snapshots from the repository
-                        type: string
-                      schedule:
-                        description: 'schedule is a cronspec (https://en.wikipedia.org/wiki/Cron#Overview)
-                          that can be used to schedule datamover(volsync) synchronization
-                          to occur at regular, time-based intervals. For example,
-                          in order to enforce datamover SnapshotRetainPolicy at a
-                          regular interval you need to specify this Schedule trigger
-                          as a cron expression, by default the trigger is a manual
-                          trigger. For more details on Volsync triggers, refer: https://volsync.readthedocs.io/en/stable/usage/triggers.html'
-                        pattern: ^(\d+|\*)(/\d+)?(\s+(\d+|\*)(/\d+)?){4}$
-                        type: string
-                      snapshotRetainPolicy:
-                        description: defines the parameters that can be specified
-                          for retention of datamover snapshots
-                        properties:
-                          daily:
-                            description: Daily defines the number of snapshots to
-                              be kept daily
-                            type: string
-                          hourly:
-                            description: Hourly defines the number of snapshots to
-                              be kept hourly
-                            type: string
-                          monthly:
-                            description: Monthly defines the number of snapshots to
-                              be kept monthly
-                            type: string
-                          weekly:
-                            description: Weekly defines the number of snapshots to
-                              be kept weekly
-                            type: string
-                          within:
-                            description: Within defines the number of snapshots to
-                              be kept Within the given time period
-                            type: string
-                          yearly:
-                            description: Yearly defines the number of snapshots to
-                              be kept yearly
-                            type: string
-                        type: object
-                      timeout:
-                        description: User supplied timeout to be used for VolumeSnapshotBackup
-                          and VolumeSnapshotRestore to complete, default value is
-                          10m
-                        type: string
-                      volumeOptionsForStorageClasses:
-                        additionalProperties:
-                          properties:
-                            destinationVolumeOptions:
-                              description: VolumeOptions defines configurations for
-                                VolSync options
-                              properties:
-                                accessMode:
-                                  description: accessMode can be used to override
-                                    the accessMode of the source or destination PVC
-                                  type: string
-                                cacheAccessMode:
-                                  description: cacheAccessMode is the access mode
-                                    to be used to provision the cache volume
-                                  type: string
-                                cacheCapacity:
-                                  description: cacheCapacity determines the size of
-                                    the restic metadata cache volume
-                                  type: string
-                                cacheStorageClassName:
-                                  description: cacheStorageClassName is the storageClass
-                                    that should be used when provisioning the data
-                                    mover cache volume
-                                  type: string
-                                storageClassName:
-                                  description: storageClassName can be used to override
-                                    the StorageClass of the source or destination
-                                    PVC
-                                  type: string
-                              type: object
-                            sourceVolumeOptions:
-                              description: VolumeOptions defines configurations for
-                                VolSync options
-                              properties:
-                                accessMode:
-                                  description: accessMode can be used to override
-                                    the accessMode of the source or destination PVC
-                                  type: string
-                                cacheAccessMode:
-                                  description: cacheAccessMode is the access mode
-                                    to be used to provision the cache volume
-                                  type: string
-                                cacheCapacity:
-                                  description: cacheCapacity determines the size of
-                                    the restic metadata cache volume
-                                  type: string
-                                cacheStorageClassName:
-                                  description: cacheStorageClassName is the storageClass
-                                    that should be used when provisioning the data
-                                    mover cache volume
-                                  type: string
-                                storageClassName:
-                                  description: storageClassName can be used to override
-                                    the StorageClass of the source or destination
-                                    PVC
-                                  type: string
-                              type: object
-                          type: object
-                        description: defines configurations for data mover volume
-                          options for a storageClass
-                        type: object
-                    type: object
-                type: object
-              podAnnotations:
-                additionalProperties:
-                  type: string
-                description: add annotations to pods deployed by operator
-                type: object
-              podDnsConfig:
-                description: podDnsConfig defines the DNS parameters of a pod in addition
-                  to those generated from DNSPolicy. https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config
-                properties:
-                  nameservers:
-                    description: A list of DNS name server IP addresses. This will
-                      be appended to the base nameservers generated from DNSPolicy.
-                      Duplicated nameservers will be removed.
-                    items:
-                      type: string
-                    type: array
-                  options:
-                    description: A list of DNS resolver options. This will be merged
-                      with the base options generated from DNSPolicy. Duplicated entries
-                      will be removed. Resolution options given in Options will override
-                      those that appear in the base DNSPolicy.
-                    items:
-                      description: PodDNSConfigOption defines DNS resolver options
-                        of a pod.
-                      properties:
-                        name:
-                          description: Required.
-                          type: string
-                        value:
-                          type: string
-                      type: object
-                    type: array
-                  searches:
-                    description: A list of DNS search domains for host-name lookup.
-                      This will be appended to the base search paths generated from
-                      DNSPolicy. Duplicated search paths will be removed.
-                    items:
-                      type: string
-                    type: array
-                type: object
-              podDnsPolicy:
-                description: podDnsPolicy defines how a pod's DNS will be configured.
-                  https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
-                type: string
-              snapshotLocations:
-                description: snapshotLocations defines the list of desired configuration
-                  to use for VolumeSnapshotLocations
-                items:
-                  description: SnapshotLocation defines the configuration for the
-                    DPA snapshot store
+                features:
+                  description: features defines the configuration for the DPA to enable the OADP tech preview features
                   properties:
-                    velero:
-                      description: VolumeSnapshotLocationSpec defines the specification
-                        for a Velero VolumeSnapshotLocation.
+                    dataMover:
+                      description: Contains data mover specific configurations
                       properties:
-                        config:
+                        credentialName:
+                          description: User supplied Restic Secret name
+                          type: string
+                        enable:
+                          description: enable flag is used to specify whether you want to deploy the volume snapshot mover controller
+                          type: boolean
+                        maxConcurrentBackupVolumes:
+                          description: the number of batched volumeSnapshotBackups that can be inProgress at once, default value is 10
+                          type: string
+                        maxConcurrentRestoreVolumes:
+                          description: the number of batched volumeSnapshotRestores that can be inProgress at once, default value is 10
+                          type: string
+                        pruneInterval:
+                          description: defines how often (in days) to prune the datamover snapshots from the repository
+                          type: string
+                        schedule:
+                          description: 'schedule is a cronspec (https://en.wikipedia.org/wiki/Cron#Overview) that can be used to schedule datamover(volsync) synchronization to occur at regular, time-based intervals. For example, in order to enforce datamover SnapshotRetainPolicy at a regular interval you need to specify this Schedule trigger as a cron expression, by default the trigger is a manual trigger. For more details on Volsync triggers, refer: https://volsync.readthedocs.io/en/stable/usage/triggers.html'
+                          pattern: ^(\d+|\*)(/\d+)?(\s+(\d+|\*)(/\d+)?){4}$
+                          type: string
+                        snapshotRetainPolicy:
+                          description: defines the parameters that can be specified for retention of datamover snapshots
+                          properties:
+                            daily:
+                              description: Daily defines the number of snapshots to be kept daily
+                              type: string
+                            hourly:
+                              description: Hourly defines the number of snapshots to be kept hourly
+                              type: string
+                            monthly:
+                              description: Monthly defines the number of snapshots to be kept monthly
+                              type: string
+                            weekly:
+                              description: Weekly defines the number of snapshots to be kept weekly
+                              type: string
+                            within:
+                              description: Within defines the number of snapshots to be kept Within the given time period
+                              type: string
+                            yearly:
+                              description: Yearly defines the number of snapshots to be kept yearly
+                              type: string
+                          type: object
+                        timeout:
+                          description: User supplied timeout to be used for VolumeSnapshotBackup and VolumeSnapshotRestore to complete, default value is 10m
+                          type: string
+                        volumeOptionsForStorageClasses:
                           additionalProperties:
-                            type: string
-                          description: Config is for provider-specific configuration
-                            fields.
+                            properties:
+                              destinationVolumeOptions:
+                                description: VolumeOptions defines configurations for VolSync options
+                                properties:
+                                  accessMode:
+                                    description: accessMode can be used to override the accessMode of the source or destination PVC
+                                    type: string
+                                  cacheAccessMode:
+                                    description: cacheAccessMode is the access mode to be used to provision the cache volume
+                                    type: string
+                                  cacheCapacity:
+                                    description: cacheCapacity determines the size of the restic metadata cache volume
+                                    type: string
+                                  cacheStorageClassName:
+                                    description: cacheStorageClassName is the storageClass that should be used when provisioning the data mover cache volume
+                                    type: string
+                                  storageClassName:
+                                    description: storageClassName can be used to override the StorageClass of the source or destination PVC
+                                    type: string
+                                type: object
+                              sourceVolumeOptions:
+                                description: VolumeOptions defines configurations for VolSync options
+                                properties:
+                                  accessMode:
+                                    description: accessMode can be used to override the accessMode of the source or destination PVC
+                                    type: string
+                                  cacheAccessMode:
+                                    description: cacheAccessMode is the access mode to be used to provision the cache volume
+                                    type: string
+                                  cacheCapacity:
+                                    description: cacheCapacity determines the size of the restic metadata cache volume
+                                    type: string
+                                  cacheStorageClassName:
+                                    description: cacheStorageClassName is the storageClass that should be used when provisioning the data mover cache volume
+                                    type: string
+                                  storageClassName:
+                                    description: storageClassName can be used to override the StorageClass of the source or destination PVC
+                                    type: string
+                                type: object
+                            type: object
+                          description: defines configurations for data mover volume options for a storageClass
                           type: object
-                        credential:
-                          description: Credential contains the credential information
-                            intended to be used with this location
-                          properties:
-                            key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                            optional:
-                              description: Specify whether the Secret or its key must
-                                be defined
-                              type: boolean
-                          required:
-                          - key
-                          type: object
-                        provider:
-                          description: Provider is the provider of the volume storage.
-                          type: string
-                      required:
-                      - provider
                       type: object
-                  required:
-                  - velero
                   type: object
-                type: array
-              unsupportedOverrides:
-                additionalProperties:
-                  type: string
-                description: 'unsupportedOverrides can be used to override images
-                  used in deployments. Available keys are:   - veleroImageFqin   -
-                  awsPluginImageFqin   - openshiftPluginImageFqin   - azurePluginImageFqin   -
-                  gcpPluginImageFqin   - csiPluginImageFqin   - dataMoverImageFqin   -
-                  resticRestoreImageFqin   - kubevirtPluginImageFqin'
-                type: object
-            required:
-            - configuration
-            type: object
-          status:
-            description: DataProtectionApplicationStatus defines the observed state
-              of DataProtectionApplication
-            properties:
-              conditions:
-                items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource. --- This struct is intended for direct
-                    use as an array at the field path .status.conditions.  For example,
-                    \n \ttype FooStatus struct{ \t    // Represents the observations
-                    of a foo's current state. \t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\" \t    //
-                    +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map
-                    \t    // +listMapKey=type \t    Conditions []metav1.Condition
-                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields
-                    \t}"
+                podAnnotations:
+                  additionalProperties:
+                    type: string
+                  description: add annotations to pods deployed by operator
+                  type: object
+                podDnsConfig:
+                  description: podDnsConfig defines the DNS parameters of a pod in addition to those generated from DNSPolicy. https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config
                   properties:
-                    lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another. This should be when
-                        the underlying condition changed.  If that is not known, then
-                        using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: message is a human readable message indicating
-                        details about the transition. This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers
-                        of specific condition types may define expected values and
-                        meanings for this field, and whether the values are considered
-                        a guaranteed API. The value should be a CamelCase string.
-                        This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        --- Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                      type: string
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
+                    nameservers:
+                      description: A list of DNS name server IP addresses. This will be appended to the base nameservers generated from DNSPolicy. Duplicated nameservers will be removed.
+                      items:
+                        type: string
+                      type: array
+                    options:
+                      description: A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy.
+                      items:
+                        description: PodDNSConfigOption defines DNS resolver options of a pod.
+                        properties:
+                          name:
+                            description: Required.
+                            type: string
+                          value:
+                            type: string
+                        type: object
+                      type: array
+                    searches:
+                      description: A list of DNS search domains for host-name lookup. This will be appended to the base search paths generated from DNSPolicy. Duplicated search paths will be removed.
+                      items:
+                        type: string
+                      type: array
                   type: object
-                type: array
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                podDnsPolicy:
+                  description: podDnsPolicy defines how a pod's DNS will be configured. https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
+                  type: string
+                snapshotLocations:
+                  description: snapshotLocations defines the list of desired configuration to use for VolumeSnapshotLocations
+                  items:
+                    description: SnapshotLocation defines the configuration for the DPA snapshot store
+                    properties:
+                      velero:
+                        description: VolumeSnapshotLocationSpec defines the specification for a Velero VolumeSnapshotLocation.
+                        properties:
+                          config:
+                            additionalProperties:
+                              type: string
+                            description: Config is for provider-specific configuration fields.
+                            type: object
+                          credential:
+                            description: Credential contains the credential information intended to be used with this location
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key must be defined
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                          provider:
+                            description: Provider is the provider of the volume storage.
+                            type: string
+                        required:
+                          - provider
+                        type: object
+                    required:
+                      - velero
+                    type: object
+                  type: array
+                unsupportedOverrides:
+                  additionalProperties:
+                    type: string
+                  description: 'unsupportedOverrides can be used to override images used in deployments. Available keys are:   - veleroImageFqin   - awsPluginImageFqin   - openshiftPluginImageFqin   - azurePluginImageFqin   - gcpPluginImageFqin   - csiPluginImageFqin   - dataMoverImageFqin   - resticRestoreImageFqin   - kubevirtPluginImageFqin'
+                  type: object
+              required:
+                - configuration
+              type: object
+            status:
+              description: DataProtectionApplicationStatus defines the observed state of DataProtectionApplication
+              properties:
+                conditions:
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n \ttype FooStatus struct{ \t    // Represents the observations of a foo's current state. \t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" \t    // +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map \t    // +listMapKey=type \t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields \t}"
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""

--- a/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
@@ -1,3 +1,5 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -12,893 +14,1226 @@ spec:
     listKind: DataProtectionApplicationList
     plural: dataprotectionapplications
     shortNames:
-      - dpa
+    - dpa
     singular: dataprotectionapplication
   scope: Namespaced
   versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: DataProtectionApplication is the Schema for the dpa API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: DataProtectionApplicationSpec defines the desired state of Velero
-              properties:
-                backupImages:
-                  description: backupImages is used to specify whether you want to deploy a registry for enabling backup and restore of images
-                  type: boolean
-                backupLocations:
-                  description: backupLocations defines the list of desired configuration to use for BackupStorageLocations
-                  items:
-                    description: BackupLocation defines the configuration for the DPA backup storage
-                    properties:
-                      bucket:
-                        properties:
-                          backupSyncPeriod:
-                            description: backupSyncPeriod defines how frequently to sync backup API objects from object storage. A value of 0 disables sync.
-                            nullable: true
-                            type: string
-                          cloudStorageRef:
-                            description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
-                            properties:
-                              name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
-                                type: string
-                            type: object
-                          config:
-                            additionalProperties:
-                              type: string
-                            description: config is for provider-specific configuration fields.
-                            type: object
-                          credential:
-                            description: credential contains the credential information intended to be used with this location
-                            properties:
-                              key:
-                                description: The key of the secret to select from.  Must be a valid secret key.
-                                type: string
-                              name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
-                                type: string
-                              optional:
-                                description: Specify whether the Secret or its key must be defined
-                                type: boolean
-                            required:
-                              - key
-                            type: object
-                          default:
-                            description: default indicates this location is the default backup storage location.
-                            type: boolean
-                        required:
-                          - cloudStorageRef
-                        type: object
-                      name:
-                        type: string
-                      velero:
-                        description: BackupStorageLocationSpec defines the desired state of a Velero BackupStorageLocation
-                        properties:
-                          accessMode:
-                            description: AccessMode defines the permissions for the backup storage location.
-                            enum:
-                              - ReadOnly
-                              - ReadWrite
-                            type: string
-                          backupSyncPeriod:
-                            description: BackupSyncPeriod defines how frequently to sync backup API objects from object storage. A value of 0 disables sync.
-                            nullable: true
-                            type: string
-                          config:
-                            additionalProperties:
-                              type: string
-                            description: Config is for provider-specific configuration fields.
-                            type: object
-                          credential:
-                            description: Credential contains the credential information intended to be used with this location
-                            properties:
-                              key:
-                                description: The key of the secret to select from.  Must be a valid secret key.
-                                type: string
-                              name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
-                                type: string
-                              optional:
-                                description: Specify whether the Secret or its key must be defined
-                                type: boolean
-                            required:
-                              - key
-                            type: object
-                          default:
-                            description: Default indicates this location is the default backup storage location.
-                            type: boolean
-                          objectStorage:
-                            description: ObjectStorageLocation specifies the settings necessary to connect to a provider's object storage.
-                            properties:
-                              bucket:
-                                description: Bucket is the bucket to use for object storage.
-                                type: string
-                              caCert:
-                                description: CACert defines a CA bundle to use when verifying TLS connections to the provider.
-                                format: byte
-                                type: string
-                              prefix:
-                                description: Prefix is the path inside a bucket to use for Velero storage. Optional.
-                                type: string
-                            required:
-                              - bucket
-                            type: object
-                          provider:
-                            description: Provider is the provider of the backup storage.
-                            type: string
-                          validationFrequency:
-                            description: ValidationFrequency defines how frequently to validate the corresponding object storage. A value of 0 disables validation.
-                            nullable: true
-                            type: string
-                        required:
-                          - objectStorage
-                          - provider
-                        type: object
-                    type: object
-                  type: array
-                configuration:
-                  description: configuration is used to configure the data protection application's server config
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: DataProtectionApplication is the Schema for the dpa API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DataProtectionApplicationSpec defines the desired state of
+              Velero
+            properties:
+              backupImages:
+                description: backupImages is used to specify whether you want to deploy
+                  a registry for enabling backup and restore of images
+                type: boolean
+              backupLocations:
+                description: backupLocations defines the list of desired configuration
+                  to use for BackupStorageLocations
+                items:
+                  description: BackupLocation defines the configuration for the DPA
+                    backup storage
                   properties:
-                    restic:
-                      description: ResticConfig is the configuration for restic server
+                    bucket:
                       properties:
-                        enable:
-                          description: enable defines a boolean pointer whether we want the daemonset to exist or not
-                          type: boolean
-                        podConfig:
-                          description: Pod specific configuration
+                        backupSyncPeriod:
+                          description: backupSyncPeriod defines how frequently to
+                            sync backup API objects from object storage. A value of
+                            0 disables sync.
+                          nullable: true
+                          type: string
+                        cloudStorageRef:
+                          description: LocalObjectReference contains enough information
+                            to let you locate the referenced object inside the same
+                            namespace.
                           properties:
-                            env:
-                              description: env defines the list of environment variables to be supplied to podSpec
-                              items:
-                                description: EnvVar represents an environment variable present in a Container.
-                                properties:
-                                  name:
-                                    description: Name of the environment variable. Must be a C_IDENTIFIER.
-                                    type: string
-                                  value:
-                                    description: 'Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
-                                    type: string
-                                  valueFrom:
-                                    description: Source for the environment variable's value. Cannot be used if value is not empty.
-                                    properties:
-                                      configMapKeyRef:
-                                        description: Selects a key of a ConfigMap.
-                                        properties:
-                                          key:
-                                            description: The key to select.
-                                            type: string
-                                          name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
-                                            type: string
-                                          optional:
-                                            description: Specify whether the ConfigMap or its key must be defined
-                                            type: boolean
-                                        required:
-                                          - key
-                                        type: object
-                                      fieldRef:
-                                        description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
-                                        properties:
-                                          apiVersion:
-                                            description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
-                                            type: string
-                                          fieldPath:
-                                            description: Path of the field to select in the specified API version.
-                                            type: string
-                                        required:
-                                          - fieldPath
-                                        type: object
-                                      resourceFieldRef:
-                                        description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
-                                        properties:
-                                          containerName:
-                                            description: 'Container name: required for volumes, optional for env vars'
-                                            type: string
-                                          divisor:
-                                            anyOf:
-                                              - type: integer
-                                              - type: string
-                                            description: Specifies the output format of the exposed resources, defaults to "1"
-                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                            x-kubernetes-int-or-string: true
-                                          resource:
-                                            description: 'Required: resource to select'
-                                            type: string
-                                        required:
-                                          - resource
-                                        type: object
-                                      secretKeyRef:
-                                        description: Selects a key of a secret in the pod's namespace
-                                        properties:
-                                          key:
-                                            description: The key of the secret to select from.  Must be a valid secret key.
-                                            type: string
-                                          name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
-                                            type: string
-                                          optional:
-                                            description: Specify whether the Secret or its key must be defined
-                                            type: boolean
-                                        required:
-                                          - key
-                                        type: object
-                                    type: object
-                                required:
-                                  - name
-                                type: object
-                              type: array
-                            labels:
-                              additionalProperties:
-                                type: string
-                              description: labels to add to pods
-                              type: object
-                            nodeSelector:
-                              additionalProperties:
-                                type: string
-                              description: nodeSelector defines the nodeSelector to be supplied to Restic podSpec
-                              type: object
-                            resourceAllocations:
-                              description: resourceAllocations defines the CPU and Memory resource allocations for the restic Pod
-                              nullable: true
-                              properties:
-                                claims:
-                                  description: "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable."
-                                  items:
-                                    description: ResourceClaim references one entry in PodSpec.ResourceClaims.
-                                    properties:
-                                      name:
-                                        description: Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.
-                                        type: string
-                                    required:
-                                      - name
-                                    type: object
-                                  type: array
-                                  x-kubernetes-list-map-keys:
-                                    - name
-                                  x-kubernetes-list-type: map
-                                limits:
-                                  additionalProperties:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                    nullable: true
-                                  description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                                  type: object
-                                  nullable: true
-                                requests:
-                                  additionalProperties:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                    nullable: true
-                                  description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                                  type: object
-                                  nullable: true
-                              type: object
-                            tolerations:
-                              description: tolerations defines the list of tolerations to be applied to Restic daemonset
-                              items:
-                                description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
-                                properties:
-                                  effect:
-                                    description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
-                                    type: string
-                                  key:
-                                    description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
-                                    type: string
-                                  operator:
-                                    description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
-                                    type: string
-                                  tolerationSeconds:
-                                    description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
-                                    format: int64
-                                    type: integer
-                                  value:
-                                    description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
-                                    type: string
-                                type: object
-                              type: array
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
                           type: object
-                        supplementalGroups:
-                          description: supplementalGroups defines the linux groups to be applied to the Restic Pod
-                          items:
+                        config:
+                          additionalProperties:
+                            type: string
+                          description: config is for provider-specific configuration
+                            fields.
+                          type: object
+                        credential:
+                          description: credential contains the credential information
+                            intended to be used with this location
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                        default:
+                          description: default indicates this location is the default
+                            backup storage location.
+                          type: boolean
+                      required:
+                      - cloudStorageRef
+                      type: object
+                    name:
+                      type: string
+                    velero:
+                      description: BackupStorageLocationSpec defines the desired state
+                        of a Velero BackupStorageLocation
+                      properties:
+                        accessMode:
+                          description: AccessMode defines the permissions for the
+                            backup storage location.
+                          enum:
+                          - ReadOnly
+                          - ReadWrite
+                          type: string
+                        backupSyncPeriod:
+                          description: BackupSyncPeriod defines how frequently to
+                            sync backup API objects from object storage. A value of
+                            0 disables sync.
+                          nullable: true
+                          type: string
+                        config:
+                          additionalProperties:
+                            type: string
+                          description: Config is for provider-specific configuration
+                            fields.
+                          type: object
+                        credential:
+                          description: Credential contains the credential information
+                            intended to be used with this location
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                        default:
+                          description: Default indicates this location is the default
+                            backup storage location.
+                          type: boolean
+                        objectStorage:
+                          description: ObjectStorageLocation specifies the settings
+                            necessary to connect to a provider's object storage.
+                          properties:
+                            bucket:
+                              description: Bucket is the bucket to use for object
+                                storage.
+                              type: string
+                            caCert:
+                              description: CACert defines a CA bundle to use when
+                                verifying TLS connections to the provider.
+                              format: byte
+                              type: string
+                            prefix:
+                              description: Prefix is the path inside a bucket to use
+                                for Velero storage. Optional.
+                              type: string
+                          required:
+                          - bucket
+                          type: object
+                        provider:
+                          description: Provider is the provider of the backup storage.
+                          type: string
+                        validationFrequency:
+                          description: ValidationFrequency defines how frequently
+                            to validate the corresponding object storage. A value
+                            of 0 disables validation.
+                          nullable: true
+                          type: string
+                      required:
+                      - objectStorage
+                      - provider
+                      type: object
+                  type: object
+                type: array
+              configuration:
+                description: configuration is used to configure the data protection
+                  application's server config
+                properties:
+                  restic:
+                    description: ResticConfig is the configuration for restic server
+                    properties:
+                      enable:
+                        description: enable defines a boolean pointer whether we want
+                          the daemonset to exist or not
+                        type: boolean
+                      podConfig:
+                        description: Pod specific configuration
+                        properties:
+                          env:
+                            description: env defines the list of environment variables
+                              to be supplied to podSpec
+                            items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
+                              properties:
+                                name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
+                                  type: string
+                                value:
+                                  description: 'Variable references $(VAR_NAME) are
+                                    expanded using the previously defined environment
+                                    variables in the container and any service environment
+                                    variables. If a variable cannot be resolved, the
+                                    reference in the input string will be unchanged.
+                                    Double $$ are reduced to a single $, which allows
+                                    for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                    will produce the string literal "$(VAR_NAME)".
+                                    Escaped references will never be expanded, regardless
+                                    of whether the variable exists or not. Defaults
+                                    to "".'
+                                  type: string
+                                valueFrom:
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    fieldRef:
+                                      description: 'Selects a field of the pod: supports
+                                        metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                        `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                        spec.serviceAccountName, status.hostIP, status.podIP,
+                                        status.podIPs.'
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                        only resources limits and requests (limits.cpu,
+                                        limits.memory, limits.ephemeral-storage, requests.cpu,
+                                        requests.memory and requests.ephemeral-storage)
+                                        are currently supported.'
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          labels:
+                            additionalProperties:
+                              type: string
+                            description: labels to add to pods
+                            type: object
+                          nodeSelector:
+                            additionalProperties:
+                              type: string
+                            description: nodeSelector defines the nodeSelector to
+                              be supplied to podSpec
+                            type: object
+                          resourceAllocations:
+                            description: resourceAllocations defines the CPU and Memory
+                              resource allocations for the Pod
+                            nullable: true
+                            properties:
+                              claims:
+                                description: "Claims lists the names of resources,
+                                  defined in spec.resourceClaims, that are used by
+                                  this container. \n This is an alpha field and requires
+                                  enabling the DynamicResourceAllocation feature gate.
+                                  \n This field is immutable."
+                                items:
+                                  description: ResourceClaim references one entry
+                                    in PodSpec.ResourceClaims.
+                                  properties:
+                                    name:
+                                      description: Name must match the name of one
+                                        entry in pod.spec.resourceClaims of the Pod
+                                        where this field is used. It makes that resource
+                                        available inside a container.
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Limits describes the maximum amount
+                                  of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Requests describes the minimum amount
+                                  of compute resources required. If Requests is omitted
+                                  for a container, it defaults to Limits if that is
+                                  explicitly specified, otherwise to an implementation-defined
+                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                type: object
+                            type: object
+                          tolerations:
+                            description: tolerations defines the list of tolerations
+                              to be applied
+                            items:
+                              description: The pod this Toleration is attached to
+                                tolerates any taint that matches the triple <key,value,effect>
+                                using the matching operator <operator>.
+                              properties:
+                                effect:
+                                  description: Effect indicates the taint effect to
+                                    match. Empty means match all taint effects. When
+                                    specified, allowed values are NoSchedule, PreferNoSchedule
+                                    and NoExecute.
+                                  type: string
+                                key:
+                                  description: Key is the taint key that the toleration
+                                    applies to. Empty means match all taint keys.
+                                    If the key is empty, operator must be Exists;
+                                    this combination means to match all values and
+                                    all keys.
+                                  type: string
+                                operator:
+                                  description: Operator represents a key's relationship
+                                    to the value. Valid operators are Exists and Equal.
+                                    Defaults to Equal. Exists is equivalent to wildcard
+                                    for value, so that a pod can tolerate all taints
+                                    of a particular category.
+                                  type: string
+                                tolerationSeconds:
+                                  description: TolerationSeconds represents the period
+                                    of time the toleration (which must be of effect
+                                    NoExecute, otherwise this field is ignored) tolerates
+                                    the taint. By default, it is not set, which means
+                                    tolerate the taint forever (do not evict). Zero
+                                    and negative values will be treated as 0 (evict
+                                    immediately) by the system.
+                                  format: int64
+                                  type: integer
+                                value:
+                                  description: Value is the taint value the toleration
+                                    matches to. If the operator is Exists, the value
+                                    should be empty, otherwise just a regular string.
+                                  type: string
+                              type: object
+                            type: array
+                        type: object
+                      supplementalGroups:
+                        description: supplementalGroups defines the linux groups to
+                          be applied to the Restic Pod
+                        items:
+                          format: int64
+                          type: integer
+                        type: array
+                      timeout:
+                        description: timeout defines the Restic timeout, default value
+                          is 1h
+                        type: string
+                    type: object
+                  velero:
+                    properties:
+                      args:
+                        description: Velero args are settings to customize velero
+                          server arguments. Overrides values in other fields.
+                        properties:
+                          add_dir_header:
+                            description: If true, adds the file directory to the header
+                              of the log messages
+                            type: boolean
+                          alsologtostderr:
+                            description: log to standard error as well as files (no
+                              effect when -logtostderr=true)
+                            type: boolean
+                          backup-sync-period:
+                            description: How often to ensure all Velero backups in
+                              object storage exist as Backup API objects in the cluster.
+                              This is the default sync period if none is explicitly
+                              specified for a backup storage location.
                             format: int64
                             type: integer
-                          type: array
-                        timeout:
-                          description: timeout defines the Restic timeout, default value is 1h
-                          type: string
-                      type: object
-                    velero:
-                      properties:
-                        args:
-                          description: Velero args are settings to customize velero server arguments. Overrides values in other fields.
-                          properties:
-                            add_dir_header:
-                              description: If true, adds the file directory to the header of the log messages
-                              type: boolean
-                            alsologtostderr:
-                              description: log to standard error as well as files (no effect when -logtostderr=true)
-                              type: boolean
-                            backup-sync-period:
-                              description: How often to ensure all Velero backups in object storage exist as Backup API objects in the cluster. This is the default sync period if none is explicitly specified for a backup storage location.
-                              format: int64
-                              type: integer
-                            client-burst:
-                              description: Maximum number of requests by the server to the Kubernetes API in a short period of time.
-                              type: integer
-                            client-page-size:
-                              description: Page size of requests by the server to the Kubernetes API when listing objects during a backup. Set to 0 to disable paging.
-                              type: integer
-                            client-qps:
-                              description: Maximum number of requests per second by the server to the Kubernetes API once the burst limit has been reached. this will be validated as a valid float32
-                              type: string
-                            colorized:
-                              description: Show colored output in TTY
-                              type: boolean
-                            default-backup-ttl:
-                              description: default 720h0m0s
-                              format: int64
-                              type: integer
-                            default-item-operation-timeout:
-                              description: How long to wait on asynchronous BackupItemActions and RestoreItemActions to complete before timing out. (default 1h0m0s)
-                              format: int64
-                              type: integer
-                            default-repo-maintain-frequency:
-                              description: How often 'maintain' is run for backup repositories by default.
-                              format: int64
-                              type: integer
-                            default-volumes-to-fs-backup:
-                              description: Backup all volumes with pod volume file system backup by default.
-                              type: boolean
-                            disabled-controllers:
-                              description: List of controllers to disable on startup. Valid values are backup,backup-operations,backup-deletion,backup-finalizer,backup-sync,download-request,gc,backup-repo,restore,restore-operations,schedule,server-status-request
-                              enum:
-                                - backup
-                                - backup-operations
-                                - backup-deletion
-                                - backup-finalizer
-                                - backup-sync
-                                - download-request
-                                - gc
-                                - backup-repo
-                                - restore
-                                - restore-operations
-                                - schedule
-                                - server-status-request
-                              items:
-                                type: string
-                              type: array
-                            fs-backup-timeout:
-                              description: How long pod volume file system backups/restores should be allowed to run before timing out. (default 4h0m0s)
-                              format: int64
-                              type: integer
-                            garbage-collection-frequency:
-                              description: How long to wait by default before backups can be garbage collected. (default 720h0m0s)
-                              format: int64
-                              type: integer
-                            item-operation-sync-frequency:
-                              description: How often to check status on backup/restore operations after backup/restore processing.
-                              format: int64
-                              type: integer
-                            log-format:
-                              description: The format for log output. Valid values are text, json. (default text)
-                              enum:
-                                - text
-                                - json
-                              type: string
-                            log_backtrace_at:
-                              description: when logging hits line file:N, emit a stack trace
-                              type: string
-                            log_dir:
-                              description: If non-empty, write log files in this directory (no effect when -logtostderr=true)
-                              type: string
-                            log_file:
-                              description: If non-empty, use this log file (no effect when -logtostderr=true)
-                              type: string
-                            log_file_max_size:
-                              description: Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-                              format: int64
-                              minimum: 0
-                              type: integer
-                            logtostderr:
-                              description: 'Boolean flags. Not handled atomically because the flag.Value interface does not let us avoid the =true, and that shorthand is necessary for compatibility. TODO: does this matter enough to fix? Seems unlikely.'
-                              type: boolean
-                            max-concurrent-k8s-connections:
-                              description: Max concurrent connections number that Velero can create with kube-apiserver. Default is 30. (default 30)
-                              type: integer
-                            metrics-address:
-                              description: The address to expose prometheus metrics
-                              type: string
-                            one_output:
-                              description: If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
-                              type: boolean
-                            profiler-address:
-                              description: The address to expose the pprof profiler.
-                              type: string
-                            resource-timeout:
-                              description: How long to wait for resource processes which are not covered by other specific timeout parameters. Default is 10 minutes. (default 10m0s)
-                              format: int64
-                              type: integer
-                            restore-resource-priorities:
-                              description: Desired order of resource restores, the priority list contains two parts which are split by "-" element. The resources before "-" element are restored first as high priorities, the resources after "-" element are restored last as low priorities, and any resource not in the list will be restored alphabetically between the high and low priorities. (default customresourcedefinitions,namespaces,storageclasses,volumesnapshotbackups.datamover.oadp.openshift.io,volumesnapshotclass.snapshot.storage.k8s.io,volumesnapshotcontents.snapshot.storage.k8s.io,volumesnapshots.snapshot.storage.k8s.io,persistentvolumes,persistentvolumeclaims,serviceaccounts,secrets,configmaps,limitranges,pods,replicasets.apps,clusterclasses.cluster.x-k8s.io,services,-,clusterbootstraps.run.tanzu.vmware.com,clusters.cluster.x-k8s.io,clusterresourcesets.addons.cluster.x-k8s.io)
-                              type: string
-                            skip_headers:
-                              description: If true, avoid header prefixes in the log messages
-                              type: boolean
-                            skip_log_headers:
-                              description: If true, avoid headers when opening log files (no effect when -logtostderr=true)
-                              type: boolean
-                            stderrthreshold:
-                              description: logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
-                              type: integer
-                            store-validation-frequency:
-                              description: How often to verify if the storage is valid. Optional. Set this to `0s` to disable sync. Default 1 minute.
-                              format: int64
-                              type: integer
-                            terminating-resource-timeout:
-                              description: How long to wait on persistent volumes and namespaces to terminate during a restore before timing out.
-                              format: int64
-                              type: integer
-                            v:
-                              description: number for the log level verbosity
-                              type: integer
-                            vmodule:
-                              description: comma-separated list of pattern=N settings for file-filtered logging
-                              type: string
-                          type: object
-                        customPlugins:
-                          description: customPlugins defines the custom plugin to be installed with Velero
-                          items:
-                            properties:
-                              image:
-                                type: string
-                              name:
-                                type: string
-                            required:
-                              - image
-                              - name
-                            type: object
-                          type: array
-                        defaultItemOperationTimeout:
-                          description: How long to wait on asynchronous BackupItemActions and RestoreItemActions to complete before timing out. Default value is 1h.
-                          type: string
-                        defaultPlugins:
-                          items:
+                          client-burst:
+                            description: Maximum number of requests by the server
+                              to the Kubernetes API in a short period of time.
+                            type: integer
+                          client-page-size:
+                            description: Page size of requests by the server to the
+                              Kubernetes API when listing objects during a backup.
+                              Set to 0 to disable paging.
+                            type: integer
+                          client-qps:
+                            description: Maximum number of requests per second by
+                              the server to the Kubernetes API once the burst limit
+                              has been reached. this will be validated as a valid
+                              float32
                             type: string
-                          type: array
-                        featureFlags:
-                          description: featureFlags defines the list of features to enable for Velero instance
-                          items:
+                          colorized:
+                            description: Show colored output in TTY
+                            type: boolean
+                          default-backup-ttl:
+                            description: default 720h0m0s
+                            format: int64
+                            type: integer
+                          default-item-operation-timeout:
+                            description: How long to wait on asynchronous BackupItemActions
+                              and RestoreItemActions to complete before timing out.
+                              (default 1h0m0s)
+                            format: int64
+                            type: integer
+                          default-repo-maintain-frequency:
+                            description: How often 'maintain' is run for backup repositories
+                              by default.
+                            format: int64
+                            type: integer
+                          default-volumes-to-fs-backup:
+                            description: Backup all volumes with pod volume file system
+                              backup by default.
+                            type: boolean
+                          disabled-controllers:
+                            description: List of controllers to disable on startup.
+                              Valid values are backup,backup-operations,backup-deletion,backup-finalizer,backup-sync,download-request,gc,backup-repo,restore,restore-operations,schedule,server-status-request
+                            enum:
+                            - backup
+                            - backup-operations
+                            - backup-deletion
+                            - backup-finalizer
+                            - backup-sync
+                            - download-request
+                            - gc
+                            - backup-repo
+                            - restore
+                            - restore-operations
+                            - schedule
+                            - server-status-request
+                            items:
+                              type: string
+                            type: array
+                          fs-backup-timeout:
+                            description: How long pod volume file system backups/restores
+                              should be allowed to run before timing out. (default
+                              4h0m0s)
+                            format: int64
+                            type: integer
+                          garbage-collection-frequency:
+                            description: How long to wait by default before backups
+                              can be garbage collected. (default 720h0m0s)
+                            format: int64
+                            type: integer
+                          item-operation-sync-frequency:
+                            description: How often to check status on backup/restore
+                              operations after backup/restore processing.
+                            format: int64
+                            type: integer
+                          log-format:
+                            description: The format for log output. Valid values are
+                              text, json. (default text)
+                            enum:
+                            - text
+                            - json
                             type: string
-                          type: array
-                        itemOperationSyncFrequency:
-                          description: How often to check status on async backup/restore operations after backup processing. Default value is 2m.
-                          type: string
-                        logLevel:
-                          description: Velero server’s log level (use debug for the most logging, leave unset for velero default)
-                          enum:
-                            - trace
-                            - debug
-                            - info
-                            - warning
-                            - error
-                            - fatal
-                            - panic
-                          type: string
-                        noDefaultBackupLocation:
-                          description: If you need to install Velero without a default backup storage location noDefaultBackupLocation flag is required for confirmation
-                          type: boolean
-                        podConfig:
-                          description: Pod specific configuration
-                          properties:
-                            env:
-                              description: env defines the list of environment variables to be supplied to podSpec
-                              items:
-                                description: EnvVar represents an environment variable present in a Container.
-                                properties:
-                                  name:
-                                    description: Name of the environment variable. Must be a C_IDENTIFIER.
-                                    type: string
-                                  value:
-                                    description: 'Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
-                                    type: string
-                                  valueFrom:
-                                    description: Source for the environment variable's value. Cannot be used if value is not empty.
-                                    properties:
-                                      configMapKeyRef:
-                                        description: Selects a key of a ConfigMap.
-                                        properties:
-                                          key:
-                                            description: The key to select.
-                                            type: string
-                                          name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
-                                            type: string
-                                          optional:
-                                            description: Specify whether the ConfigMap or its key must be defined
-                                            type: boolean
-                                        required:
-                                          - key
-                                        type: object
-                                      fieldRef:
-                                        description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
-                                        properties:
-                                          apiVersion:
-                                            description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
-                                            type: string
-                                          fieldPath:
-                                            description: Path of the field to select in the specified API version.
-                                            type: string
-                                        required:
-                                          - fieldPath
-                                        type: object
-                                      resourceFieldRef:
-                                        description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
-                                        properties:
-                                          containerName:
-                                            description: 'Container name: required for volumes, optional for env vars'
-                                            type: string
-                                          divisor:
-                                            anyOf:
-                                              - type: integer
-                                              - type: string
-                                            description: Specifies the output format of the exposed resources, defaults to "1"
-                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                            x-kubernetes-int-or-string: true
-                                          resource:
-                                            description: 'Required: resource to select'
-                                            type: string
-                                        required:
-                                          - resource
-                                        type: object
-                                      secretKeyRef:
-                                        description: Selects a key of a secret in the pod's namespace
-                                        properties:
-                                          key:
-                                            description: The key of the secret to select from.  Must be a valid secret key.
-                                            type: string
-                                          name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
-                                            type: string
-                                          optional:
-                                            description: Specify whether the Secret or its key must be defined
-                                            type: boolean
-                                        required:
-                                          - key
-                                        type: object
-                                    type: object
-                                required:
-                                  - name
-                                type: object
-                              type: array
-                            labels:
-                              additionalProperties:
-                                type: string
-                              description: labels to add to pods
-                              type: object
-                            nodeSelector:
-                              additionalProperties:
-                                type: string
-                              description: nodeSelector defines the nodeSelector to be supplied to Restic podSpec
-                              type: object
-                            resourceAllocations:
-                              description: resourceAllocations defines the CPU and Memory resource allocations for the restic Pod
-                              nullable: true
-                              properties:
-                                claims:
-                                  description: "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable."
-                                  items:
-                                    description: ResourceClaim references one entry in PodSpec.ResourceClaims.
-                                    properties:
-                                      name:
-                                        description: Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.
-                                        type: string
-                                    required:
-                                      - name
-                                    type: object
-                                  type: array
-                                  x-kubernetes-list-map-keys:
-                                    - name
-                                  x-kubernetes-list-type: map
-                                limits:
-                                  additionalProperties:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                    nullable: true
-                                  description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                                  type: object
-                                  nullable: true
-                                requests:
-                                  additionalProperties:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                    nullable: true
-                                  description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                                  type: object
-                                  nullable: true
-                              type: object
-                            tolerations:
-                              description: tolerations defines the list of tolerations to be applied to Restic daemonset
-                              items:
-                                description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
-                                properties:
-                                  effect:
-                                    description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
-                                    type: string
-                                  key:
-                                    description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
-                                    type: string
-                                  operator:
-                                    description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
-                                    type: string
-                                  tolerationSeconds:
-                                    description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
-                                    format: int64
-                                    type: integer
-                                  value:
-                                    description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
-                                    type: string
-                                type: object
-                              type: array
-                          type: object
-                        resourceTimeout:
-                          description: resourceTimeout defines how long to wait for several Velero resources before timeout occurs, such as Velero CRD availability, volumeSnapshot deletion, and repo availability. Default is 10m
-                          type: string
-                        restoreResourcesVersionPriority:
-                          description: restoreResourceVersionPriority represents a configmap that will be created if defined for use in conjunction with EnableAPIGroupVersions feature flag Defining this field automatically add EnableAPIGroupVersions to the velero server feature flag
-                          type: string
-                      type: object
-                  type: object
-                features:
-                  description: features defines the configuration for the DPA to enable the OADP tech preview features
-                  properties:
-                    dataMover:
-                      description: Contains data mover specific configurations
-                      properties:
-                        credentialName:
-                          description: User supplied Restic Secret name
-                          type: string
-                        enable:
-                          description: enable flag is used to specify whether you want to deploy the volume snapshot mover controller
-                          type: boolean
-                        maxConcurrentBackupVolumes:
-                          description: the number of batched volumeSnapshotBackups that can be inProgress at once, default value is 10
-                          type: string
-                        maxConcurrentRestoreVolumes:
-                          description: the number of batched volumeSnapshotRestores that can be inProgress at once, default value is 10
-                          type: string
-                        pruneInterval:
-                          description: defines how often (in days) to prune the datamover snapshots from the repository
-                          type: string
-                        schedule:
-                          description: 'schedule is a cronspec (https://en.wikipedia.org/wiki/Cron#Overview) that can be used to schedule datamover(volsync) synchronization to occur at regular, time-based intervals. For example, in order to enforce datamover SnapshotRetainPolicy at a regular interval you need to specify this Schedule trigger as a cron expression, by default the trigger is a manual trigger. For more details on Volsync triggers, refer: https://volsync.readthedocs.io/en/stable/usage/triggers.html'
-                          pattern: ^(\d+|\*)(/\d+)?(\s+(\d+|\*)(/\d+)?){4}$
-                          type: string
-                        snapshotRetainPolicy:
-                          description: defines the parameters that can be specified for retention of datamover snapshots
-                          properties:
-                            daily:
-                              description: Daily defines the number of snapshots to be kept daily
-                              type: string
-                            hourly:
-                              description: Hourly defines the number of snapshots to be kept hourly
-                              type: string
-                            monthly:
-                              description: Monthly defines the number of snapshots to be kept monthly
-                              type: string
-                            weekly:
-                              description: Weekly defines the number of snapshots to be kept weekly
-                              type: string
-                            within:
-                              description: Within defines the number of snapshots to be kept Within the given time period
-                              type: string
-                            yearly:
-                              description: Yearly defines the number of snapshots to be kept yearly
-                              type: string
-                          type: object
-                        timeout:
-                          description: User supplied timeout to be used for VolumeSnapshotBackup and VolumeSnapshotRestore to complete, default value is 10m
-                          type: string
-                        volumeOptionsForStorageClasses:
-                          additionalProperties:
-                            properties:
-                              destinationVolumeOptions:
-                                description: VolumeOptions defines configurations for VolSync options
-                                properties:
-                                  accessMode:
-                                    description: accessMode can be used to override the accessMode of the source or destination PVC
-                                    type: string
-                                  cacheAccessMode:
-                                    description: cacheAccessMode is the access mode to be used to provision the cache volume
-                                    type: string
-                                  cacheCapacity:
-                                    description: cacheCapacity determines the size of the restic metadata cache volume
-                                    type: string
-                                  cacheStorageClassName:
-                                    description: cacheStorageClassName is the storageClass that should be used when provisioning the data mover cache volume
-                                    type: string
-                                  storageClassName:
-                                    description: storageClassName can be used to override the StorageClass of the source or destination PVC
-                                    type: string
-                                type: object
-                              sourceVolumeOptions:
-                                description: VolumeOptions defines configurations for VolSync options
-                                properties:
-                                  accessMode:
-                                    description: accessMode can be used to override the accessMode of the source or destination PVC
-                                    type: string
-                                  cacheAccessMode:
-                                    description: cacheAccessMode is the access mode to be used to provision the cache volume
-                                    type: string
-                                  cacheCapacity:
-                                    description: cacheCapacity determines the size of the restic metadata cache volume
-                                    type: string
-                                  cacheStorageClassName:
-                                    description: cacheStorageClassName is the storageClass that should be used when provisioning the data mover cache volume
-                                    type: string
-                                  storageClassName:
-                                    description: storageClassName can be used to override the StorageClass of the source or destination PVC
-                                    type: string
-                                type: object
-                            type: object
-                          description: defines configurations for data mover volume options for a storageClass
-                          type: object
-                      type: object
-                  type: object
-                podAnnotations:
-                  additionalProperties:
-                    type: string
-                  description: add annotations to pods deployed by operator
-                  type: object
-                podDnsConfig:
-                  description: podDnsConfig defines the DNS parameters of a pod in addition to those generated from DNSPolicy. https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config
-                  properties:
-                    nameservers:
-                      description: A list of DNS name server IP addresses. This will be appended to the base nameservers generated from DNSPolicy. Duplicated nameservers will be removed.
-                      items:
-                        type: string
-                      type: array
-                    options:
-                      description: A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy.
-                      items:
-                        description: PodDNSConfigOption defines DNS resolver options of a pod.
-                        properties:
-                          name:
-                            description: Required.
+                          log_backtrace_at:
+                            description: when logging hits line file:N, emit a stack
+                              trace
                             type: string
-                          value:
+                          log_dir:
+                            description: If non-empty, write log files in this directory
+                              (no effect when -logtostderr=true)
+                            type: string
+                          log_file:
+                            description: If non-empty, use this log file (no effect
+                              when -logtostderr=true)
+                            type: string
+                          log_file_max_size:
+                            description: Defines the maximum size a log file can grow
+                              to (no effect when -logtostderr=true). Unit is megabytes.
+                              If the value is 0, the maximum file size is unlimited.
+                              (default 1800)
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          logtostderr:
+                            description: 'Boolean flags. Not handled atomically because
+                              the flag.Value interface does not let us avoid the =true,
+                              and that shorthand is necessary for compatibility. TODO:
+                              does this matter enough to fix? Seems unlikely.'
+                            type: boolean
+                          max-concurrent-k8s-connections:
+                            description: Max concurrent connections number that Velero
+                              can create with kube-apiserver. Default is 30. (default
+                              30)
+                            type: integer
+                          metrics-address:
+                            description: The address to expose prometheus metrics
+                            type: string
+                          one_output:
+                            description: If true, only write logs to their native
+                              severity level (vs also writing to each lower severity
+                              level; no effect when -logtostderr=true)
+                            type: boolean
+                          profiler-address:
+                            description: The address to expose the pprof profiler.
+                            type: string
+                          resource-timeout:
+                            description: How long to wait for resource processes which
+                              are not covered by other specific timeout parameters.
+                              Default is 10 minutes. (default 10m0s)
+                            format: int64
+                            type: integer
+                          restore-resource-priorities:
+                            description: Desired order of resource restores, the priority
+                              list contains two parts which are split by "-" element.
+                              The resources before "-" element are restored first
+                              as high priorities, the resources after "-" element
+                              are restored last as low priorities, and any resource
+                              not in the list will be restored alphabetically between
+                              the high and low priorities. (default customresourcedefinitions,namespaces,storageclasses,volumesnapshotbackups.datamover.oadp.openshift.io,volumesnapshotclass.snapshot.storage.k8s.io,volumesnapshotcontents.snapshot.storage.k8s.io,volumesnapshots.snapshot.storage.k8s.io,persistentvolumes,persistentvolumeclaims,serviceaccounts,secrets,configmaps,limitranges,pods,replicasets.apps,clusterclasses.cluster.x-k8s.io,services,-,clusterbootstraps.run.tanzu.vmware.com,clusters.cluster.x-k8s.io,clusterresourcesets.addons.cluster.x-k8s.io)
+                            type: string
+                          skip_headers:
+                            description: If true, avoid header prefixes in the log
+                              messages
+                            type: boolean
+                          skip_log_headers:
+                            description: If true, avoid headers when opening log files
+                              (no effect when -logtostderr=true)
+                            type: boolean
+                          stderrthreshold:
+                            description: logs at or above this threshold go to stderr
+                              when writing to files and stderr (no effect when -logtostderr=true
+                              or -alsologtostderr=false) (default 2)
+                            type: integer
+                          store-validation-frequency:
+                            description: How often to verify if the storage is valid.
+                              Optional. Set this to `0s` to disable sync. Default
+                              1 minute.
+                            format: int64
+                            type: integer
+                          terminating-resource-timeout:
+                            description: How long to wait on persistent volumes and
+                              namespaces to terminate during a restore before timing
+                              out.
+                            format: int64
+                            type: integer
+                          v:
+                            description: number for the log level verbosity
+                            type: integer
+                          vmodule:
+                            description: comma-separated list of pattern=N settings
+                              for file-filtered logging
                             type: string
                         type: object
-                      type: array
-                    searches:
-                      description: A list of DNS search domains for host-name lookup. This will be appended to the base search paths generated from DNSPolicy. Duplicated search paths will be removed.
-                      items:
+                      customPlugins:
+                        description: customPlugins defines the custom plugin to be
+                          installed with Velero
+                        items:
+                          properties:
+                            image:
+                              type: string
+                            name:
+                              type: string
+                          required:
+                          - image
+                          - name
+                          type: object
+                        type: array
+                      defaultItemOperationTimeout:
+                        description: How long to wait on asynchronous BackupItemActions
+                          and RestoreItemActions to complete before timing out. Default
+                          value is 1h.
                         type: string
-                      type: array
-                  type: object
-                podDnsPolicy:
-                  description: podDnsPolicy defines how a pod's DNS will be configured. https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
-                  type: string
-                snapshotLocations:
-                  description: snapshotLocations defines the list of desired configuration to use for VolumeSnapshotLocations
-                  items:
-                    description: SnapshotLocation defines the configuration for the DPA snapshot store
-                    properties:
-                      velero:
-                        description: VolumeSnapshotLocationSpec defines the specification for a Velero VolumeSnapshotLocation.
+                      defaultPlugins:
+                        items:
+                          type: string
+                        type: array
+                      featureFlags:
+                        description: featureFlags defines the list of features to
+                          enable for Velero instance
+                        items:
+                          type: string
+                        type: array
+                      itemOperationSyncFrequency:
+                        description: How often to check status on async backup/restore
+                          operations after backup processing. Default value is 2m.
+                        type: string
+                      logLevel:
+                        description: Velero server’s log level (use debug for the
+                          most logging, leave unset for velero default)
+                        enum:
+                        - trace
+                        - debug
+                        - info
+                        - warning
+                        - error
+                        - fatal
+                        - panic
+                        type: string
+                      noDefaultBackupLocation:
+                        description: If you need to install Velero without a default
+                          backup storage location noDefaultBackupLocation flag is
+                          required for confirmation
+                        type: boolean
+                      podConfig:
+                        description: Pod specific configuration
                         properties:
-                          config:
+                          env:
+                            description: env defines the list of environment variables
+                              to be supplied to podSpec
+                            items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
+                              properties:
+                                name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
+                                  type: string
+                                value:
+                                  description: 'Variable references $(VAR_NAME) are
+                                    expanded using the previously defined environment
+                                    variables in the container and any service environment
+                                    variables. If a variable cannot be resolved, the
+                                    reference in the input string will be unchanged.
+                                    Double $$ are reduced to a single $, which allows
+                                    for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                    will produce the string literal "$(VAR_NAME)".
+                                    Escaped references will never be expanded, regardless
+                                    of whether the variable exists or not. Defaults
+                                    to "".'
+                                  type: string
+                                valueFrom:
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    fieldRef:
+                                      description: 'Selects a field of the pod: supports
+                                        metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                        `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                        spec.serviceAccountName, status.hostIP, status.podIP,
+                                        status.podIPs.'
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                        only resources limits and requests (limits.cpu,
+                                        limits.memory, limits.ephemeral-storage, requests.cpu,
+                                        requests.memory and requests.ephemeral-storage)
+                                        are currently supported.'
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          labels:
                             additionalProperties:
                               type: string
-                            description: Config is for provider-specific configuration fields.
+                            description: labels to add to pods
                             type: object
-                          credential:
-                            description: Credential contains the credential information intended to be used with this location
+                          nodeSelector:
+                            additionalProperties:
+                              type: string
+                            description: nodeSelector defines the nodeSelector to
+                              be supplied to podSpec
+                            type: object
+                          resourceAllocations:
+                            description: resourceAllocations defines the CPU and Memory
+                              resource allocations for the Pod
+                            nullable: true
                             properties:
-                              key:
-                                description: The key of the secret to select from.  Must be a valid secret key.
-                                type: string
-                              name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
-                                type: string
-                              optional:
-                                description: Specify whether the Secret or its key must be defined
-                                type: boolean
-                            required:
-                              - key
+                              claims:
+                                description: "Claims lists the names of resources,
+                                  defined in spec.resourceClaims, that are used by
+                                  this container. \n This is an alpha field and requires
+                                  enabling the DynamicResourceAllocation feature gate.
+                                  \n This field is immutable."
+                                items:
+                                  description: ResourceClaim references one entry
+                                    in PodSpec.ResourceClaims.
+                                  properties:
+                                    name:
+                                      description: Name must match the name of one
+                                        entry in pod.spec.resourceClaims of the Pod
+                                        where this field is used. It makes that resource
+                                        available inside a container.
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Limits describes the maximum amount
+                                  of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Requests describes the minimum amount
+                                  of compute resources required. If Requests is omitted
+                                  for a container, it defaults to Limits if that is
+                                  explicitly specified, otherwise to an implementation-defined
+                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                type: object
                             type: object
-                          provider:
-                            description: Provider is the provider of the volume storage.
-                            type: string
-                        required:
-                          - provider
+                          tolerations:
+                            description: tolerations defines the list of tolerations
+                              to be applied
+                            items:
+                              description: The pod this Toleration is attached to
+                                tolerates any taint that matches the triple <key,value,effect>
+                                using the matching operator <operator>.
+                              properties:
+                                effect:
+                                  description: Effect indicates the taint effect to
+                                    match. Empty means match all taint effects. When
+                                    specified, allowed values are NoSchedule, PreferNoSchedule
+                                    and NoExecute.
+                                  type: string
+                                key:
+                                  description: Key is the taint key that the toleration
+                                    applies to. Empty means match all taint keys.
+                                    If the key is empty, operator must be Exists;
+                                    this combination means to match all values and
+                                    all keys.
+                                  type: string
+                                operator:
+                                  description: Operator represents a key's relationship
+                                    to the value. Valid operators are Exists and Equal.
+                                    Defaults to Equal. Exists is equivalent to wildcard
+                                    for value, so that a pod can tolerate all taints
+                                    of a particular category.
+                                  type: string
+                                tolerationSeconds:
+                                  description: TolerationSeconds represents the period
+                                    of time the toleration (which must be of effect
+                                    NoExecute, otherwise this field is ignored) tolerates
+                                    the taint. By default, it is not set, which means
+                                    tolerate the taint forever (do not evict). Zero
+                                    and negative values will be treated as 0 (evict
+                                    immediately) by the system.
+                                  format: int64
+                                  type: integer
+                                value:
+                                  description: Value is the taint value the toleration
+                                    matches to. If the operator is Exists, the value
+                                    should be empty, otherwise just a regular string.
+                                  type: string
+                              type: object
+                            type: array
                         type: object
-                    required:
-                      - velero
+                      resourceTimeout:
+                        description: resourceTimeout defines how long to wait for
+                          several Velero resources before timeout occurs, such as
+                          Velero CRD availability, volumeSnapshot deletion, and repo
+                          availability. Default is 10m
+                        type: string
+                      restoreResourcesVersionPriority:
+                        description: restoreResourceVersionPriority represents a configmap
+                          that will be created if defined for use in conjunction with
+                          EnableAPIGroupVersions feature flag Defining this field
+                          automatically add EnableAPIGroupVersions to the velero server
+                          feature flag
+                        type: string
                     type: object
-                  type: array
-                unsupportedOverrides:
-                  additionalProperties:
-                    type: string
-                  description: 'unsupportedOverrides can be used to override images used in deployments. Available keys are:   - veleroImageFqin   - awsPluginImageFqin   - openshiftPluginImageFqin   - azurePluginImageFqin   - gcpPluginImageFqin   - csiPluginImageFqin   - dataMoverImageFqin   - resticRestoreImageFqin   - kubevirtPluginImageFqin'
-                  type: object
-              required:
-                - configuration
-              type: object
-            status:
-              description: DataProtectionApplicationStatus defines the observed state of DataProtectionApplication
-              properties:
-                conditions:
-                  items:
-                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n \ttype FooStatus struct{ \t    // Represents the observations of a foo's current state. \t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" \t    // +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map \t    // +listMapKey=type \t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields \t}"
+                type: object
+              features:
+                description: features defines the configuration for the DPA to enable
+                  the OADP tech preview features
+                properties:
+                  dataMover:
+                    description: Contains data mover specific configurations
                     properties:
-                      lastTransitionTime:
-                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                        format: date-time
+                      credentialName:
+                        description: User supplied Restic Secret name
                         type: string
-                      message:
-                        description: message is a human readable message indicating details about the transition. This may be an empty string.
-                        maxLength: 32768
+                      enable:
+                        description: enable flag is used to specify whether you want
+                          to deploy the volume snapshot mover controller
+                        type: boolean
+                      maxConcurrentBackupVolumes:
+                        description: the number of batched volumeSnapshotBackups that
+                          can be inProgress at once, default value is 10
                         type: string
-                      observedGeneration:
-                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
-                        format: int64
-                        minimum: 0
-                        type: integer
-                      reason:
-                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
-                        maxLength: 1024
-                        minLength: 1
-                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      maxConcurrentRestoreVolumes:
+                        description: the number of batched volumeSnapshotRestores
+                          that can be inProgress at once, default value is 10
                         type: string
-                      status:
-                        description: status of the condition, one of True, False, Unknown.
-                        enum:
-                          - "True"
-                          - "False"
-                          - Unknown
+                      pruneInterval:
+                        description: defines how often (in days) to prune the datamover
+                          snapshots from the repository
                         type: string
-                      type:
-                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                        maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      schedule:
+                        description: 'schedule is a cronspec (https://en.wikipedia.org/wiki/Cron#Overview)
+                          that can be used to schedule datamover(volsync) synchronization
+                          to occur at regular, time-based intervals. For example,
+                          in order to enforce datamover SnapshotRetainPolicy at a
+                          regular interval you need to specify this Schedule trigger
+                          as a cron expression, by default the trigger is a manual
+                          trigger. For more details on Volsync triggers, refer: https://volsync.readthedocs.io/en/stable/usage/triggers.html'
+                        pattern: ^(\d+|\*)(/\d+)?(\s+(\d+|\*)(/\d+)?){4}$
                         type: string
-                    required:
-                      - lastTransitionTime
-                      - message
-                      - reason
-                      - status
-                      - type
+                      snapshotRetainPolicy:
+                        description: defines the parameters that can be specified
+                          for retention of datamover snapshots
+                        properties:
+                          daily:
+                            description: Daily defines the number of snapshots to
+                              be kept daily
+                            type: string
+                          hourly:
+                            description: Hourly defines the number of snapshots to
+                              be kept hourly
+                            type: string
+                          monthly:
+                            description: Monthly defines the number of snapshots to
+                              be kept monthly
+                            type: string
+                          weekly:
+                            description: Weekly defines the number of snapshots to
+                              be kept weekly
+                            type: string
+                          within:
+                            description: Within defines the number of snapshots to
+                              be kept Within the given time period
+                            type: string
+                          yearly:
+                            description: Yearly defines the number of snapshots to
+                              be kept yearly
+                            type: string
+                        type: object
+                      timeout:
+                        description: User supplied timeout to be used for VolumeSnapshotBackup
+                          and VolumeSnapshotRestore to complete, default value is
+                          10m
+                        type: string
+                      volumeOptionsForStorageClasses:
+                        additionalProperties:
+                          properties:
+                            destinationVolumeOptions:
+                              description: VolumeOptions defines configurations for
+                                VolSync options
+                              properties:
+                                accessMode:
+                                  description: accessMode can be used to override
+                                    the accessMode of the source or destination PVC
+                                  type: string
+                                cacheAccessMode:
+                                  description: cacheAccessMode is the access mode
+                                    to be used to provision the cache volume
+                                  type: string
+                                cacheCapacity:
+                                  description: cacheCapacity determines the size of
+                                    the restic metadata cache volume
+                                  type: string
+                                cacheStorageClassName:
+                                  description: cacheStorageClassName is the storageClass
+                                    that should be used when provisioning the data
+                                    mover cache volume
+                                  type: string
+                                storageClassName:
+                                  description: storageClassName can be used to override
+                                    the StorageClass of the source or destination
+                                    PVC
+                                  type: string
+                              type: object
+                            sourceVolumeOptions:
+                              description: VolumeOptions defines configurations for
+                                VolSync options
+                              properties:
+                                accessMode:
+                                  description: accessMode can be used to override
+                                    the accessMode of the source or destination PVC
+                                  type: string
+                                cacheAccessMode:
+                                  description: cacheAccessMode is the access mode
+                                    to be used to provision the cache volume
+                                  type: string
+                                cacheCapacity:
+                                  description: cacheCapacity determines the size of
+                                    the restic metadata cache volume
+                                  type: string
+                                cacheStorageClassName:
+                                  description: cacheStorageClassName is the storageClass
+                                    that should be used when provisioning the data
+                                    mover cache volume
+                                  type: string
+                                storageClassName:
+                                  description: storageClassName can be used to override
+                                    the StorageClass of the source or destination
+                                    PVC
+                                  type: string
+                              type: object
+                          type: object
+                        description: defines configurations for data mover volume
+                          options for a storageClass
+                        type: object
                     type: object
-                  type: array
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                type: object
+              podAnnotations:
+                additionalProperties:
+                  type: string
+                description: add annotations to pods deployed by operator
+                type: object
+              podDnsConfig:
+                description: podDnsConfig defines the DNS parameters of a pod in addition
+                  to those generated from DNSPolicy. https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config
+                properties:
+                  nameservers:
+                    description: A list of DNS name server IP addresses. This will
+                      be appended to the base nameservers generated from DNSPolicy.
+                      Duplicated nameservers will be removed.
+                    items:
+                      type: string
+                    type: array
+                  options:
+                    description: A list of DNS resolver options. This will be merged
+                      with the base options generated from DNSPolicy. Duplicated entries
+                      will be removed. Resolution options given in Options will override
+                      those that appear in the base DNSPolicy.
+                    items:
+                      description: PodDNSConfigOption defines DNS resolver options
+                        of a pod.
+                      properties:
+                        name:
+                          description: Required.
+                          type: string
+                        value:
+                          type: string
+                      type: object
+                    type: array
+                  searches:
+                    description: A list of DNS search domains for host-name lookup.
+                      This will be appended to the base search paths generated from
+                      DNSPolicy. Duplicated search paths will be removed.
+                    items:
+                      type: string
+                    type: array
+                type: object
+              podDnsPolicy:
+                description: podDnsPolicy defines how a pod's DNS will be configured.
+                  https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
+                type: string
+              snapshotLocations:
+                description: snapshotLocations defines the list of desired configuration
+                  to use for VolumeSnapshotLocations
+                items:
+                  description: SnapshotLocation defines the configuration for the
+                    DPA snapshot store
+                  properties:
+                    velero:
+                      description: VolumeSnapshotLocationSpec defines the specification
+                        for a Velero VolumeSnapshotLocation.
+                      properties:
+                        config:
+                          additionalProperties:
+                            type: string
+                          description: Config is for provider-specific configuration
+                            fields.
+                          type: object
+                        credential:
+                          description: Credential contains the credential information
+                            intended to be used with this location
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                        provider:
+                          description: Provider is the provider of the volume storage.
+                          type: string
+                      required:
+                      - provider
+                      type: object
+                  required:
+                  - velero
+                  type: object
+                type: array
+              unsupportedOverrides:
+                additionalProperties:
+                  type: string
+                description: 'unsupportedOverrides can be used to override images
+                  used in deployments. Available keys are:   - veleroImageFqin   -
+                  awsPluginImageFqin   - openshiftPluginImageFqin   - azurePluginImageFqin   -
+                  gcpPluginImageFqin   - csiPluginImageFqin   - dataMoverImageFqin   -
+                  resticRestoreImageFqin   - kubevirtPluginImageFqin'
+                type: object
+            required:
+            - configuration
+            type: object
+          status:
+            description: DataProtectionApplicationStatus defines the observed state
+              of DataProtectionApplication
+            properties:
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n \ttype FooStatus struct{ \t    // Represents the observations
+                    of a foo's current state. \t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\" \t    //
+                    +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map
+                    \t    // +listMapKey=type \t    Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields
+                    \t}"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""


### PR DESCRIPTION
There is a typo in the DataProtectionApplication CRD description that use to describe Restic attributes but actually it is a Velero attributes.

I encountered it when reviewing documentation bugs.

`oc explain dataprotectionapplication.spec.configuration.velero.podConfig.resourceAllocations
KIND:     DataProtectionApplication
VERSION:  oadp.openshift.io/v1alpha1

DESCRIPTION:
     resourceAllocations defines the CPU and Memory resource allocations for the
     restic Pod
`

`oc explain dataprotectionapplication.spec.configuration.velero.podConfig.nodeSelector       
KIND:     DataProtectionApplication
VERSION:  oadp.openshift.io/v1alpha1

FIELD:    nodeSelector <map[string]string>

DESCRIPTION:
     nodeSelector defines the nodeSelector to be supplied to Restic podSpec
`

` oc explain dataprotectionapplication.spec.configuration.velero.podConfig.tolerations        
KIND:     DataProtectionApplication
VERSION:  oadp.openshift.io/v1alpha1

RESOURCE: tolerations <[]Object>

DESCRIPTION:
     tolerations defines the list of tolerations to be applied to Restic
     daemonset
`

