### PR TITLE
Mysql restic e2e test failure on ocp4.12

### DIFF
--- a/tests/e2e/sample-applications/mysql-persistent/mysql-persistent.yaml
+++ b/tests/e2e/sample-applications/mysql-persistent/mysql-persistent.yaml
@@ -97,7 +97,7 @@ items:
               runAsGroup: 27
               runAsUser: 27
               fsGroup: 27
-              privileged: false
+              privileged: true
             env:
               - name: MYSQL_USER
                 value: changeme


### PR DESCRIPTION
Mysql-restic-e2e failure: 

- Failure log: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/41941/rehearse-41941-pull-ci-openshift-oadp-operator-oadp-1.2-4.12-operator-e2e-aws/1686901299854970880#1:build-log.txt%3A1400

- Reason:  time out,  "deployment is not ready" after restore. The backup and restore for MYSQL-RESTIC  are completing without errors. 

Mysql pod logs from the CI Cluster after restore is completed: 
[mysql-f5c69fb9d-2fgvb-log.log](https://github.com/openshift/oadp-operator/files/12280208/mysql-f5c69fb9d-2fgvb-log.log)

This PR runs the tests on OCP-4.12 Cluster.  https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_oadp-operator/1113/pull-ci-openshift-oadp-operator-oadp-1.2-4.12-operator-e2e-aws/1687569170750771200