### PR TITLE
OADP-659 Avoid overwriting good hostname.

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -213,6 +213,8 @@ func StripDefaultPorts(fromUrl string) (string, error) {
 		URL: u,
 	}
 	request.SanitizeHostForHeader(&r)
-	r.URL.Host = r.Host
+	if r.Host != "" {
+		r.URL.Host = r.Host
+	}
 	return r.URL.String(), nil
 }


### PR DESCRIPTION
Fix an issue with StripDefaultPorts that breaks a new test case being added for https://github.com/openshift/oadp-operator/pull/1169.
