### PR TITLE
fix: README OCP versions for E2E tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
   [![Go Report Card](https://goreportcard.com/badge/github.com/openshift/oadp-operator)](https://goreportcard.com/report/github.com/openshift/oadp-operator) [![codecov](https://codecov.io/gh/openshift/oadp-operator/branch/master/graph/badge.svg?token=qLM0hAzjpD)](https://codecov.io/gh/openshift/oadp-operator) [![License](https://img.shields.io/:license-apache-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0.html) [![Go Reference](https://pkg.go.dev/badge/github.com/openshift/oadp-operator.svg)](https://pkg.go.dev/github.com/openshift/oadp-operator)
 
-4.8, 4.9, 4.10, 4.11 Periodic E2E Tests
+4.10, 4.11 Periodic E2E Tests
 
 AWS :
 [![AWS builds](https://prow.ci.openshift.org/badge.svg?jobs=periodic-ci-openshift-oadp-operator-master-4.10-operator-e2e-aws-periodic-slack)](https://prow.ci.openshift.org/job-history/gs/origin-ci-test/logs/periodic-ci-openshift-oadp-operator-master-4.10-operator-e2e-aws-periodic-slack)


### PR DESCRIPTION
Remove versions 4.8 and 4.9 of OCP from E2E tests reference in README (in master branch, only 4.10 and 4.11 are being tested).