### PR TITLE
OADP-5158: Do not allow restic config use in OADP 1.5+; Deprecate restic for file system backups

### DIFF
--- a/api/v1alpha1/dataprotectionapplication_types.go
+++ b/api/v1alpha1/dataprotectionapplication_types.go
@@ -374,10 +374,8 @@ type ResticConfig struct {
 // ApplicationConfig defines the configuration for the Data Protection Application
 type ApplicationConfig struct {
 	Velero *VeleroConfig `json:"velero,omitempty"`
-	// (deprecation warning) ResticConfig is the configuration for restic DaemonSet.
-	// restic is for backwards compatibility and is replaced by the nodeAgent
-	// restic will be removed in the future
-	// +kubebuilder:deprecatedversion:warning=1.3
+	// (do not use warning) restic field is for backwards compatibility and
+	// will be removed in the future. Use nodeAgent field instead
 	// +optional
 	Restic *ResticConfig `json:"restic,omitempty"`
 
@@ -761,8 +759,6 @@ func (dpa *DataProtectionApplication) AutoCorrect() {
 		if dpa.Spec.Configuration != nil {
 			if dpa.Spec.Configuration.NodeAgent != nil && len(dpa.Spec.Configuration.NodeAgent.Timeout) > 0 {
 				fsBackupTimeout = dpa.Spec.Configuration.NodeAgent.Timeout
-			} else if dpa.Spec.Configuration.Restic != nil && len(dpa.Spec.Configuration.Restic.Timeout) > 0 {
-				fsBackupTimeout = dpa.Spec.Configuration.Restic.Timeout
 			}
 		}
 		if pvOperationTimeout, err := time.ParseDuration(fsBackupTimeout); err == nil && dpa.Spec.Configuration.Velero.Args.PodVolumeOperationTimeout == nil {

--- a/bundle/manifests/oadp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/oadp-operator.clusterserviceversion.yaml
@@ -34,7 +34,7 @@ metadata:
             "configuration": {
               "nodeAgent": {
                 "enable": true,
-                "uploaderType": "restic"
+                "uploaderType": "kopia"
               },
               "velero": {
                 "defaultPlugins": [

--- a/bundle/manifests/oadp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/oadp-operator.clusterserviceversion.yaml
@@ -1245,7 +1245,6 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
-                - name: RESTIC_PV_HOSTPATH
                 - name: FS_PV_HOSTPATH
                 - name: PLUGINS_HOSTPATH
                 - name: RELATED_IMAGE_VELERO

--- a/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
@@ -457,9 +457,8 @@ spec:
                       type: object
                     restic:
                       description: |-
-                        (deprecation warning) ResticConfig is the configuration for restic DaemonSet.
-                        restic is for backwards compatibility and is replaced by the nodeAgent
-                        restic will be removed in the future
+                        (do not use warning) restic field is for backwards compatibility and
+                        will be removed in the future. Use nodeAgent field instead
                       properties:
                         enable:
                           description: |-

--- a/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
@@ -457,9 +457,8 @@ spec:
                       type: object
                     restic:
                       description: |-
-                        (deprecation warning) ResticConfig is the configuration for restic DaemonSet.
-                        restic is for backwards compatibility and is replaced by the nodeAgent
-                        restic will be removed in the future
+                        (do not use warning) restic field is for backwards compatibility and
+                        will be removed in the future. Use nodeAgent field instead
                       properties:
                         enable:
                           description: |-

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -56,8 +56,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            - name: RESTIC_PV_HOSTPATH
-              value: ""
             - name: FS_PV_HOSTPATH
               value: ""
             - name: PLUGINS_HOSTPATH

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -8,7 +8,6 @@ resources:
 - downloadrequest.yaml
 - podvolumebackup.yaml
 - podvolumerestore.yaml
-- resticrepository.yaml
 - backup.yaml
 - restore.yaml
 - schedule.yaml

--- a/config/samples/oadp_v1alpha1_dataprotectionapplication.yaml
+++ b/config/samples/oadp_v1alpha1_dataprotectionapplication.yaml
@@ -11,7 +11,7 @@ spec:
       - kubevirt
     nodeAgent:
       enable: true
-      uploaderType: restic
+      uploaderType: kopia
   backupLocations:
     - velero:
         provider: aws
@@ -26,7 +26,7 @@ spec:
           name: cloud-credentials
           key: cloud
   snapshotLocations:
-    - velero:  
+    - velero:
         provider: aws
         config:
           region: us-west-2

--- a/config/samples/resticrepository.yaml
+++ b/config/samples/resticrepository.yaml
@@ -1,6 +1,0 @@
-apiVersion: velero.io/v1
-kind: ResticRepository
-metadata:
-  name: resticrepository
-  namespace: openshift-adp
-spec: {}

--- a/internal/controller/nodeagent.go
+++ b/internal/controller/nodeagent.go
@@ -371,9 +371,8 @@ func (r *DataProtectionApplicationReconciler) customizeNodeAgentDaemonset(ds *ap
 		return nil, err
 	}
 
-	if err := credentials.AppendCloudProviderVolumes(dpa, ds, providerNeedsDefaultCreds, hasCloudStorage); err != nil {
-		return nil, err
-	}
+	credentials.AppendCloudProviderVolumes(dpa, ds, providerNeedsDefaultCreds, hasCloudStorage)
+
 	setPodTemplateSpecDefaults(&ds.Spec.Template)
 	if ds.Spec.UpdateStrategy.Type == appsv1.RollingUpdateDaemonSetStrategyType {
 		ds.Spec.UpdateStrategy.RollingUpdate = &appsv1.RollingUpdateDaemonSet{

--- a/internal/controller/nodeagent.go
+++ b/internal/controller/nodeagent.go
@@ -16,7 +16,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/pointer"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -27,7 +26,6 @@ import (
 )
 
 const (
-	ResticRestoreHelperCM   = "restic-restore-action-config"
 	FsRestoreHelperCM       = "fs-restore-action-config"
 	HostPods                = "host-pods"
 	HostPlugins             = "host-plugins"
@@ -37,7 +35,6 @@ const (
 	IBMCloudPVHostPath      = "/var/data/kubelet/pods"
 	GenericPluginsHostPath  = "/var/lib/kubelet/plugins"
 	IBMCloudPluginsHostPath = "/var/data/kubelet/plugins"
-	ResticPVHostPathEnvVar  = "RESTIC_PV_HOSTPATH"
 	FSPVHostPathEnvVar      = "FS_PV_HOSTPATH"
 	PluginsHostPathEnvVar   = "PLUGINS_HOSTPATH"
 )
@@ -61,10 +58,6 @@ func getFsPvHostPath(platformType string) string {
 	// Check if environment variables are set for host paths
 	if envFs := os.Getenv(FSPVHostPathEnvVar); envFs != "" {
 		return envFs
-	}
-
-	if env := os.Getenv(ResticPVHostPathEnvVar); env != "" {
-		return env
 	}
 
 	// Return platform-specific host paths
@@ -108,16 +101,7 @@ func (r *DataProtectionApplicationReconciler) ReconcileNodeAgentDaemonset(log lo
 		ObjectMeta: getNodeAgentObjectMeta(r),
 	}
 
-	if dpa.Spec.Configuration.Restic != nil {
-		// V(-1) corresponds to the warn level
-		var deprecationMsg string = "(Deprecation Warning) Use nodeAgent instead of restic, which is deprecated and will be removed in the future"
-		log.V(-1).Info(deprecationMsg)
-		r.EventRecorder.Event(dpa, corev1.EventTypeWarning, "DeprecationResticConfig", deprecationMsg)
-	}
-
-	if dpa.Spec.Configuration.Restic != nil && dpa.Spec.Configuration.Restic.Enable != nil && *dpa.Spec.Configuration.Restic.Enable {
-		deleteDaemonSet = false
-	} else if dpa.Spec.Configuration.NodeAgent != nil && dpa.Spec.Configuration.NodeAgent.Enable != nil && *dpa.Spec.Configuration.NodeAgent.Enable {
+	if dpa.Spec.Configuration.NodeAgent != nil && dpa.Spec.Configuration.NodeAgent.Enable != nil && *dpa.Spec.Configuration.NodeAgent.Enable {
 		deleteDaemonSet = false
 	}
 
@@ -132,11 +116,9 @@ func (r *DataProtectionApplicationReconciler) ReconcileNodeAgentDaemonset(log lo
 			}
 			return false, err
 		}
-		// no errors means there already is an existing DaeMonset.
+		// no errors means there is already an existing DaemonSet.
 		// TODO: Check if NodeAgent is in use, a backup is running, so don't blindly delete NodeAgent.
-		// If dpa.Spec.Configuration.NodeAgent enable exists and is false, attempt to delete.
-		deleteOptionPropagationForeground := metav1.DeletePropagationForeground
-		if err := r.Delete(deleteContext, ds, &client.DeleteOptions{PropagationPolicy: &deleteOptionPropagationForeground}); err != nil {
+		if err := r.Delete(deleteContext, ds, &client.DeleteOptions{PropagationPolicy: ptr.To(metav1.DeletePropagationForeground)}); err != nil {
 			// TODO: Come back and fix event recording to be consistent
 			r.EventRecorder.Event(ds, corev1.EventTypeNormal, "DeleteDaemonSetFailed", "Got DaemonSet to delete but could not delete err:"+err.Error())
 			return false, err
@@ -214,24 +196,16 @@ func (r *DataProtectionApplicationReconciler) ReconcileNodeAgentDaemonset(log lo
  */
 func (r *DataProtectionApplicationReconciler) buildNodeAgentDaemonset(ds *appsv1.DaemonSet) (*appsv1.DaemonSet, error) {
 	dpa := r.dpa
-	if dpa == nil {
-		return nil, fmt.Errorf("dpa cannot be nil")
-	}
+
 	if ds == nil {
-		return nil, fmt.Errorf("ds cannot be nil")
+		return nil, fmt.Errorf("DaemonSet cannot be nil")
 	}
 
 	var nodeAgentResourceReqs corev1.ResourceRequirements
 
 	// get resource requirements for nodeAgent ds
 	// ignoring err here as it is checked in validator.go
-	if dpa.Spec.Configuration.Restic != nil {
-		nodeAgentResourceReqs, _ = getResticResourceReqs(dpa)
-	} else if dpa.Spec.Configuration.NodeAgent != nil {
-		nodeAgentResourceReqs, _ = getNodeAgentResourceReqs(dpa)
-	} else {
-		return nil, fmt.Errorf("NodeAgent or Restic configuration cannot be nil")
-	}
+	nodeAgentResourceReqs, _ = getNodeAgentResourceReqs(dpa)
 
 	installDs := install.DaemonSet(ds.Namespace,
 		install.WithResources(nodeAgentResourceReqs),
@@ -257,29 +231,6 @@ func (r *DataProtectionApplicationReconciler) buildNodeAgentDaemonset(ds *appsv1
 
 func (r *DataProtectionApplicationReconciler) customizeNodeAgentDaemonset(ds *appsv1.DaemonSet) (*appsv1.DaemonSet, error) {
 	dpa := r.dpa
-	if dpa.Spec.Configuration == nil || (dpa.Spec.Configuration.Restic == nil && dpa.Spec.Configuration.NodeAgent == nil) {
-		// if restic and nodeAgent are not configured, therefore not enabled, return early.
-		return nil, nil
-	}
-
-	var useResticConf bool = true
-
-	if dpa.Spec.Configuration.NodeAgent != nil {
-		useResticConf = false
-	}
-
-	// add custom pod labels
-	var err error
-	if useResticConf {
-		if dpa.Spec.Configuration.Restic.PodConfig != nil && dpa.Spec.Configuration.Restic.PodConfig.Labels != nil {
-			ds.Spec.Template.Labels, err = common.AppendUniqueKeyTOfTMaps(ds.Spec.Template.Labels, dpa.Spec.Configuration.Restic.PodConfig.Labels)
-		}
-	} else if dpa.Spec.Configuration.NodeAgent.PodConfig != nil && dpa.Spec.Configuration.NodeAgent.PodConfig.Labels != nil {
-		ds.Spec.Template.Labels, err = common.AppendUniqueKeyTOfTMaps(ds.Spec.Template.Labels, dpa.Spec.Configuration.NodeAgent.PodConfig.Labels)
-	}
-	if err != nil {
-		return nil, fmt.Errorf("NodeAgent daemonset template custom label: %s", err)
-	}
 
 	// customize specs
 	ds.Spec.Selector = nodeAgentLabelSelector
@@ -288,16 +239,9 @@ func (r *DataProtectionApplicationReconciler) customizeNodeAgentDaemonset(ds *ap
 	}
 
 	// customize template specs
-	if useResticConf {
-		ds.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
-			RunAsUser:          pointer.Int64(0),
-			SupplementalGroups: dpa.Spec.Configuration.Restic.SupplementalGroups,
-		}
-	} else {
-		ds.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
-			RunAsUser:          pointer.Int64(0),
-			SupplementalGroups: dpa.Spec.Configuration.NodeAgent.SupplementalGroups,
-		}
+	ds.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
+		RunAsUser:          ptr.To(int64(0)),
+		SupplementalGroups: dpa.Spec.Configuration.NodeAgent.SupplementalGroups,
 	}
 	ds.Spec.Template.Spec.Volumes = append(ds.Spec.Template.Spec.Volumes,
 		// append certs volume
@@ -344,14 +288,17 @@ func (r *DataProtectionApplicationReconciler) customizeNodeAgentDaemonset(ds *ap
 	}
 
 	// Update with any pod config values
-	if useResticConf {
-		if dpa.Spec.Configuration.Restic.PodConfig != nil {
-			ds.Spec.Template.Spec.Tolerations = dpa.Spec.Configuration.Restic.PodConfig.Tolerations
-			ds.Spec.Template.Spec.NodeSelector = dpa.Spec.Configuration.Restic.PodConfig.NodeSelector
-		}
-	} else if dpa.Spec.Configuration.NodeAgent.PodConfig != nil {
+	if dpa.Spec.Configuration.NodeAgent.PodConfig != nil {
 		ds.Spec.Template.Spec.Tolerations = dpa.Spec.Configuration.NodeAgent.PodConfig.Tolerations
 		ds.Spec.Template.Spec.NodeSelector = dpa.Spec.Configuration.NodeAgent.PodConfig.NodeSelector
+		// add custom pod labels
+		if dpa.Spec.Configuration.NodeAgent.PodConfig.Labels != nil {
+			var err error
+			ds.Spec.Template.Labels, err = common.AppendUniqueKeyTOfTMaps(ds.Spec.Template.Labels, dpa.Spec.Configuration.NodeAgent.PodConfig.Labels)
+			if err != nil {
+				return nil, fmt.Errorf("NodeAgent daemonset template custom label: %s", err)
+			}
+		}
 	}
 
 	// fetch nodeAgent container in order to customize it
@@ -380,11 +327,7 @@ func (r *DataProtectionApplicationReconciler) customizeNodeAgentDaemonset(ds *ap
 				}
 			}
 			// append PodConfig envs to nodeAgent container
-			if useResticConf {
-				if dpa.Spec.Configuration.Restic.PodConfig != nil && dpa.Spec.Configuration.Restic.PodConfig.Env != nil {
-					nodeAgentContainer.Env = common.AppendUniqueEnvVars(nodeAgentContainer.Env, dpa.Spec.Configuration.Restic.PodConfig.Env)
-				}
-			} else if dpa.Spec.Configuration.NodeAgent.PodConfig != nil && dpa.Spec.Configuration.NodeAgent.PodConfig.Env != nil {
+			if dpa.Spec.Configuration.NodeAgent.PodConfig != nil && dpa.Spec.Configuration.NodeAgent.PodConfig.Env != nil {
 				nodeAgentContainer.Env = common.AppendUniqueEnvVars(nodeAgentContainer.Env, dpa.Spec.Configuration.NodeAgent.PodConfig.Env)
 			}
 
@@ -392,7 +335,7 @@ func (r *DataProtectionApplicationReconciler) customizeNodeAgentDaemonset(ds *ap
 			nodeAgentContainer.Env = common.AppendUniqueEnvVars(nodeAgentContainer.Env, proxy.ReadProxyVarsFromEnv())
 
 			nodeAgentContainer.SecurityContext = &corev1.SecurityContext{
-				Privileged: pointer.Bool(true),
+				Privileged: ptr.To(true),
 			}
 
 			imagePullPolicy, err := common.GetImagePullPolicy(dpa.Spec.ImagePullPolicy, getVeleroImage(dpa))
@@ -445,7 +388,7 @@ func (r *DataProtectionApplicationReconciler) customizeNodeAgentDaemonset(ds *ap
 		}
 	}
 	if ds.Spec.RevisionHistoryLimit == nil {
-		ds.Spec.RevisionHistoryLimit = pointer.Int32(10)
+		ds.Spec.RevisionHistoryLimit = ptr.To(int32(10))
 	}
 
 	return ds, nil
@@ -457,17 +400,6 @@ func (r *DataProtectionApplicationReconciler) ReconcileFsRestoreHelperConfig(log
 			Name:      FsRestoreHelperCM,
 			Namespace: r.NamespacedName.Namespace,
 		},
-	}
-
-	// Delete renamed CM restic-restore-action-config
-	// Velero uses labels to identify the CM. For consistency we have the
-	// same name as upstream, whch is `fs-restore-action-config`
-	resticRestoreHelperCM := corev1.ConfigMap{}
-	if err := r.Get(r.Context, types.NamespacedName{Namespace: r.NamespacedName.Namespace, Name: ResticRestoreHelperCM}, &resticRestoreHelperCM); err == nil {
-		r.Log.Info("Deleting deprecated ConfigMap restic-restore-action-config.")
-		if err := r.Delete(r.Context, &resticRestoreHelperCM); err != nil {
-			return false, err
-		}
 	}
 
 	op, err := controllerutil.CreateOrPatch(r.Context, r.Client, &fsRestoreHelperCM, func() error {

--- a/internal/controller/nodeagent_test.go
+++ b/internal/controller/nodeagent_test.go
@@ -471,13 +471,9 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 		errorMessage           string
 	}{
 		{
-			name:         "DPA CR is nil, error is returned",
-			errorMessage: "dpa cannot be nil",
-		},
-		{
 			name:         "NodeAgent DaemonSet is nil, error is returned",
 			dpa:          &oadpv1alpha1.DataProtectionApplication{},
-			errorMessage: "ds cannot be nil",
+			errorMessage: "DaemonSet cannot be nil",
 		},
 		{
 			name: "valid DPA CR, NodeAgent DaemonSet is built",
@@ -569,6 +565,7 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 					},
 				},
 			),
+			clientObjects:      []client.Object{testGenericInfrastructure},
 			nodeAgentDaemonSet: testNodeAgentDaemonSet.DeepCopy(),
 			errorMessage:       "NodeAgent daemonset template custom label: conflicting key name with value not-node-agent may not override node-agent",
 		},
@@ -1321,49 +1318,36 @@ func Test_getFsPvHostPath(t *testing.T) {
 	tests := []struct {
 		name         string
 		platformType string
-		envRestic    string
 		envFS        string
 		want         string
 	}{
 		{
 			name:         "generic pv host path returned for empty platform type case",
 			platformType: "",
-			envRestic:    "",
 			envFS:        "",
 			want:         GenericPVHostPath,
 		},
 		{
 			name:         "IBMCloud pv host path returned for IBMCloud platform type",
 			platformType: IBMCloudPlatform,
-			envRestic:    "",
 			envFS:        "",
 			want:         IBMCloudPVHostPath,
 		},
 		{
-			name:         "empty platform type with restic env var set",
-			platformType: "",
-			envRestic:    "/foo/restic/bar",
-			envFS:        "",
-			want:         "/foo/restic/bar",
-		},
-		{
 			name:         "empty platform type with fs env var set",
 			platformType: "",
-			envRestic:    "",
 			envFS:        "/foo/file-system/bar",
 			want:         "/foo/file-system/bar",
 		},
 		{
 			name:         "IBMCloud platform type but env var also set, env var takes precedence",
 			platformType: IBMCloudPlatform,
-			envRestic:    "",
 			envFS:        "/foo/file-system/env/var/override",
 			want:         "/foo/file-system/env/var/override",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Setenv(ResticPVHostPathEnvVar, tt.envRestic)
 			t.Setenv(FSPVHostPathEnvVar, tt.envFS)
 			if got := getFsPvHostPath(tt.platformType); got != tt.want {
 				t.Errorf("getFsPvHostPath() = %v, want %v", got, tt.want)

--- a/internal/controller/validator_test.go
+++ b/internal/controller/validator_test.go
@@ -353,7 +353,7 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 								},
 							},
 						},
-						Restic: &oadpv1alpha1.ResticConfig{
+						NodeAgent: &oadpv1alpha1.NodeAgentConfig{
 							NodeAgentCommonFields: oadpv1alpha1.NodeAgentCommonFields{
 								PodConfig: &oadpv1alpha1.PodConfig{
 									ResourceAllocations: corev1.ResourceRequirements{
@@ -363,6 +363,7 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 									},
 								},
 							},
+							UploaderType: "restic",
 						},
 					},
 					BackupImages: pointer.Bool(false),

--- a/internal/controller/velero.go
+++ b/internal/controller/velero.go
@@ -173,8 +173,6 @@ func (r *DataProtectionApplicationReconciler) buildVeleroDeployment(veleroDeploy
 		return fmt.Errorf("error appending pod annotations: %v", err)
 	}
 
-	// Since `restic` can be still be used and it default's to an empty string, we can't just
-	// pass the dpa.Spec.Configuration.NodeAgent.UploaderType directly
 	uploaderType := ""
 	if dpa.Spec.Configuration.NodeAgent != nil && len(dpa.Spec.Configuration.NodeAgent.UploaderType) > 0 {
 		uploaderType = dpa.Spec.Configuration.NodeAgent.UploaderType
@@ -566,9 +564,6 @@ func (r *DataProtectionApplicationReconciler) customizeVeleroContainer(veleroCon
 }
 
 func getFsBackupTimeout(dpa *oadpv1alpha1.DataProtectionApplication) string {
-	if dpa.Spec.Configuration.Restic != nil && len(dpa.Spec.Configuration.Restic.Timeout) > 0 {
-		return dpa.Spec.Configuration.Restic.Timeout
-	}
 	if dpa.Spec.Configuration.NodeAgent != nil && len(dpa.Spec.Configuration.NodeAgent.Timeout) > 0 {
 		return dpa.Spec.Configuration.NodeAgent.Timeout
 	}
@@ -718,17 +713,7 @@ func (r *DataProtectionApplicationReconciler) getVeleroResourceReqs() (corev1.Re
 	return *defaultContainerResourceRequirements.DeepCopy(), nil
 }
 
-// Get Restic Resource Requirements
-func getResticResourceReqs(dpa *oadpv1alpha1.DataProtectionApplication) (corev1.ResourceRequirements, error) {
-	if dpa.Spec.Configuration.Restic != nil && dpa.Spec.Configuration.Restic.PodConfig != nil {
-		return getResourceReqs(&dpa.Spec.Configuration.Restic.PodConfig.ResourceAllocations)
-	}
-	return *defaultContainerResourceRequirements.DeepCopy(), nil
-}
-
 // Get NodeAgent Resource Requirements
-// Separate function to getResticResourceReqs, so once Restic config is removed in the future
-// It will be easier to delete obsolete getResticResourceReqs
 func getNodeAgentResourceReqs(dpa *oadpv1alpha1.DataProtectionApplication) (corev1.ResourceRequirements, error) {
 	if dpa.Spec.Configuration.NodeAgent != nil && dpa.Spec.Configuration.NodeAgent.PodConfig != nil {
 		return getResourceReqs(&dpa.Spec.Configuration.NodeAgent.PodConfig.ResourceAllocations)

--- a/pkg/credentials/credentials.go
+++ b/pkg/credentials/credentials.go
@@ -184,14 +184,10 @@ func GetPluginImage(defaultPlugin oadpv1alpha1.DefaultPlugin, dpa *oadpv1alpha1.
 }
 
 func AppendCloudProviderVolumes(dpa *oadpv1alpha1.DataProtectionApplication, ds *appsv1.DaemonSet, providerNeedsDefaultCreds map[string]bool, hasCloudStorage bool) error {
-	if dpa.Spec.Configuration.Velero == nil {
-		return errors.New("velero configuration not found")
-	}
-	var resticContainer *corev1.Container
-	// Find Velero container
+	var nodeAgentContainer *corev1.Container
 	for i, container := range ds.Spec.Template.Spec.Containers {
 		if container.Name == common.NodeAgent {
-			resticContainer = &ds.Spec.Template.Spec.Containers[i]
+			nodeAgentContainer = &ds.Spec.Template.Spec.Containers[i]
 		}
 	}
 	for _, plugin := range dpa.Spec.Configuration.Velero.DefaultPlugins {
@@ -228,16 +224,16 @@ func AppendCloudProviderVolumes(dpa *oadpv1alpha1.DataProtectionApplication, ds 
 					},
 				},
 			)
-			if resticContainer != nil {
-				resticContainer.VolumeMounts = append(
-					resticContainer.VolumeMounts,
+			if nodeAgentContainer != nil {
+				nodeAgentContainer.VolumeMounts = append(
+					nodeAgentContainer.VolumeMounts,
 					corev1.VolumeMount{
 						Name:      secretName,
 						MountPath: cloudProviderMap.MountPath,
 					},
 				)
-				resticContainer.Env = append(
-					resticContainer.Env,
+				nodeAgentContainer.Env = append(
+					nodeAgentContainer.Env,
 					corev1.EnvVar{
 						Name:  cloudProviderMap.EnvCredentialsFile,
 						Value: cloudProviderMap.MountPath + "/" + CloudFieldPath,

--- a/pkg/credentials/credentials.go
+++ b/pkg/credentials/credentials.go
@@ -183,7 +183,7 @@ func GetPluginImage(defaultPlugin oadpv1alpha1.DefaultPlugin, dpa *oadpv1alpha1.
 	return ""
 }
 
-func AppendCloudProviderVolumes(dpa *oadpv1alpha1.DataProtectionApplication, ds *appsv1.DaemonSet, providerNeedsDefaultCreds map[string]bool, hasCloudStorage bool) error {
+func AppendCloudProviderVolumes(dpa *oadpv1alpha1.DataProtectionApplication, ds *appsv1.DaemonSet, providerNeedsDefaultCreds map[string]bool, hasCloudStorage bool) {
 	var nodeAgentContainer *corev1.Container
 	for i, container := range ds.Spec.Template.Spec.Containers {
 		if container.Name == common.NodeAgent {
@@ -263,7 +263,6 @@ func AppendCloudProviderVolumes(dpa *oadpv1alpha1.DataProtectionApplication, ds 
 		}
 
 	}
-	return nil
 }
 
 // TODO: remove duplicate func in registry.go - refactoring away registry.go later


### PR DESCRIPTION
## Description

This PR removes logic of using old restic field (it should use nodeAgent field instead) from 1.5+ code. But it does not remove old restic field from DPA (which should only be removed when DPA version is updated), for a safe upgrade and better user experience for the users.

Also, log a Deprecation Warning when using restic in NodeAgent config.

## How to test

### OADP 1.5

run `make deploy-olm` and test that
- DPA is Reconciled false if old restic field (`spec.configuration.restic`) is present
- OADP manager pod has 1 warning log and OADP namespace has 1 warning event if DPA `spec.configuration.nodeAgent.uploaderType` is set to `restic`

### Simulate a upgrade

Simulate a upgrade from OADP 1.4 to 1.5 (this PR branch), by 
- running `make catalog-test-upgrade`
- installing OADP 1.4
- creating a DPA with old restic field (wait until it is reconciled true)
- and update to OADP 1.5

[More info](https://github.com/openshift/oadp-operator/blob/master/docs/developer/testing/test_oadp_version_upgrade.md)

Update should finish successfully and DPA should:
- be reconciled false, with the error message that restic field is not allowed
- restic fields should be still in DPA