### PR TITLE
[oadp-1.3] update velero version number in go.mod to 1.12.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 require (
 	github.com/deckarep/golang-set/v2 v2.3.0
 	github.com/google/go-cmp v0.5.9
-	github.com/vmware-tanzu/velero v1.12.0
+	github.com/vmware-tanzu/velero v1.12.3
 	sigs.k8s.io/yaml v1.3.0
 )
 


### PR DESCRIPTION
This is a cosmetic/doc-level change so that people reading this know what version of Velero is pulled in. The go mod replace at the bottom pulls from a specific velero fork commit which is already the right one for 1.12.3