### PR TITLE
Use full URI as the mongodb container image path.

### DIFF
--- a/tests/e2e/sample-applications/mongo-persistent/mongo-persistent-block.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/mongo-persistent-block.yaml
@@ -70,7 +70,7 @@ items:
           # Used to format the block device (put filesystem on it).
           # This allows Mongo to use the filesystem which lives on block device.
           initContainers:
-            - image: mongo:latest
+            - image: docker.io/library/mongo:latest
               securityContext:
                 privileged: true
               name: setup-block-device
@@ -100,7 +100,7 @@ items:
                 - name: block-volume-pv
                   devicePath: /dev/xvdx
           containers:
-            - image: mongo:latest
+            - image: docker.io/library/mongo:latest
               name: mongo
               securityContext:
                 privileged: true

--- a/tests/e2e/sample-applications/mongo-persistent/mongo-persistent-csi.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/mongo-persistent-csi.yaml
@@ -66,7 +66,7 @@ items:
         spec:
           serviceAccountName: mongo-persistent-sa
           containers:
-          - image: mongo:latest
+          - image: docker.io/library/mongo:latest
             name: mongo
             securityContext:
               privileged: true

--- a/tests/e2e/sample-applications/mongo-persistent/mongo-persistent.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/mongo-persistent.yaml
@@ -79,7 +79,7 @@ items:
         spec:
           serviceAccountName: mongo-persistent-sa
           containers:
-          - image: mongo:latest
+          - image: docker.io/library/mongo:latest
             name: mongo
             securityContext:
               privileged: true


### PR DESCRIPTION
Use of mongodb container path should use full URI which will limit chances of failures while trying to pull it from other sources.