### PR TITLE
fix: Fix codecov post job

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -275,7 +275,7 @@ submit-coverage:
 	curl -Os https://uploader.codecov.io/latest/$(OS_String)/codecov
 	chmod +x codecov
 	./codecov -C $(shell git rev-parse HEAD) -r openshift/oadp-operator
-	rm -f codecov tmp.*
+	rm -f codecov
 
 # go-install-tool will 'go install' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))

--- a/Makefile
+++ b/Makefile
@@ -274,14 +274,7 @@ endif
 submit-coverage:
 	curl -Os https://uploader.codecov.io/latest/$(OS_String)/codecov
 	chmod +x codecov
-	./codecov > tmp.results 2> tmp.err
-	cat tmp.results || echo "tmp.results not found"
-	cat tmp.err || echo "tmp.err not found"
-	@echo $$(cat tmp.results | grep 'resultURL' -c)
-	@echo $$(cat tmp.err | grep 'please specify sha and slug manually' -c)
-	if [ $$(cat tmp.err | grep 'please specify sha and slug manually' -c) == 1 ]; then \
-		echo "specifying sha and slug manually" && ./codecov -C $(shell git rev-parse HEAD) -r openshift/oadp-operator; \
-	fi
+	./codecov -C $(shell git rev-parse HEAD) -r openshift/oadp-operator
 	rm -f codecov tmp.*
 
 # go-install-tool will 'go install' any package $2 and install it to $1.


### PR DESCRIPTION
Fix silent error happening in CI. Example
```
[2023-12-11T19:59:53.180Z] ['error'] There was an error running the uploader: 
Unable to detect SHA and slug, please specify them manually.
See the help for more details.
```
Reference https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/branch-ci-openshift-oadp-operator-master-unit-test-post/1734300664726556672/artifacts/unit-test-post/unit/build-log.txt