### PR TITLE
CI: Avoid DPA cleanup error on virt-only AfterSuite.

### DIFF
--- a/tests/e2e/virt_backup_restore_suite_test.go
+++ b/tests/e2e/virt_backup_restore_suite_test.go
@@ -14,6 +14,9 @@ var _ = Describe("VM backup and restore tests", Ordered, func() {
 	wasInstalledFromTest := false
 
 	var _ = BeforeAll(func() {
+		dpaCR.CustomResource.Name = "dummyDPA"
+		dpaCR.CustomResource.Namespace = "openshift-adp"
+
 		v, err = GetVirtOperator(runTimeClientForSuiteRun, kubernetesClientForSuiteRun, dynamicClientForSuiteRun)
 		Expect(err).To(BeNil())
 		Expect(v).ToNot(BeNil())


### PR DESCRIPTION
Avoid an error when CI is running only virtualization tests, so that https://github.com/openshift/release/pull/48623 has a chance of passing. This pull request adds some dummy values that will be removed when virtualization testing is ready to do actual backups and restores.