### PR TITLE
implement GCP WIF support

### DIFF
--- a/controllers/dpa_controller.go
+++ b/controllers/dpa_controller.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/go-logr/logr"
 	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
+	oadpClient "github.com/openshift/oadp-operator/pkg/client"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
@@ -86,6 +87,9 @@ func (r *DPAReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		log.Error(err, "unable to fetch DataProtectionApplication CR")
 		return result, nil
 	}
+
+	// set client to pkg/client for use in non-reconcile functions
+	oadpClient.SetClient(r.Client)
 
 	_, err := ReconcileBatch(r.Log,
 		r.ValidateDataProtectionCR,

--- a/controllers/velero.go
+++ b/controllers/velero.go
@@ -232,7 +232,7 @@ func (r *DPAReconciler) customizeVeleroDeployment(dpa *oadpv1alpha1.DataProtecti
 		}
 	}
 
-	hasShortLivedCredentials, err := credentials.BlsUsesShortLivedCredential(dpa.Spec.BackupLocations, dpa.Namespace)
+	hasShortLivedCredentials, err := credentials.BslUsesShortLivedCredential(dpa.Spec.BackupLocations, dpa.Namespace)
 
 	// Selector: veleroDeployment.Spec.Selector,
 	replicas := int32(1)

--- a/controllers/velero_test.go
+++ b/controllers/velero_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
 	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
+	oadpClient "github.com/openshift/oadp-operator/pkg/client"
 	"github.com/openshift/oadp-operator/pkg/common"
 	"github.com/openshift/oadp-operator/pkg/velero/server"
 	"github.com/sirupsen/logrus"
@@ -2459,6 +2460,7 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 			r := DPAReconciler{
 				Client: fakeClient,
 			}
+			oadpClient.SetClient(fakeClient)
 			if tt.testProxy {
 				os.Setenv(proxyEnvKey, proxyEnvValue)
 				defer os.Unsetenv(proxyEnvKey)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1,0 +1,35 @@
+package client
+
+// Provides a common client for functions outside of controllers to use.
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var commonClient client.Client
+
+func SetClient(c client.Client) {
+	commonClient = c
+}
+
+func NewClientFromConfig(cfg *rest.Config) (c client.Client, err error) {
+	commonClient, err = client.New(cfg, client.Options{})
+	return commonClient, err
+}
+
+func GetClient() client.Client {
+	return commonClient
+}
+
+func CreateOrUpdate(ctx context.Context, obj client.Object) error {
+	err := commonClient.Create(ctx, obj)
+	// if err is alreadyexists, try update
+	if errors.IsAlreadyExists(err) {
+		return commonClient.Update(ctx, obj)
+	}
+	return err
+}

--- a/pkg/credentials/credentials.go
+++ b/pkg/credentials/credentials.go
@@ -428,7 +428,7 @@ func GetSecretNameKeyConfigProviderForBackupLocation(blspec oadpv1alpha1.BackupL
 }
 
 // Iterate through all backup locations and return true if any of them use short lived credentials
-func BlsUsesShortLivedCredential(bls []oadpv1alpha1.BackupLocation, namespace string) (ret bool, err error) {
+func BslUsesShortLivedCredential(bls []oadpv1alpha1.BackupLocation, namespace string) (ret bool, err error) {
 	for _, blspec := range bls {
 		if blspec.CloudStorage != nil && blspec.CloudStorage.Credential != nil {
 			// Get CloudStorageRef provider

--- a/pkg/credentials/credentials_test.go
+++ b/pkg/credentials/credentials_test.go
@@ -1,12 +1,16 @@
 package credentials
 
 import (
+	"context"
 	"os"
 	"testing"
 
 	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
+	"github.com/openshift/oadp-operator/pkg/client"
 	"github.com/openshift/oadp-operator/pkg/common"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
 )
 
 func TestCredentials_getPluginImage(t *testing.T) {
@@ -507,6 +511,105 @@ func TestCredentials_getPluginImage(t *testing.T) {
 			gotImage := getPluginImage(tt.pluginName, tt.dpa)
 			if gotImage != tt.wantImage {
 				t.Errorf("Expected plugin image %v did not match %v", tt.wantImage, gotImage)
+			}
+		})
+	}
+}
+
+func TestSecretContainsShortLivedCredential(t *testing.T) {
+	type args struct {
+		decodedSecret string
+		provider      string
+		config        map[string]string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    bool
+		wantErr bool
+	}{
+		{
+			name: "given gcp decoded with service_account, should return false",
+			args: args{
+				decodedSecret: `{
+  "type": "service_account",
+  "project_id": "PROJECT_ID",
+  "private_key_id": "KEY_ID",
+  "private_key": "-----BEGIN PRIVATE KEY-----\nPRIVATE_KEY\n-----END PRIVATE KEY-----\n",
+  "client_email": "SERVICE_ACCOUNT_EMAIL",
+  "client_id": "CLIENT_ID",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://accounts.google.com/o/oauth2/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/SERVICE_ACCOUNT_EMAIL"
+}
+`,
+				provider: "gcp",
+				config:   nil,
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "given gcp decoded with external_account, should return true",
+			args: args{
+				decodedSecret: `{
+  "type": "external_account",
+  "audience": "//iam.googleapis.com/locations/global/workforcePools/WORKFORCE_POOL_ID/providers/PROVIDER_ID",
+  "subject_token_type": "urn:ietf:params:oauth:token-type:id_token",
+  "token_url": "https://sts.googleapis.com/v1/token",
+  "workforce_pool_user_project": "WORKFORCE_POOL_USER_PROJECT",
+  "credential_source": {
+    "file": "PATH_TO_OIDC_CREDENTIALS_FILE"
+  }
+}
+`,
+				provider: "gcp",
+				config:   nil,
+			},
+			want:    true,
+			wantErr: false,
+		},
+	}
+	testEnv := &envtest.Environment{}
+	//start testEnv
+	cfg, err := testEnv.Start()
+	if err != nil {
+		t.Fatalf("failed to start testEnv: %v", err)
+	}
+	defer testEnv.Stop()
+	_, err = client.NewClientFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+	namespace := "test-ns"
+	secretName := "test-secret"
+	secretKey := "cloud"
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ns := corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: namespace,
+				},
+			}
+			err = client.CreateOrUpdate(context.Background(), &ns)
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-secret",
+					Namespace: namespace,
+				},
+				Data: map[string][]byte{
+					secretKey: []byte(tt.args.decodedSecret),
+				},
+			}
+			err = client.CreateOrUpdate(context.Background(), secret)
+			if err != nil {
+				t.Fatalf("failed to create secret: %v", err)
+			}
+			if got, err := SecretContainsShortLivedCredential(secretName, secretKey, tt.args.provider, namespace, tt.args.config); got != tt.want {
+				t.Errorf("SecretContainsShortLivedCredential() = %v, want %v", got, tt.want)
+			} else if err != nil && !tt.wantErr {
+				t.Errorf("SecretContainsShortLivedCredential() = %v, want %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/pkg/credentials/gcp.go
+++ b/pkg/credentials/gcp.go
@@ -1,0 +1,32 @@
+package credentials
+
+import "encoding/json"
+
+type gcpCredAccountKeys string
+
+// From https://github.com/golang/oauth2/blob/d3ed0bb246c8d3c75b63937d9a5eecff9c74d7fe/google/google.go#L95
+const (
+	serviceAccountKey  gcpCredAccountKeys = "service_account"
+	externalAccountKey gcpCredAccountKeys = "external_account"
+)
+
+func getGCPSecretAccountTypeKey(secretByte []byte) (gcpCredAccountKeys, error) {
+	var f map[string]interface{}
+	if err := json.Unmarshal(secretByte, &f); err != nil {
+		return "", err
+	}
+	// following will panic if cannot cast to credAccountKeys
+	return gcpCredAccountKeys(f["type"].(string)), nil
+}
+
+func gcpSecretAccountTypeIsShortLived(secretName, secretKey, namespace string) (bool, error) {
+	secretBytes, err := GetDecodedSecretAsByte(secretName, secretKey, namespace)
+	if err != nil {
+		return false, err
+	}
+	credAccountTypeKey, err := getGCPSecretAccountTypeKey(secretBytes)
+	if err != nil {
+		return false, err
+	}
+	return credAccountTypeKey == externalAccountKey, nil
+}


### PR DESCRIPTION
design #1109 

Target release: OADP 1.3

Features
- [x] Basic BSL WIF support
- [ ] Validation/Enhancements to support imagestream backup

#### Testing instructions
Prerequisites:
- [ocp setup instruction](https://github.com/openshift/oadp-operator/wiki/GCP-WIF-Authentication-on-OpenShift#apply-credentials-secret-to-openshift-adp-namespace). Substitute operator install steps for the following operator-sdk run command.

To try this patch, get [operator-sdk](https://sdk.operatorframework.io/docs/installation/) and run
```bash
export OADP_TEST_NS=openshift-adp
(oc create namespace $OADP_TEST_NS || true) && \
operator-sdk run bundle ghcr.io/kaovilai/oadp-operator:wif-support-bundle --namespace $OADP_TEST_NS
```

cleanup
```
operator-sdk cleanup oadp-operator --namespace $OADP_TEST_NS
```
After cleanup, you will have to create dpa again.

#### dev notes
bundle build command
```bash
IMG=ghcr.io/kaovilai/oadp-operator:wif-support-operator BUNDLE_IMG=ghcr.io/kaovilai/oadp-operator:wif-support-bundle make docker-build docker-push bundle bundle-build bundle-push
```
bundle run command + dpa
```bash
operator-sdk run bundle ghcr.io/kaovilai/oadp-operator:wif-support-bundle --namespace openshift-adp && echo 'apiVersion: oadp.openshift.io/v1alpha1
kind: DataProtectionApplication
metadata:
  name: dpa-sample
  namespace: openshift-adp
spec:
  configuration:
    velero:
      defaultPlugins:
      - openshift
      - gcp
  backupLocations:
    - velero:
        provider: gcp
        default: true
        credential:
          key: service_account.json
          name: cloud-credentials-gcp 
        objectStorage:
          bucket: tkaovila-bucket
          prefix: velero
  # Temporary image override while https://github.com/vmware-tanzu/velero-plugin-for-gcp/pull/142 is in draft.
  unsupportedOverrides:
    gcpPluginImageFqin: ghcr.io/kaovilai/velero-plugin-for-gcp:file-wif
' | oc apply -f -
```