### PR TITLE
Mysql-restic template to aligned with changed pod security on OCP-4.12 

### DIFF
--- a/tests/e2e/sample-applications/mysql-persistent/mysql-persistent.yaml
+++ b/tests/e2e/sample-applications/mysql-persistent/mysql-persistent.yaml
@@ -85,19 +85,19 @@ items:
             app: mysql
         spec:
           securityContext:
-            runAsGroup: 27
-            runAsUser: 27
-            fsGroup: 27
-            privileged: true
+            runAsNonRoot: true
           serviceAccountName: mysql-persistent-sa
           containers:
           - image: registry.redhat.io/rhel8/mariadb-105:latest
             name: mysql
             securityContext:
-              runAsGroup: 27
-              runAsUser: 27
-              fsGroup: 27
-              privileged: true
+              privileged: false
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
             env:
               - name: MYSQL_USER
                 value: changeme

--- a/tests/e2e/sample-applications/mysql-persistent/mysql-persistent.yaml
+++ b/tests/e2e/sample-applications/mysql-persistent/mysql-persistent.yaml
@@ -97,7 +97,7 @@ items:
               runAsGroup: 27
               runAsUser: 27
               fsGroup: 27
-              privileged: false
+              privileged: true
             env:
               - name: MYSQL_USER
                 value: changeme


### PR DESCRIPTION
Restic does not change file permission after restore. The reason it deployment was not ready on 4.12 because of change in pod security  `restricted:v1.24`. 
```
          securityContext:
            runAsGroup: 27
            runAsUser: 27
            fsGroup: 27
            privileged: false
```
When  privileged: false, deployment try to set permission to GID 27. However, 27 is an invalid value. Therefore Deployment is not ready within set ”Progress deadline seconds”.  Error: `provider restricted-v2: .spec.securityContext.fsGroup: Invalid value: []int64{27}: 27 is not an allowed group, spec.containers[0].securityContext.runAsUser: Invalid value: 27: must be in the ranges: [1000800000, 1000809999]`

When privileged: true, deployment will not try to set permission to GID 27. Therefore, this error disappeared in previous patch (https://github.com/openshift/oadp-operator/pull/1113/files ). However, this is not the reliable solution.  

This patch removes GID 27, and keeps `privileged: false`
Other changes were just warnings when creating deployment. It was not the failure in creating pod. However, it is good that have. https://access.redhat.com/solutions/7002730

Example warnings: 
`W0807 22:16:26.493591   84515 warnings.go:70] unknown field "spec.template.spec.containers[0].securityContext.fsGroup"
W0807 22:16:26.493950   84515 warnings.go:70] unknown field "spec.template.spec.securityContext.privileged"
W0807 22:16:26.493961   84515 warnings.go:70] would violate PodSecurity "restricted:v1.24": allowPrivilegeEscalation != false (container "mysql" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "mysql" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or container "mysql" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container "mysql" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")`