### PR TITLE
Do not error test on uninstall/delete

### DIFF
--- a/tests/e2e/backup_restore_suite_test.go
+++ b/tests/e2e/backup_restore_suite_test.go
@@ -176,8 +176,7 @@ func runBackupAndRestore(brCase BackupRestoreCase, expectedErr error, updateLast
 
 	// uninstall app
 	log.Printf("Uninstalling app for case %s", brCase.Name)
-	err = UninstallApplication(dpaCR.Client, brCase.ApplicationTemplate)
-	Expect(err).ToNot(HaveOccurred())
+	UninstallApplication(dpaCR.Client, brCase.ApplicationTemplate)
 
 	// Wait for namespace to be deleted
 	Eventually(IsNamespaceDeleted(kubernetesClientForSuiteRun, brCase.ApplicationNamespace), timeoutMultiplier*time.Minute*4, time.Second*5).Should(BeTrue())
@@ -250,8 +249,7 @@ func tearDownBackupAndRestore(brCase BackupRestoreCase, installTime time.Time, r
 	if brCase.BackupRestoreType == CSI || brCase.BackupRestoreType == CSIDataMover {
 		log.Printf("Deleting VolumeSnapshot for CSI backuprestore of %s", brCase.Name)
 		snapshotClassPath := fmt.Sprintf("./sample-applications/snapclass-csi/%s.yaml", provider)
-		err := UninstallApplication(dpaCR.Client, snapshotClassPath)
-		Expect(err).ToNot(HaveOccurred())
+		UninstallApplication(dpaCR.Client, snapshotClassPath)
 	}
 	err := dpaCR.Client.Delete(context.Background(), &corev1.Namespace{ObjectMeta: v1.ObjectMeta{
 		Name:      brCase.ApplicationNamespace,
@@ -260,10 +258,7 @@ func tearDownBackupAndRestore(brCase BackupRestoreCase, installTime time.Time, r
 	if k8serror.IsNotFound(err) {
 		err = nil
 	}
-	Expect(err).ToNot(HaveOccurred())
-
-	err = dpaCR.Delete(runTimeClientForSuiteRun)
-	Expect(err).ToNot(HaveOccurred())
+	dpaCR.Delete(runTimeClientForSuiteRun)
 	Eventually(IsNamespaceDeleted(kubernetesClientForSuiteRun, brCase.ApplicationNamespace), timeoutMultiplier*time.Minute*2, time.Second*5).Should(BeTrue())
 }
 

--- a/tests/e2e/lib/apps.go
+++ b/tests/e2e/lib/apps.go
@@ -156,6 +156,7 @@ func DoesSCCExist(ocClient client.Client, sccName string) (bool, error) {
 func UninstallApplication(ocClient client.Client, file string) error {
 	template, err := os.ReadFile(file)
 	if err != nil {
+		log.Printf("UninstallApplication got errors while reading file: %v", err)
 		return err
 	}
 	obj := &unstructured.UnstructuredList{}
@@ -163,6 +164,7 @@ func UninstallApplication(ocClient client.Client, file string) error {
 	dec := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
 	_, _, err = dec.Decode([]byte(template), nil, obj)
 	if err != nil {
+		log.Printf("UninstallApplication got errors while decoding JSON: %v", err)
 		return err
 	}
 	for _, resource := range obj.Items {
@@ -170,6 +172,7 @@ func UninstallApplication(ocClient client.Client, file string) error {
 		if apierrors.IsNotFound(err) {
 			continue
 		} else if err != nil {
+			log.Printf("UninstallApplication got errors while performing Delete: %v", err)
 			return err
 		}
 	}

--- a/tests/e2e/lib/dpa_helpers.go
+++ b/tests/e2e/lib/dpa_helpers.go
@@ -255,9 +255,14 @@ func (v *DpaCustomResource) CreateOrUpdateWithRetries(c client.Client, spec *oad
 func (v *DpaCustomResource) Delete(c client.Client) error {
 	err := v.SetClient(c)
 	if err != nil {
+		log.Printf("Error while Delete, SetClient: %v", err)
 		return err
 	}
 	err = v.Client.Delete(context.Background(), v.CustomResource)
+	if err != nil {
+		log.Printf("Error while Delete: %v", err)
+	}
+
 	if apierrors.IsNotFound(err) {
 		return nil
 	}


### PR DESCRIPTION
The test should not fail when uninstall/delete operation is failing, this is not something OADP e2e should be testing, just a wrapper around actual project test.

Of course it's not ideal when there are some objects left after test ran, but they should not interfere with the test result. If there are left overs after test there is a bug, but in testing code/framework and not OADP itself.