### PR TITLE
OADP-2770:  Mongodb e2e datamover with block mode

### DIFF
--- a/tests/e2e/sample-applications/mongo-persistent/mongo-persistent-block.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/mongo-persistent-block.yaml
@@ -1,0 +1,271 @@
+apiVersion: v1
+kind: List
+items:
+  - kind: Namespace
+    apiVersion: v1
+    metadata:
+      name: mongo-persistent
+      labels:
+        app: todolist-mongo-go
+  - apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: mongo-persistent-sa
+      namespace: mongo-persistent
+      labels:
+        component: mongo-persistent
+  - kind: SecurityContextConstraints
+    apiVersion: security.openshift.io/v1
+    metadata:
+      name: mongo-persistent-scc
+    allowPrivilegeEscalation: true
+    allowPrivilegedContainer: true
+    runAsUser:
+      type: RunAsAny
+    seLinuxContext:
+      type: RunAsAny
+    fsGroup:
+      type: RunAsAny
+    supplementalGroups:
+      type: RunAsAny
+    volumes:
+    - '*'
+    users:
+    - system:admin
+    - system:serviceaccount:mongo-persistent:mongo-persistent-sa
+  - kind: ImageStream
+    apiVersion: image.openshift.io/v1
+    metadata:
+      name: todolist-mongo-go
+      namespace: mongo-persistent
+      labels:
+        app: todolist
+    spec: {}
+    status:
+      dockerImageRepository: ''
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations:
+        template.alpha.openshift.io/wait-for-ready: 'true'
+      name: mongo
+      namespace: mongo-persistent
+      labels:
+        e2e-app: "true"
+    spec:
+      selector:
+        matchLabels:
+          app: mongo
+      strategy:
+        type: Recreate
+      template:
+        metadata:
+          labels:
+            e2e-app: "true"
+            app: mongo
+        spec:
+          serviceAccountName: mongo-persistent-sa
+          securityContext:
+            runAsUser: 0  
+          # Used to format the block device (put filesystem on it).
+          # This allows Mongo to use the filesystem which lives on block device.
+          initContainers:
+            - image: mongo:latest
+              securityContext:
+                privileged: true
+              name: setup-block-device
+              command:
+                - "sh"
+                - "-c"
+                - |
+                  DEVICE="/dev/xvdx"
+                  MOUNT_POINT="/data/db"
+                  if [ ! -e $DEVICE ]; then
+                    echo "$DEVICE does not exist."
+                    exit 1
+                  fi
+                  if dumpe2fs -h $DEVICE 2>/dev/null; then
+                    echo "Filesystem already exists on $DEVICE"
+                  else
+                    echo "Formatting $DEVICE"
+                    mkfs.ext4 $DEVICE
+                  fi
+                  mkdir -p $MOUNT_POINT
+                  echo "Mounting $DEVICE in the $MOUNT_POINT"
+                  mount $DEVICE $MOUNT_POINT
+                  echo $(date +%s) > $MOUNT_POINT/format_timestamp
+                  echo "Recorded timestamp: $(cat $MOUNT_POINT/format_timestamp)"
+                  umount $MOUNT_POINT
+              volumeDevices:
+                - name: block-volume-pv
+                  devicePath: /dev/xvdx
+          containers:
+            - image: mongo:latest
+              name: mongo
+              securityContext:
+                privileged: true
+              env:
+                - name: MONGO_INITDB_ROOT_USERNAME
+                  value: changeme
+                - name: MONGO_INITDB_ROOT_PASSWORD
+                  value: changeme
+                - name: MONGO_INITDB_DATABASE
+                  value: todolist
+              ports:
+                - containerPort: 27017
+                  name: mongo
+              resources:
+                limits:
+                  memory: 512Mi
+              command:
+                - "sh"
+                - "-c"
+                - |
+                  DEVICE="/dev/xvdx"
+                  MOUNT_POINT="/data/db"
+                  mkdir -p $MOUNT_POINT
+                  mount $DEVICE $MOUNT_POINT
+                  docker-entrypoint.sh mongod --auth --bind_ip_all --dbpath $MOUNT_POINT
+              volumeDevices:
+                - name:  block-volume-pv
+                  devicePath: /dev/xvdx
+          volumes:
+          - name: block-volume-pv
+            persistentVolumeClaim:
+              claimName: mongo
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        template.openshift.io/expose-uri: mongodb://{.spec.clusterIP}:{.spec.ports[?(.name=="mongo")].port}
+      name: mongo
+      namespace: mongo-persistent
+      labels:
+        app: mongo
+        service: mongo
+    spec:
+      ports:
+      - protocol: TCP
+        name: mongo
+        port: 27017
+      selector:
+        app: mongo
+  - kind: BuildConfig
+    apiVersion: build.openshift.io/v1
+    metadata:
+      name: todolist
+      namespace: mongo-persistent
+      labels:
+        app.kubernetes.io/name: todolist
+    spec:
+      triggers:
+      - type: GitHub
+        github:
+          secret: 4Xwu0tyAab90aaoasd88qweAasdaqvjknfrl3qwpo
+      - type: Generic
+        generic:
+          secret: 4Xwu0tyAab90aaoasd88qweAasdaqvjknfrl3qwpo
+      - type: ConfigChange
+      - type: ImageChange
+        imageChange: {}
+      source:
+        type: Git
+        git:
+          uri: https://github.com/konveyor/mig-demo-apps.git
+          ref: master
+      strategy:
+        type: Docker
+        dockerStrategy:
+          dockerfilePath: apps/todolist-mongo-go/Dockerfile
+      output:
+        to:
+          kind: ImageStreamTag
+          name: "todolist-mongo-go:latest"
+      resources: {}
+  - apiVersion: apps.openshift.io/v1
+    kind: DeploymentConfig
+    metadata:
+      name: todolist
+      namespace: mongo-persistent
+      labels:
+        app: todolist
+        app.kubernetes.io/name: todolist
+        application: todolist
+        deploymentconfig: todolist-mongo-go
+    spec:
+      selector:
+        app: todolist
+      strategy:
+        type: Rolling
+      triggers:
+        - type: ConfigChange
+          imageChangeParams:
+            containerNames:
+              - todolist
+            from:
+              kind: ImageStreamTag
+              namespace: mongo-persistent
+              name: 'todolist-mongo-go:latest'
+        - type: ImageChange
+          imageChangeParams:
+            automatic: true
+            containerNames:
+              - todolist
+            from:
+              kind: ImageStreamTag
+              namespace: mongo-persistent
+              name: 'todolist-mongo-go:latest'
+      replicas: 1
+      template:
+        metadata:
+          creationTimestamp:
+          labels:
+            e2e-app: "true"
+            app: todolist
+            application: todolist
+            deploymentconfig: todolist-mongo-go
+            app.kubernetes.io/name: todolist
+        spec:
+          containers:
+          - name: todolist
+            image:  >-
+              image-registry.openshift-image-registry.svc:5000/mongo-persistent/todolist-mongo-go
+            ports:
+              - containerPort: 8000
+                protocol: TCP
+          initContainers:
+          - name: init-myservice
+            image: registry.access.redhat.com/ubi8/ubi:latest
+            command: ['sh', '-c', 'sleep 10; until getent hosts mongo; do echo waiting for mongo; sleep 5; done;']
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: todolist
+      namespace: mongo-persistent
+      labels:
+        app: todolist
+        service: todolist
+      annotations:
+        app: todolist
+    spec:
+      ports:
+        - name: web
+          protocol: TCP
+          port: 8000
+          targetPort: 8000
+      selector:
+        app: todolist
+      sessionAffinity: None
+      ipFamilies:
+        - IPv4
+      ipFamilyPolicy: SingleStack
+  - apiVersion: route.openshift.io/v1
+    kind: Route
+    metadata:
+      name: todolist-route
+      namespace: mongo-persistent
+    spec:
+      path: "/"
+      to:
+        kind: Service
+        name: todolist

--- a/tests/e2e/sample-applications/mongo-persistent/pvc/aws-block-mode.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/pvc/aws-block-mode.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: mongo
+      namespace: mongo-persistent
+      labels:
+        app: mongo
+    spec:
+      volumeMode: Block 
+      accessModes:
+      - ReadWriteOnce
+      storageClassName: gp2-csi
+      resources:
+        requests:
+          storage: 1Gi

--- a/tests/e2e/sample-applications/mongo-persistent/pvc/azure-block-mode.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/pvc/azure-block-mode.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: mongo
+      namespace: mongo-persistent
+      labels:
+        app: mongo
+    spec:
+      volumeMode: Block 
+      accessModes:
+      - ReadWriteOnce
+      storageClassName: managed-csi
+      resources:
+        requests:
+          storage: 1Gi

--- a/tests/e2e/sample-applications/mongo-persistent/pvc/default_sc-block-mode.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/pvc/default_sc-block-mode.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: mongo
+      namespace: mongo-persistent
+      labels:
+        app: mongo
+    spec:
+      volumeMode: Block 
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 1Gi

--- a/tests/e2e/sample-applications/mongo-persistent/pvc/gcp-block-mode.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/pvc/gcp-block-mode.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: mongo
+      namespace: mongo-persistent
+      labels:
+        app: mongo
+    spec:
+      volumeMode: Block 
+      accessModes:
+      - ReadWriteOnce
+      storageClassName: standard-csi
+      resources:
+        requests:
+          storage: 1Gi

--- a/tests/e2e/sample-applications/mongo-persistent/pvc/ibmcloud-block-mode.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/pvc/ibmcloud-block-mode.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: mongo
+      namespace: mongo-persistent
+      labels:
+        app: mongo
+    spec:
+      volumeMode: Block 
+      accessModes:
+      - ReadWriteOnce
+      storageClassName: ocs-storagecluster-cephfs
+      resources:
+        requests:
+          storage: 1Gi


### PR DESCRIPTION
E2E test case for the block mode.

The concept is to use PVC which is a type of *volumeMode: Block*. This PVC is used by the mongodb container to be used in:
 - initContainers
   That container is responsible of using the PV as a block `volumeDevice`. It first creates filesystem on that device and then checks if it can be mounted. For debug information it also creates a flat file with EPOCH timestamp inside.
   We use init container mongo, which has the `mkfs.ext4` CLI in it. UBI image is missing that CLI. We use mongo image so we don't download to the cluster multiple different images to create deployment.

 - containers
   That container has also the `volumeDevice` available, so first thing it do is to use previously formatted block device and mounts it to a given path. That path is then used by `docker-entrypoint.sh` to initialize mongo database and use it as persistent volume.

Above method allows to create an application with block device and use it for backup and restore. Once the application is restored it will contain files from the filesystem on the block device.

Such patter can be used across other test cases.


To deploy sample application:
```
 $ oc create ns mongo-persistent
 $ oc apply -f pvc/default_sc-block-mode.yaml
 $ oc apply -f mongo-persistent-block.yaml
```