### PR TITLE
OADP-3055:  Add more keywords, categories and change maintainers to group e-mail

### DIFF
--- a/bundle/manifests/oadp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/oadp-operator.clusterserviceversion.yaml
@@ -149,7 +149,8 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    categories: OpenShift Optional
+    categories: |
+      Cloud Provider,Developer Tools,Modernization & Migration,OpenShift Optional,Storage
     certified: "false"
     containerImage: quay.io/konveyor/oadp-operator:latest
     createdAt: "2020-09-08T12:21:00Z"
@@ -945,17 +946,44 @@ spec:
   - supported: false
     type: AllNamespaces
   keywords:
+  - disaster backup
+  - disaster recovery
+  - disaster restore
+  - disaster
+  - backup
+  - restore
+  - backup automation
+  - recovery
+  - data protection
+  - data management
+  - data
+  - protection
+  - management
+  - application resilience
+  - resilience
   - velero
   - openshift
   - oadp
+  - cloud-native
+  - replication
+  - kopia
+  - restic
+  - network file system
+  - nfs
+  - simple cloud storage
+  - s3
+  - minio
+  - cloud storage
+  - data foundation
+  - ceph
+  - csi
+  - container storage interface
   links:
   - name: OADP Operator
     url: https://github.com/openshift/oadp-operator
   maintainers:
-  - email: dymurray@redhat.com
-    name: Dylan Murray
-  - email: spampatt@redhat.com
-    name: Shubham Dilip Pampattiwar
+  - email: oadp-maintainers@redhat.com
+    name: OADP Operator maintainers
   maturity: stable
   provider:
     name: Red Hat

--- a/config/manifests/bases/oadp-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/oadp-operator.clusterserviceversion.yaml
@@ -3,7 +3,8 @@ kind: ClusterServiceVersion
 metadata:
   annotations:
     capabilities: Seamless Upgrades
-    categories: OpenShift Optional
+    categories: |
+      Cloud Provider,Developer Tools,Modernization & Migration,OpenShift Optional,Storage
     certified: "false"
     containerImage: quay.io/konveyor/oadp-operator:latest
     createdAt: "2020-09-08T12:21:00Z"
@@ -442,17 +443,44 @@ spec:
   - supported: false
     type: AllNamespaces
   keywords:
+  - disaster backup
+  - disaster recovery
+  - disaster restore
+  - disaster
+  - backup
+  - restore
+  - backup automation
+  - recovery
+  - data protection
+  - data management
+  - data
+  - protection
+  - management
+  - application resilience
+  - resilience
   - velero
   - openshift
   - oadp
+  - cloud-native
+  - replication
+  - kopia
+  - restic
+  - network file system
+  - nfs
+  - simple cloud storage
+  - s3
+  - minio
+  - cloud storage
+  - data foundation
+  - ceph
+  - csi
+  - container storage interface
   links:
   - name: OADP Operator
     url: https://github.com/openshift/oadp-operator
   maintainers:
-  - email: dymurray@redhat.com
-    name: Dylan Murray
-  - email: spampatt@redhat.com
-    name: Shubham Dilip Pampattiwar
+  - email: oadp-maintainers@redhat.com
+    name: OADP Operator maintainers
   maturity: stable
   provider:
     name: Red Hat


### PR DESCRIPTION
Partially fixes improvements as defined in the issue [OADP-3055](https://issues.redhat.com//browse/OADP-3055)
 - Add maintainers e-mail group instead of individuals
 - Adds keywords to be able to find the operator easier within OperatorHub
 - Used additional categories, so it's easier to find within OperatorHub: 
   - **Cloud Provider** - integrations with various cloud providers to facilitate backup and restore operations
   - **Developer Tools** - used in development and operations workflows for managing backups and restores
   - **Modernization & Migration** - used during migration and modernization efforts when moving applications to and from OCP clusters 
   - **OpenShift Optional** - current category, won't be changing that
   - **Storage** - closely associated with storage-related operations