### PR TITLE
OADP-3189: do not remove labels from OADP namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,7 @@ envtest: $(ENVTEST)
 
 .PHONY: test
 test: vet envtest ## Run Go linter and unit tests and check Go code format and if api and bundle folders are up to date.
-	KUBEBUILDER_ASSETS="$(ENVTESTPATH)" go test -mod=mod ./controllers/... ./pkg/... -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(ENVTESTPATH)" go test -mod=mod $(shell go list ./... | grep -v /tests/e2e) -coverprofile cover.out
 	@make fmt-isupdated
 	@make api-isupdated
 	@make bundle-isupdated

--- a/Makefile
+++ b/Makefile
@@ -173,9 +173,15 @@ $(ENVTEST): ## Download envtest-setup locally if necessary.
 .PHONY: envtest
 envtest: $(ENVTEST)
 
+# If test results in prow are different, it is because the environment used.
+# You can simulate their env by running
+# docker run --platform linux/amd64 -w $PWD -v $PWD:$PWD -it registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.14 sh -c "make test"
+# where the image corresponds to the prow config for the test job, https://github.com/openshift/release/blob/master/ci-operator/config/openshift/oadp-operator/openshift-oadp-operator-master.yaml#L1-L5
+# to login to registry cluster follow https://docs.ci.openshift.org/docs/how-tos/use-registries-in-build-farm/#how-do-i-log-in-to-pull-images-that-require-authentication
+# If bin/ contains binaries of different arch, you may remove them so the container can install their arch.
 .PHONY: test
 test: vet envtest ## Run Go linter and unit tests and check Go code format and if api and bundle folders are up to date.
-	KUBEBUILDER_ASSETS="$(ENVTESTPATH)" go test -mod=mod $(shell go list ./... | grep -v /tests/e2e) -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(ENVTESTPATH)" go test -mod=mod $(shell go list -mod=mod ./... | grep -v /tests/e2e) -coverprofile cover.out
 	@make fmt-isupdated
 	@make api-isupdated
 	@make bundle-isupdated

--- a/main.go
+++ b/main.go
@@ -67,10 +67,10 @@ const (
 	CloudCredentialsCRDName     = "credentialsrequests"
 
 	// Pod security admission (PSA) labels
-	pSALabelPrefix = "pod-security.kubernetes.io/"
-	enforceLabel   = pSALabelPrefix + "enforce"
-	auditLabel     = pSALabelPrefix + "audit"
-	warnLabel      = pSALabelPrefix + "warn"
+	psaLabelPrefix = "pod-security.kubernetes.io/"
+	enforceLabel   = psaLabelPrefix + "enforce"
+	auditLabel     = psaLabelPrefix + "audit"
+	warnLabel      = psaLabelPrefix + "warn"
 
 	privileged = "privileged"
 )

--- a/main.go
+++ b/main.go
@@ -247,7 +247,10 @@ func addPodSecurityPrivilegedLabels(watchNamespaceName string) error {
 		setupLog.Error(err, "problem getting client")
 		return err
 	}
+	return addPodSecurityPrivilegedLabelsWithClientSet(watchNamespaceName, clientset)
+}
 
+func addPodSecurityPrivilegedLabelsWithClientSet(watchNamespaceName string, clientset kubernetes.Interface) error {
 	operatorNamespace, err := clientset.CoreV1().Namespaces().Get(context.TODO(), watchNamespaceName, metav1.GetOptions{})
 	if err != nil {
 		setupLog.Error(err, "problem getting operator namespace")

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"testing"
+
+	coreV1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
+)
+
+// Tests that addPodSecurityPrivilegedLabels do not override the existing labels in oadp namespace
+func Test_addPodSecurityPrivilegedLabels(t *testing.T) {
+	var watchNamespaceName = "openshift-adp"
+	tests := []struct {
+		name    string
+		existingLabels map[string]string
+		expectedLabels map[string]string
+		wantErr bool
+	}{
+		{
+			name: "existing labels",
+			existingLabels: map[string]string{
+				"existing-label": "existing-value",
+			},
+			expectedLabels: map[string]string{
+				"existing-label": "existing-value",
+				enforceLabel: privileged,
+				auditLabel: privileged,
+				warnLabel: privileged,
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// make a copy of the existing labels to avoid modifying the test case map
+			var labels map[string]string
+			labels = make(map[string]string)
+			for key, value := range tt.existingLabels {
+				labels[key] = value
+			}
+			// Create a new namespace with the existing labels
+			namespace := coreV1.Namespace{
+				ObjectMeta: v1.ObjectMeta{
+					Name: watchNamespaceName,
+					Labels: labels,
+				},
+			}
+			// fake clientset
+			clientset := fake.NewSimpleClientset(&namespace)
+			if err := addPodSecurityPrivilegedLabelsWithClientSet(watchNamespaceName, clientset); (err != nil) != tt.wantErr {
+				t.Errorf("addPodSecurityPrivilegedLabels() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			nsFromCluster, err := clientset.CoreV1().Namespaces().Get(context.TODO(), watchNamespaceName, v1.GetOptions{})
+			if err != nil {
+				t.Errorf("addPodSecurityPrivilegedLabels() error = %v", err)
+			}
+			// assert that existing labels are not overridden
+			for key, value := range tt.existingLabels {
+				if nsFromCluster.Labels[key] != value {
+					t.Errorf("namespace from cluster label for key %v is %v, want %v", key, nsFromCluster.Labels[key], value)
+				}
+			}
+			for key, value := range tt.expectedLabels {
+				if nsFromCluster.Labels[key] != value {
+					t.Errorf("namespace from cluster label for key %v is %v, want %v", key, nsFromCluster.Labels[key], value)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Instead of adding/patching PSA labels to OADP namespace, controller manager would remove all labels, and then add PSA labels to OADP namespace. This PR fixes this behavior.

## How to test

From master branch and this PR branch, create a namespace and check its labels
```sh
oc get namespace <name> --show-labels
```
Add some custom labels, for example
```sh
oc label ns <name> app.kubernetes.io/instance=in-cluster-oadp-operator
oc label ns <name> mateus=hi
oc label ns <name> day=today
```
Run `OADP_TEST_NAMESPACE=<name> make deploy-olm` and check the namespace's labels again. In master branch some labels should have been removed. In this PR branch, no labels should have been removed (and only `pod-security.kubernetes.io/...` labels should have been modified).