### PR TITLE
New infrastructure annotation format

### DIFF
--- a/bundle/manifests/oadp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/oadp-operator.clusterserviceversion.yaml
@@ -155,16 +155,28 @@ metadata:
     createdAt: "2020-09-08T12:21:00Z"
     description: OADP (OpenShift API for Data Protection) operator sets up and installs
       Data Protection Applications on the OpenShift platform.
-    features.operators.openshift.io/token-auth-aws: "true"
     olm.skipRange: '>=0.0.0 <99.0.0'
     operatorframework.io/suggested-namespace: openshift-adp
-    operators.openshift.io/infrastructure-features: '["Disconnected"]'
     operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift
       Platform Plus"]'
     operators.operatorframework.io/builder: operator-sdk-v1.23.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/openshift/oadp-operator
     support: Red Hat
+    # DEPRECATED but still functional starting with OCP v4.14
+    operators.openshift.io/infrastructure-features: '["Disconnected"]'
+    # New infrastructure annotation format
+    # MUST provide either the string value (not boolean) "true" or "false" for each
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "false"
+    features.operators.openshift.io/proxy-aware: "false"
+    features.operators.openshift.io/cnf: "false"
+    features.operators.openshift.io/cni: "false"
+    features.operators.openshift.io/csi: "false"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "true"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.arm64: supported

--- a/config/manifests/bases/oadp-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/oadp-operator.clusterserviceversion.yaml
@@ -9,14 +9,26 @@ metadata:
     createdAt: "2020-09-08T12:21:00Z"
     description: OADP (OpenShift API for Data Protection) operator sets up and installs
       Data Protection Applications on the OpenShift platform.
-    features.operators.openshift.io/token-auth-aws: "true"
     olm.skipRange: '>=0.0.0 <99.0.0'
     operatorframework.io/suggested-namespace: openshift-adp
-    operators.openshift.io/infrastructure-features: '["Disconnected"]'
     operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift
       Platform Plus"]'
     repository: https://github.com/openshift/oadp-operator
     support: Red Hat
+    # DEPRECATED but still functional starting with OCP v4.14
+    operators.openshift.io/infrastructure-features: '["Disconnected"]'
+    # New infrastructure annotation format
+    # MUST provide either the string value (not boolean) "true" or "false" for each
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "false"
+    features.operators.openshift.io/proxy-aware: "false"
+    features.operators.openshift.io/cnf: "false"
+    features.operators.openshift.io/cni: "false"
+    features.operators.openshift.io/csi: "false"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "true"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.arm64: supported


### PR DESCRIPTION
https://docs.engineering.redhat.com/display/CFC/Best_Practices#Best_Practices-(New)RequiredInfrastructureAnnotations

The release pipelines will start to block in case of absence of the annotations in the namespace features.operators.openshift.io in Q1 2024. The old annotations weren't enforced in the pipeline because of their format providing no way to differentiate between deliberate absence of a value from human obliviousness. Support for the new annotations will be backported all the way to OpenShift 4.10.

Latest by Q1 2024, you MUST provide either the string value (not boolean) "true" or "false" for each of the following list of annotations:

    features.operators.openshift.io/disconnected: "true"
    features.operators.openshift.io/fips-compliant: "false"
    features.operators.openshift.io/proxy-aware: "false"
    features.operators.openshift.io/cnf: "false"
    features.operators.openshift.io/cni: "false"
    features.operators.openshift.io/csi: "false"
    features.operators.openshift.io/tls-profiles: "false"
    features.operators.openshift.io/token-auth-aws: "false"
    features.operators.openshift.io/token-auth-azure: "false"
    features.operators.openshift.io/token-auth-gcp: "false"

You MUST provide a value for all of these fields.