### PR TITLE
fix: dc post restore script logic to delete disconnected pods

### DIFF
--- a/docs/scripts/dc-post-restore.sh
+++ b/docs/scripts/dc-post-restore.sh
@@ -17,21 +17,18 @@ label_name () {
     echo "${1:0:57}${sha:0:6}"
 }
 
-OADP_NAMESPACE=${OADP_NAMESPACE:=openshift-adp}
-
 if [[ $# -ne 1 ]]; then
     echo "usage: ${BASH_SOURCE} restore-name"
     exit 1
 fi
 
-echo using OADP Namespace $OADP_NAMESPACE
 echo restore: $1
 
 label=$(label_name $1)
 echo label: $label
 
 echo Deleting disconnected restore pods
-oc delete pods -l oadp.openshift.io/disconnected-from-dc=$label
+oc delete pods --all-namespaces -l oadp.openshift.io/disconnected-from-dc=$label
 
 for dc in $(oc get dc --all-namespaces -l oadp.openshift.io/replicas-modified=$label -o jsonpath='{range .items[*]}{.metadata.namespace}{","}{.metadata.name}{","}{.metadata.annotations.oadp\.openshift\.io/original-replicas}{","}{.metadata.annotations.oadp\.openshift\.io/original-paused}{"\n"}')
 do


### PR DESCRIPTION
Add `--all-namespaces` flag to delete command. This should make CI more stable.