### PR TITLE
fix: One kubernetes client per E2E suite run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -514,6 +514,7 @@ test-e2e: test-e2e-setup install-ginkgo
 	-timeout_multiplier=$(E2E_TIMEOUT_MULTIPLIER) \
 	-artifact_dir=$(ARTIFACT_DIR) \
 	-oc_cli=$(OC_CLI) \
+	--ginkgo.no-color=$(OPENSHIFT_CI) \
 	--ginkgo.label-filter="$(TEST_FILTER)" \
 	--ginkgo.timeout=2h
 

--- a/docs/developer/testing/TESTING.md
+++ b/docs/developer/testing/TESTING.md
@@ -20,6 +20,7 @@ To get started, you need to provide the following **required** environment varia
 | `VSL_REGION` | The region of snapshotLocations | - | true |
 | `BSL_REGION` | The region of backupLocations | `us-east-1` | false |
 | `OADP_TEST_NAMESPACE` | The namespace where OADP operator is installed | `openshift-adp` | false |
+| `OPENSHIFT_CI` | Disable colored output from tests suite run | `true` | false |
 
 The expected format for `OADP_CRED_FILE` and `CI_CRED_FILE` files is:
 ```
@@ -38,6 +39,7 @@ export VSL_REGION=<snapshotLocations_region>
 # non required
 export BSL_REGION=<backupLocations_region>
 export OADP_TEST_NAMESPACE=<test_namespace>
+export OPENSHIFT_CI=false
 ```
 
 It is also possible to set the environment variables during make command call. Example
@@ -48,6 +50,7 @@ CI_CRED_FILE=<path_to_snapshotLocations_credentials_file> \
 VSL_REGION=<snapshotLocations_region> \
 BSL_REGION=<backupLocations_region> \
 OADP_TEST_NAMESPACE=<test_namespace> \
+OPENSHIFT_CI=false \
 make test-e2e
 ```
 

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -104,6 +104,11 @@ var _ = BeforeSuite(func() {
 
 	var err error
 	kubeConf := config.GetConfigOrDie()
+	log.Printf(
+		"Kubernetes client configuration: QPS %v, Burst %#v",
+		kubeConf.QPS,
+		kubeConf.Burst,
+	)
 
 	kubernetesClientForSuiteRun, err = kubernetes.NewForConfig(kubeConf)
 	Expect(err).NotTo(HaveOccurred())

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -8,10 +8,15 @@ import (
 	"testing"
 	"time"
 
+	snapshotv1client "github.com/kubernetes-csi/external-snapshotter/client/v4/clientset/versioned"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/openshift/oadp-operator/tests/e2e/lib"
 	"github.com/openshift/oadp-operator/tests/e2e/utils"
+	veleroClientset "github.com/vmware-tanzu/velero/pkg/generated/clientset/versioned"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
 // Common vars obtained from flags passed in ginkgo.
@@ -84,6 +89,10 @@ func TestOADPE2E(t *testing.T) {
 	RunSpecs(t, "OADP E2E Suite")
 }
 
+var kubernetesClientForSuiteRun *kubernetes.Clientset
+var runTimeClientForSuiteRun client.Client
+var veleroClientForSuiteRun veleroClientset.Interface
+var csiClientForSuiteRun *snapshotv1client.Clientset
 var dpaCR *DpaCustomResource
 
 var _ = BeforeSuite(func() {
@@ -92,6 +101,21 @@ var _ = BeforeSuite(func() {
 	if errString != "" {
 		Expect(errors.New(errString)).NotTo(HaveOccurred())
 	}
+
+	var err error
+	kubeConf := config.GetConfigOrDie()
+
+	kubernetesClientForSuiteRun, err = kubernetes.NewForConfig(kubeConf)
+	Expect(err).NotTo(HaveOccurred())
+
+	runTimeClientForSuiteRun, err = client.New(kubeConf, client.Options{})
+	Expect(err).NotTo(HaveOccurred())
+
+	veleroClientForSuiteRun, err = veleroClientset.NewForConfig(kubeConf)
+	Expect(err).NotTo(HaveOccurred())
+
+	csiClientForSuiteRun, err = snapshotv1client.NewForConfig(kubeConf)
+	Expect(err).NotTo(HaveOccurred())
 
 	dpaCR = &DpaCustomResource{
 		Namespace: namespace,
@@ -103,28 +127,32 @@ var _ = BeforeSuite(func() {
 
 	bslCredFileData, err := utils.ReadFile(bslCredFile)
 	Expect(err).NotTo(HaveOccurred())
-	err = CreateCredentialsSecret(bslCredFileData, namespace, "bsl-cloud-credentials-"+provider)
+	err = CreateCredentialsSecret(kubernetesClientForSuiteRun, bslCredFileData, namespace, "bsl-cloud-credentials-"+provider)
 	Expect(err).NotTo(HaveOccurred())
-	err = CreateCredentialsSecret(utils.ReplaceSecretDataNewLineWithCarriageReturn(bslCredFileData), namespace, "bsl-cloud-credentials-"+provider+"-with-carriage-return")
+	err = CreateCredentialsSecret(
+		kubernetesClientForSuiteRun,
+		utils.ReplaceSecretDataNewLineWithCarriageReturn(bslCredFileData),
+		namespace, "bsl-cloud-credentials-"+provider+"-with-carriage-return",
+	)
 	Expect(err).NotTo(HaveOccurred())
 
 	vslCredFileData, err := utils.ReadFile(vslCredFile)
 	Expect(err).NotTo(HaveOccurred())
-	err = CreateCredentialsSecret(vslCredFileData, namespace, credSecretRef)
+	err = CreateCredentialsSecret(kubernetesClientForSuiteRun, vslCredFileData, namespace, credSecretRef)
 	Expect(err).NotTo(HaveOccurred())
-	dpaCR.SetClient()
-	Expect(DoesNamespaceExist(namespace)).Should(BeTrue())
+	dpaCR.SetClient(runTimeClientForSuiteRun)
+	Expect(DoesNamespaceExist(kubernetesClientForSuiteRun, namespace)).Should(BeTrue())
 })
 
 var _ = AfterSuite(func() {
 	log.Printf("Deleting Velero CR")
-	err := DeleteSecret(namespace, credSecretRef)
+	err := DeleteSecret(kubernetesClientForSuiteRun, namespace, credSecretRef)
 	Expect(err).ToNot(HaveOccurred())
-	err = DeleteSecret(namespace, "bsl-cloud-credentials-"+provider)
+	err = DeleteSecret(kubernetesClientForSuiteRun, namespace, "bsl-cloud-credentials-"+provider)
 	Expect(err).ToNot(HaveOccurred())
-	err = DeleteSecret(namespace, "bsl-cloud-credentials-"+provider+"-with-carriage-return")
+	err = DeleteSecret(kubernetesClientForSuiteRun, namespace, "bsl-cloud-credentials-"+provider+"-with-carriage-return")
 	Expect(err).ToNot(HaveOccurred())
-	err = dpaCR.Delete()
+	err = dpaCR.Delete(runTimeClientForSuiteRun)
 	Expect(err).ToNot(HaveOccurred())
-	Eventually(dpaCR.IsDeleted(), timeoutMultiplier*time.Minute*2, time.Second*5).Should(BeTrue())
+	Eventually(dpaCR.IsDeleted(runTimeClientForSuiteRun), timeoutMultiplier*time.Minute*2, time.Second*5).Should(BeTrue())
 })

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -104,11 +104,8 @@ var _ = BeforeSuite(func() {
 
 	var err error
 	kubeConf := config.GetConfigOrDie()
-	log.Printf(
-		"Kubernetes client configuration: QPS %v, Burst %#v",
-		kubeConf.QPS,
-		kubeConf.Burst,
-	)
+	kubeConf.QPS = 50
+	kubeConf.Burst = 100
 
 	kubernetesClientForSuiteRun, err = kubernetes.NewForConfig(kubeConf)
 	Expect(err).NotTo(HaveOccurred())

--- a/tests/e2e/lib/apps.go
+++ b/tests/e2e/lib/apps.go
@@ -370,7 +370,7 @@ func AreApplicationPodsRunning(c *kubernetes.Clientset, namespace string) wait.C
 			LabelSelector: e2eAppLabelSelector.String(),
 		}
 		// get pods in test namespace with labelSelector
-		podList, err := c.CoreV1().Pods(namespace).List(context.TODO(), veleroOptions)
+		podList, err := c.CoreV1().Pods(namespace).List(context.Background(), veleroOptions)
 		if err != nil {
 			return false, nil
 		}
@@ -411,7 +411,7 @@ func InstalledSubscriptionCSV(ocClient client.Client, namespace, subscriptionNam
 
 func PrintNamespaceEventsAfterTime(c *kubernetes.Clientset, namespace string, startTime time.Time) {
 	log.Println("Printing events for namespace: ", namespace)
-	events, err := c.CoreV1().Events(namespace).List(context.TODO(), metav1.ListOptions{})
+	events, err := c.CoreV1().Events(namespace).List(context.Background(), metav1.ListOptions{})
 	if err != nil {
 		ginkgo.GinkgoWriter.Write([]byte(fmt.Sprintf("Error getting events: %v\n", err)))
 		return

--- a/tests/e2e/lib/apps.go
+++ b/tests/e2e/lib/apps.go
@@ -36,8 +36,8 @@ import (
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
 const e2eAppLabelKey = "e2e-app"
@@ -363,18 +363,14 @@ func areAppBuildsReady(ocClient client.Client, namespace string) (bool, error) {
 	return true, nil
 }
 
-func AreApplicationPodsRunning(namespace string) wait.ConditionFunc {
+func AreApplicationPodsRunning(c *kubernetes.Clientset, namespace string) wait.ConditionFunc {
 	return func() (bool, error) {
-		clientset, err := setUpClient()
-		if err != nil {
-			return false, err
-		}
 		// select Velero pod with this label
 		veleroOptions := metav1.ListOptions{
 			LabelSelector: e2eAppLabelSelector.String(),
 		}
 		// get pods in test namespace with labelSelector
-		podList, err := clientset.CoreV1().Pods(namespace).List(context.TODO(), veleroOptions)
+		podList, err := c.CoreV1().Pods(namespace).List(context.TODO(), veleroOptions)
 		if err != nil {
 			return false, nil
 		}
@@ -413,14 +409,9 @@ func InstalledSubscriptionCSV(ocClient client.Client, namespace, subscriptionNam
 	}
 }
 
-func PrintNamespaceEventsAfterTime(namespace string, startTime time.Time) {
+func PrintNamespaceEventsAfterTime(c *kubernetes.Clientset, namespace string, startTime time.Time) {
 	log.Println("Printing events for namespace: ", namespace)
-	clientset, err := setUpClient()
-	if err != nil {
-		ginkgo.GinkgoWriter.Write([]byte(fmt.Sprintf("Error getting client: %v\n", err)))
-		return
-	}
-	events, err := clientset.CoreV1().Events(namespace).List(context.TODO(), metav1.ListOptions{})
+	events, err := c.CoreV1().Events(namespace).List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		ginkgo.GinkgoWriter.Write([]byte(fmt.Sprintf("Error getting events: %v\n", err)))
 		return
@@ -467,16 +458,12 @@ func makeRequest(request string, api string, todo string) {
 }
 
 // VerifyBackupRestoreData verifies if app ready before backup and after restore to compare data.
-func VerifyBackupRestoreData(artifact_dir string, namespace string, routeName string, app string, prebackupState bool, twoVol bool, backupRestoretype BackupRestoreType) error {
+func VerifyBackupRestoreData(clientv1 client.Client, artifact_dir string, namespace string, routeName string, app string, prebackupState bool, twoVol bool, backupRestoretype BackupRestoreType) error {
 	log.Printf("Verifying backup/restore data of %s", app)
 	appRoute := &routev1.Route{}
-	clientv1, err := client.New(config.GetConfigOrDie(), client.Options{})
-	if err != nil {
-		return err
-	}
 	backupFile := artifact_dir + "/backup-data.txt"
 	routev1.AddToScheme(clientv1.Scheme())
-	err = clientv1.Get(context.Background(), client.ObjectKey{
+	err := clientv1.Get(context.Background(), client.ObjectKey{
 		Namespace: namespace,
 		Name:      routeName,
 	}, appRoute)

--- a/tests/e2e/lib/dpa_helpers.go
+++ b/tests/e2e/lib/dpa_helpers.go
@@ -28,9 +28,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/yaml"
 )
 
@@ -174,8 +174,8 @@ func (v *DpaCustomResource) ProviderStorageClassName(e2eRoot string) (string, er
 	return *pvcList.Items[0].Spec.StorageClassName, nil
 }
 
-func (v *DpaCustomResource) Create() error {
-	err := v.SetClient()
+func (v *DpaCustomResource) Create(c client.Client) error {
+	err := v.SetClient(c)
 	if err != nil {
 		return err
 	}
@@ -188,8 +188,8 @@ func (v *DpaCustomResource) Create() error {
 	return nil
 }
 
-func (v *DpaCustomResource) Get() (*oadpv1alpha1.DataProtectionApplication, error) {
-	err := v.SetClient()
+func (v *DpaCustomResource) Get(c client.Client) (*oadpv1alpha1.DataProtectionApplication, error) {
+	err := v.SetClient(c)
 	if err != nil {
 		return nil, err
 	}
@@ -204,21 +204,21 @@ func (v *DpaCustomResource) Get() (*oadpv1alpha1.DataProtectionApplication, erro
 	return &vel, nil
 }
 
-func (v *DpaCustomResource) GetNoErr() *oadpv1alpha1.DataProtectionApplication {
-	Dpa, _ := v.Get()
+func (v *DpaCustomResource) GetNoErr(c client.Client) *oadpv1alpha1.DataProtectionApplication {
+	Dpa, _ := v.Get(c)
 	return Dpa
 }
 
-func (v *DpaCustomResource) CreateOrUpdate(spec *oadpv1alpha1.DataProtectionApplicationSpec) error {
-	return v.CreateOrUpdateWithRetries(spec, 3)
+func (v *DpaCustomResource) CreateOrUpdate(c client.Client, spec *oadpv1alpha1.DataProtectionApplicationSpec) error {
+	return v.CreateOrUpdateWithRetries(c, spec, 3)
 }
-func (v *DpaCustomResource) CreateOrUpdateWithRetries(spec *oadpv1alpha1.DataProtectionApplicationSpec, retries int) error {
+func (v *DpaCustomResource) CreateOrUpdateWithRetries(c client.Client, spec *oadpv1alpha1.DataProtectionApplicationSpec, retries int) error {
 	var (
 		err error
 		cr  *oadpv1alpha1.DataProtectionApplication
 	)
 	for i := 0; i < retries; i++ {
-		if cr, err = v.Get(); apierrors.IsNotFound(err) {
+		if cr, err = v.Get(c); apierrors.IsNotFound(err) {
 			v.CustomResource = &oadpv1alpha1.DataProtectionApplication{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "DataProtectionApplication",
@@ -230,7 +230,7 @@ func (v *DpaCustomResource) CreateOrUpdateWithRetries(spec *oadpv1alpha1.DataPro
 				},
 				Spec: *spec.DeepCopy(),
 			}
-			return v.Create()
+			return v.Create(c)
 		} else if err != nil {
 			return err
 		}
@@ -251,8 +251,8 @@ func (v *DpaCustomResource) CreateOrUpdateWithRetries(spec *oadpv1alpha1.DataPro
 	return err
 }
 
-func (v *DpaCustomResource) Delete() error {
-	err := v.SetClient()
+func (v *DpaCustomResource) Delete(c client.Client) error {
+	err := v.SetClient(c)
 	if err != nil {
 		return err
 	}
@@ -263,11 +263,7 @@ func (v *DpaCustomResource) Delete() error {
 	return err
 }
 
-func (v *DpaCustomResource) SetClient() error {
-	client, err := client.New(config.GetConfigOrDie(), client.Options{})
-	if err != nil {
-		return err
-	}
+func (v *DpaCustomResource) SetClient(client client.Client) error {
 	oadpv1alpha1.AddToScheme(client.Scheme())
 	velero.AddToScheme(client.Scheme())
 	appsv1.AddToScheme(client.Scheme())
@@ -283,11 +279,7 @@ func (v *DpaCustomResource) SetClient() error {
 	return nil
 }
 
-func GetVeleroPods(namespace string) (*corev1.PodList, error) {
-	clientset, err := setUpClient()
-	if err != nil {
-		return nil, err
-	}
+func GetVeleroPods(c *kubernetes.Clientset, namespace string) (*corev1.PodList, error) {
 	// select Velero pod with this label
 	veleroOptions := metav1.ListOptions{
 		LabelSelector: "component=velero",
@@ -297,21 +289,22 @@ func GetVeleroPods(namespace string) (*corev1.PodList, error) {
 	}
 	// get pods in test namespace with labelSelector
 	var podList *corev1.PodList
-	if podList, err = clientset.CoreV1().Pods(namespace).List(context.TODO(), veleroOptions); err != nil {
+	var err error
+	if podList, err = c.CoreV1().Pods(namespace).List(context.TODO(), veleroOptions); err != nil {
 		return nil, err
 	}
 	if len(podList.Items) == 0 {
 		// handle some oadp versions where label was deploy=velero
-		if podList, err = clientset.CoreV1().Pods(namespace).List(context.TODO(), veleroOptionsDeploy); err != nil {
+		if podList, err = c.CoreV1().Pods(namespace).List(context.TODO(), veleroOptionsDeploy); err != nil {
 			return nil, err
 		}
 	}
 	return podList, nil
 }
 
-func AreVeleroPodsRunning(namespace string) wait.ConditionFunc {
+func AreVeleroPodsRunning(c *kubernetes.Clientset, namespace string) wait.ConditionFunc {
 	return func() (bool, error) {
-		podList, err := GetVeleroPods(namespace)
+		podList, err := GetVeleroPods(c, namespace)
 		if err != nil {
 			return false, err
 		}
@@ -330,17 +323,17 @@ func AreVeleroPodsRunning(namespace string) wait.ConditionFunc {
 	}
 }
 
-func GetOpenShiftADPLogs(namespace string) (string, error) {
-	return GetPodWithPrefixContainerLogs(namespace, "openshift-adp-controller-manager-", "manager")
+func GetOpenShiftADPLogs(c *kubernetes.Clientset, namespace string) (string, error) {
+	return GetPodWithPrefixContainerLogs(c, namespace, "openshift-adp-controller-manager-", "manager")
 }
 
 // Returns logs from velero container on velero pod
-func GetVeleroContainerLogs(namespace string) (string, error) {
-	return GetPodWithPrefixContainerLogs(namespace, "velero-", "velero")
+func GetVeleroContainerLogs(c *kubernetes.Clientset, namespace string) (string, error) {
+	return GetPodWithPrefixContainerLogs(c, namespace, "velero-", "velero")
 }
 
-func GetVeleroContainerFailureLogs(namespace string) []string {
-	containerLogs, err := GetVeleroContainerLogs(namespace)
+func GetVeleroContainerFailureLogs(c *kubernetes.Clientset, namespace string) []string {
+	containerLogs, err := GetVeleroContainerLogs(c, namespace)
 	if err != nil {
 		log.Printf("cannot get velero container logs")
 		return nil
@@ -355,9 +348,9 @@ func GetVeleroContainerFailureLogs(namespace string) []string {
 	return failureArr
 }
 
-func (v *DpaCustomResource) IsDeleted() wait.ConditionFunc {
+func (v *DpaCustomResource) IsDeleted(c client.Client) wait.ConditionFunc {
 	return func() (bool, error) {
-		err := v.SetClient()
+		err := v.SetClient(c)
 		if err != nil {
 			return false, err
 		}
@@ -417,14 +410,9 @@ func DoesVSLSpecMatchesDpa(namespace string, vslspec velero.VolumeSnapshotLocati
 }
 
 // check velero tolerations
-func VerifyVeleroTolerations(namespace string, t []corev1.Toleration) wait.ConditionFunc {
+func VerifyVeleroTolerations(c *kubernetes.Clientset, namespace string, t []corev1.Toleration) wait.ConditionFunc {
 	return func() (bool, error) {
-		clientset, err := setUpClient()
-		if err != nil {
-			return false, err
-		}
-
-		veldep, _ := clientset.AppsV1().Deployments(namespace).Get(context.Background(), "velero", metav1.GetOptions{})
+		veldep, _ := c.AppsV1().Deployments(namespace).Get(context.Background(), "velero", metav1.GetOptions{})
 
 		if !reflect.DeepEqual(t, veldep.Spec.Template.Spec.Tolerations) {
 			return false, errors.New("given Velero tolerations does not match the deployed velero tolerations")
@@ -434,13 +422,9 @@ func VerifyVeleroTolerations(namespace string, t []corev1.Toleration) wait.Condi
 }
 
 // check for velero resource requests
-func VerifyVeleroResourceRequests(namespace string, requests corev1.ResourceList) wait.ConditionFunc {
+func VerifyVeleroResourceRequests(c *kubernetes.Clientset, namespace string, requests corev1.ResourceList) wait.ConditionFunc {
 	return func() (bool, error) {
-		clientset, err := setUpClient()
-		if err != nil {
-			return false, err
-		}
-		veldep, _ := clientset.AppsV1().Deployments(namespace).Get(context.Background(), "velero", metav1.GetOptions{})
+		veldep, _ := c.AppsV1().Deployments(namespace).Get(context.Background(), "velero", metav1.GetOptions{})
 
 		for _, c := range veldep.Spec.Template.Spec.Containers {
 			if c.Name == common.Velero {
@@ -454,13 +438,9 @@ func VerifyVeleroResourceRequests(namespace string, requests corev1.ResourceList
 }
 
 // check for velero resource limits
-func VerifyVeleroResourceLimits(namespace string, limits corev1.ResourceList) wait.ConditionFunc {
+func VerifyVeleroResourceLimits(c *kubernetes.Clientset, namespace string, limits corev1.ResourceList) wait.ConditionFunc {
 	return func() (bool, error) {
-		clientset, err := setUpClient()
-		if err != nil {
-			return false, err
-		}
-		veldep, _ := clientset.AppsV1().Deployments(namespace).Get(context.Background(), "velero", metav1.GetOptions{})
+		veldep, _ := c.AppsV1().Deployments(namespace).Get(context.Background(), "velero", metav1.GetOptions{})
 
 		for _, c := range veldep.Spec.Template.Spec.Containers {
 			if c.Name == common.Velero {

--- a/tests/e2e/lib/dpa_helpers.go
+++ b/tests/e2e/lib/dpa_helpers.go
@@ -290,12 +290,12 @@ func GetVeleroPods(c *kubernetes.Clientset, namespace string) (*corev1.PodList, 
 	// get pods in test namespace with labelSelector
 	var podList *corev1.PodList
 	var err error
-	if podList, err = c.CoreV1().Pods(namespace).List(context.TODO(), veleroOptions); err != nil {
+	if podList, err = c.CoreV1().Pods(namespace).List(context.Background(), veleroOptions); err != nil {
 		return nil, err
 	}
 	if len(podList.Items) == 0 {
 		// handle some oadp versions where label was deploy=velero
-		if podList, err = c.CoreV1().Pods(namespace).List(context.TODO(), veleroOptionsDeploy); err != nil {
+		if podList, err = c.CoreV1().Pods(namespace).List(context.Background(), veleroOptionsDeploy); err != nil {
 			return nil, err
 		}
 	}

--- a/tests/e2e/lib/kube_helpers.go
+++ b/tests/e2e/lib/kube_helpers.go
@@ -111,7 +111,7 @@ func CreateCredentialsSecret(clientset *kubernetes.Clientset, data []byte, names
 		},
 		Type: corev1.SecretTypeOpaque,
 	}
-	_, err := clientset.CoreV1().Secrets(namespace).Create(context.TODO(), &secret, metav1.CreateOptions{})
+	_, err := clientset.CoreV1().Secrets(namespace).Create(context.Background(), &secret, metav1.CreateOptions{})
 	if apierrors.IsAlreadyExists(err) {
 		return nil
 	}
@@ -199,11 +199,11 @@ func GetPodContainerLogs(clientset *kubernetes.Clientset, namespace, podname, co
 
 func GetDeploymentPodContainerLogs(clientset *kubernetes.Clientset, namespace, deploymentName, containerName string) (string, error) {
 	// get replicasets owned by deployment
-	replicasets, err := clientset.AppsV1().ReplicaSets(namespace).List(context.TODO(), metav1.ListOptions{})
+	replicasets, err := clientset.AppsV1().ReplicaSets(namespace).List(context.Background(), metav1.ListOptions{})
 	if err != nil {
 		return "", err
 	}
-	pods, err := clientset.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{})
+	pods, err := clientset.CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{})
 	if err != nil {
 		return "", err
 	}

--- a/tests/e2e/lib/kube_helpers.go
+++ b/tests/e2e/lib/kube_helpers.go
@@ -15,8 +15,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
-	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
 type K8sVersion struct {
@@ -57,16 +55,16 @@ func k8sVersionLesser(v1 *K8sVersion, v2 *K8sVersion) bool {
 	return false
 }
 
-func serverK8sVersion() *K8sVersion {
-	version, err := serverVersion()
+func serverK8sVersion(clientset *kubernetes.Clientset) *K8sVersion {
+	version, err := serverVersion(clientset)
 	if err != nil {
 		return nil
 	}
 	return &K8sVersion{Major: version.Major, Minor: version.Minor}
 }
 
-func NotServerVersionTarget(minVersion *K8sVersion, maxVersion *K8sVersion) (bool, string) {
-	serverVersion := serverK8sVersion()
+func NotServerVersionTarget(clientset *kubernetes.Clientset, minVersion *K8sVersion, maxVersion *K8sVersion) (bool, string) {
+	serverVersion := serverK8sVersion(clientset)
 	if maxVersion != nil && k8sVersionGreater(serverVersion, maxVersion) {
 		return true, "Server Version is greater than max target version"
 	}
@@ -76,75 +74,17 @@ func NotServerVersionTarget(minVersion *K8sVersion, maxVersion *K8sVersion) (boo
 	return false, ""
 }
 
-func setUpClient() (*kubernetes.Clientset, error) {
-	kubeConf := getKubeConfig()
-	// create client for pod
-	clientset, err := kubernetes.NewForConfig(kubeConf)
-	if err != nil {
-		return nil, err
-	}
-	return clientset, nil
-}
-
-// FIXME: Remove
-func createOADPTestNamespace(namespace string) error {
-	// default OADP Namespace
-	kubeConf := getKubeConfig()
-	clientset, err := kubernetes.NewForConfig(kubeConf)
-	if err != nil {
-		return err
-	}
-	ns := corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: namespace,
-		},
-	}
-	_, err = clientset.CoreV1().Namespaces().Create(context.TODO(), &ns, metav1.CreateOptions{})
-	if apierrors.IsAlreadyExists(err) {
-		return nil
-	}
-
-	return err
-}
-
-// FIXME: Remove
-func deleteOADPTestNamespace(namespace string) error {
-	// default OADP Namespace
-	kubeConf := getKubeConfig()
-	clientset, err := kubernetes.NewForConfig(kubeConf)
-
-	if err != nil {
-		return err
-	}
-	err = clientset.CoreV1().Namespaces().Delete(context.TODO(), namespace, metav1.DeleteOptions{})
-	return err
-}
-
-func getKubeConfig() *rest.Config {
-	return config.GetConfigOrDie()
-}
-
-// FIXME: Remove
-func DoesNamespaceExist(namespace string) (bool, error) {
-	clientset, err := setUpClient()
-	if err != nil {
-		return false, err
-	}
-	_, err = clientset.CoreV1().Namespaces().Get(context.Background(), namespace, metav1.GetOptions{})
+func DoesNamespaceExist(clientset *kubernetes.Clientset, namespace string) (bool, error) {
+	_, err := clientset.CoreV1().Namespaces().Get(context.Background(), namespace, metav1.GetOptions{})
 	if err != nil {
 		return false, err
 	}
 	return true, nil
 }
 
-// Keeping it for now.
-func IsNamespaceDeleted(namespace string) wait.ConditionFunc {
+func IsNamespaceDeleted(clientset *kubernetes.Clientset, namespace string) wait.ConditionFunc {
 	return func() (bool, error) {
-		clientset, err := setUpClient()
-		if err != nil {
-			return false, err
-		}
-		_, err = clientset.CoreV1().Namespaces().Get(context.Background(), namespace, metav1.GetOptions{})
+		_, err := clientset.CoreV1().Namespaces().Get(context.Background(), namespace, metav1.GetOptions{})
 		if err != nil {
 			return true, nil
 		}
@@ -152,19 +92,11 @@ func IsNamespaceDeleted(namespace string) wait.ConditionFunc {
 	}
 }
 
-func serverVersion() (*version.Info, error) {
-	clientset, err := setUpClient()
-	if err != nil {
-		return nil, err
-	}
+func serverVersion(clientset *kubernetes.Clientset) (*version.Info, error) {
 	return clientset.Discovery().ServerVersion()
 }
 
-func CreateCredentialsSecret(data []byte, namespace string, credSecretRef string) error {
-	clientset, err := setUpClient()
-	if err != nil {
-		return err
-	}
+func CreateCredentialsSecret(clientset *kubernetes.Clientset, data []byte, namespace string, credSecretRef string) error {
 	secret := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      credSecretRef,
@@ -179,32 +111,24 @@ func CreateCredentialsSecret(data []byte, namespace string, credSecretRef string
 		},
 		Type: corev1.SecretTypeOpaque,
 	}
-	_, err = clientset.CoreV1().Secrets(namespace).Create(context.TODO(), &secret, metav1.CreateOptions{})
+	_, err := clientset.CoreV1().Secrets(namespace).Create(context.TODO(), &secret, metav1.CreateOptions{})
 	if apierrors.IsAlreadyExists(err) {
 		return nil
 	}
 	return err
 }
 
-func DeleteSecret(namespace string, credSecretRef string) error {
-	clientset, err := setUpClient()
-	if err != nil {
-		return err
-	}
-	err = clientset.CoreV1().Secrets(namespace).Delete(context.Background(), credSecretRef, metav1.DeleteOptions{})
+func DeleteSecret(clientset *kubernetes.Clientset, namespace string, credSecretRef string) error {
+	err := clientset.CoreV1().Secrets(namespace).Delete(context.Background(), credSecretRef, metav1.DeleteOptions{})
 	if apierrors.IsNotFound(err) {
 		return nil
 	}
 	return err
 }
 
-func isCredentialsSecretDeleted(namespace string, credSecretRef string) wait.ConditionFunc {
+func isCredentialsSecretDeleted(clientset *kubernetes.Clientset, namespace string, credSecretRef string) wait.ConditionFunc {
 	return func() (bool, error) {
-		clientset, err := setUpClient()
-		if err != nil {
-			return false, err
-		}
-		_, err = clientset.CoreV1().Secrets(namespace).Get(context.Background(), credSecretRef, metav1.GetOptions{})
+		_, err := clientset.CoreV1().Secrets(namespace).Get(context.Background(), credSecretRef, metav1.GetOptions{})
 		if err != nil {
 			log.Printf("Secret in test namespace has been deleted")
 			return true, nil
@@ -214,18 +138,14 @@ func isCredentialsSecretDeleted(namespace string, credSecretRef string) wait.Con
 	}
 }
 
-func GetPodWithPrefixContainerLogs(namespace string, podPrefix string, container string) (string, error) {
-	clientset, err := setUpClient()
-	if err != nil {
-		return "", err
-	}
+func GetPodWithPrefixContainerLogs(clientset *kubernetes.Clientset, namespace string, podPrefix string, container string) (string, error) {
 	podList, err := clientset.CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{})
 	if err != nil {
 		return "", err
 	}
 	for _, pod := range podList.Items {
 		if strings.HasPrefix(pod.Name, podPrefix) {
-			logs, err := GetPodContainerLogs(namespace, pod.Name, container)
+			logs, err := GetPodContainerLogs(clientset, namespace, pod.Name, container)
 			if err != nil {
 				return "", err
 			}
@@ -235,11 +155,7 @@ func GetPodWithPrefixContainerLogs(namespace string, podPrefix string, container
 	return "", fmt.Errorf("No pod found with prefix %s", podPrefix)
 }
 
-func SavePodLogs(namespace, dir string) error {
-	clientset, err := setUpClient()
-	if err != nil {
-		return nil
-	}
+func SavePodLogs(clientset *kubernetes.Clientset, namespace, dir string) error {
 	podList, err := clientset.CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{})
 	if err != nil {
 		return nil
@@ -251,7 +167,7 @@ func SavePodLogs(namespace, dir string) error {
 			log.Printf("Error creating pod directory: %v", err)
 		}
 		for _, container := range pod.Spec.Containers {
-			logs, err := GetPodContainerLogs(namespace, pod.Name, container.Name)
+			logs, err := GetPodContainerLogs(clientset, namespace, pod.Name, container.Name)
 			if err != nil {
 				return nil
 			}
@@ -264,11 +180,7 @@ func SavePodLogs(namespace, dir string) error {
 	return nil
 }
 
-func GetPodContainerLogs(namespace, podname, container string) (string, error) {
-	clientset, err := setUpClient()
-	if err != nil {
-		return "", err
-	}
+func GetPodContainerLogs(clientset *kubernetes.Clientset, namespace, podname, container string) (string, error) {
 	req := clientset.CoreV1().Pods(namespace).GetLogs(podname, &corev1.PodLogOptions{
 		Container: container,
 	})
@@ -285,11 +197,7 @@ func GetPodContainerLogs(namespace, podname, container string) (string, error) {
 	return buf.String(), nil
 }
 
-func GetDeploymentPodContainerLogs(namespace, deploymentName, containerName string) (string, error) {
-	clientset, err := setUpClient()
-	if err != nil {
-		return "", err
-	}
+func GetDeploymentPodContainerLogs(clientset *kubernetes.Clientset, namespace, deploymentName, containerName string) (string, error) {
 	// get replicasets owned by deployment
 	replicasets, err := clientset.AppsV1().ReplicaSets(namespace).List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
@@ -306,7 +214,7 @@ func GetDeploymentPodContainerLogs(namespace, deploymentName, containerName stri
 			for _, p := range pods.Items {
 				if p.OwnerReferences[0].Name == r.Name {
 					podLogs += "pod logs for " + p.Name + ":"
-					thisPodLogs, err := GetPodContainerLogs(namespace, p.Name, containerName)
+					thisPodLogs, err := GetPodContainerLogs(clientset, namespace, p.Name, containerName)
 					if err != nil {
 						return podLogs, err
 					}

--- a/tests/e2e/lib/nodeagent_helpers.go
+++ b/tests/e2e/lib/nodeagent_helpers.go
@@ -18,7 +18,7 @@ func HasCorrectNumNodeAgentPods(c *kubernetes.Clientset, namespace string) wait.
 		nodeAgentOptions := metav1.ListOptions{
 			FieldSelector: "metadata.name=" + common.NodeAgent,
 		}
-		nodeAgentDaemeonSet, err := c.AppsV1().DaemonSets(namespace).List(context.TODO(), nodeAgentOptions)
+		nodeAgentDaemeonSet, err := c.AppsV1().DaemonSets(namespace).List(context.Background(), nodeAgentOptions)
 		if err != nil {
 			return false, err
 		}
@@ -57,7 +57,7 @@ func AreNodeAgentPodsRunning(c *kubernetes.Clientset, namespace string) wait.Con
 			LabelSelector: "name=" + common.NodeAgent,
 		}
 		// get pods in the oadp-operator-e2e namespace with label selector
-		podList, err := c.CoreV1().Pods(namespace).List(context.TODO(), nodeAgentOptions)
+		podList, err := c.CoreV1().Pods(namespace).List(context.Background(), nodeAgentOptions)
 		if err != nil {
 			return false, nil
 		}
@@ -86,7 +86,7 @@ func IsNodeAgentDaemonsetDeleted(c *kubernetes.Clientset, namespace string) wait
 
 func NodeAgentDaemonSetHasNodeSelector(c *kubernetes.Clientset, namespace, key, value string) wait.ConditionFunc {
 	return func() (bool, error) {
-		ds, err := c.AppsV1().DaemonSets(namespace).Get(context.TODO(), common.NodeAgent, metav1.GetOptions{})
+		ds, err := c.AppsV1().DaemonSets(namespace).Get(context.Background(), common.NodeAgent, metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -105,7 +105,7 @@ func GetNodeAgentDaemonsetList(c *kubernetes.Clientset, namespace string) (*apps
 		LabelSelector: "component=velero",
 	}
 	// get pods in the oadp-operator-e2e namespace with label selector
-	deploymentList, err := c.AppsV1().DaemonSets(namespace).List(context.TODO(), registryListOptions)
+	deploymentList, err := c.AppsV1().DaemonSets(namespace).List(context.Background(), registryListOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/e2e/lib/plugins_helpers.go
+++ b/tests/e2e/lib/plugins_helpers.go
@@ -38,7 +38,7 @@ func (d *DpaCustomResource) RemoveVeleroPlugin(c client.Client, string, instance
 
 func DoesPluginExist(c *kubernetes.Clientset, namespace string, plugin oadpv1alpha1.DefaultPlugin) wait.ConditionFunc {
 	return func() (bool, error) {
-		veleroDeployment, err := c.AppsV1().Deployments(namespace).Get(context.TODO(), "velero", metav1.GetOptions{})
+		veleroDeployment, err := c.AppsV1().Deployments(namespace).Get(context.Background(), "velero", metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -57,7 +57,7 @@ func DoesPluginExist(c *kubernetes.Clientset, namespace string, plugin oadpv1alp
 
 func DoesCustomPluginExist(c *kubernetes.Clientset, namespace string, plugin oadpv1alpha1.CustomPlugin) wait.ConditionFunc {
 	return func() (bool, error) {
-		veleroDeployment, err := c.AppsV1().Deployments(namespace).Get(context.TODO(), "velero", metav1.GetOptions{})
+		veleroDeployment, err := c.AppsV1().Deployments(namespace).Get(context.Background(), "velero", metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}

--- a/tests/e2e/lib/registry_helpers.go
+++ b/tests/e2e/lib/registry_helpers.go
@@ -9,13 +9,14 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
 )
 
-func AreRegistryDeploymentsAvailable(namespace string) wait.ConditionFunc {
+func AreRegistryDeploymentsAvailable(c *kubernetes.Clientset, namespace string) wait.ConditionFunc {
 	log.Printf("Checking for available registry deployments")
 	return func() (bool, error) {
 		// get pods in the oadp-operator-e2e namespace with label selector
-		deploymentList, err := GetRegistryDeploymentList(namespace)
+		deploymentList, err := GetRegistryDeploymentList(c, namespace)
 		if err != nil {
 			return false, err
 		}
@@ -34,27 +35,23 @@ func AreRegistryDeploymentsAvailable(namespace string) wait.ConditionFunc {
 	}
 }
 
-func GetRegistryDeploymentList(namespace string) (*appsv1.DeploymentList, error) {
-	client, err := setUpClient()
-	if err != nil {
-		return nil, err
-	}
+func GetRegistryDeploymentList(c *kubernetes.Clientset, namespace string) (*appsv1.DeploymentList, error) {
 	registryListOptions := metav1.ListOptions{
 		LabelSelector: "app.kubernetes.io/component=Registry",
 	}
 	// get pods in the oadp-operator-e2e namespace with label selector
-	deploymentList, err := client.AppsV1().Deployments(namespace).List(context.TODO(), registryListOptions)
+	deploymentList, err := c.AppsV1().Deployments(namespace).List(context.TODO(), registryListOptions)
 	if err != nil {
 		return nil, err
 	}
 	return deploymentList, nil
 }
 
-func AreRegistryDeploymentsNotAvailable(namespace string) wait.ConditionFunc {
+func AreRegistryDeploymentsNotAvailable(c *kubernetes.Clientset, namespace string) wait.ConditionFunc {
 	log.Printf("Checking for unavailable registry deployments")
 	return func() (bool, error) {
 		// get pods in the oadp-operator-e2e namespace with label selector
-		deploymentList, err := GetRegistryDeploymentList(namespace)
+		deploymentList, err := GetRegistryDeploymentList(c, namespace)
 		if err != nil {
 			return false, err
 		}

--- a/tests/e2e/lib/registry_helpers.go
+++ b/tests/e2e/lib/registry_helpers.go
@@ -40,7 +40,7 @@ func GetRegistryDeploymentList(c *kubernetes.Clientset, namespace string) (*apps
 		LabelSelector: "app.kubernetes.io/component=Registry",
 	}
 	// get pods in the oadp-operator-e2e namespace with label selector
-	deploymentList, err := c.AppsV1().Deployments(namespace).List(context.TODO(), registryListOptions)
+	deploymentList, err := c.AppsV1().Deployments(namespace).List(context.Background(), registryListOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/e2e/lib/subscription_helpers.go
+++ b/tests/e2e/lib/subscription_helpers.go
@@ -75,6 +75,7 @@ func (s *Subscription) CsvIsReady(c client.Client) bool {
 	log.Default().Printf("CSV status phase: %v", csv.Status.Phase)
 	return csv.Status.Phase == operators.CSVPhaseSucceeded
 }
+
 func (s *Subscription) CsvIsInstalling(c client.Client) bool {
 	csv, err := s.getCSV(c)
 	if err != nil {

--- a/tests/e2e/lib/velero_helpers.go
+++ b/tests/e2e/lib/velero_helpers.go
@@ -40,13 +40,13 @@ func DescribeBackup(veleroClient veleroClientset.Interface, csiClient *snapshotv
 	caCertFile := ""
 
 	deleteRequestListOptions := pkgbackup.NewDeleteBackupRequestListOptions(backup.Name, string(backup.UID))
-	deleteRequestList, err := veleroClient.VeleroV1().DeleteBackupRequests(backup.Namespace).List(context.TODO(), deleteRequestListOptions)
+	deleteRequestList, err := veleroClient.VeleroV1().DeleteBackupRequests(backup.Namespace).List(context.Background(), deleteRequestListOptions)
 	if err != nil {
 		log.Printf("error getting DeleteBackupRequests for backup %s: %v\n", backup.Name, err)
 	}
 
 	opts := label.NewListOptionsForBackup(backup.Name)
-	podVolumeBackupList, err := veleroClient.VeleroV1().PodVolumeBackups(backup.Namespace).List(context.TODO(), opts)
+	podVolumeBackupList, err := veleroClient.VeleroV1().PodVolumeBackups(backup.Namespace).List(context.Background(), opts)
 	if err != nil {
 		log.Printf("error getting PodVolumeBackups for backup %s: %v\n", backup.Name, err)
 	}
@@ -54,7 +54,7 @@ func DescribeBackup(veleroClient veleroClientset.Interface, csiClient *snapshotv
 	// declare vscList up here since it may be empty and we'll pass the empty Items field into DescribeBackup
 	vscList := new(snapshotv1api.VolumeSnapshotContentList)
 	if features.IsEnabled(velero.CSIFeatureFlag) {
-		vscList, err = csiClient.SnapshotV1().VolumeSnapshotContents().List(context.TODO(), opts)
+		vscList, err = csiClient.SnapshotV1().VolumeSnapshotContents().List(context.Background(), opts)
 		if err != nil {
 			log.Printf("error getting VolumeSnapshotContent objects for backup %s: %v\n", backup.Name, err)
 		}
@@ -84,7 +84,7 @@ func DescribeRestore(veleroClient veleroClientset.Interface, ocClient client.Cli
 	insecureSkipTLSVerify := true
 	caCertFile := ""
 	opts := newPodVolumeRestoreListOptions(restore.Name)
-	podvolumeRestoreList, err := veleroClient.VeleroV1().PodVolumeRestores(restore.Namespace).List(context.TODO(), opts)
+	podvolumeRestoreList, err := veleroClient.VeleroV1().PodVolumeRestores(restore.Namespace).List(context.Background(), opts)
 	if err != nil {
 		log.Printf("error getting PodVolumeRestores for restore %s: %v\n", restore.Name, err)
 	}
@@ -199,7 +199,7 @@ func GetVeleroDeploymentList(c *kubernetes.Clientset, namespace string) (*appsv1
 		LabelSelector: "component=velero",
 	}
 	// get pods in the oadp-operator-e2e namespace with label selector
-	deploymentList, err := c.AppsV1().Deployments(namespace).List(context.TODO(), registryListOptions)
+	deploymentList, err := c.AppsV1().Deployments(namespace).List(context.Background(), registryListOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/e2e/must-gather_suite_test.go
+++ b/tests/e2e/must-gather_suite_test.go
@@ -53,16 +53,16 @@ var _ = Describe("Must-gather backup restore tests", func() {
 			// print namespace error events for app namespace
 			if lastBRCase.ApplicationNamespace != "" {
 				GinkgoWriter.Println("Printing app namespace events")
-				PrintNamespaceEventsAfterTime(lastBRCase.ApplicationNamespace, lastInstallTime)
+				PrintNamespaceEventsAfterTime(kubernetesClientForSuiteRun, lastBRCase.ApplicationNamespace, lastInstallTime)
 			}
 			GinkgoWriter.Println("Printing oadp namespace events")
-			PrintNamespaceEventsAfterTime(namespace, lastInstallTime)
+			PrintNamespaceEventsAfterTime(kubernetesClientForSuiteRun, namespace, lastInstallTime)
 			baseReportDir := artifact_dir + "/" + report.LeafNodeText
 			err := os.MkdirAll(baseReportDir, 0755)
 			Expect(err).NotTo(HaveOccurred())
-			err = SavePodLogs(namespace, baseReportDir)
+			err = SavePodLogs(kubernetesClientForSuiteRun, namespace, baseReportDir)
 			Expect(err).NotTo(HaveOccurred())
-			err = SavePodLogs(lastBRCase.ApplicationNamespace, baseReportDir)
+			err = SavePodLogs(kubernetesClientForSuiteRun, lastBRCase.ApplicationNamespace, baseReportDir)
 			Expect(err).NotTo(HaveOccurred())
 		}
 		// remove app namespace if leftover (likely previously failed before reaching uninstall applications) to clear items such as PVCs which are immutable so that next test can create new ones
@@ -75,9 +75,9 @@ var _ = Describe("Must-gather backup restore tests", func() {
 		}
 		Expect(err).ToNot(HaveOccurred())
 
-		err = dpaCR.Delete()
+		err = dpaCR.Delete(runTimeClientForSuiteRun)
 		Expect(err).ToNot(HaveOccurred())
-		Eventually(IsNamespaceDeleted(lastBRCase.ApplicationNamespace), timeoutMultiplier*time.Minute*2, time.Second*5).Should(BeTrue())
+		Eventually(IsNamespaceDeleted(kubernetesClientForSuiteRun, lastBRCase.ApplicationNamespace), timeoutMultiplier*time.Minute*2, time.Second*5).Should(BeTrue())
 	})
 
 	updateLastInstallTime := func() {
@@ -92,7 +92,7 @@ var _ = Describe("Must-gather backup restore tests", func() {
 					brCase.MinK8SVersion = &K8sVersion{Major: "1", Minor: "23"}
 				}
 			}
-			if notVersionTarget, reason := NotServerVersionTarget(brCase.MinK8SVersion, brCase.MaxK8SVersion); notVersionTarget {
+			if notVersionTarget, reason := NotServerVersionTarget(kubernetesClientForSuiteRun, brCase.MinK8SVersion, brCase.MaxK8SVersion); notVersionTarget {
 				Skip(reason)
 			}
 
@@ -104,17 +104,17 @@ var _ = Describe("Must-gather backup restore tests", func() {
 			//updateLastInstallingNamespace(dpaCR.Namespace)
 			updateLastInstallTime()
 
-			err = dpaCR.CreateOrUpdate(&dpaCR.CustomResource.Spec)
+			err = dpaCR.CreateOrUpdate(runTimeClientForSuiteRun, &dpaCR.CustomResource.Spec)
 			Expect(err).NotTo(HaveOccurred())
 
 			fmt.Printf("Cluster type: %s \n", provider)
 
 			log.Printf("Waiting for velero pod to be running")
-			Eventually(AreVeleroPodsRunning(namespace), timeoutMultiplier*time.Minute*3, time.Second*5).Should(BeTrue())
+			Eventually(AreVeleroPodsRunning(kubernetesClientForSuiteRun, namespace), timeoutMultiplier*time.Minute*3, time.Second*5).Should(BeTrue())
 
 			if brCase.BackupRestoreType == RESTIC || brCase.BackupRestoreType == KOPIA || brCase.BackupRestoreType == CSIDataMover {
 				log.Printf("Waiting for Node Agent pods to be running")
-				Eventually(AreNodeAgentPodsRunning(namespace), timeoutMultiplier*time.Minute*3, time.Second*5).Should(BeTrue())
+				Eventually(AreNodeAgentPodsRunning(kubernetesClientForSuiteRun, namespace), timeoutMultiplier*time.Minute*3, time.Second*5).Should(BeTrue())
 			}
 			if brCase.BackupRestoreType == CSI || brCase.BackupRestoreType == CSIDataMover {
 				if provider == "aws" || provider == "ibmcloud" || provider == "gcp" || provider == "azure" {
@@ -152,7 +152,7 @@ var _ = Describe("Must-gather backup restore tests", func() {
 
 			// wait for pods to be running
 			Eventually(AreAppBuildsReady(dpaCR.Client, brCase.ApplicationNamespace), timeoutMultiplier*time.Minute*5, time.Second*5).Should(BeTrue())
-			Eventually(AreApplicationPodsRunning(brCase.ApplicationNamespace), timeoutMultiplier*time.Minute*9, time.Second*5).Should(BeTrue())
+			Eventually(AreApplicationPodsRunning(kubernetesClientForSuiteRun, brCase.ApplicationNamespace), timeoutMultiplier*time.Minute*9, time.Second*5).Should(BeTrue())
 
 			// Run optional custom verification
 			log.Printf("Running pre-backup function for case %s", brCase.Name)
@@ -171,11 +171,11 @@ var _ = Describe("Must-gather backup restore tests", func() {
 
 			// wait for backup to not be running
 			Eventually(IsBackupDone(dpaCR.Client, namespace, backupName), timeoutMultiplier*time.Minute*20, time.Second*10).Should(BeTrue())
-			GinkgoWriter.Println(DescribeBackup(dpaCR.Client, backup))
-			Expect(BackupErrorLogs(dpaCR.Client, backup)).To(Equal([]string{}))
+			GinkgoWriter.Println(DescribeBackup(veleroClientForSuiteRun, csiClientForSuiteRun, dpaCR.Client, backup))
+			Expect(BackupErrorLogs(kubernetesClientForSuiteRun, dpaCR.Client, backup)).To(Equal([]string{}))
 
 			// check if backup succeeded
-			succeeded, err := IsBackupCompletedSuccessfully(dpaCR.Client, backup)
+			succeeded, err := IsBackupCompletedSuccessfully(kubernetesClientForSuiteRun, dpaCR.Client, backup)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(succeeded).To(Equal(true))
 			log.Printf("Backup for case %s succeeded", brCase.Name)
@@ -191,7 +191,7 @@ var _ = Describe("Must-gather backup restore tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// Wait for namespace to be deleted
-			Eventually(IsNamespaceDeleted(brCase.ApplicationNamespace), timeoutMultiplier*time.Minute*4, time.Second*5).Should(BeTrue())
+			Eventually(IsNamespaceDeleted(kubernetesClientForSuiteRun, brCase.ApplicationNamespace), timeoutMultiplier*time.Minute*4, time.Second*5).Should(BeTrue())
 
 			updateLastInstallTime()
 			// run restore
@@ -199,11 +199,11 @@ var _ = Describe("Must-gather backup restore tests", func() {
 			restore, err := CreateRestoreFromBackup(dpaCR.Client, namespace, backupName, restoreName)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(IsRestoreDone(dpaCR.Client, namespace, restoreName), timeoutMultiplier*time.Minute*60, time.Second*10).Should(BeTrue())
-			GinkgoWriter.Println(DescribeRestore(dpaCR.Client, restore))
-			Expect(RestoreErrorLogs(dpaCR.Client, restore)).To(Equal([]string{}))
+			GinkgoWriter.Println(DescribeRestore(veleroClientForSuiteRun, dpaCR.Client, restore))
+			Expect(RestoreErrorLogs(kubernetesClientForSuiteRun, dpaCR.Client, restore)).To(Equal([]string{}))
 
 			// Check if restore succeeded
-			succeeded, err = IsRestoreCompletedSuccessfully(dpaCR.Client, namespace, restoreName)
+			succeeded, err = IsRestoreCompletedSuccessfully(kubernetesClientForSuiteRun, dpaCR.Client, namespace, restoreName)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(succeeded).To(Equal(true))
 
@@ -220,7 +220,7 @@ var _ = Describe("Must-gather backup restore tests", func() {
 
 			// verify app is running
 			Eventually(AreAppBuildsReady(dpaCR.Client, brCase.ApplicationNamespace), timeoutMultiplier*time.Minute*3, time.Second*5).Should(BeTrue())
-			Eventually(AreApplicationPodsRunning(brCase.ApplicationNamespace), timeoutMultiplier*time.Minute*9, time.Second*5).Should(BeTrue())
+			Eventually(AreApplicationPodsRunning(kubernetesClientForSuiteRun, brCase.ApplicationNamespace), timeoutMultiplier*time.Minute*9, time.Second*5).Should(BeTrue())
 
 			// Run optional custom verification
 			log.Printf("Running post-restore function for case %s", brCase.Name)


### PR DESCRIPTION
After talking to @shawn-hurley, we should just have one kubernetes client per suite run, but we were creating more than one per test. With this PR, all necessary clients are created in TOP-LEVEL before-suite and passed along where necessary. Refactor can be done, but not the goal of this PR.

This is important, because with each client created,  a new cache would also be created. This could create memory problems.

With only one client, we could have out of date cache, but if this happens, we can disable cache from that client.

Also, increased the default QPS (20) to 50 and Burst (30) to 100 in client configuration.

### Other changes

Change all `context.TODO()` in tests code for `context.Background()`. This should not change the behavior of tests, since it does not run in parallel today.

Make colored output an option in suite run, so logs in PROW are easier to read.