### PR TITLE
OADP-1737: Fix defaultl credentials logic

### DIFF
--- a/controllers/velero.go
+++ b/controllers/velero.go
@@ -712,7 +712,7 @@ func (r DPAReconciler) noDefaultCredentials(dpa oadpv1alpha1.DataProtectionAppli
 			}
 			if bsl.Velero != nil && bsl.Velero.Credential != nil {
 				bslProvider := strings.TrimPrefix(bsl.Velero.Provider, veleroIOPrefix)
-				if found := providerNeedsDefaultCreds[bslProvider]; !found {
+				if _, found := providerNeedsDefaultCreds[bslProvider]; !found {
 					providerNeedsDefaultCreds[bslProvider] = false
 				}
 			}
@@ -736,7 +736,9 @@ func (r DPAReconciler) noDefaultCredentials(dpa oadpv1alpha1.DataProtectionAppli
 			// Bucket credentials via configuration. Only AWS is supported
 			provider := strings.TrimPrefix(vsl.Velero.Provider, veleroIOPrefix)
 			if vsl.Velero.Credential != nil || provider == string(oadpv1alpha1.AWSBucketProvider) && hasCloudStorage {
-				providerNeedsDefaultCreds[provider] = false
+				if _, found := providerNeedsDefaultCreds[provider]; !found {
+					providerNeedsDefaultCreds[provider] = false
+				}
 			} else {
 				providerNeedsDefaultCreds[provider] = true
 			}


### PR DESCRIPTION
A logic which was looping over BSL and VSL then setting requirement for default credentials was broken as the loop was overriding need for those credentials finally setting it to false rather then requireing it on a first need.

This fixes [OADP-1737](https://issues.redhat.com//browse/OADP-1737) in which the BSL was going to an unavailable phase when VSL credentials were specified as there were no credentials mounted to the velero pod nor the AWS_SHARED_CREDENTIALS_FILE env specified for that pod.

########## Testing:
create DPA with snapshotLocation that uses credentials and check if the default credentials are used in the velero pod by checking at the env. values for that pod or by checking existence of the `/credentials/` directory within that pod e.g.:
```
[...]
  snapshotLocations:
    - velero:
        config:
          profile: default
          region: us-west-2
        credential:
          key: cloud
          name: cloud-credentials
        provider: aws
```
