### PR TITLE
feat: Add uninstall command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -372,10 +372,7 @@ GIT_REV:=$(shell git rev-parse --short HEAD)
 deploy-olm: THIS_OPERATOR_IMAGE?=ttl.sh/oadp-operator-$(GIT_REV):1h # Set target specific variable
 deploy-olm: THIS_BUNDLE_IMAGE?=ttl.sh/oadp-operator-bundle-$(GIT_REV):1h # Set target specific variable
 deploy-olm: DEPLOY_TMP:=$(shell mktemp -d)/ # Set target specific variable
-deploy-olm: operator-sdk ## Build current branch operator image, bundle image, push and install via OLM
-	oc whoami # Check if logged in
-	oc create namespace $(OADP_TEST_NAMESPACE) || true
-	$(OPERATOR_SDK) cleanup oadp-operator --namespace $(OADP_TEST_NAMESPACE)
+deploy-olm: operator-sdk undeploy-olm ## Build current branch operator image, bundle image, push and install via OLM
 	@echo "DEPLOY_TMP: $(DEPLOY_TMP)"
 	# build and push operator and bundle image
 	# use $(OPERATOR_SDK) to install bundle to authenticated cluster
@@ -384,6 +381,12 @@ deploy-olm: operator-sdk ## Build current branch operator image, bundle image, p
 		make docker-build docker-push bundle bundle-build bundle-push; \
 	rm -rf $(DEPLOY_TMP)
 	$(OPERATOR_SDK) run bundle $(THIS_BUNDLE_IMAGE) --namespace $(OADP_TEST_NAMESPACE)
+
+.PHONY: undeploy-olm
+undeploy-olm: ## Uninstall current branch operator via OLM
+	oc whoami # Check if logged in
+	oc create namespace $(OADP_TEST_NAMESPACE) || true
+	$(OPERATOR_SDK) cleanup oadp-operator --namespace $(OADP_TEST_NAMESPACE)
 
 .PHONY: opm
 OPM = ./bin/opm

--- a/docs/developer/install_from_source.md
+++ b/docs/developer/install_from_source.md
@@ -24,6 +24,11 @@ To install CRDs and deploy the OADP operator to the `openshift-adp`
 $ make deploy-olm
 ```
 
+After testing, uninstall CRDs and undeploy the OADP operator from `openshift-adp` namespace, running
+```
+$ make undeploy-olm
+```
+
 ### Installing Velero + Restic
 
 #### Creating credentials secret

--- a/docs/developer/olm_hacking.md
+++ b/docs/developer/olm_hacking.md
@@ -2,7 +2,7 @@
 <h1 align="center">OLM Integration</h1>
 
 # Creating your own CatalogSource
-If you just want to use latest code without making your own catalogsource, you can use `make deploy-olm` as described in [install_olm.md](install_olm.md)
+If you just want to use latest code without making your own catalogsource, you can follow steps from  [Installing the Operator](install_from_source.md#installing-the-operator).
 
 Create `oadp-operator-source.yaml` file like below in the oadp-operator directory:
 

--- a/docs/developer/testing/AttatchingIDEDebuggers.md
+++ b/docs/developer/testing/AttatchingIDEDebuggers.md
@@ -56,7 +56,7 @@ You can now use Run and Debug menu to launch
 - Debug E2E Test
   - This runs the test suite in debug mode. You can add breakpoints to step through the end to end test.
   - Prerequisites:
-    - You have installed OADP Operator. To install current commit run `make deploy-olm`
+    - You have installed OADP Operator. To install current commit follow steps from  [Installing the Operator](../install_from_source.md#installing-the-operator).
 - Launch main.go
   - This runs the operator on your machine in debug mode. You can add breakpoints and step through the code.
   - You will not see OADP in Installed Operators but it will be watching for DPA resources in the namespace as if it was installed.


### PR DESCRIPTION
Add uninstall opeartor-sdk command.

The command was already run prior to install (which is good, removes CRDs to avoid version conflict), just moved it a part so it can be run standalone.