### PR TITLE
feat: Add golangci-lint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,97 @@
+# Documentation reference https://golangci-lint.run/usage/configuration/
+run:
+  concurrency: 4
+  skip-dirs-use-default: false
+  modules-download-mode: readonly
+  allow-parallel-runners: false
+
+output:
+  format: colored-line-number
+  print-issued-lines: true
+  print-linter-name: true
+  uniq-by-line: true
+  sort-results: true
+
+linters-settings:
+  dogsled:
+    max-blank-identifiers: 2
+  errcheck:
+    check-type-assertions: true
+    check-blank: true
+  goconst:
+    min-len: 3
+    min-occurrences: 5
+  gofmt:
+    simplify: true
+  govet:
+    disable-all: false
+    enable:
+      - atomicalign
+    enable-all: false
+  misspell:
+    locale: US
+  nakedret:
+    max-func-lines: 30
+  nolintlint:
+    allow-unused: false
+    allow-no-explanation: []
+    require-explanation: true
+    require-specific: true
+  revive:
+    enable-all-rules: true
+    rules:
+      - name: line-length-limit
+        arguments: [120]
+  unparam:
+    check-exported: true
+  whitespace:
+    multi-if: false
+    multi-func: false
+
+linters:
+  disable-all: true
+  enable:
+    - asasalint
+    - asciicheck
+    - bidichk
+    - bodyclose
+    - dogsled
+    - dupword
+    - durationcheck
+    - errcheck
+    - errchkjson
+    - exportloopref
+    - ginkgolinter
+    - goconst
+    - gofmt
+    - goheader
+    - goimports
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - govet
+    - importas
+    - ineffassign
+    - misspell
+    - nakedret
+    - nilerr
+    - noctx
+    - nolintlint
+    - nosprintfhostport
+    - revive
+    - staticcheck
+    - stylecheck
+    - unconvert
+    - unparam
+    - unused
+    - usestdlibvars
+    - whitespace
+  fast: false
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
+severity:
+  default-severity: error
+  case-sensitive: false

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,6 +1,5 @@
-# Documentation reference https://golangci-lint.run/usage/configuration/
+# Documentation reference https://github.com/golangci/golangci-lint/blob/v1.55.2/.golangci.reference.yml
 run:
-  concurrency: 4
   skip-dirs-use-default: false
   modules-download-mode: readonly
   allow-parallel-runners: false
@@ -24,10 +23,7 @@ linters-settings:
   gofmt:
     simplify: true
   govet:
-    disable-all: false
-    enable:
-      - atomicalign
-    enable-all: false
+    enable-all: true
   misspell:
     locale: US
   nakedret:
@@ -89,6 +85,11 @@ linters:
   fast: false
 
 issues:
+  exclude-use-default: false
+  exclude-rules:
+    - linters:
+        - revive
+      text: "^struct-tag: unknown option 'inline' in JSON tag$"
   max-issues-per-linter: 0
   max-same-issues: 0
 

--- a/controllers/bsl.go
+++ b/controllers/bsl.go
@@ -218,7 +218,7 @@ func (r *DPAReconciler) UpdateCredentialsSecretLabels(secretName string, namespa
 			return false, err
 		}
 
-		r.EventRecorder.Event(&secret, corev1.EventTypeNormal, "SecretLabelled", fmt.Sprintf("Secret %s has been labelled", secretName))
+		r.EventRecorder.Event(&secret, corev1.EventTypeNormal, "SecretLabelled", fmt.Sprintf("Secret %s has been labeled", secretName))
 	}
 	return true, nil
 }

--- a/controllers/bucket_controller.go
+++ b/controllers/bucket_controller.go
@@ -3,13 +3,14 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"os"
+	"strconv"
+	"time"
+
 	"github.com/openshift/oadp-operator/pkg/common"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"os"
-	"strconv"
-	"time"
 
 	"github.com/go-logr/logr"
 	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
@@ -159,12 +160,10 @@ func (b BucketReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 
 // SetupWithManager sets up the controller with the Manager.
 func (b *BucketReconciler) SetupWithManager(mgr ctrl.Manager) error {
-
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&oadpv1alpha1.CloudStorage{}).
 		WithEventFilter(bucketPredicate()).
 		Complete(b)
-
 }
 
 func bucketPredicate() predicate.Predicate {
@@ -216,7 +215,6 @@ func (b *BucketReconciler) WaitForSecret(namespace, name string) (*corev1.Secret
 	}
 
 	err := wait.PollImmediate(5*time.Second, timeout, func() (bool, error) {
-
 		err := b.Client.Get(context.Background(), key, &secret)
 		if err != nil {
 			if errors.IsNotFound(err) {

--- a/controllers/dpa_controller.go
+++ b/controllers/dpa_controller.go
@@ -116,7 +116,6 @@ func (r *DPAReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 				Message: err.Error(),
 			},
 		)
-
 	} else {
 		apimeta.SetStatusCondition(&dpa.Status.Conditions,
 			metav1.Condition{
@@ -167,10 +166,8 @@ func (l *labelHandler) Create(evt event.CreateEvent, q workqueue.RateLimitingInt
 		Name:      dpaname,
 		Namespace: namespace,
 	}})
-
 }
 func (l *labelHandler) Delete(evt event.DeleteEvent, q workqueue.RateLimitingInterface) {
-
 	namespace := evt.Object.GetNamespace()
 	dpaname := evt.Object.GetLabels()[namespace+".dataprotectionapplication"]
 	if evt.Object.GetLabels()[oadpv1alpha1.OadpOperatorLabel] == "" || dpaname == "" {
@@ -180,7 +177,6 @@ func (l *labelHandler) Delete(evt event.DeleteEvent, q workqueue.RateLimitingInt
 		Name:      dpaname,
 		Namespace: namespace,
 	}})
-
 }
 func (l *labelHandler) Update(evt event.UpdateEvent, q workqueue.RateLimitingInterface) {
 	namespace := evt.ObjectNew.GetNamespace()
@@ -192,10 +188,8 @@ func (l *labelHandler) Update(evt event.UpdateEvent, q workqueue.RateLimitingInt
 		Name:      dpaname,
 		Namespace: namespace,
 	}})
-
 }
 func (l *labelHandler) Generic(evt event.GenericEvent, q workqueue.RateLimitingInterface) {
-
 	namespace := evt.Object.GetNamespace()
 	dpaname := evt.Object.GetLabels()[namespace+".dataprotectionapplication"]
 	if evt.Object.GetLabels()[oadpv1alpha1.OadpOperatorLabel] == "" || dpaname == "" {
@@ -205,7 +199,6 @@ func (l *labelHandler) Generic(evt event.GenericEvent, q workqueue.RateLimitingI
 		Name:      dpaname,
 		Namespace: namespace,
 	}})
-
 }
 
 type ReconcileFunc func(logr.Logger) (bool, error)

--- a/controllers/nodeagent.go
+++ b/controllers/nodeagent.go
@@ -392,7 +392,6 @@ func (r *DPAReconciler) ReconcileFsRestoreHelperConfig(log logr.Logger) (bool, e
 	}
 
 	op, err := controllerutil.CreateOrPatch(r.Context, r.Client, &fsRestoreHelperCM, func() error {
-
 		// update the Config Map
 		err := r.updateFsRestoreHelperCM(&fsRestoreHelperCM, &dpa)
 		return err
@@ -416,7 +415,6 @@ func (r *DPAReconciler) ReconcileFsRestoreHelperConfig(log logr.Logger) (bool, e
 }
 
 func (r *DPAReconciler) updateFsRestoreHelperCM(fsRestoreHelperCM *corev1.ConfigMap, dpa *oadpv1alpha1.DataProtectionApplication) error {
-
 	// Setting controller owner reference on the FS restore helper CM
 	err := controllerutil.SetControllerReference(dpa, fsRestoreHelperCM, r.Scheme)
 	if err != nil {

--- a/controllers/nodeagent_test.go
+++ b/controllers/nodeagent_test.go
@@ -2489,7 +2489,6 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 }
 
 func TestDPAReconciler_updateFsRestoreHelperCM(t *testing.T) {
-
 	tests := []struct {
 		name                  string
 		fsRestoreHelperCM     *v1.ConfigMap

--- a/controllers/registry.go
+++ b/controllers/registry.go
@@ -214,7 +214,6 @@ func registryName(bsl *velerov1.BackupStorageLocation) string {
 }
 
 func (r *DPAReconciler) getProviderSecret(secretName string) (corev1.Secret, error) {
-
 	secret := corev1.Secret{}
 	key := types.NamespacedName{
 		Name:      secretName,
@@ -244,7 +243,6 @@ func replaceCarriageReturn(data map[string][]byte, logger logr.Logger) map[strin
 }
 
 func (r *DPAReconciler) getSecretNameAndKeyforBackupLocation(bslspec oadpv1alpha1.BackupLocation) (string, string) {
-
 	if bslspec.CloudStorage != nil {
 		if bslspec.CloudStorage.Credential != nil {
 			return bslspec.CloudStorage.Credential.Name, bslspec.CloudStorage.Credential.Key
@@ -258,7 +256,7 @@ func (r *DPAReconciler) getSecretNameAndKeyforBackupLocation(bslspec oadpv1alpha
 }
 
 func (r *DPAReconciler) getSecretNameAndKey(bslSpec *velerov1.BackupStorageLocationSpec, plugin oadpv1alpha1.DefaultPlugin) (string, string) {
-	// Assume default values unless user has overriden them
+	// Assume default values unless user has overridden them
 	secretName := credentials.PluginSpecificFields[plugin].SecretName
 	secretKey := credentials.PluginSpecificFields[plugin].PluginSecretKey
 	if _, ok := bslSpec.Config["credentialsFile"]; ok {
@@ -283,7 +281,6 @@ func (r *DPAReconciler) getSecretNameAndKey(bslSpec *velerov1.BackupStorageLocat
 }
 
 func (r *DPAReconciler) parseAWSSecret(secret corev1.Secret, secretKey string, matchProfile string) (string, string, error) {
-
 	AWSAccessKey, AWSSecretKey, profile := "", "", ""
 	splitString := strings.Split(string(secret.Data[secretKey]), "\n")
 	keyNameRegex, err := regexp.Compile(`\[.*\]`)
@@ -368,7 +365,6 @@ func (r *DPAReconciler) parseAWSSecret(secret corev1.Secret, secretKey string, m
 }
 
 func (r *DPAReconciler) parseAzureSecret(secret corev1.Secret, secretKey string) (azureCredentials, error) {
-
 	azcreds := azureCredentials{}
 
 	splitString := strings.Split(string(secret.Data[secretKey]), "\n")
@@ -577,7 +573,6 @@ func (r *DPAReconciler) ReconcileRegistryRoutes(log logr.Logger) (bool, error) {
 }
 
 func (r *DPAReconciler) ReconcileRegistryRouteConfigs(log logr.Logger) (bool, error) {
-
 	// Now for each of these bsl instances, create a registry route cm for each of them
 	registryRouteCM := corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{

--- a/controllers/registry_test.go
+++ b/controllers/registry_test.go
@@ -297,7 +297,6 @@ func TestDPAReconciler_getSecretNameAndKeyforBackupLocation(t *testing.T) {
 }
 
 func TestDPAReconciler_populateAWSRegistrySecret(t *testing.T) {
-
 	tests := []struct {
 		name           string
 		bsl            *velerov1.BackupStorageLocation

--- a/controllers/validator.go
+++ b/controllers/validator.go
@@ -55,7 +55,6 @@ func (r *DPAReconciler) ValidateDataProtectionCR(log logr.Logger) (bool, error) 
 
 		// Check the Velero flags 'no-secret' or 'no-default-backup-location' are not set
 		if !dpa.Spec.Configuration.Velero.HasFeatureFlag("no-secret") || dpa.Spec.Configuration.Velero.NoDefaultBackupLocation {
-
 			// Check if the BSL secret key configured in the DPA exists with a secret data
 			secretName, secretKey := r.getSecretNameAndKeyforBackupLocation(location)
 			bslSecret, err := r.getProviderSecret(secretName)

--- a/controllers/velero.go
+++ b/controllers/velero.go
@@ -143,7 +143,6 @@ func (r *DPAReconciler) veleroClusterRoleBinding(dpa *oadpv1alpha1.DataProtectio
 
 // Build VELERO Deployment
 func (r *DPAReconciler) buildVeleroDeployment(veleroDeployment *appsv1.Deployment, dpa *oadpv1alpha1.DataProtectionApplication) error {
-
 	if dpa == nil {
 		return fmt.Errorf("DPA CR cannot be nil")
 	}
@@ -448,7 +447,6 @@ func getFsBackupTimeout(dpa *oadpv1alpha1.DataProtectionApplication) string {
 }
 
 func (r *DPAReconciler) isSTSTokenNeeded(bsls []oadpv1alpha1.BackupLocation, ns string) bool {
-
 	for _, bsl := range bsls {
 		if bsl.CloudStorage != nil {
 			bucket := &oadpv1alpha1.CloudStorage{}
@@ -502,7 +500,6 @@ func getAppLabels(instanceName string) map[string]string {
 
 // Get Velero Resource Requirements
 func (r *DPAReconciler) getVeleroResourceReqs(dpa *oadpv1alpha1.DataProtectionApplication) (corev1.ResourceRequirements, error) {
-
 	// Set default values
 	ResourcesReqs := corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
@@ -550,7 +547,6 @@ func (r *DPAReconciler) getVeleroResourceReqs(dpa *oadpv1alpha1.DataProtectionAp
 				return ResourcesReqs, err
 			}
 		}
-
 	}
 
 	return ResourcesReqs, nil
@@ -558,7 +554,6 @@ func (r *DPAReconciler) getVeleroResourceReqs(dpa *oadpv1alpha1.DataProtectionAp
 
 // Get Restic Resource Requirements
 func getResticResourceReqs(dpa *oadpv1alpha1.DataProtectionApplication) (corev1.ResourceRequirements, error) {
-
 	// Set default values
 	ResourcesReqs := corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
@@ -606,7 +601,6 @@ func getResticResourceReqs(dpa *oadpv1alpha1.DataProtectionApplication) (corev1.
 				return ResourcesReqs, err
 			}
 		}
-
 	}
 
 	return ResourcesReqs, nil
@@ -616,7 +610,6 @@ func getResticResourceReqs(dpa *oadpv1alpha1.DataProtectionApplication) (corev1.
 // Separate function to getResticResourceReqs, so once Restic config is removed in OADP 1.4+
 // It will be easier to delete obsolete getResticResourceReqs
 func getNodeAgentResourceReqs(dpa *oadpv1alpha1.DataProtectionApplication) (corev1.ResourceRequirements, error) {
-
 	// Set default values
 	ResourcesReqs := corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
@@ -664,7 +657,6 @@ func getNodeAgentResourceReqs(dpa *oadpv1alpha1.DataProtectionApplication) (core
 				return ResourcesReqs, err
 			}
 		}
-
 	}
 
 	return ResourcesReqs, nil
@@ -672,7 +664,7 @@ func getNodeAgentResourceReqs(dpa *oadpv1alpha1.DataProtectionApplication) (core
 
 // noDefaultCredentials determines if a provider needs the default credentials.
 // This returns a map of providers found to if they need a default credential,
-// a boolean if Cloud Storage backup storage location was used and an error if any occured.
+// a boolean if Cloud Storage backup storage location was used and an error if any occurred.
 func (r DPAReconciler) noDefaultCredentials(dpa oadpv1alpha1.DataProtectionApplication) (map[string]bool, bool, error) {
 	providerNeedsDefaultCreds := map[string]bool{}
 	hasCloudStorage := false
@@ -731,5 +723,4 @@ func (r DPAReconciler) noDefaultCredentials(dpa oadpv1alpha1.DataProtectionAppli
 	}
 
 	return providerNeedsDefaultCreds, hasCloudStorage, nil
-
 }

--- a/controllers/vsl.go
+++ b/controllers/vsl.go
@@ -99,7 +99,6 @@ func (r *DPAReconciler) LabelVSLSecrets(log logr.Logger) (bool, error) {
 				}
 			}
 		}
-
 	}
 	return true, nil
 }
@@ -161,7 +160,6 @@ func (r *DPAReconciler) ValidateVolumeSnapshotLocations(dpa oadpv1alpha1.DataPro
 
 		//GCP
 		if vslSpec.Velero.Provider == GCPProvider {
-
 			// check for invalid config key
 			for key := range vslSpec.Velero.Config {
 				valid := validGCPKeys[key]
@@ -183,7 +181,6 @@ func (r *DPAReconciler) ValidateVolumeSnapshotLocations(dpa oadpv1alpha1.DataPro
 
 		//Azure
 		if vslSpec.Velero.Provider == Azure {
-
 			// check for invalid config key
 			for key := range vslSpec.Velero.Config {
 				valid := validAzureKeys[key]
@@ -251,7 +248,6 @@ func (r *DPAReconciler) ReconcileVolumeSnapshotLocations(log logr.Logger) (bool,
 				fmt.Sprintf("performed %s on volumesnapshotlocation %s/%s", op, vsl.Namespace, vsl.Name),
 			)
 		}
-
 	}
 	return true, nil
 }

--- a/controllers/vsl_test.go
+++ b/controllers/vsl_test.go
@@ -520,7 +520,6 @@ func TestDPAReconciler_ValidateVolumeSnapshotLocation(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestDPAReconciler_ReconcileVolumeSnapshotLocations(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"os"
+
 	"github.com/openshift/oadp-operator/pkg/common"
 	monitor "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -27,7 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes"
-	"os"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
@@ -283,7 +284,6 @@ func DoesCRDExist(CRDGroupVersion, CRDName string) (bool, error) {
 		}
 	}
 	return discoveryResult, nil
-
 }
 
 // CreateCredRequest WITP : WebIdentityTokenPath

--- a/pkg/bucket/client.go
+++ b/pkg/bucket/client.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/openshift/oadp-operator/pkg/common"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+
+	"github.com/openshift/oadp-operator/pkg/common"
 
 	"github.com/openshift/oadp-operator/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"

--- a/pkg/credentials/credentials.go
+++ b/pkg/credentials/credentials.go
@@ -153,7 +153,6 @@ func getKubeVirtPluginImage(dpa *oadpv1alpha1.DataProtectionApplication) string 
 
 func getPluginImage(pluginName string, dpa *oadpv1alpha1.DataProtectionApplication) string {
 	switch pluginName {
-
 	case common.VeleroPluginForAWS:
 		return getAWSPluginImage(dpa)
 
@@ -195,7 +194,6 @@ func AppendCloudProviderVolumes(dpa *oadpv1alpha1.DataProtectionApplication, ds 
 			cloudProviderMap.IsCloudProvider && //if plugin is a cloud provider plugin, and one of the following condition is true
 			(!dpa.Spec.Configuration.Velero.NoDefaultBackupLocation || // it has a backup location in OADP/velero context OR
 				dpa.Spec.UnsupportedOverrides[oadpv1alpha1.OperatorTypeKey] == oadpv1alpha1.OperatorTypeMTC) { // OADP is installed via MTC
-
 			pluginNeedsCheck, foundProviderPlugin := providerNeedsDefaultCreds[string(plugin)]
 			if !foundProviderPlugin && !hasCloudStorage {
 				pluginNeedsCheck = true
@@ -235,7 +233,6 @@ func AppendCloudProviderVolumes(dpa *oadpv1alpha1.DataProtectionApplication, ds 
 					},
 				)
 			}
-
 		}
 	}
 	for _, bslSpec := range dpa.Spec.BackupLocations {
@@ -260,7 +257,6 @@ func AppendCloudProviderVolumes(dpa *oadpv1alpha1.DataProtectionApplication, ds 
 
 // add plugin specific specs to velero deployment
 func AppendPluginSpecificSpecs(dpa *oadpv1alpha1.DataProtectionApplication, veleroDeployment *appsv1.Deployment, veleroContainer *corev1.Container, providerNeedsDefaultCreds map[string]bool, hasCloudStorage bool) error {
-
 	init_container_resources := veleroContainer.Resources
 
 	for _, plugin := range dpa.Spec.Configuration.Velero.DefaultPlugins {
@@ -356,7 +352,7 @@ func AppendPluginSpecificSpecs(dpa *oadpv1alpha1.DataProtectionApplication, vele
 
 // TODO: remove duplicate func in registry.go - refactoring away registry.go later
 func GetSecretNameAndKey(bslSpec *velerov1.BackupStorageLocationSpec, plugin oadpv1alpha1.DefaultPlugin) (string, string) {
-	// Assume default values unless user has overriden them
+	// Assume default values unless user has overridden them
 	secretName := PluginSpecificFields[plugin].SecretName
 	secretKey := PluginSpecificFields[plugin].PluginSecretKey
 	if _, ok := bslSpec.Config["credentialsFile"]; ok {

--- a/tests/e2e/lib/apps.go
+++ b/tests/e2e/lib/apps.go
@@ -150,7 +150,6 @@ func DoesSCCExist(ocClient client.Client, sccName string) (bool, error) {
 		return false, err
 	}
 	return true, nil
-
 }
 
 func UninstallApplication(ocClient client.Client, file string) error {
@@ -543,7 +542,6 @@ func verifyVolume(volumeFile string, volumeApi string, prebackupState bool, back
 		if err != nil {
 			return err
 		}
-
 	} else {
 		volumeBackupData, err := os.ReadFile(volumeFile)
 		if err != nil {

--- a/tests/e2e/lib/restore.go
+++ b/tests/e2e/lib/restore.go
@@ -52,7 +52,6 @@ func IsRestoreDone(ocClient client.Client, veleroNamespace, name string) wait.Co
 			}
 		}
 		return true, nil
-
 	}
 }
 


### PR DESCRIPTION
Add more linting checks to project with `golangci-lint`.

`.golangci.yaml` is similar to the one proposed at https://github.com/vmware-tanzu/velero/pull/7194

## Test

Run `golangci-lint` with new `make lint` and `make lint-fix` commands.

## TODO

All go files changes where done through `make lint-fix` command. There are still a lot of issues to be resolved in the code.

`golangci-lint` comes with newer versions of kubebuilder, if https://github.com/openshift/oadp-operator/pull/1250 is accepted, merge this one first and add `golangci-lint` to operator-sdk version update docs.