### PR TITLE
Mysql-restic template to aligned with changed pod security on OCP-4.1…

### DIFF
--- a/tests/e2e/sample-applications/mysql-persistent/mysql-persistent.yaml
+++ b/tests/e2e/sample-applications/mysql-persistent/mysql-persistent.yaml
@@ -85,19 +85,19 @@ items:
             app: mysql
         spec:
           securityContext:
-            runAsGroup: 27
-            runAsUser: 27
-            fsGroup: 27
-            privileged: true
+            runAsNonRoot: true
           serviceAccountName: mysql-persistent-sa
           containers:
           - image: registry.redhat.io/rhel8/mariadb-105:latest
             name: mysql
             securityContext:
-              runAsGroup: 27
-              runAsUser: 27
-              fsGroup: 27
               privileged: false
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
             env:
               - name: MYSQL_USER
                 value: changeme


### PR DESCRIPTION
…2  (#1122)

* Mysql restic e2e test failure on ocp4.12, ocp4.13