### PR TITLE
OADP-3229: must-gather collect CRDs

### DIFF
--- a/must-gather/Dockerfile
+++ b/must-gather/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/konveyor/builder:latest as konveyor-builder
+FROM quay.io/konveyor/builder:latest AS konveyor-builder
 ARG RESTIC_BRANCH=konveyor-0.15.0
 ARG VELERO_BRANCH=konveyor-dev
 WORKDIR /build
@@ -12,11 +12,11 @@ RUN curl --location --output velero.tgz https://github.com/openshift/velero/arch
     CGO_ENABLED=0 GOOS=linux go build -a -mod=mod -ldflags '-extldflags "-static"' -o /restic github.com/restic/restic/cmd/restic && \
     cd .. && rm -rf restic.tgz restic-${RESTIC_BRANCH}
 
-FROM registry.access.redhat.com/ubi8/go-toolset:1.17.10 as gobuilder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.17.10 AS gobuilder
 
 RUN go install -v github.com/google/pprof@latest
 
-FROM quay.io/openshift/origin-must-gather:4.10 as builder
+FROM quay.io/openshift/origin-must-gather:4.10 AS builder
 
 FROM registry.access.redhat.com/ubi8-minimal:latest
 

--- a/must-gather/collection-scripts/gather
+++ b/must-gather/collection-scripts/gather
@@ -24,8 +24,8 @@ for ns in ${namespaces[@]}; do
   done
 
 # Collect Velero and OADP CRs
-echo "Gathering Velero and OADP CRs for namespaces [${namespaces[@]}]"
-/usr/bin/gather_crs ${clusterID} ${namespaces[@]} &
+echo "Gathering Velero and OADP CRs"
+/usr/bin/gather_crs ${clusterID} &
 pids+=($!)
 
 # Collect Velero and OADP CRDs

--- a/must-gather/collection-scripts/gather
+++ b/must-gather/collection-scripts/gather
@@ -23,8 +23,8 @@ for ns in ${namespaces[@]}; do
     pids+=($!)
   done
 
-# Collect DPA CRs
-echo "Gathering DPA CRs for namespaces [${namespaces[@]}]"
+# Collect Velero and OADP CRs
+echo "Gathering Velero and OADP CRs for namespaces [${namespaces[@]}]"
 /usr/bin/gather_crs ${clusterID} ${namespaces[@]} &
 pids+=($!)
 
@@ -68,7 +68,7 @@ else
   find /must-gather/clusters/*/namespaces/*/pods/ -name '*.log' -delete
 fi
 
-# Tar all must-gather artifacts for faster transmission 
+# Tar all must-gather artifacts for faster transmission
 echo "Tarring must-gather artifacts..."
 archive_path="/must-gather-archive"
 mkdir -p ${archive_path}

--- a/must-gather/collection-scripts/gather
+++ b/must-gather/collection-scripts/gather
@@ -28,6 +28,11 @@ echo "Gathering DPA CRs for namespaces [${namespaces[@]}]"
 /usr/bin/gather_crs ${clusterID} ${namespaces[@]} &
 pids+=($!)
 
+# Collect Velero and OADP CRDs
+echo "Gathering Velero and OADP CRDs"
+/usr/bin/gather_crds ${clusterID} &
+pids+=($!)
+
 # Collect the logs"
 echo "[cluster=${clusterID}] Gathering logs for namespaces [${namespaces[@]}]"
 /usr/bin/gather_logs ${clusterID} ${logs_since} ${request_timeout} ${skip_tls} ${namespaces[@]} &

--- a/must-gather/collection-scripts/gather_crds
+++ b/must-gather/collection-scripts/gather_crds
@@ -1,6 +1,4 @@
 #!/bin/bash
-source pwait
-max_parallelism=10
 
 # Cluster passed in from main gather
 clusterID=$1
@@ -14,12 +12,12 @@ resources+=($(/usr/bin/oc get crd | awk '/oadp.openshift.io/{print $1}'))
 # Velero
 resources+=($(/usr/bin/oc get crd | awk '/velero.io/{print $1}'))
 
-echo "Starting collection of CRDs: [${resources[@]}]"
+echo "Starting collection of CRDs:" "${resources[@]}"
 object_collection_path=/must-gather/clusters/${clusterID}/cluster-scoped-resources/apiextensions.k8s.io/customresourcedefinitions
 
-for resource in ${resources[@]}; do
+for resource in "${resources[@]}"; do
   echo "Collecting ${resource} CRD"
-  mkdir -p ${object_collection_path}
-  /usr/bin/oc get crd ${resource} -o yaml &> ${object_collection_path}/${resource}.yaml &
+  mkdir -p "${object_collection_path}"
+  /usr/bin/oc get crd "${resource}" -o yaml &> "${object_collection_path}/${resource}.yaml" &
 done
 wait

--- a/must-gather/collection-scripts/gather_crds
+++ b/must-gather/collection-scripts/gather_crds
@@ -1,0 +1,31 @@
+#!/bin/bash
+source pwait
+max_parallelism=10
+
+# Cluster passed in from main gather
+clusterID=$1
+
+# Resource list
+resources=()
+
+# OADP
+for i in $(/usr/bin/oc get crd | grep oadp.openshift.io | awk '{print $1}'); do
+  resources+=($i)
+done
+
+# Velero
+for i in $(/usr/bin/oc get crd | grep velero.io | awk '{print $1}'); do
+  resources+=($i)
+done
+
+echo "Starting collection of: [${resources[@]}]"
+
+# we use nested loops to nicely output objects partitioned per kind
+for resource in ${resources[@]}; do
+  echo "Collecting ${resource} CRD"
+  # cluster-scoped-resources/apiextensions.k8s.io/customresourcedefinitions/
+  object_collection_path=/must-gather/cluster-scoped-resources/apiextensions.k8s.io/customresourcedefinitions
+  mkdir -p ${object_collection_path}
+  /usr/bin/oc get crd ${resource} -o yaml &> ${object_collection_path}/${resource}.yaml &
+done
+wait

--- a/must-gather/collection-scripts/gather_crds
+++ b/must-gather/collection-scripts/gather_crds
@@ -22,7 +22,7 @@ echo "Starting collection of CRDs: [${resources[@]}]"
 
 for resource in ${resources[@]}; do
   echo "Collecting ${resource} CRD"
-  object_collection_path=/must-gather/cluster-scoped-resources/apiextensions.k8s.io/customresourcedefinitions
+  object_collection_path=/must-gather/clusters/${clusterID}/cluster-scoped-resources/apiextensions.k8s.io/customresourcedefinitions
   mkdir -p ${object_collection_path}
   /usr/bin/oc get crd ${resource} -o yaml &> ${object_collection_path}/${resource}.yaml &
 done

--- a/must-gather/collection-scripts/gather_crds
+++ b/must-gather/collection-scripts/gather_crds
@@ -18,12 +18,10 @@ for i in $(/usr/bin/oc get crd | grep velero.io | awk '{print $1}'); do
   resources+=($i)
 done
 
-echo "Starting collection of: [${resources[@]}]"
+echo "Starting collection of CRDs: [${resources[@]}]"
 
-# we use nested loops to nicely output objects partitioned per kind
 for resource in ${resources[@]}; do
   echo "Collecting ${resource} CRD"
-  # cluster-scoped-resources/apiextensions.k8s.io/customresourcedefinitions/
   object_collection_path=/must-gather/cluster-scoped-resources/apiextensions.k8s.io/customresourcedefinitions
   mkdir -p ${object_collection_path}
   /usr/bin/oc get crd ${resource} -o yaml &> ${object_collection_path}/${resource}.yaml &

--- a/must-gather/collection-scripts/gather_crds
+++ b/must-gather/collection-scripts/gather_crds
@@ -9,20 +9,16 @@ clusterID=$1
 resources=()
 
 # OADP
-for i in $(/usr/bin/oc get crd | grep oadp.openshift.io | awk '{print $1}'); do
-  resources+=($i)
-done
+resources+=($(/usr/bin/oc get crd | awk '/oadp.openshift.io/{print $1}'))
 
 # Velero
-for i in $(/usr/bin/oc get crd | grep velero.io | awk '{print $1}'); do
-  resources+=($i)
-done
+resources+=($(/usr/bin/oc get crd | awk '/velero.io/{print $1}'))
 
 echo "Starting collection of CRDs: [${resources[@]}]"
+object_collection_path=/must-gather/clusters/${clusterID}/cluster-scoped-resources/apiextensions.k8s.io/customresourcedefinitions
 
 for resource in ${resources[@]}; do
   echo "Collecting ${resource} CRD"
-  object_collection_path=/must-gather/clusters/${clusterID}/cluster-scoped-resources/apiextensions.k8s.io/customresourcedefinitions
   mkdir -p ${object_collection_path}
   /usr/bin/oc get crd ${resource} -o yaml &> ${object_collection_path}/${resource}.yaml &
 done

--- a/must-gather/collection-scripts/gather_crs
+++ b/must-gather/collection-scripts/gather_crs
@@ -4,8 +4,6 @@ max_parallelism=10
 
 # Cluster passed in from main gather
 clusterID=$1
-shift
-namespaces=("$@")
 
 # Resource list
 resources=()
@@ -16,21 +14,21 @@ resources+=($(/usr/bin/oc get crd | awk '/oadp.openshift.io/{print $1}'))
 # Velero
 resources+=($(/usr/bin/oc get crd | awk '/velero.io/{print $1}'))
 
-echo "Starting collection of: [${resources[@]}]"
+echo "Starting collection of:" "${resources[@]}"
 
 # we use nested loops to nicely output objects partitioned per namespace, kind
-for resource in ${resources[@]}; do
-  /usr/bin/oc get ${resource} --all-namespaces -o custom-columns=NAMESPACE:.metadata.namespace --no-headers 2> /dev/null | uniq | \
+for resource in "${resources[@]}"; do
+  /usr/bin/oc get "${resource}" --all-namespaces -o custom-columns=NAMESPACE:.metadata.namespace --no-headers 2> /dev/null | uniq | \
   while read namespace; do
-    resource_name=$(echo $resource | cut -d "." -f 1)
+    resource_name=$(echo "$resource" | cut -d "." -f 1)
     echo "Collecting ${resource_name} in ${namespace} namespace"
     if echo "${resource}" | grep -q velero.io; then
       object_collection_path=/must-gather/clusters/${clusterID}/namespaces/${namespace}/velero.io/${resource_name}
     else
       object_collection_path=/must-gather/clusters/${clusterID}/namespaces/${namespace}/oadp.openshift.io/${resource_name}
     fi
-    mkdir -p ${object_collection_path}
-    /usr/bin/oc get ${resource} -n ${namespace} -o yaml &> ${object_collection_path}/${resource_name}.yaml &
+    mkdir -p "${object_collection_path}"
+    /usr/bin/oc get "${resource}" -n "${namespace}" -o yaml &> "${object_collection_path}/${resource_name}.yaml" &
     pwait $max_parallelism
   done
 done

--- a/must-gather/collection-scripts/gather_crs
+++ b/must-gather/collection-scripts/gather_crs
@@ -11,20 +11,16 @@ namespaces=("$@")
 resources=()
 
 # OADP
-for i in $(/usr/bin/oc get crd | grep oadp.openshift.io | awk '{print $1}'); do
-  resources+=($i)
-done
+resources+=($(/usr/bin/oc get crd | awk '/oadp.openshift.io/{print $1}'))
 
 # Velero
-for i in $(/usr/bin/oc get crd | grep velero.io | awk '{print $1}'); do
-  resources+=($i)
-done
+resources+=($(/usr/bin/oc get crd | awk '/velero.io/{print $1}'))
 
 echo "Starting collection of: [${resources[@]}]"
 
 # we use nested loops to nicely output objects partitioned per namespace, kind
 for resource in ${resources[@]}; do
-  /usr/bin/oc get ${resource} --all-namespaces -o custom-columns=NAMESPACE:.metadata.namespace --no-headers 2> /dev/null | \
+  /usr/bin/oc get ${resource} --all-namespaces -o custom-columns=NAMESPACE:.metadata.namespace --no-headers 2> /dev/null | uniq | \
   while read namespace; do
     resource_name=$(echo $resource | cut -d "." -f 1)
     echo "Collecting ${resource_name} in ${namespace} namespace"

--- a/must-gather/collection-scripts/gather_crs
+++ b/must-gather/collection-scripts/gather_crs
@@ -27,7 +27,7 @@ for resource in ${resources[@]}; do
   /usr/bin/oc get ${resource} --all-namespaces -o custom-columns=NAMESPACE:.metadata.namespace --no-headers 2> /dev/null | \
   while read namespace; do
     resource_name=$(echo $resource | cut -d "." -f 1)
-    echo "Collecting ${resource_name}"
+    echo "Collecting ${resource_name} in ${namespace} namespace"
     if echo "${resource}" | grep -q velero.io; then
       object_collection_path=/must-gather/clusters/${clusterID}/namespaces/${namespace}/velero.io/${resource_name}
     else

--- a/must-gather/collection-scripts/gather_crs
+++ b/must-gather/collection-scripts/gather_crs
@@ -24,33 +24,17 @@ echo "Starting collection of: [${resources[@]}]"
 
 # we use nested loops to nicely output objects partitioned per namespace, kind
 for resource in ${resources[@]}; do
-  echo "Collecting ${resource}"
-  /usr/bin/oc get ${resource} --all-namespaces -o custom-columns=NAME:.metadata.name,NAMESPACE:.metadata.namespace --no-headers 2> /dev/null | \
-  while read ocresource; do
-    ocobject=$(echo $ocresource | awk '{print $1}')
-    ocproject=$(echo $ocresource | awk '{print $2}')
-    if [ -z "${ocproject}" ]|[ "${ocproject}" == "<none>" ]; then
-      object_collection_path=/must-gather/clusters/${clusterID}/cluster-scoped-resources/${resource}
-      mkdir -p ${object_collection_path}
-      /usr/bin/oc get ${resource} -o yaml ${ocobject} &> ${object_collection_path}/${ocobject}.yaml &
+  /usr/bin/oc get ${resource} --all-namespaces -o custom-columns=NAMESPACE:.metadata.namespace --no-headers 2> /dev/null | \
+  while read namespace; do
+    resource_name=$(echo $resource | cut -d "." -f 1)
+    echo "Collecting ${resource_name}"
+    if echo "${resource}" | grep -q velero.io; then
+      object_collection_path=/must-gather/clusters/${clusterID}/namespaces/${namespace}/velero.io/${resource_name}
     else
-      #TODO: verify if there are more crds to add for oadp
-      skip=("dataprotectionapplications.oadp.openshift.io")
-      if [[ ${skip[*]} =~ "${resource}" ]]; then
-        continue
-      fi
-      object_collection_path=/must-gather/clusters/${clusterID}/namespaces/${ocproject}/velero.io/${resource}
-      mkdir -p ${object_collection_path}
-      /usr/bin/oc get ${resource} -n ${ocproject} -o yaml ${ocobject} &> ${object_collection_path}/${ocobject}.yaml & 
+      object_collection_path=/must-gather/clusters/${clusterID}/namespaces/${namespace}/oadp.openshift.io/${resource_name}
     fi
-    pwait $max_parallelism
-  done
-done
-
-for ns in ${namespaces[@]}; do
-  for dpa in $(oc get dpa --namespace ${ns} --no-headers | awk '{print $1}'); do
-    mkdir -p "/must-gather/clusters/${clusterID}/namespaces/${ns}/oadp.openshift.io/dpa-${dpa}"
-    oc get dpa ${dpa} -o yaml --namespace ${ns} &> "/must-gather/clusters/${clusterID}/namespaces/${ns}/oadp.openshift.io/dpa-${dpa}/${dpa}.yml" &
+    mkdir -p ${object_collection_path}
+    /usr/bin/oc get ${resource} -n ${namespace} -o yaml &> ${object_collection_path}/${resource_name}.yaml &
     pwait $max_parallelism
   done
 done

--- a/must-gather/collection-scripts/gather_logs_without_zip
+++ b/must-gather/collection-scripts/gather_logs_without_zip
@@ -25,15 +25,6 @@ for ns in ${namespaces[@]}; do
     /usr/bin/gather_logs_pods ${clusterID} ${ns} ${logs_since} ${max_parallelism} &
 done
 
-# Collect the DPA CR
-for ns in ${namespaces[@]}; do
-  for dpa in $(oc get dpa --namespace ${ns} --no-headers | awk '{print $1}'); do
-    mkdir -p "/must-gather/clusters/${clusterID}/namespaces/${ns}/oadp.openshift.io/dpa-${dpa}"
-    oc get dpa ${dpa} -o yaml --namespace ${ns} &> "/must-gather/clusters/${clusterID}/namespaces/${ns}/oadp.openshift.io/dpa-${dpa}/${dpa}.yml" &
-    pwait $max_parallelism
-  done
-done
-
 # Waits for gather_crs, gather_logs, gather_metrics running in background
 echo "Waiting for background gather tasks to finish"
 wait


### PR DESCRIPTION
## Description

Add collection of Velero and OADP CRDs to must-gather.

## What was done

- Used `must-gather/collection-scripts/gather_crs` as base for new shell file writing. 
- Removed duplicated logic.
- Add collection of all OADP CRs (not only DPA).

> **WARNING:** some folder structures changed (example, DPAs where stored one by one in `oadp.openshift.io/dpa-<dpa-name>/<dpa-name>.yml` now are stored in a list in `oadp.openshift.io/dataprotectionapplications/dataprotectionapplications.yaml`. This was done to `omg` tool to work with generated must-gather folder. CHECK IF THIS DOES NOT BREAK ANYTHING

## How to test

On master branch and in this PR branch, run
```sh
cd must-gather/
make run
tar xzf must-gather.local.<rand>/ttl-sh-oadp-must-gather-<rand>/must-gather.tar.gz
```
Create `test.Dockerfile` file in `must-gather/` folder
```dockerfile
FROM python:3.10.12-slim-bullseye

WORKDIR /test-omg
COPY ./ ./
RUN pip install o-must-gather
```
Run
```sh
docker image build --tag omg-container -f test.Dockerfile .
docker container run -ti --rm omg-container bash
# inside container
omg use must-gather/clusters/
omg get backup -n <namespace> # and other Velero and OADP resources
```
In master branch, `omg get` should fail, but should succeed and show resources in this PR branch.
