### PR TITLE
OADP-3379: fix wrong descriptions on time fields

### DIFF
--- a/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
@@ -493,7 +493,7 @@ spec:
                               description: log to standard error as well as files (no effect when -logtostderr=true)
                               type: boolean
                             backup-sync-period:
-                              description: How often (in minutes) to ensure all Velero backups in object storage exist as Backup API objects in the cluster. This is the default sync period if none is explicitly specified for a backup storage location.
+                              description: How often (in nanoseconds) to ensure all Velero backups in object storage exist as Backup API objects in the cluster. This is the default sync period if none is explicitly specified for a backup storage location.
                               format: int64
                               type: integer
                             client-burst:
@@ -509,15 +509,15 @@ spec:
                               description: Show colored output in TTY
                               type: boolean
                             default-backup-ttl:
-                              description: ' default 720h0m0s'
+                              description: How long (in nanoseconds) to wait by default before backups can be garbage collected. (default is 720 hours)
                               format: int64
                               type: integer
                             default-item-operation-timeout:
-                              description: ' How long to wait on asynchronous BackupItemActions and RestoreItemActions to complete before timing out. (default 1h0m0s)'
+                              description: How long (in nanoseconds) to wait on asynchronous BackupItemActions and RestoreItemActions to complete before timing out. (default is 1 hour)
                               format: int64
                               type: integer
                             default-repo-maintain-frequency:
-                              description: ' How often ''maintain'' is run for backup repositories by default.'
+                              description: How often (in nanoseconds) 'maintain' is run for backup repositories by default.
                               format: int64
                               type: integer
                             default-volumes-to-fs-backup:
@@ -542,15 +542,15 @@ spec:
                                 type: string
                               type: array
                             fs-backup-timeout:
-                              description: ' How long pod volume file system backups/restores should be allowed to run before timing out. (default 4h0m0s)'
+                              description: How long (in nanoseconds) pod volume file system backups/restores should be allowed to run before timing out. (default is 4 hours)
                               format: int64
                               type: integer
                             garbage-collection-frequency:
-                              description: ' How long to wait by default before backups can be garbage collected. (default 720h0m0s)'
+                              description: How long (in nanoseconds) to wait by default before backups can be garbage collected. (default is 720 hours)
                               format: int64
                               type: integer
                             item-operation-sync-frequency:
-                              description: ' How often to check status on backup/restore operations after backup/restore processing.'
+                              description: How often (in nanoseconds) to check status on backup/restore operations after backup/restore processing.
                               format: int64
                               type: integer
                             log-format:
@@ -589,7 +589,7 @@ spec:
                               description: The address to expose the pprof profiler.
                               type: string
                             resource-timeout:
-                              description: ' How long to wait for resource processes which are not covered by other specific timeout parameters. Default is 10 minutes. (default 10m0s)'
+                              description: How long (in nanoseconds) to wait for resource processes which are not covered by other specific timeout parameters. (default is 10 minutes)
                               format: int64
                               type: integer
                             restore-resource-priorities:
@@ -605,11 +605,11 @@ spec:
                               description: logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
                               type: integer
                             store-validation-frequency:
-                              description: ' How often to verify if the storage is valid. Optional. Set this to `0s` to disable sync. Default 1 minute.'
+                              description: How often (in nanoseconds) to verify if the storage is valid. Optional. Set this to `0` to disable sync. (default is 1 minute)
                               format: int64
                               type: integer
                             terminating-resource-timeout:
-                              description: ' How long to wait on persistent volumes and namespaces to terminate during a restore before timing out.'
+                              description: How long (in nanoseconds) to wait on persistent volumes and namespaces to terminate during a restore before timing out.
                               format: int64
                               type: integer
                             v:

--- a/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
@@ -493,7 +493,7 @@ spec:
                               description: log to standard error as well as files (no effect when -logtostderr=true)
                               type: boolean
                             backup-sync-period:
-                              description: How often to ensure all Velero backups in object storage exist as Backup API objects in the cluster. This is the default sync period if none is explicitly specified for a backup storage location.
+                              description: How often (in minutes) to ensure all Velero backups in object storage exist as Backup API objects in the cluster. This is the default sync period if none is explicitly specified for a backup storage location.
                               format: int64
                               type: integer
                             client-burst:
@@ -509,15 +509,15 @@ spec:
                               description: Show colored output in TTY
                               type: boolean
                             default-backup-ttl:
-                              description: default 720h0m0s
+                              description: ' default 720h0m0s'
                               format: int64
                               type: integer
                             default-item-operation-timeout:
-                              description: How long to wait on asynchronous BackupItemActions and RestoreItemActions to complete before timing out. (default 1h0m0s)
+                              description: ' How long to wait on asynchronous BackupItemActions and RestoreItemActions to complete before timing out. (default 1h0m0s)'
                               format: int64
                               type: integer
                             default-repo-maintain-frequency:
-                              description: How often 'maintain' is run for backup repositories by default.
+                              description: ' How often ''maintain'' is run for backup repositories by default.'
                               format: int64
                               type: integer
                             default-volumes-to-fs-backup:
@@ -542,15 +542,15 @@ spec:
                                 type: string
                               type: array
                             fs-backup-timeout:
-                              description: How long pod volume file system backups/restores should be allowed to run before timing out. (default 4h0m0s)
+                              description: ' How long pod volume file system backups/restores should be allowed to run before timing out. (default 4h0m0s)'
                               format: int64
                               type: integer
                             garbage-collection-frequency:
-                              description: How long to wait by default before backups can be garbage collected. (default 720h0m0s)
+                              description: ' How long to wait by default before backups can be garbage collected. (default 720h0m0s)'
                               format: int64
                               type: integer
                             item-operation-sync-frequency:
-                              description: How often to check status on backup/restore operations after backup/restore processing.
+                              description: ' How often to check status on backup/restore operations after backup/restore processing.'
                               format: int64
                               type: integer
                             log-format:
@@ -589,7 +589,7 @@ spec:
                               description: The address to expose the pprof profiler.
                               type: string
                             resource-timeout:
-                              description: How long to wait for resource processes which are not covered by other specific timeout parameters. Default is 10 minutes. (default 10m0s)
+                              description: ' How long to wait for resource processes which are not covered by other specific timeout parameters. Default is 10 minutes. (default 10m0s)'
                               format: int64
                               type: integer
                             restore-resource-priorities:
@@ -605,11 +605,11 @@ spec:
                               description: logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
                               type: integer
                             store-validation-frequency:
-                              description: How often to verify if the storage is valid. Optional. Set this to `0s` to disable sync. Default 1 minute.
+                              description: ' How often to verify if the storage is valid. Optional. Set this to `0s` to disable sync. Default 1 minute.'
                               format: int64
                               type: integer
                             terminating-resource-timeout:
-                              description: How long to wait on persistent volumes and namespaces to terminate during a restore before timing out.
+                              description: ' How long to wait on persistent volumes and namespaces to terminate during a restore before timing out.'
                               format: int64
                               type: integer
                             v:

--- a/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
@@ -493,7 +493,7 @@ spec:
                               description: log to standard error as well as files (no effect when -logtostderr=true)
                               type: boolean
                             backup-sync-period:
-                              description: How often (in minutes) to ensure all Velero backups in object storage exist as Backup API objects in the cluster. This is the default sync period if none is explicitly specified for a backup storage location.
+                              description: How often (in nanoseconds) to ensure all Velero backups in object storage exist as Backup API objects in the cluster. This is the default sync period if none is explicitly specified for a backup storage location.
                               format: int64
                               type: integer
                             client-burst:
@@ -509,15 +509,15 @@ spec:
                               description: Show colored output in TTY
                               type: boolean
                             default-backup-ttl:
-                              description: ' default 720h0m0s'
+                              description: How long (in nanoseconds) to wait by default before backups can be garbage collected. (default is 720 hours)
                               format: int64
                               type: integer
                             default-item-operation-timeout:
-                              description: ' How long to wait on asynchronous BackupItemActions and RestoreItemActions to complete before timing out. (default 1h0m0s)'
+                              description: How long (in nanoseconds) to wait on asynchronous BackupItemActions and RestoreItemActions to complete before timing out. (default is 1 hour)
                               format: int64
                               type: integer
                             default-repo-maintain-frequency:
-                              description: ' How often ''maintain'' is run for backup repositories by default.'
+                              description: How often (in nanoseconds) 'maintain' is run for backup repositories by default.
                               format: int64
                               type: integer
                             default-volumes-to-fs-backup:
@@ -542,15 +542,15 @@ spec:
                                 type: string
                               type: array
                             fs-backup-timeout:
-                              description: ' How long pod volume file system backups/restores should be allowed to run before timing out. (default 4h0m0s)'
+                              description: How long (in nanoseconds) pod volume file system backups/restores should be allowed to run before timing out. (default is 4 hours)
                               format: int64
                               type: integer
                             garbage-collection-frequency:
-                              description: ' How long to wait by default before backups can be garbage collected. (default 720h0m0s)'
+                              description: How long (in nanoseconds) to wait by default before backups can be garbage collected. (default is 720 hours)
                               format: int64
                               type: integer
                             item-operation-sync-frequency:
-                              description: ' How often to check status on backup/restore operations after backup/restore processing.'
+                              description: How often (in nanoseconds) to check status on backup/restore operations after backup/restore processing.
                               format: int64
                               type: integer
                             log-format:
@@ -589,7 +589,7 @@ spec:
                               description: The address to expose the pprof profiler.
                               type: string
                             resource-timeout:
-                              description: ' How long to wait for resource processes which are not covered by other specific timeout parameters. Default is 10 minutes. (default 10m0s)'
+                              description: How long (in nanoseconds) to wait for resource processes which are not covered by other specific timeout parameters. (default is 10 minutes)
                               format: int64
                               type: integer
                             restore-resource-priorities:
@@ -605,11 +605,11 @@ spec:
                               description: logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
                               type: integer
                             store-validation-frequency:
-                              description: ' How often to verify if the storage is valid. Optional. Set this to `0s` to disable sync. Default 1 minute.'
+                              description: How often (in nanoseconds) to verify if the storage is valid. Optional. Set this to `0` to disable sync. (default is 1 minute)
                               format: int64
                               type: integer
                             terminating-resource-timeout:
-                              description: ' How long to wait on persistent volumes and namespaces to terminate during a restore before timing out.'
+                              description: How long (in nanoseconds) to wait on persistent volumes and namespaces to terminate during a restore before timing out.
                               format: int64
                               type: integer
                             v:

--- a/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
@@ -493,7 +493,7 @@ spec:
                               description: log to standard error as well as files (no effect when -logtostderr=true)
                               type: boolean
                             backup-sync-period:
-                              description: How often to ensure all Velero backups in object storage exist as Backup API objects in the cluster. This is the default sync period if none is explicitly specified for a backup storage location.
+                              description: How often (in minutes) to ensure all Velero backups in object storage exist as Backup API objects in the cluster. This is the default sync period if none is explicitly specified for a backup storage location.
                               format: int64
                               type: integer
                             client-burst:
@@ -509,15 +509,15 @@ spec:
                               description: Show colored output in TTY
                               type: boolean
                             default-backup-ttl:
-                              description: default 720h0m0s
+                              description: ' default 720h0m0s'
                               format: int64
                               type: integer
                             default-item-operation-timeout:
-                              description: How long to wait on asynchronous BackupItemActions and RestoreItemActions to complete before timing out. (default 1h0m0s)
+                              description: ' How long to wait on asynchronous BackupItemActions and RestoreItemActions to complete before timing out. (default 1h0m0s)'
                               format: int64
                               type: integer
                             default-repo-maintain-frequency:
-                              description: How often 'maintain' is run for backup repositories by default.
+                              description: ' How often ''maintain'' is run for backup repositories by default.'
                               format: int64
                               type: integer
                             default-volumes-to-fs-backup:
@@ -542,15 +542,15 @@ spec:
                                 type: string
                               type: array
                             fs-backup-timeout:
-                              description: How long pod volume file system backups/restores should be allowed to run before timing out. (default 4h0m0s)
+                              description: ' How long pod volume file system backups/restores should be allowed to run before timing out. (default 4h0m0s)'
                               format: int64
                               type: integer
                             garbage-collection-frequency:
-                              description: How long to wait by default before backups can be garbage collected. (default 720h0m0s)
+                              description: ' How long to wait by default before backups can be garbage collected. (default 720h0m0s)'
                               format: int64
                               type: integer
                             item-operation-sync-frequency:
-                              description: How often to check status on backup/restore operations after backup/restore processing.
+                              description: ' How often to check status on backup/restore operations after backup/restore processing.'
                               format: int64
                               type: integer
                             log-format:
@@ -589,7 +589,7 @@ spec:
                               description: The address to expose the pprof profiler.
                               type: string
                             resource-timeout:
-                              description: How long to wait for resource processes which are not covered by other specific timeout parameters. Default is 10 minutes. (default 10m0s)
+                              description: ' How long to wait for resource processes which are not covered by other specific timeout parameters. Default is 10 minutes. (default 10m0s)'
                               format: int64
                               type: integer
                             restore-resource-priorities:
@@ -605,11 +605,11 @@ spec:
                               description: logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
                               type: integer
                             store-validation-frequency:
-                              description: How often to verify if the storage is valid. Optional. Set this to `0s` to disable sync. Default 1 minute.
+                              description: ' How often to verify if the storage is valid. Optional. Set this to `0s` to disable sync. Default 1 minute.'
                               format: int64
                               type: integer
                             terminating-resource-timeout:
-                              description: How long to wait on persistent volumes and namespaces to terminate during a restore before timing out.
+                              description: ' How long to wait on persistent volumes and namespaces to terminate during a restore before timing out.'
                               format: int64
                               type: integer
                             v:

--- a/controllers/velero_test.go
+++ b/controllers/velero_test.go
@@ -4018,6 +4018,94 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Check values of time fields in Velero args",
+			veleroDeployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-velero-deployment",
+					Namespace: "test-ns",
+				},
+				Spec: appsv1.DeploymentSpec{
+					Selector: &metav1.LabelSelector{MatchLabels: veleroDeploymentMatchLabels},
+				},
+			},
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-Velero-CR",
+					Namespace: "test-ns",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{
+							Args: &server.Args{
+								ServerConfig: server.ServerConfig{
+									BackupSyncPeriod:            pointer.Duration(1),
+									PodVolumeOperationTimeout:   pointer.Duration(1),
+									ResourceTerminatingTimeout:  pointer.Duration(1),
+									DefaultBackupTTL:            pointer.Duration(1),
+									StoreValidationFrequency:    pointer.Duration(1),
+									ItemOperationSyncFrequency:  pointer.Duration(1),
+									RepoMaintenanceFrequency:    pointer.Duration(1),
+									GarbageCollectionFrequency:  pointer.Duration(1),
+									DefaultItemOperationTimeout: pointer.Duration(1),
+									ResourceTimeout:             pointer.Duration(1),
+								},
+							},
+						},
+					},
+				},
+			},
+			wantVeleroDeployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-velero-deployment",
+					Namespace: "test-ns",
+					Labels:    veleroDeploymentLabel,
+				},
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Deployment",
+					APIVersion: appsv1.SchemeGroupVersion.String(),
+				},
+				Spec: appsv1.DeploymentSpec{
+					Selector: &metav1.LabelSelector{MatchLabels: veleroDeploymentMatchLabels},
+					Replicas: pointer.Int32(1),
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: veleroPodObjectMeta,
+						Spec: corev1.PodSpec{
+							RestartPolicy:      corev1.RestartPolicyAlways,
+							ServiceAccountName: common.Velero,
+							Containers: []corev1.Container{
+								{
+									Name:            common.Velero,
+									Image:           common.VeleroImage,
+									ImagePullPolicy: corev1.PullAlways,
+									Ports:           []corev1.ContainerPort{{Name: "metrics", ContainerPort: 8085}},
+									Resources:       corev1.ResourceRequirements{Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("500m"), corev1.ResourceMemory: resource.MustParse("128Mi")}},
+									Command:         []string{"/velero"},
+									Args: []string{
+										"server",
+										"--backup-sync-period=1ns",
+										"--default-backup-ttl=1ns",
+										"--default-item-operation-timeout=1ns",
+										"--resource-timeout=1ns",
+										"--default-repo-maintain-frequency=1ns",
+										"--garbage-collection-frequency=1ns",
+										"--fs-backup-timeout=1ns",
+										"--item-operation-sync-frequency=1ns",
+										defaultRestoreResourcePriorities,
+										"--store-validation-frequency=1ns",
+										"--terminating-resource-timeout=1ns",
+									},
+									VolumeMounts: baseVolumeMounts,
+									Env:          baseEnvVars,
+								},
+							},
+							Volumes:        baseVolumes,
+							InitContainers: []corev1.Container{},
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/controllers/velero_test.go
+++ b/controllers/velero_test.go
@@ -4094,6 +4094,7 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 										defaultRestoreResourcePriorities,
 										"--store-validation-frequency=1ns",
 										"--terminating-resource-timeout=1ns",
+										defaultDisableInformerCache,
 									},
 									VolumeMounts: baseVolumeMounts,
 									Env:          baseEnvVars,

--- a/pkg/velero/server/args.go
+++ b/pkg/velero/server/args.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/openshift/oadp-operator/pkg/klog"
 	"github.com/openshift/oadp-operator/pkg/velero/client"
@@ -47,7 +48,7 @@ func (a Args) StringArr(dpaFeatureFlags []string, logLevel string) ([]string, er
 		args = append(args, fmt.Sprintf("--log-level=%s", logrusLevel.String()))
 	}
 	if a.BackupSyncPeriod != nil {
-		args = append(args, fmt.Sprintf("--backup-sync-period=%s", a.BackupSyncPeriod.String())) // duration
+		args = append(args, fmt.Sprintf("--backup-sync-period=%s", (time.Duration(*a.BackupSyncPeriod)*time.Minute).String())) // duration
 	}
 	if a.ClientBurst != nil {
 		args = append(args, fmt.Sprintf("--client-burst=%s", strconv.Itoa(*a.ClientBurst))) // int

--- a/pkg/velero/server/args.go
+++ b/pkg/velero/server/args.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/openshift/oadp-operator/pkg/klog"
 	"github.com/openshift/oadp-operator/pkg/velero/client"
@@ -48,7 +47,7 @@ func (a Args) StringArr(dpaFeatureFlags []string, logLevel string) ([]string, er
 		args = append(args, fmt.Sprintf("--log-level=%s", logrusLevel.String()))
 	}
 	if a.BackupSyncPeriod != nil {
-		args = append(args, fmt.Sprintf("--backup-sync-period=%s", (time.Duration(*a.BackupSyncPeriod)*time.Minute).String())) // duration
+		args = append(args, fmt.Sprintf("--backup-sync-period=%s", a.BackupSyncPeriod.String())) // duration
 	}
 	if a.ClientBurst != nil {
 		args = append(args, fmt.Sprintf("--client-burst=%s", strconv.Itoa(*a.ClientBurst))) // int

--- a/pkg/velero/server/config.go
+++ b/pkg/velero/server/config.go
@@ -23,19 +23,19 @@ type ServerConfig struct {
 	// defaultBackupLocation will be defined outside of server config in DataProtectionApplication
 	// defaultBackupLocation                        string
 
-	// How often (in minutes) to ensure all Velero backups in object storage exist as Backup API objects in the cluster. This is the default sync period if none is explicitly specified for a backup storage location.
+	// How often (in nanoseconds) to ensure all Velero backups in object storage exist as Backup API objects in the cluster. This is the default sync period if none is explicitly specified for a backup storage location.
 	// +optional
-	BackupSyncPeriod *int64 `json:"backup-sync-period,omitempty"`
-	//  How long pod volume file system backups/restores should be allowed to run before timing out. (default 4h0m0s)
+	BackupSyncPeriod *time.Duration `json:"backup-sync-period,omitempty"`
+	// How long (in nanoseconds) pod volume file system backups/restores should be allowed to run before timing out. (default is 4 hours)
 	// +optional
 	PodVolumeOperationTimeout *time.Duration `json:"fs-backup-timeout,omitempty"`
-	//  How long to wait on persistent volumes and namespaces to terminate during a restore before timing out.
+	// How long (in nanoseconds) to wait on persistent volumes and namespaces to terminate during a restore before timing out.
 	// +optional
 	ResourceTerminatingTimeout *time.Duration `json:"terminating-resource-timeout,omitempty"`
-	//  default 720h0m0s
+	// How long (in nanoseconds) to wait by default before backups can be garbage collected. (default is 720 hours)
 	// +optional
 	DefaultBackupTTL *time.Duration `json:"default-backup-ttl,omitempty"`
-	//  How often to verify if the storage is valid. Optional. Set this to `0s` to disable sync. Default 1 minute.
+	// How often (in nanoseconds) to verify if the storage is valid. Optional. Set this to `0` to disable sync. (default is 1 minute)
 	// +optional
 	StoreValidationFrequency *time.Duration `json:"store-validation-frequency,omitempty"`
 	// Desired order of resource restores, the priority list contains two parts which are split by "-" element. The resources before "-" element are restored first as high priorities, the resources after "-" element are restored last as low priorities, and any resource not in the list will be restored alphabetically between the high and low priorities. (default securitycontextconstraints,customresourcedefinitions,namespaces,roles,rolebindings,clusterrolebindings,managedcluster.cluster.open-cluster-management.io,managedcluster.clusterview.open-cluster-management.io,klusterletaddonconfig.agent.open-cluster-management.io,managedclusteraddon.addon.open-cluster-management.io,storageclasses,volumesnapshotclass.snapshot.storage.k8s.io,volumesnapshotcontents.snapshot.storage.k8s.io,volumesnapshots.snapshot.storage.k8s.io,datauploads.velero.io,persistentvolumes,persistentvolumeclaims,serviceaccounts,secrets,configmaps,limitranges,pods,replicasets.apps,clusterclasses.cluster.x-k8s.io,endpoints,services,-,clusterbootstraps.run.tanzu.vmware.com,clusters.cluster.x-k8s.io,clusterresourcesets.addons.cluster.x-k8s.io)
@@ -65,25 +65,25 @@ type ServerConfig struct {
 	// The address to expose the pprof profiler.
 	// +optional
 	ProfilerAddress string `json:"profiler-address,omitempty"`
-	//  How often to check status on backup/restore operations after backup/restore processing.
+	// How often (in nanoseconds) to check status on backup/restore operations after backup/restore processing.
 	// +optional
 	ItemOperationSyncFrequency *time.Duration `json:"item-operation-sync-frequency,omitempty"`
 	// The format for log output. Valid values are text, json. (default text)
 	// +kubebuilder:validation:Enum=text;json
 	// +optional
 	FormatFlag string `json:"log-format,omitempty"`
-	//  How often 'maintain' is run for backup repositories by default.
+	// How often (in nanoseconds) 'maintain' is run for backup repositories by default.
 	// +optional
 	RepoMaintenanceFrequency *time.Duration `json:"default-repo-maintain-frequency,omitempty"`
-	//  How long to wait by default before backups can be garbage collected. (default 720h0m0s)
+	// How long (in nanoseconds) to wait by default before backups can be garbage collected. (default is 720 hours)
 	// +optional
 	GarbageCollectionFrequency *time.Duration `json:"garbage-collection-frequency,omitempty"`
 	// Backup all volumes with pod volume file system backup by default.
 	// +optional
 	DefaultVolumesToFsBackup *bool `json:"default-volumes-to-fs-backup,omitempty"`
-	//  How long to wait on asynchronous BackupItemActions and RestoreItemActions to complete before timing out. (default 1h0m0s)
+	// How long (in nanoseconds) to wait on asynchronous BackupItemActions and RestoreItemActions to complete before timing out. (default is 1 hour)
 	DefaultItemOperationTimeout *time.Duration `json:"default-item-operation-timeout,omitempty"`
-	//  How long to wait for resource processes which are not covered by other specific timeout parameters. Default is 10 minutes. (default 10m0s)
+	// How long (in nanoseconds) to wait for resource processes which are not covered by other specific timeout parameters. (default is 10 minutes)
 	ResourceTimeout *time.Duration `json:"resource-timeout,omitempty"`
 	// Max concurrent connections number that Velero can create with kube-apiserver. Default is 30. (default 30)
 	MaxConcurrentK8SConnections *int `json:"max-concurrent-k8s-connections,omitempty"`

--- a/pkg/velero/server/config.go
+++ b/pkg/velero/server/config.go
@@ -23,19 +23,19 @@ type ServerConfig struct {
 	// defaultBackupLocation will be defined outside of server config in DataProtectionApplication
 	// defaultBackupLocation                        string
 
-	// How often to ensure all Velero backups in object storage exist as Backup API objects in the cluster. This is the default sync period if none is explicitly specified for a backup storage location.
+	// How often (in minutes) to ensure all Velero backups in object storage exist as Backup API objects in the cluster. This is the default sync period if none is explicitly specified for a backup storage location.
 	// +optional
-	BackupSyncPeriod *time.Duration `json:"backup-sync-period,omitempty"`
-	// How long pod volume file system backups/restores should be allowed to run before timing out. (default 4h0m0s)
+	BackupSyncPeriod *int64 `json:"backup-sync-period,omitempty"`
+	//  How long pod volume file system backups/restores should be allowed to run before timing out. (default 4h0m0s)
 	// +optional
 	PodVolumeOperationTimeout *time.Duration `json:"fs-backup-timeout,omitempty"`
-	// How long to wait on persistent volumes and namespaces to terminate during a restore before timing out.
+	//  How long to wait on persistent volumes and namespaces to terminate during a restore before timing out.
 	// +optional
 	ResourceTerminatingTimeout *time.Duration `json:"terminating-resource-timeout,omitempty"`
-	// default 720h0m0s
+	//  default 720h0m0s
 	// +optional
 	DefaultBackupTTL *time.Duration `json:"default-backup-ttl,omitempty"`
-	// How often to verify if the storage is valid. Optional. Set this to `0s` to disable sync. Default 1 minute.
+	//  How often to verify if the storage is valid. Optional. Set this to `0s` to disable sync. Default 1 minute.
 	// +optional
 	StoreValidationFrequency *time.Duration `json:"store-validation-frequency,omitempty"`
 	// Desired order of resource restores, the priority list contains two parts which are split by "-" element. The resources before "-" element are restored first as high priorities, the resources after "-" element are restored last as low priorities, and any resource not in the list will be restored alphabetically between the high and low priorities. (default securitycontextconstraints,customresourcedefinitions,namespaces,roles,rolebindings,clusterrolebindings,managedcluster.cluster.open-cluster-management.io,managedcluster.clusterview.open-cluster-management.io,klusterletaddonconfig.agent.open-cluster-management.io,managedclusteraddon.addon.open-cluster-management.io,storageclasses,volumesnapshotclass.snapshot.storage.k8s.io,volumesnapshotcontents.snapshot.storage.k8s.io,volumesnapshots.snapshot.storage.k8s.io,datauploads.velero.io,persistentvolumes,persistentvolumeclaims,serviceaccounts,secrets,configmaps,limitranges,pods,replicasets.apps,clusterclasses.cluster.x-k8s.io,endpoints,services,-,clusterbootstraps.run.tanzu.vmware.com,clusters.cluster.x-k8s.io,clusterresourcesets.addons.cluster.x-k8s.io)
@@ -65,25 +65,25 @@ type ServerConfig struct {
 	// The address to expose the pprof profiler.
 	// +optional
 	ProfilerAddress string `json:"profiler-address,omitempty"`
-	// How often to check status on backup/restore operations after backup/restore processing.
+	//  How often to check status on backup/restore operations after backup/restore processing.
 	// +optional
 	ItemOperationSyncFrequency *time.Duration `json:"item-operation-sync-frequency,omitempty"`
 	// The format for log output. Valid values are text, json. (default text)
 	// +kubebuilder:validation:Enum=text;json
 	// +optional
 	FormatFlag string `json:"log-format,omitempty"`
-	// How often 'maintain' is run for backup repositories by default.
+	//  How often 'maintain' is run for backup repositories by default.
 	// +optional
 	RepoMaintenanceFrequency *time.Duration `json:"default-repo-maintain-frequency,omitempty"`
-	// How long to wait by default before backups can be garbage collected. (default 720h0m0s)
+	//  How long to wait by default before backups can be garbage collected. (default 720h0m0s)
 	// +optional
 	GarbageCollectionFrequency *time.Duration `json:"garbage-collection-frequency,omitempty"`
 	// Backup all volumes with pod volume file system backup by default.
 	// +optional
 	DefaultVolumesToFsBackup *bool `json:"default-volumes-to-fs-backup,omitempty"`
-	// How long to wait on asynchronous BackupItemActions and RestoreItemActions to complete before timing out. (default 1h0m0s)
+	//  How long to wait on asynchronous BackupItemActions and RestoreItemActions to complete before timing out. (default 1h0m0s)
 	DefaultItemOperationTimeout *time.Duration `json:"default-item-operation-timeout,omitempty"`
-	// How long to wait for resource processes which are not covered by other specific timeout parameters. Default is 10 minutes. (default 10m0s)
+	//  How long to wait for resource processes which are not covered by other specific timeout parameters. Default is 10 minutes. (default 10m0s)
 	ResourceTimeout *time.Duration `json:"resource-timeout,omitempty"`
 	// Max concurrent connections number that Velero can create with kube-apiserver. Default is 30. (default 30)
 	MaxConcurrentK8SConnections *int `json:"max-concurrent-k8s-connections,omitempty"`


### PR DESCRIPTION
## Description

All velero args time fields have wrong description, saying they are string, but actually are integer.

A better solution would be to change fields from integer nanoseconds to time syntax strings, but this is dangerous, adding possibility of breaking updates to users. Changing the unit of measure is also dangerous, as can change a value from minutes to years, when user updates OADP.

## How to test

Check that description of the fields are correct now, by creating a DPA like this
```yaml
apiVersion: oadp.openshift.io/v1alpha1
kind: DataProtectionApplication
metadata:
  name: test-time-field
  namespace: openshift-adp
spec:
  configuration:
    velero:
      args:
        backup-sync-period: 1
        default-backup-ttl: 1
        default-item-operation-timeout: 1
        default-repo-maintain-frequency: 1
        fs-backup-timeout: 1
        garbage-collection-frequency: 1
        item-operation-sync-frequency: 1
        resource-timeout: 1
        store-validation-frequency: 1
        terminating-resource-timeout: 1
      defaultPlugins:
      - openshift
      - aws
  backupLocations:
    - velero:
        provider: aws
        config:
            region: #
            profile: default
            s3ForcePathStyle: 'true'
            s3Url: #
        default: true
        credential:
            name: cloud-credentials
            key: cloud
        objectStorage:
            bucket: #
            prefix: velero
```
and check Velero deployment pod args.