### PR TITLE
OADP-659/OADP-2862 Add unit tests for #1169 and #1177.

### DIFF
--- a/pkg/common/common_test.go
+++ b/pkg/common/common_test.go
@@ -103,3 +103,48 @@ func TestAppendTTMapAsCopy(t *testing.T) {
 		}
 	})
 }
+
+func TestStripDefaultPorts(t *testing.T) {
+	tests := []struct {
+		name string
+		base string
+		want string
+	}{
+		{
+			name: "port-free URL is returned unchanged",
+			base: "https://s3.region.cloud-object-storage.appdomain.cloud/bucket-name",
+			want: "https://s3.region.cloud-object-storage.appdomain.cloud/bucket-name",
+		},
+		{
+			name: "HTTPS port is removed from URL",
+			base: "https://s3.region.cloud-object-storage.appdomain.cloud:443/bucket-name",
+			want: "https://s3.region.cloud-object-storage.appdomain.cloud/bucket-name",
+		},
+		{
+			name: "HTTP port is removed from URL",
+			base: "http://s3.region.cloud-object-storage.appdomain.cloud:80/bucket-name",
+			want: "http://s3.region.cloud-object-storage.appdomain.cloud/bucket-name",
+		},
+		{
+			name: "alternate HTTP port is preserved",
+			base: "http://10.0.188.30:9000",
+			want: "http://10.0.188.30:9000",
+		},
+		{
+			name: "alternate HTTPS port is preserved",
+			base: "https://10.0.188.30:9000",
+			want: "https://10.0.188.30:9000",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := StripDefaultPorts(tt.base)
+			if err != nil {
+				t.Errorf("An error occurred: %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("StripDefaultPorts() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Pull in Mateus' unit test from [his review](https://github.com/openshift/oadp-operator/pull/1169#pullrequestreview-1665112443) and update it to test more URLs.
