### PR TITLE
Add flake attempts to the flaky tests and include known flakes pattern detection

### DIFF
--- a/tests/e2e/lib/apps.go
+++ b/tests/e2e/lib/apps.go
@@ -385,6 +385,14 @@ func AreApplicationPodsRunning(c *kubernetes.Clientset, namespace string) wait.C
 				log.Printf("Pod %v not yet succeeded: phase is %v", podInfo.Name, phase)
 				return false, nil
 			}
+
+			conditionType := corev1.ContainersReady
+			for _, condition := range podInfo.Status.Conditions {
+				if condition.Type == conditionType && condition.Status != corev1.ConditionTrue {
+					log.Printf("Pod %v not yet succeeded: condition is false: %v", podInfo.Name, conditionType)
+					return false, nil
+				}
+			}
 		}
 		return true, err
 	}

--- a/tests/e2e/lib/flakes.go
+++ b/tests/e2e/lib/flakes.go
@@ -1,0 +1,61 @@
+package lib
+
+import (
+	"log"
+	"regexp"
+)
+
+var errorIgnorePatterns = []string{
+	"received EOF, stopping recv loop",
+	"Checking for AWS specific error information",
+	"awserr.Error contents",
+	"Error creating parent directories for blob-info-cache-v1.boltdb",
+	"blob unknown",
+	"num errors=0",
+	"level=debug", // debug logs may contain the text error about recoverable errors so ignore them
+	"Unable to retrieve in-cluster version",
+	"restore warning",
+
+	// Ignore managed fields errors per https://github.com/vmware-tanzu/velero/pull/6110 and avoid e2e failure.
+	// https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_oadp-operator/1126/pull-ci-openshift-oadp-operator-master-4.10-operator-e2e-aws/1690109468546699264#1:build-log.txt%3A686
+	"level=error msg=\"error patch for managed fields ",
+}
+
+type FlakePattern struct {
+	Issue               string
+	Description         string
+	StringSearchPattern string
+}
+
+// CheckIfFlakeOccured checks for known flake patterns in the provided input string (typically log from the test ran).
+// It updates the value pointed to by knownFlake based on whether a known flake pattern is found.
+//
+// Parameters:
+//
+//	input (string):     The input string to be examined for known flake patterns.
+//	knownFlake (*bool): A pointer to a boolean variable that will be updated based on whether a known flake pattern is found in the input.
+func CheckIfFlakeOccured(input string, knownFlake *bool) {
+	flakePatterns := []FlakePattern{
+		{
+			Issue:               "https://github.com/kubernetes-csi/external-snapshotter/pull/876",
+			Description:         "Race condition in the VolumeSnapshotBeingCreated",
+			StringSearchPattern: "Failed to check and update snapshot content: failed to remove VolumeSnapshotBeingCreated annotation on the content snapcontent-",
+		},
+		{
+			Issue:               "https://github.com/vmware-tanzu/velero/issues/5856",
+			Description:         "Transient S3 bucket errors and limits",
+			StringSearchPattern: "Error copying image: writing blob: uploading layer chunked: received unexpected HTTP status: 500 Internal Server Error",
+		},
+	}
+
+	for _, pattern := range flakePatterns {
+		re := regexp.MustCompile(pattern.StringSearchPattern)
+		if re.MatchString(input) {
+			log.Printf("FLAKE DETECTION: Match found for issue %s: %s\n", pattern.Issue, pattern.Description)
+			*knownFlake = true
+			return
+		}
+	}
+	log.Println("FLAKE DETECTION: No known flakes found.")
+	*knownFlake = false
+}

--- a/tests/e2e/lib/velero_helpers.go
+++ b/tests/e2e/lib/velero_helpers.go
@@ -134,22 +134,6 @@ func RestoreLogs(c *kubernetes.Clientset, ocClient client.Client, restore velero
 	return logs.String()
 }
 
-var errorIgnorePatterns = []string{
-	"received EOF, stopping recv loop",
-	"Checking for AWS specific error information",
-	"awserr.Error contents",
-	"Error creating parent directories for blob-info-cache-v1.boltdb",
-	"blob unknown",
-	"num errors=0",
-	"level=debug", // debug logs may contain the text error about recoverable errors so ignore them
-	"Unable to retrieve in-cluster version",
-	"restore warning",
-
-	// Ignore managed fields errors per https://github.com/vmware-tanzu/velero/pull/6110 and avoid e2e failure.
-	// https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_oadp-operator/1126/pull-ci-openshift-oadp-operator-master-4.10-operator-e2e-aws/1690109468546699264#1:build-log.txt%3A686
-	"level=error msg=\"error patch for managed fields ",
-}
-
 func recoverFromPanicLogs(c *kubernetes.Clientset, veleroNamespace string, panicReason interface{}, panicFrom string) string {
 	log.Printf("Recovered from panic in %s: %v\n", panicFrom, panicReason)
 	log.Print("returning container logs instead")

--- a/tests/e2e/must-gather_suite_test.go
+++ b/tests/e2e/must-gather_suite_test.go
@@ -28,6 +28,9 @@ var _ = Describe("Backup and restore tests with must-gather", func() {
 
 	DescribeTable("Backup and restore applications and run must-gather",
 		func(brCase BackupRestoreCase, expectedErr error) {
+			if CurrentSpecReport().NumAttempts > 1 && !knownFlake {
+				Fail("No known FLAKE found in a previous run, marking test as failed.")
+			}
 			runBackupAndRestore(brCase, expectedErr, updateLastBRcase, updateLastInstallTime)
 
 			// TODO look for duplications in tearDownBackupAndRestore
@@ -71,7 +74,7 @@ var _ = Describe("Backup and restore tests with must-gather", func() {
 				Expect(err).ToNot(HaveOccurred())
 			}
 		},
-		Entry("Mongo application DATAMOVER", BackupRestoreCase{
+		Entry("Mongo application DATAMOVER", FlakeAttempts(flakeAttempts), BackupRestoreCase{
 			ApplicationTemplate:  "./sample-applications/mongo-persistent/mongo-persistent-csi.yaml",
 			ApplicationNamespace: "mongo-persistent",
 			Name:                 "mongo-datamover-e2e",

--- a/tests/e2e/sample-applications/mongo-persistent/mongo-persistent-block.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/mongo-persistent-block.yaml
@@ -129,6 +129,25 @@ items:
               volumeDevices:
                 - name:  block-volume-pv
                   devicePath: /dev/xvdx
+              livenessProbe:
+                tcpSocket:
+                  port: mongo
+                initialDelaySeconds: 5
+                periodSeconds: 10
+              startupProbe:
+                exec:
+                  command:
+                  - mongosh
+                  - admin
+                  - -u $(MONGO_INITDB_ROOT_USERNAME)
+                  - -p $(MONGO_INITDB_ROOT_PASSWORD)
+                  - --eval 'printjson(db.getCollectionNames())'
+                initialDelaySeconds: 5
+                periodSeconds: 30
+                timeoutSeconds: 2
+                successThreshold: 1
+                failureThreshold: 40 # 40x30sec before restart pod
+              restartPolicy: Always
           volumes:
           - name: block-volume-pv
             persistentVolumeClaim:

--- a/tests/e2e/sample-applications/mongo-persistent/mongo-persistent-csi.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/mongo-persistent-csi.yaml
@@ -86,6 +86,25 @@ items:
             volumeMounts:
             - name: mongo-data
               mountPath: /data/db
+            livenessProbe:
+              tcpSocket:
+                port: mongo
+              initialDelaySeconds: 5
+              periodSeconds: 10
+            startupProbe:
+              exec:
+                command:
+                - mongosh
+                - admin
+                - -u $(MONGO_INITDB_ROOT_USERNAME)
+                - -p $(MONGO_INITDB_ROOT_PASSWORD)
+                - --eval 'printjson(db.getCollectionNames())'
+              initialDelaySeconds: 5
+              periodSeconds: 30
+              timeoutSeconds: 2
+              successThreshold: 1
+              failureThreshold: 40 # 40x30sec before restart pod
+            restartPolicy: Always
           volumes:
           - name: mongo-data
             persistentVolumeClaim:

--- a/tests/e2e/sample-applications/mongo-persistent/mongo-persistent.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/mongo-persistent.yaml
@@ -99,6 +99,25 @@ items:
             volumeMounts:
             - name: mongo-data
               mountPath: /data/db
+            livenessProbe:
+              tcpSocket:
+                port: mongo
+              initialDelaySeconds: 5
+              periodSeconds: 10
+            startupProbe:
+              exec:
+                command:
+                - mongosh
+                - admin
+                - -u $(MONGO_INITDB_ROOT_USERNAME)
+                - -p $(MONGO_INITDB_ROOT_PASSWORD)
+                - --eval 'printjson(db.getCollectionNames())'
+              initialDelaySeconds: 5
+              periodSeconds: 30
+              timeoutSeconds: 2
+              successThreshold: 1
+              failureThreshold: 40 # 40x30sec before restart pod
+            restartPolicy: Always
           volumes:
           - name: mongo-data
             persistentVolumeClaim:

--- a/tests/e2e/sample-applications/mysql-persistent/mysql-persistent-csi.yaml
+++ b/tests/e2e/sample-applications/mysql-persistent/mysql-persistent-csi.yaml
@@ -103,6 +103,30 @@ items:
             volumeMounts:
             - name: mysql-data
               mountPath: /var/lib/mysql
+            livenessProbe:
+              tcpSocket:
+                port: mysql
+              initialDelaySeconds: 30
+              periodSeconds: 10
+              timeoutSeconds: 5
+            startupProbe:
+              exec:
+                command:
+                - /usr/bin/timeout
+                - 1s
+                - /usr/bin/mysql
+                - $(MYSQL_DATABASE)
+                - -h
+                - 127.0.0.1
+                - -u$(MYSQL_USER)
+                - -p$(MYSQL_PASSWORD)
+                - -e EXIT
+              initialDelaySeconds: 5
+              periodSeconds: 30
+              timeoutSeconds: 2
+              successThreshold: 1
+              failureThreshold: 40 # 40x30sec before restart pod
+            restartPolicy: Always
           volumes:
           - name: mysql-data
             persistentVolumeClaim:

--- a/tests/e2e/sample-applications/mysql-persistent/mysql-persistent-twovol-csi.yaml
+++ b/tests/e2e/sample-applications/mysql-persistent/mysql-persistent-twovol-csi.yaml
@@ -95,6 +95,30 @@ items:
             volumeMounts:
             - name: mysql-data
               mountPath: /var/lib/mysql
+            livenessProbe:
+              tcpSocket:
+                port: mysql
+              initialDelaySeconds: 30
+              periodSeconds: 10
+              timeoutSeconds: 5
+            startupProbe:
+              exec:
+                command:
+                - /usr/bin/timeout
+                - 1s
+                - /usr/bin/mysql
+                - $(MYSQL_DATABASE)
+                - -h
+                - 127.0.0.1
+                - -u$(MYSQL_USER)
+                - -p$(MYSQL_PASSWORD)
+                - -e EXIT
+              initialDelaySeconds: 5
+              periodSeconds: 30
+              timeoutSeconds: 2
+              successThreshold: 1
+              failureThreshold: 40 # 40x30sec before restart pod
+            restartPolicy: Always
           volumes:
           - name: mysql-data
             persistentVolumeClaim:

--- a/tests/e2e/sample-applications/mysql-persistent/mysql-persistent.yaml
+++ b/tests/e2e/sample-applications/mysql-persistent/mysql-persistent.yaml
@@ -116,6 +116,30 @@ items:
             volumeMounts:
             - name: mysql-data
               mountPath: /var/lib/mysql
+            livenessProbe:
+              tcpSocket:
+                port: mysql
+              initialDelaySeconds: 10
+              periodSeconds: 10
+              timeoutSeconds: 5
+            startupProbe:
+              exec:
+                command:
+                - /usr/bin/timeout
+                - 1s
+                - /usr/bin/mysql
+                - $(MYSQL_DATABASE)
+                - -h
+                - 127.0.0.1
+                - -u$(MYSQL_USER)
+                - -p$(MYSQL_PASSWORD)
+                - -e EXIT
+              initialDelaySeconds: 5
+              periodSeconds: 30
+              timeoutSeconds: 2
+              successThreshold: 1
+              failureThreshold: 40 # 40x30sec before restart pod
+            restartPolicy: Always
           volumes:
           - name: mysql-data
             persistentVolumeClaim:


### PR DESCRIPTION
Add flake attempts to the flaky tests and include known flakes pattern detection
    
This adds attempts to the flaky tests, which are caused by known issues.

The known flake pattern detection allows us to specify which flakes are the ones on which we will retry.

Also adds ivenessProbe and startupProbe to the sample-applications. [More info](https://github.com/openshift/oadp-operator/pull/1270#issue-2084844294)