### PR TITLE
fix: [oadp-1.2] Remove 1.1 CRD

### DIFF
--- a/bundle/manifests/oadp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/oadp-operator.clusterserviceversion.yaml
@@ -720,6 +720,14 @@ spec:
           - patch
           - watch
         - apiGroups:
+          - apiextensions.k8s.io
+          resourceNames:
+          - resticrepositories.velero.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - delete
+        - apiGroups:
           - authentication.k8s.io
           resources:
           - tokenreviews

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -223,3 +223,11 @@ rules:
   - update
   - patch
   - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  verbs:
+  - delete
+  resources:
+  - customresourcedefinitions
+  resourceNames:
+  - resticrepositories.velero.io

--- a/controllers/dpa_controller.go
+++ b/controllers/dpa_controller.go
@@ -88,7 +88,6 @@ func (r *DPAReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	}
 
 	_, err := ReconcileBatch(r.Log,
-		// TODO create updateOadpVersion.go and create function there?
 		r.ValidateDataProtectionCR,
 		r.ReconcileResticRestoreHelperConfig,
 		r.ReconcileBackupStorageLocations,

--- a/controllers/restic.go
+++ b/controllers/restic.go
@@ -24,10 +24,6 @@ import (
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-
-	appsV1 "k8s.io/api/apps/v1"
-	apiErrors "k8s.io/apimachinery/pkg/api/errors"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -71,9 +67,9 @@ func (r *DPAReconciler) ReconcileResticDaemonset(log logr.Logger) (bool, error) 
 	// When updating from OADP version 1.1.x to 1.2.x, delete
 	// daemonset.apps/restic (it was renamed to daemonset.apps/node-agent)
 	// resticrepositories.velero.io CRD (it was renamed to backuprepositories.velero.io)
-	if err := r.Delete(r.Context, &appsV1.DaemonSet{ObjectMeta: metaV1.ObjectMeta{
+	if err := r.Delete(r.Context, &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{
 		Name: "restic", Namespace: r.NamespacedName.Namespace,
-	}}); err != nil && !apiErrors.IsNotFound(err) {
+	}}); err != nil && !errors.IsNotFound(err) {
 		return false, err
 	}
 	resticRepositoriesResource := &unstructured.Unstructured{}
@@ -83,7 +79,7 @@ func (r *DPAReconciler) ReconcileResticDaemonset(log logr.Logger) (bool, error) 
 		Kind:    "CustomResourceDefinition",
 	})
 	resticRepositoriesResource.SetName("resticrepositories.velero.io")
-	if err := r.Delete(r.Context, resticRepositoriesResource); err != nil && !apiErrors.IsNotFound(err) {
+	if err := r.Delete(r.Context, resticRepositoriesResource); err != nil && !errors.IsNotFound(err) {
 		return false, err
 	}
 

--- a/docs/upgrade1-1.md
+++ b/docs/upgrade1-1.md
@@ -16,7 +16,7 @@
 
 - `restic` DaemonSet was renamed to `node-agent` (no changes required, OADP code handles this change)
 
-- `resticrepositories.velero.io` CustomResourceDefinition was renamed to `backuprepositories.velero.io` (you can delete `resticrepositories.velero.io` CRD from your cluster, if you want)
+- `resticrepositories.velero.io` CustomResourceDefinition was renamed to `backuprepositories.velero.io` (no changes required, OADP code handles this change)
 
 ## Upgrade steps
 


### PR DESCRIPTION
Follow up PR for https://github.com/openshift/oadp-operator/pull/1137

Removes instances and CRD of 1.1 leftover.