### PR TITLE
Updating Velero version for OADP 1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,4 +83,5 @@ versions. Here is the default mapping of versions:
 | v1.1.1          |         v1.9.4 |
 | v1.1.2 - v1.1.5 |         v1.9.5 |
 | v1.2.0          |        v1.11.0 |
+| v1.3.0          |        v1.12.1 |
 


### PR DESCRIPTION
Just updating the Velero version on the README.md to  v1.12.1 for OADP 1.3.0:

Line 86

| OADP Version    | Velero Version |
|:----------------|---------------:|
| v1.3.0          |        v1.12.1 |

