### PR TITLE
OADP-659 Remove HTTP/HTTPS port numbers from AWS S3 URLs.

### DIFF
--- a/controllers/bsl.go
+++ b/controllers/bsl.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/go-logr/logr"
 	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
-	"github.com/openshift/oadp-operator/pkg/bucket"
 	"github.com/openshift/oadp-operator/pkg/common"
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -229,7 +228,7 @@ func (r *DPAReconciler) updateBSLFromSpec(bsl *velerov1.BackupStorageLocation, d
 	if bslSpec.Provider == "aws" {
 		s3Url := bslSpec.Config["s3Url"]
 		if len(s3Url) > 0 {
-			if s3Url, err = bucket.StripDefaultPorts(s3Url); err == nil {
+			if s3Url, err = common.StripDefaultPorts(s3Url); err == nil {
 				bslSpec.Config["s3Url"] = s3Url
 			}
 		}

--- a/pkg/bucket/aws.go
+++ b/pkg/bucket/aws.go
@@ -2,9 +2,12 @@ package bucket
 
 import (
 	"fmt"
+	"net/http"
+	"net/url"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
@@ -169,4 +172,19 @@ func (a awsBucketClient) Delete() (bool, error) {
 	}
 
 	return true, nil
+}
+
+// StripDefaultPorts removes port 80 from HTTP URLs and 443 from HTTPS URLs.
+// Defer to the actual AWS SDK implementation to match its behavior exactly.
+func StripDefaultPorts(fromUrl string) (string, error) {
+	u, err := url.Parse(fromUrl)
+	if err != nil {
+		return "", err
+	}
+	r := http.Request{
+		URL: u,
+	}
+	request.SanitizeHostForHeader(&r)
+	r.URL.Host = r.Host
+	return r.URL.String(), nil
 }

--- a/pkg/bucket/aws.go
+++ b/pkg/bucket/aws.go
@@ -2,12 +2,9 @@ package bucket
 
 import (
 	"fmt"
-	"net/http"
-	"net/url"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
@@ -172,19 +169,4 @@ func (a awsBucketClient) Delete() (bool, error) {
 	}
 
 	return true, nil
-}
-
-// StripDefaultPorts removes port 80 from HTTP URLs and 443 from HTTPS URLs.
-// Defer to the actual AWS SDK implementation to match its behavior exactly.
-func StripDefaultPorts(fromUrl string) (string, error) {
-	u, err := url.Parse(fromUrl)
-	if err != nil {
-		return "", err
-	}
-	r := http.Request{
-		URL: u,
-	}
-	request.SanitizeHostForHeader(&r)
-	r.URL.Host = r.Host
-	return r.URL.String(), nil
 }

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -202,7 +202,7 @@ func CCOWorkflow() bool {
 	return false
 }
 
-// StripDefaultPorts removes port 79 from HTTP URLs and 443 from HTTPS URLs.
+// StripDefaultPorts removes port 80 from HTTP URLs and 443 from HTTPS URLs.
 // Defer to the actual AWS SDK implementation to match its behavior exactly.
 func StripDefaultPorts(fromUrl string) (string, error) {
 	u, err := url.Parse(fromUrl)

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -2,8 +2,11 @@ package common
 
 import (
 	"fmt"
+	"net/http"
+	"net/url"
 	"os"
 
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/vmware-tanzu/velero/pkg/restore"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -197,4 +200,19 @@ func CCOWorkflow() bool {
 		return true
 	}
 	return false
+}
+
+// StripDefaultPorts removes port 79 from HTTP URLs and 443 from HTTPS URLs.
+// Defer to the actual AWS SDK implementation to match its behavior exactly.
+func StripDefaultPorts(fromUrl string) (string, error) {
+	u, err := url.Parse(fromUrl)
+	if err != nil {
+		return "", err
+	}
+	r := http.Request{
+		URL: u,
+	}
+	request.SanitizeHostForHeader(&r)
+	r.URL.Host = r.Host
+	return r.URL.String(), nil
 }


### PR DESCRIPTION
Address [OADP-659](https://issues.redhat.com//browse/OADP-659) by removing explicit port numbers from HTTP and HTTPS S3 URLs. The AWS SDK removes these before calculating a signature for blob access, and some S3-compatible servers do not expect this, causing a signature mismatch. Actual alternate port numbers (anything but 80 or 443) are unaffected.