### PR TITLE
fix: Remove unused CI file

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,0 @@
-build_root_image:
-  name: release
-  namespace: openshift
-  tag: rhel-8-release-golang-1.17-openshift-4.9


### PR DESCRIPTION
Per docs https://docs.ci.openshift.org/docs/architecture/ci-operator/#build-root-image we do not use this file in master branch CI. 

And is better to have all configuration in one place (`openshift/release` repo), instead of multiple places.