### PR TITLE
CI: Add filter for virtualization testing.

### DIFF
--- a/docs/developer/testing/TESTING.md
+++ b/docs/developer/testing/TESTING.md
@@ -21,7 +21,7 @@ To get started, you need to provide the following **required** environment varia
 | `BSL_REGION` | The region of backupLocations | `us-east-1` | false |
 | `OADP_TEST_NAMESPACE` | The namespace where OADP operator is installed | `openshift-adp` | false |
 | `OPENSHIFT_CI` | Disable colored output from tests suite run | `true` | false |
-| `TEST_VIRT` | Enable Virtual Machine backup/restore testing | `true` | false |
+| `TEST_VIRT` | Exclusively run Virtual Machine backup/restore testing | `false` | false |
 
 The expected format for `OADP_CRED_FILE` and `CI_CRED_FILE` files is:
 ```

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"os"
 	"strconv"
-	"strings"
 	"testing"
 	"time"
 
@@ -26,7 +25,6 @@ import (
 var bslCredFile, namespace, credSecretRef, instanceName, provider, vslCredFile, settings, artifact_dir, oc_cli, stream string
 var timeoutMultiplierInput, flakeAttempts int64
 var timeoutMultiplier time.Duration
-var virtTestingEnabled bool
 
 func init() {
 	// TODO better descriptions to flags
@@ -42,7 +40,6 @@ func init() {
 	flag.StringVar(&oc_cli, "oc_cli", "oc", "OC CLI Client")
 	flag.StringVar(&stream, "stream", "up", "[up, down] upstream or downstream")
 	flag.Int64Var(&timeoutMultiplierInput, "timeout_multiplier", 1, "Customize timeout multiplier from default (1)")
-	flag.BoolVar(&virtTestingEnabled, "test_virt", false, "Enable Virtual Machine backup/restore testing (default false)")
 	timeoutMultiplier = time.Duration(timeoutMultiplierInput)
 	flag.Int64Var(&flakeAttempts, "flakeAttempts", 3, "Customize the number of flake retries (3)")
 
@@ -88,9 +85,6 @@ func init() {
 			} else {
 				flakeAttempts = parsedValue
 			}
-		}
-		if strings.ToLower(os.Getenv("TEST_VIRT")) == "true" {
-			virtTestingEnabled = true
 		}
 	}
 }

--- a/tests/e2e/virt_backup_restore_suite_test.go
+++ b/tests/e2e/virt_backup_restore_suite_test.go
@@ -6,7 +6,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/openshift/oadp-operator/tests/e2e/lib"
-	"k8s.io/apimachinery/pkg/util/version"
 )
 
 var _ = Describe("VM backup and restore tests", Ordered, func() {
@@ -15,20 +14,9 @@ var _ = Describe("VM backup and restore tests", Ordered, func() {
 	wasInstalledFromTest := false
 
 	var _ = BeforeAll(func() {
-		if !virtTestingEnabled {
-			Skip("Virtualization testing is disabled, skipping tests")
-		}
-
 		v, err = GetVirtOperator(runTimeClientForSuiteRun, kubernetesClientForSuiteRun, dynamicClientForSuiteRun)
 		Expect(err).To(BeNil())
 		Expect(v).ToNot(BeNil())
-
-		minimum, err := version.ParseGeneric("4.13")
-		Expect(err).To(BeNil())
-		Expect(v.Version).ToNot(BeNil())
-		if !v.Version.AtLeast(minimum) {
-			Skip("Skipping virtualization testing on cluster version " + v.Version.String() + ", minimum required is " + minimum.String())
-		}
 
 		if !v.IsVirtInstalled() {
 			err = v.EnsureVirtInstallation(5 * time.Minute)
@@ -38,21 +26,17 @@ var _ = Describe("VM backup and restore tests", Ordered, func() {
 	})
 
 	var _ = AfterAll(func() {
-		if !virtTestingEnabled {
-			Skip("Virtualization testing is disabled, skipping test cleanup")
-		}
-
 		if v != nil && wasInstalledFromTest {
 			v.EnsureVirtRemoval(6 * time.Minute)
 		}
 	})
 
-	It("should verify virt installation", func() {
+	It("should verify virt installation", Label("virt"), func() {
 		installed := v.IsVirtInstalled()
 		Expect(installed).To(BeTrue())
 	})
 
-	It("should upload a data volume successfully", func() {
+	It("should upload a data volume successfully", Label("virt"), func() {
 		err := v.EnsureDataVolume("openshift-cnv", "cirros", "https://download.cirros-cloud.net/0.6.2/cirros-0.6.2-x86_64-disk.img", "128Mi", 5*time.Minute)
 		Expect(err).To(BeNil())
 		v.EnsureDataVolumeRemoval("openshift-cnv", "cirros", 2*time.Minute)


### PR DESCRIPTION
Replace current virtualization test skipping mechanism with a ginkgo test filter.

We will create a new prow job to run virtualization tests separately from the other E2E tests.
It will set `TEST_VIRT` to `true` which will be added to the make command in the new job.
When TEST_VIRT is true, "virt" filter will be added to the test-e2e ginkgo command line, and all current virtualization tests are updated to have this label.