### PR TITLE
OADP-2745: Testing instructions for AWS/IBM Cloud

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -435,7 +435,7 @@ catalog-build-replaces: opm ## Build a catalog image using replace mode
 catalog-push: ## Push a catalog image.
 	$(MAKE) docker-push IMG=$(CATALOG_IMG)
 
-OADP_BUCKET = $(shell cat $(OADP_BUCKET_FILE))
+OADP_BUCKET ?= $(shell cat $(OADP_BUCKET_FILE))
 TEST_FILTER := ($(shell echo '! aws && ! gcp && ! azure && ! ibmcloud' | \
 sed -r "s/[&]* [!] $(CLUSTER_TYPE)|[!] $(CLUSTER_TYPE) [&]*//")) || $(CLUSTER_TYPE)
 #TEST_FILTER := $(shell echo '! aws && ! gcp && ! azure' | sed -r "s/[&]* [!] $(CLUSTER_TYPE)|[!] $(CLUSTER_TYPE) [&]*//")
@@ -444,10 +444,20 @@ SETTINGS_TMP=/tmp/test-settings
 .PHONY: test-e2e-setup
 test-e2e-setup:
 	mkdir -p $(SETTINGS_TMP)
-	TARGET_CI_CRED_FILE="$(CI_CRED_FILE)" AZURE_RESOURCE_FILE="$(AZURE_RESOURCE_FILE)" CI_JSON_CRED_FILE="$(AZURE_CI_JSON_CRED_FILE)" \
-	OADP_JSON_CRED_FILE="$(AZURE_OADP_JSON_CRED_FILE)" OADP_CRED_FILE="$(OADP_CRED_FILE)" OPENSHIFT_CI="$(OPENSHIFT_CI)" \
-	PROVIDER="$(VELERO_PLUGIN)" BUCKET="$(OADP_BUCKET)" BSL_REGION="$(BSL_REGION)" SECRET="$(CREDS_SECRET_REF)" TMP_DIR=$(SETTINGS_TMP) \
-	VSL_REGION="$(VSL_REGION)" BSL_AWS_PROFILE="$(BSL_AWS_PROFILE)" /bin/bash "tests/e2e/scripts/$(CLUSTER_TYPE)_settings.sh"
+	TMP_DIR=$(SETTINGS_TMP) \
+	OPENSHIFT_CI="$(OPENSHIFT_CI)" \
+	PROVIDER="$(VELERO_PLUGIN)" \
+	SECRET="$(CREDS_SECRET_REF)" \
+	AZURE_RESOURCE_FILE="$(AZURE_RESOURCE_FILE)" \
+	CI_JSON_CRED_FILE="$(AZURE_CI_JSON_CRED_FILE)" \
+	OADP_JSON_CRED_FILE="$(AZURE_OADP_JSON_CRED_FILE)" \
+	OADP_CRED_FILE="$(OADP_CRED_FILE)" \
+	BUCKET="$(OADP_BUCKET)" \
+	TARGET_CI_CRED_FILE="$(CI_CRED_FILE)" \
+	VSL_REGION="$(VSL_REGION)" \
+	BSL_REGION="$(BSL_REGION)" \
+	BSL_AWS_PROFILE="$(BSL_AWS_PROFILE)" \
+	/bin/bash "tests/e2e/scripts/$(CLUSTER_TYPE)_settings.sh"
 
 .PHONY: test-e2e-ginkgo
 test-e2e-ginkgo: test-e2e-setup

--- a/Makefile
+++ b/Makefile
@@ -474,6 +474,7 @@ test-e2e: test-e2e-setup install-ginkgo
 
 .PHONY: test-e2e-cleanup
 test-e2e-cleanup:
+	oc delete volumesnapshotcontent --all
 	oc delete volumesnapshotclass oadp-example-snapclass --ignore-not-found=true
 	oc delete backup -n $(OADP_TEST_NAMESPACE) --all
 	oc delete backuprepository -n $(OADP_TEST_NAMESPACE) --all
@@ -481,4 +482,4 @@ test-e2e-cleanup:
 	oc delete podvolumerestore -n $(OADP_TEST_NAMESPACE) --all
 	oc delete restore -n $(OADP_TEST_NAMESPACE) --all --wait=false
 	for restore_name in $(shell oc get restore -n $(OADP_TEST_NAMESPACE) -o name);do oc patch "$$restore_name" -n $(OADP_TEST_NAMESPACE) -p '{"metadata":{"finalizers":null}}' --type=merge;done
-    rm -rf $(SETTINGS_TMP)
+	rm -rf $(SETTINGS_TMP)

--- a/Makefile
+++ b/Makefile
@@ -62,12 +62,13 @@ endif
 VELERO_PLUGIN ?= ${CLUSTER_TYPE}
 
 ifeq ($(CLUSTER_TYPE), ibmcloud)
-	VELERO_PLUGIN ?= aws
+	VELERO_PLUGIN = aws
 endif
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.21
 
+# update https://onsi.github.io/ginkgo/#installing-ginkgo
 .PHONY:ginkgo
 ginkgo: # Make sure ginkgo is in $GOPATH/bin
 	go get -d github.com/onsi/ginkgo/ginkgo

--- a/docs/developer/testing/TESTING.md
+++ b/docs/developer/testing/TESTING.md
@@ -6,49 +6,60 @@
 
 <!-- Can we add this as pre run for make test-e2e? -->
 ```bash
-go install -v github.com/onsi/ginkgo/v2/ginkgo
+go install -v -mod=mod github.com/onsi/ginkgo/v2/ginkgo
 ```
 
-### Setup backup storage configuration
+### AWS setup
 
-To get started, the test suite expects 2 files to use as configuration for
-Velero's backup storage. One file that contains your credentials, and another
-that contains additional configuration options (for now, the name of the
-bucket).
+> **Note:** If you are using IBM Cloud, follow this section.
 
-The default test suite expects these files in `/var/run/oadp-credentials`, but
-can be overridden with the environment variables `OADP_CRED_FILE` and
-`OADP_BUCKET_FILE`.
+To get started, you need to provide the following **required** environment variables.
 
-To get started, create these 2 files:
-`OADP_CRED_FILE`:
+| Variable | Description | Default Value | required |
+|----------|----------|---------------|---------------|
+| `OADP_CRED_FILE` | The path to credentials file for backupLocations | `/var/run/oadp-credentials/new-aws-credentials` | true |
+| `OADP_BUCKET` | The bucket name to store backups | `OADP_BUCKET_FILE` file content | true |
+| `CI_CRED_FILE` | The path to credentials file for snapshotLocations | `/Users/drajds/.aws/.awscred` | true |
+| `VSL_REGION` | The region of snapshotLocations | - | true |
+| `BSL_REGION` | The region of backupLocations | `us-east-1` | false |
+| `OADP_TEST_NAMESPACE` | The namespace were OADP will be installed (it must exist prior to run) | `openshift-adp` | false |
+
+The expected format for `OADP_CRED_FILE` and `CI_CRED_FILE` files is:
 ```
 [<INSERT_PROFILE_NAME>]
 aws_access_key_id=<access_key>
 aws_secret_access_key=<secret_key>
 ```
-If you use one profile name different from `default`, also change `BSL_AWS_PROFILE`.
+> **Note:** If you use one profile name different from `default` for backupLocations, also change `BSL_AWS_PROFILE` environment variable. snapshotLocations must use `default` profile name.
 
-<!-- change to env var? -->
-`OADP_BUCKET_FILE`:
+To set the environment variables, run
+```sh
+export OADP_CRED_FILE=<path_to_backupLocations_credentials_file>
+export OADP_BUCKET=<bucket_name>
+export CI_CRED_FILE=<path_to_snapshotLocations_credentials_file>
+export VSL_REGION=<snapshotLocations_region>
+# non required
+export BSL_REGION=<backupLocations_region>
+export OADP_TEST_NAMESPACE=<test_namespace>
 ```
-<bucket_name>
-```
 
-## Run all e2e tests
+### Azure setup
 
+TODO
+
+### GCP setup
+
+TODO
+
+## Run tests
+
+To run all E2E tests for your provider, run
 <!-- How this is run in CI? Can we add this as pre run for make test-e2e? -->
-TODO set needed variables
-- OADP_TEST_NAMESPACE ?= test-oadp-operator
-- OADP_CRED_DIR ?= MATEUS_PATH/oadp-credentials
-- CLUSTER_PROFILE_DIR ?= MATEUS_PATH/oadp-credentials
-- CI_CRED_FILE ?= ${CLUSTER_PROFILE_DIR}/new-aws-credentials
-- BSL_REGION ?= br-sao
 ```bash
 make deploy-olm
 make test-e2e
 ```
-## Run selected test
+### Run selected test
 
 You can run a particular e2e test(s) by placing an `F` at the beginning of Ginkgo objects. Example
 
@@ -56,6 +67,7 @@ You can run a particular e2e test(s) by placing an `F` at the beginning of Ginkg
 FDescribe("test description", func() { ... })
 FContext("test scenario", func() { ... })
 FIt("the assertion", func() { ... })
+...
 ```
 
 These need to be removed to run all specs.
@@ -74,7 +86,15 @@ oc delete namespace $OADP_TEST_NAMESPACE
 
 TODO
 
-## Debugging e2e tests with Visual Studio
+## Debugging
+
+```bash
+make test-e2e-setup
+cat /tmp/test-settings/oadpcreds
+```
+Check if format looks as expected.
+
+### With Visual Studio
 
 Optionally developers can debug the Ginkgo tests in tests/e2e with [Visual Studio Code](https://code.visualstudio.com/docs/editor/debugging).
 

--- a/docs/developer/testing/TESTING.md
+++ b/docs/developer/testing/TESTING.md
@@ -82,12 +82,13 @@ These need to be removed to run all specs. Checks [Ginkgo docs](https://onsi.git
 
 To clean environment after running E2E tests, run
 ```bash
+oc delete volumesnapshotclass oadp-example-snapclass
 oc delete backup -n $OADP_TEST_NAMESPACE --all
 oc delete backuprepository -n $OADP_TEST_NAMESPACE --all
 oc delete downloadrequest -n $OADP_TEST_NAMESPACE --all
 oc delete podvolumerestore -n $OADP_TEST_NAMESPACE --all
-oc delete restore -n $OADP_TEST_NAMESPACE --all # This fails because of finalizer :(
-oc delete namespace $OADP_TEST_NAMESPACE
+oc delete restore -n $OADP_TEST_NAMESPACE --all &
+for restore_name in $(oc get restore -n $OADP_TEST_NAMESPACE -o name);do oc patch "$restore_name" -n $OADP_TEST_NAMESPACE -p '{"metadata":{"finalizers":null}}' --type=merge;done
 ```
 And clean the bucket in your provider.
 

--- a/docs/developer/testing/TESTING.md
+++ b/docs/developer/testing/TESTING.md
@@ -1,61 +1,87 @@
 <h1 align="center">E2E Testing</h1>
 
-## Prerequisites:
+## Prerequisites
 
 ### Install Ginkgo
+
+<!-- Can we add this as pre run for make test-e2e? -->
 ```bash
-$ go get -u github.com/onsi/ginkgo/v2/ginkgo
+go install -v github.com/onsi/ginkgo/v2/ginkgo
 ```
 
 ### Setup backup storage configuration
+
 To get started, the test suite expects 2 files to use as configuration for
 Velero's backup storage. One file that contains your credentials, and another
-that contains additional configuration options (for now the name of the
+that contains additional configuration options (for now, the name of the
 bucket).
 
 The default test suite expects these files in `/var/run/oadp-credentials`, but
-can be overridden with the environment variables `OADP_AWS_CRED_FILE` and
-`OADP_S3_BUCKET`.
+can be overridden with the environment variables `OADP_CRED_FILE` and
+`OADP_BUCKET_FILE`.
 
 To get started, create these 2 files:
-`OADP_AWS_CRED_FILE`:
+`OADP_CRED_FILE`:
 ```
 [<INSERT_PROFILE_NAME>]
 aws_access_key_id=<access_key>
 aws_secret_access_key=<secret_key>
 ```
+If you use one profile name different from `default`, also change `BSL_AWS_PROFILE`.
 
-`OADP_S3_BUCKET`:
-```json
-{
-  "velero-bucket-name": <bucket>
-}
+<!-- change to env var? -->
+`OADP_BUCKET_FILE`:
+```
+<bucket_name>
 ```
 
 ## Run all e2e tests
+
+<!-- How this is run in CI? Can we add this as pre run for make test-e2e? -->
+TODO set needed variables
+- OADP_TEST_NAMESPACE ?= test-oadp-operator
+- OADP_CRED_DIR ?= MATEUS_PATH/oadp-credentials
+- CLUSTER_PROFILE_DIR ?= MATEUS_PATH/oadp-credentials
+- CI_CRED_FILE ?= ${CLUSTER_PROFILE_DIR}/new-aws-credentials
+- BSL_REGION ?= br-sao
 ```bash
-$ make test-e2e
+make deploy-olm
+make test-e2e
 ```
 ## Run selected test
-You can run a particular e2e test(s) by placing an `F` at the beginning of a
-`Describe`, `Context`, and `It`.
 
-```
- FDescribe("test description", func() { ... })
- FContext("test scenario", func() { ... })
- FIt("the assertion", func() { ... })
+You can run a particular e2e test(s) by placing an `F` at the beginning of Ginkgo objects. Example
+
+```go
+FDescribe("test description", func() { ... })
+FContext("test scenario", func() { ... })
+FIt("the assertion", func() { ... })
 ```
 
 These need to be removed to run all specs.
 
+## Clean up
+
+To clean environment after running E2E tests, run
+```bash
+# Delete leftover objects from tests (like backups and restores)
+make undeploy-olm
+oc delete namespace $OADP_TEST_NAMESPACE
+# And clean bucket in your provider
+```
+
+## CI jobs
+
+TODO
+
 ## Debugging e2e tests with Visual Studio
 
-Optionally developers can debug the ginko driven tests in tests/e2e with [Visual Studio Code](https://code.visualstudio.com/docs/editor/debugging).
+Optionally developers can debug the Ginkgo tests in tests/e2e with [Visual Studio Code](https://code.visualstudio.com/docs/editor/debugging).
 
 * Ensure you have a properly configured launch.json in your .vscode directory. Ensure that your kubeconfig provides access to the k8s or OpenShift environment.
 
 Example Configuration: **launch.json**
-```json=
+```json
 {
     // Use IntelliSense to learn about possible attributes.
     // Hover to view descriptions of existing attributes.
@@ -87,7 +113,7 @@ Example Configuration: **launch.json**
         * cluster_profile
 
 Example Configuration: **e2e_suite_test.go**
-```go=
+```go
 func init() {
 	flag.StringVar(&cloud, "cloud", "/home/user/oadp_e2e/aws_credentials", "Cloud Credentials file path location")
 	flag.StringVar(&namespace, "velero_namespace", "oadp-operator", "DPA Namespace")
@@ -105,11 +131,10 @@ func init() {
 Example settings file could be found under oadp-operator/tests/e2e/templates/default_settings.json, and can be overriden used with different providers with similar structure.
 
 
-* Note that your shell overrides documented [here](https://github.com/openshift/oadp-operator/blob/master/docs/developer/TESTING.md) are not accessable to Visual Studio Code.
+* Note that your shell overrides documented [here](https://github.com/openshift/oadp-operator/blob/master/docs/developer/TESTING.md) are not accessible to Visual Studio Code.
 
 ### Execute
 
 * Ensure the file you intend to set break points on has focus in Visual Studio Code
 * Set break points as needed in Visual Studio Code
 * Launch and debug according to Visual Studio Code's [debug instructions](https://code.visualstudio.com/docs/editor/debugging)
-

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/kubernetes-csi/external-snapshotter/client/v4 v4.2.0
 	github.com/onsi/ginkgo v1.16.5
-	// remove test libs? It is imported in controllers/suite_test.go
 	github.com/onsi/ginkgo/v2 v2.11.0
 	github.com/onsi/gomega v1.27.8
 	github.com/openshift/api v0.0.0-20230213134911-7ba313770556 // release-4.12

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/kubernetes-csi/external-snapshotter/client/v4 v4.2.0
 	github.com/onsi/ginkgo v1.16.5
+	// remove test libs? It is imported in controllers/suite_test.go
 	github.com/onsi/ginkgo/v2 v2.11.0
 	github.com/onsi/gomega v1.27.8
 	github.com/openshift/api v0.0.0-20230213134911-7ba313770556 // release-4.12

--- a/tests/e2e/backup_restore_suite_test.go
+++ b/tests/e2e/backup_restore_suite_test.go
@@ -21,6 +21,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8serror "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	//apimachtypes "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )

--- a/tests/e2e/dpa_deployment_suite_test.go
+++ b/tests/e2e/dpa_deployment_suite_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 var _ = Describe("Configuration testing for DPA Custom Resource", func() {
-	provider := Dpa.Spec.BackupLocations[0].Velero.Provider
+	providerFromDPA := Dpa.Spec.BackupLocations[0].Velero.Provider
 	bucket := Dpa.Spec.BackupLocations[0].Velero.ObjectStorage.Bucket
 	bslConfig := Dpa.Spec.BackupLocations[0].Velero.Config
 	bslCredential := corev1.SecretKeySelector{
@@ -60,7 +60,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 				BackupLocations: []oadpv1alpha1.BackupLocation{
 					{
 						Velero: &velero.BackupStorageLocationSpec{
-							Provider: provider,
+							Provider: providerFromDPA,
 							Config:   bslConfig,
 							Default:  true,
 							StorageType: velero.StorageType{
@@ -96,7 +96,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 				BackupLocations: []oadpv1alpha1.BackupLocation{
 					{
 						Velero: &velero.BackupStorageLocationSpec{
-							Provider: provider,
+							Provider: providerFromDPA,
 							Config:   bslConfig,
 							Default:  true,
 							StorageType: velero.StorageType{
@@ -140,7 +140,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 				BackupLocations: []oadpv1alpha1.BackupLocation{
 					{
 						Velero: &velero.BackupStorageLocationSpec{
-							Provider: provider,
+							Provider: providerFromDPA,
 							Config:   bslConfig,
 							Default:  true,
 							StorageType: velero.StorageType{
@@ -189,7 +189,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 				BackupLocations: []oadpv1alpha1.BackupLocation{
 					{
 						Velero: &velero.BackupStorageLocationSpec{
-							Provider: provider,
+							Provider: providerFromDPA,
 							Config:   bslConfig,
 							Default:  true,
 							StorageType: velero.StorageType{
@@ -215,11 +215,11 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 						DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
 							oadpv1alpha1.DefaultPluginCSI,
 							func() oadpv1alpha1.DefaultPlugin {
-								if provider == "aws" {
+								if providerFromDPA == "aws" {
 									return oadpv1alpha1.DefaultPluginAWS
-								} else if provider == "azure" {
+								} else if providerFromDPA == "azure" {
 									return oadpv1alpha1.DefaultPluginMicrosoftAzure
-								} else if provider == "gcp" {
+								} else if providerFromDPA == "gcp" {
 									return oadpv1alpha1.DefaultPluginGCP
 								}
 								return ""
@@ -237,7 +237,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 				BackupLocations: []oadpv1alpha1.BackupLocation{
 					{
 						Velero: &velero.BackupStorageLocationSpec{
-							Provider: provider,
+							Provider: providerFromDPA,
 							Config:   bslConfig,
 							Default:  true,
 							StorageType: velero.StorageType{
@@ -273,7 +273,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 				BackupLocations: []oadpv1alpha1.BackupLocation{
 					{
 						Velero: &velero.BackupStorageLocationSpec{
-							Provider: provider,
+							Provider: providerFromDPA,
 							Config:   bslConfig,
 							Default:  true,
 							StorageType: velero.StorageType{
@@ -308,7 +308,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 				BackupLocations: []oadpv1alpha1.BackupLocation{
 					{
 						Velero: &velero.BackupStorageLocationSpec{
-							Provider: provider,
+							Provider: providerFromDPA,
 							Config:   bslConfig,
 							Default:  true,
 							StorageType: velero.StorageType{
@@ -345,7 +345,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 				BackupLocations: []oadpv1alpha1.BackupLocation{
 					{
 						Velero: &velero.BackupStorageLocationSpec{
-							Provider: provider,
+							Provider: providerFromDPA,
 							Config:   bslConfig,
 							Default:  true,
 							StorageType: velero.StorageType{
@@ -368,7 +368,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 				BackupLocations: []oadpv1alpha1.BackupLocation{
 					{
 						Velero: &velero.BackupStorageLocationSpec{
-							Provider: provider,
+							Provider: providerFromDPA,
 							Config:   bslConfig,
 							Default:  true,
 							StorageType: velero.StorageType{
@@ -407,7 +407,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 				BackupLocations: []oadpv1alpha1.BackupLocation{
 					{
 						Velero: &velero.BackupStorageLocationSpec{
-							Provider: provider,
+							Provider: providerFromDPA,
 							Config:   bslConfig,
 							Default:  true,
 							StorageType: velero.StorageType{
@@ -476,7 +476,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 				BackupLocations: []oadpv1alpha1.BackupLocation{
 					{
 						Velero: &velero.BackupStorageLocationSpec{
-							Provider: provider,
+							Provider: providerFromDPA,
 							Default:  true,
 							StorageType: velero.StorageType{
 								ObjectStorage: &velero.ObjectStorageLocation{
@@ -507,7 +507,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 				BackupLocations: []oadpv1alpha1.BackupLocation{
 					{
 						Velero: &velero.BackupStorageLocationSpec{
-							Provider: provider,
+							Provider: providerFromDPA,
 							Config: map[string]string{
 								"region":           bslConfig["region"],
 								"s3ForcePathStyle": "true",
@@ -543,7 +543,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 				BackupLocations: []oadpv1alpha1.BackupLocation{
 					{
 						Velero: &velero.BackupStorageLocationSpec{
-							Provider: provider,
+							Provider: providerFromDPA,
 							Config: map[string]string{
 								"s3ForcePathStyle": "true",
 							},

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -16,9 +16,11 @@ import (
 
 // Common vars obtained from flags passed in ginkgo.
 var bslCredFile, namespace, credSecretRef, instanceName, provider, vslCredFile, settings, artifact_dir, oc_cli, stream string
+var timeoutMultiplierInput int64
 var timeoutMultiplier time.Duration
 
 func init() {
+	// TODO better descriptions to flags
 	flag.StringVar(&bslCredFile, "credentials", "", "Credentials path for BackupStorageLocation")
 	flag.StringVar(&namespace, "velero_namespace", "velero", "Velero Namespace")
 	flag.StringVar(&settings, "settings", "./templates/default_settings.json", "Settings of the velero instance")
@@ -30,6 +32,8 @@ func init() {
 	flag.StringVar(&artifact_dir, "artifact_dir", "/tmp", "Directory for storing must gather")
 	flag.StringVar(&oc_cli, "oc_cli", "oc", "OC CLI Client")
 	flag.StringVar(&stream, "stream", "up", "[up, down] upstream or downstream")
+	flag.Int64Var(&timeoutMultiplierInput, "timeout_multiplier", 1, "Customize timeout multiplier from default (1)")
+	timeoutMultiplier = time.Duration(timeoutMultiplierInput)
 
 	// helps with launching debug sessions from IDE
 	if os.Getenv("E2E_USE_ENV_FLAGS") == "true" {
@@ -65,12 +69,6 @@ func init() {
 		if os.Getenv("OC_CLI") != "" {
 			oc_cli = os.Getenv("OC_CLI")
 		}
-	}
-
-	timeoutMultiplierInput := flag.Int64("timeout_multiplier", 1, "Customize timeout multiplier from default (1)")
-	timeoutMultiplier = 1
-	if timeoutMultiplierInput != nil && *timeoutMultiplierInput >= 1 {
-		timeoutMultiplier = time.Duration(*timeoutMultiplierInput)
 	}
 }
 


### PR DESCRIPTION
Update docs regarding how to run E2E (end to end) tests locally.

# How to test

## Prerequisites

- AWS or IBM Cloud with OCP cluster

## Run

Checkout PR branch locally
```sh
git clone -b fix/testing-instructions --single-branch --depth 1 https://github.com/mateusoliveira43/oadp-operator
```

Read instructions in https://github.com/mateusoliveira43/oadp-operator/blob/fix/testing-instructions/docs/developer/testing/TESTING.md about prerequisites and how to set up environment variables to run tests in AWS or IBM Cloud.

Either
- run all tests with `make test-e2e`, or
- run only **MySQL application RESTIC** test, following these steps

  Run E2E tests setup (creates DPA spec that will be used for tests run) (NORMALLY THIS STEP IS NOT NECESSARY, if running `make test-e2e`)
  ```sh
  make test-e2e-setup
  ```

  Install Ginkgo CLI (NORMALLY THIS STEP IS NOT NECESSARY, if running `make test-e2e`)
  ```sh
  make install-ginkgo
  ```

  Run **MySQL application RESTIC** test (this is basically `make test-e2e` with `--ginkgo.focus`)
  ```sh
  export CLUSTER_TYPE=$(oc get infrastructures cluster -o jsonpath='{.status.platform}' | tr A-Z a-z)
  ginkgo run -mod=mod tests/e2e/ -- \
  -settings="/tmp/test-settings/oadpcreds" \
  -oc_cli="$(which oc)" \
  -provider="$CLUSTER_TYPE" \
  -creds_secret_ref="cloud-credentials" \
  -credentials="$OADP_CRED_FILE" \
  -ci_cred_file="$CI_CRED_FILE" \
  -velero_namespace="$OADP_TEST_NAMESPACE" \
  -velero_instance_name="velero-test" \
  -timeout_multiplier=1 \
  -artifact_dir="/tmp" \
  --ginkgo.label-filter="$(echo "($(echo '! aws && ! gcp && ! azure && ! ibmcloud' | sed -r "s/[&]* [\!] $CLUSTER_TYPE|[\!] $CLUSTER_TYPE [&]*//")) || $CLUSTER_TYPE")" \
  --ginkgo.timeout=2h \
  --ginkgo.focus="MySQL application RESTIC"
  ```
