### PR TITLE
Use more reliable way for checking if DB is alive from sample app.

### DIFF
--- a/tests/e2e/sample-applications/mongo-persistent/mongo-persistent-block.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/mongo-persistent-block.yaml
@@ -235,8 +235,8 @@ items:
                 protocol: TCP
           initContainers:
           - name: init-myservice
-            image: registry.access.redhat.com/ubi8/ubi:latest
-            command: ['sh', '-c', 'sleep 10; until getent hosts mongo; do echo waiting for mongo; sleep 5; done;']
+            image: docker.io/curlimages/curl:8.5.0
+            command: ['sh', '-c', 'sleep 10; until curl -s mongo:27017; do echo Trying to connect to mongo DB port; sleep 5; done; echo mongo DB port reachable']
   - apiVersion: v1
     kind: Service
     metadata:

--- a/tests/e2e/sample-applications/mongo-persistent/mongo-persistent-csi.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/mongo-persistent-csi.yaml
@@ -187,8 +187,8 @@ items:
                 protocol: TCP
           initContainers:
           - name: init-myservice
-            image: registry.access.redhat.com/ubi8/ubi:latest
-            command: ['sh', '-c', 'sleep 10; until getent hosts mongo; do echo waiting for mongo; sleep 5; done;']
+            image: docker.io/curlimages/curl:8.5.0
+            command: ['sh', '-c', 'sleep 10; until curl -s mongo:27017; do echo Trying to connect to mongo DB port; sleep 5; done; echo mongo DB port reachable']
   - apiVersion: v1
     kind: Service
     metadata:

--- a/tests/e2e/sample-applications/mongo-persistent/mongo-persistent.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/mongo-persistent.yaml
@@ -205,8 +205,8 @@ items:
                 protocol: TCP
           initContainers:
           - name: init-myservice
-            image: registry.access.redhat.com/ubi8/ubi:latest
-            command: ['sh', '-c', 'sleep 10; until getent hosts mongo; do echo waiting for mongo; sleep 5; done;']
+            image: docker.io/curlimages/curl:8.5.0
+            command: ['sh', '-c', 'sleep 10; until curl -s mongo:27017; do echo Trying to connect to mongo DB port; sleep 5; done; echo mongo DB port reachable']
   - apiVersion: v1
     kind: Service
     metadata:

--- a/tests/e2e/sample-applications/mysql-persistent/mysql-persistent-csi.yaml
+++ b/tests/e2e/sample-applications/mysql-persistent/mysql-persistent-csi.yaml
@@ -158,8 +158,8 @@ items:
                 protocol: TCP
           initContainers:
           - name: init-myservice
-            image: registry.access.redhat.com/ubi8/ubi:latest
-            command: ['sh', '-c', 'sleep 10; until getent hosts mysql; do echo waiting for mysql; sleep 5; done;']
+            image: docker.io/curlimages/curl:8.5.0
+            command: ['sh', '-c', 'sleep 10; until /usr/bin/nc -z -w 1 mysql 3306; do echo Trying to connect to mysql DB port; sleep 5; done; echo mysql DB port reachable']
   - apiVersion: route.openshift.io/v1
     kind: Route
     metadata:

--- a/tests/e2e/sample-applications/mysql-persistent/mysql-persistent-twovol-csi.yaml
+++ b/tests/e2e/sample-applications/mysql-persistent/mysql-persistent-twovol-csi.yaml
@@ -156,8 +156,8 @@ items:
               claimName: applog
           initContainers:
           - name: init-myservice
-            image: registry.access.redhat.com/ubi8/ubi:latest
-            command: ['sh', '-c', 'sleep 10; until getent hosts mysql; do echo waiting for mysql; sleep 5; done;']
+            image: docker.io/curlimages/curl:8.5.0
+            command: ['sh', '-c', 'sleep 10; until /usr/bin/nc -z -w 1 mysql 3306; do echo Trying to connect to mysql DB port; sleep 5; done; echo mysql DB port reachable']
   - apiVersion: route.openshift.io/v1
     kind: Route
     metadata:

--- a/tests/e2e/sample-applications/mysql-persistent/mysql-persistent.yaml
+++ b/tests/e2e/sample-applications/mysql-persistent/mysql-persistent.yaml
@@ -171,8 +171,8 @@ items:
                 protocol: TCP
           initContainers:
           - name: init-myservice
-            image: registry.access.redhat.com/ubi8/ubi:latest
-            command: ['sh', '-c', 'sleep 10; until getent hosts mysql; do echo waiting for mysql; sleep 5; done;']
+            image: docker.io/curlimages/curl:8.5.0
+            command: ['sh', '-c', 'sleep 10; until /usr/bin/nc -z -w 1 mysql 3306; do echo Trying to connect to mysql DB port; sleep 5; done; echo mysql DB port reachable']
   - apiVersion: route.openshift.io/v1
     kind: Route
     metadata:


### PR DESCRIPTION
Change which modifies the way sample application checks if DB engine is alive before continuing to start.

The more reliable way is to find out if the port is actually open and not only if the host is resolvable. For the MongoDB check is over standard HTTP request, while for the MySQL nc is being used as MySQL does not understand HTTP requests.