### PR TITLE
OADP-3395: Unbreak unsupportedOverrides field in DPA

### DIFF
--- a/api/v1alpha1/oadp_types.go
+++ b/api/v1alpha1/oadp_types.go
@@ -50,6 +50,7 @@ type CustomPlugin struct {
 	Image string `json:"image"`
 }
 
+// Field does not have enum validation for development flexibility
 type UnsupportedImageKey string
 
 const VeleroImageKey UnsupportedImageKey = "veleroImageFqin"
@@ -250,7 +251,6 @@ type DataProtectionApplicationSpec struct {
 	//   - kubevirtPluginImageFqin
 	//   - operator-type
 	// +optional
-	// +kubebuilder:validation:Enum=veleroImageFqin;awsPluginImageFqin;openshiftPluginImageFqin;azurePluginImageFqin;gcpPluginImageFqin;csiPluginImageFqin;resticRestoreImageFqin;kubevirtPluginImageFqin;operator-type
 	UnsupportedOverrides map[UnsupportedImageKey]string `json:"unsupportedOverrides,omitempty"`
 	// add annotations to pods deployed by operator
 	// +optional

--- a/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
@@ -905,16 +905,6 @@ spec:
                   additionalProperties:
                     type: string
                   description: 'unsupportedOverrides can be used to override images used in deployments. Available keys are:   - veleroImageFqin   - awsPluginImageFqin   - openshiftPluginImageFqin   - azurePluginImageFqin   - gcpPluginImageFqin   - csiPluginImageFqin   - resticRestoreImageFqin   - kubevirtPluginImageFqin   - operator-type'
-                  enum:
-                    - veleroImageFqin
-                    - awsPluginImageFqin
-                    - openshiftPluginImageFqin
-                    - azurePluginImageFqin
-                    - gcpPluginImageFqin
-                    - csiPluginImageFqin
-                    - resticRestoreImageFqin
-                    - kubevirtPluginImageFqin
-                    - operator-type
                   type: object
               required:
                 - configuration

--- a/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
@@ -905,16 +905,6 @@ spec:
                   additionalProperties:
                     type: string
                   description: 'unsupportedOverrides can be used to override images used in deployments. Available keys are:   - veleroImageFqin   - awsPluginImageFqin   - openshiftPluginImageFqin   - azurePluginImageFqin   - gcpPluginImageFqin   - csiPluginImageFqin   - resticRestoreImageFqin   - kubevirtPluginImageFqin   - operator-type'
-                  enum:
-                    - veleroImageFqin
-                    - awsPluginImageFqin
-                    - openshiftPluginImageFqin
-                    - azurePluginImageFqin
-                    - gcpPluginImageFqin
-                    - csiPluginImageFqin
-                    - resticRestoreImageFqin
-                    - kubevirtPluginImageFqin
-                    - operator-type
                   type: object
               required:
                 - configuration


### PR DESCRIPTION
## Description

Revert add of enum validation to `unsupportedOverrides` field. Enum validation works with string fields, not object. To have field truly typed, it should be a struct. For development flexibility (no need to change DPA structure, only description) the field does not enforce typing.

## How to test

Run new test in master branch and this PR branch. It should fail in master and succeed here.

Also, create DPA with `unsupportedOverrides` field. It should work.

## Discussion points

- For a false validation, another structure of E2E test needs to be created, as passing wrong image, does not break DPA reconcile, only Velero deployment.

- Should we add in code validation for wrong keys?