### PR TITLE
feat: Add golangci-lint linters - imports

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,130 @@
+# Documentation reference https://github.com/golangci/golangci-lint/blob/v1.56.2/.golangci.reference.yml
+run:
+  skip-dirs-use-default: false
+  modules-download-mode: readonly
+  allow-parallel-runners: false
+
+output:
+  format: colored-line-number
+  print-issued-lines: true
+  print-linter-name: true
+  uniq-by-line: true
+  sort-results: true
+
+linters-settings:
+  dogsled:
+    max-blank-identifiers: 2
+  errcheck:
+    check-type-assertions: true
+    check-blank: true
+  gci:
+    sections:
+      - standard
+      - default
+      - prefix(github.com/openshift/oadp-operator)
+  goconst:
+    min-len: 3
+    min-occurrences: 5
+  gofmt:
+    simplify: true
+  goheader:
+    # copy from ./hack/boilerplate.go.txt
+    template: |-
+      Copyright 2021.
+
+      Licensed under the Apache License, Version 2.0 (the "License");
+      you may not use this file except in compliance with the License.
+      You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      See the License for the specific language governing permissions and
+      limitations under the License.
+  govet:
+    enable-all: true
+  misspell:
+    locale: US
+  nakedret:
+    max-func-lines: 30
+  nolintlint:
+    allow-unused: false
+    allow-no-explanation: []
+    require-explanation: true
+    require-specific: true
+  revive:
+    # TODO enable!
+    # enable-all-rules: true
+    rules:
+      - name: line-length-limit
+        disabled: true
+      # TODO delete after
+      - name: blank-imports
+      - name: dot-imports
+      - name: duplicated-imports
+      - name: import-alias-naming
+      - name: import-shadowing
+      - name: redundant-import-alias
+  unparam:
+    check-exported: true
+
+linters:
+  disable-all: true
+  # TODO enable commented ones
+  enable:
+    - asasalint
+    - asciicheck
+    - bidichk
+    - bodyclose
+    - dogsled
+    - dupword
+    # - durationcheck
+    # - errcheck
+    - errchkjson
+    - exportloopref
+    - gci
+    # - ginkgolinter
+    - goconst
+    - gofmt
+    - goheader
+    - goprintffuncname
+    # - gosec
+    - gosimple
+    # - govet
+    - ineffassign
+    - misspell
+    - nakedret
+    - nilerr
+    - noctx
+    - nolintlint
+    - nosprintfhostport
+    - revive
+    - staticcheck
+    - stylecheck
+    - unconvert
+    - unparam
+    - unused
+    - usestdlibvars
+  fast: false
+
+issues:
+  exclude-use-default: false
+  exclude-rules:
+    - linters:
+        - revive
+      text: "^struct-tag: unknown option 'inline' in JSON tag$"
+    - linters:
+        - stylecheck
+      text: "ST1000:|ST1020:|ST1021:|ST1022:"
+    - linters:
+      # TODO should be deleted
+        - stylecheck
+      text: "ST1001:|ST1003:|ST1005:"
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
+severity:
+  default-severity: error
+  case-sensitive: false

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -77,35 +77,35 @@ linters:
     - asasalint
     - asciicheck
     - bidichk
-    - bodyclose
+    # - bodyclose
     - dogsled
-    - dupword
+    # - dupword
     # - durationcheck
     # - errcheck
     - errchkjson
     - exportloopref
     - gci
     # - ginkgolinter
-    - goconst
+    # - goconst
     - gofmt
-    - goheader
+    # - goheader
     - goprintffuncname
     # - gosec
-    - gosimple
+    # - gosimple
     # - govet
-    - ineffassign
-    - misspell
+    # - ineffassign
+    # - misspell
     - nakedret
-    - nilerr
-    - noctx
+    # - nilerr
+    # - noctx
     - nolintlint
     - nosprintfhostport
     - revive
-    - staticcheck
-    - stylecheck
-    - unconvert
-    - unparam
-    - unused
+    # - staticcheck
+    # - stylecheck
+    # - unconvert
+    # - unparam
+    # - unused
     - usestdlibvars
   fast: false
 
@@ -118,10 +118,6 @@ issues:
     - linters:
         - stylecheck
       text: "ST1000:|ST1020:|ST1021:|ST1022:"
-    - linters:
-      # TODO should be deleted
-        - stylecheck
-      text: "ST1001:|ST1003:|ST1005:"
   max-issues-per-linter: 0
   max-same-issues: 0
 

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,4 +1,4 @@
-# Documentation reference https://github.com/golangci/golangci-lint/blob/v1.56.2/.golangci.reference.yml
+# Documentation reference https://github.com/golangci/golangci-lint/blob/v1.55.2/.golangci.reference.yml
 run:
   skip-dirs-use-default: false
   modules-download-mode: readonly

--- a/Makefile
+++ b/Makefile
@@ -553,7 +553,7 @@ define go-install-tool-with-version
 set -e; \
 package=$(2)@$(3) ;\
 echo "Downloading $${package}" ;\
-GOBIN=$(LOCALBIN) go install $${package} ;\
+GOBIN=$(LOCALBIN) go install -mod=mod $${package} ;\
 mv "$$(echo "$(1)" | sed "s/-$(3)$$//")" $(1) ;\
 }
 endef

--- a/Makefile
+++ b/Makefile
@@ -181,17 +181,11 @@ envtest: $(ENVTEST)
 # to login to registry cluster follow https://docs.ci.openshift.org/docs/how-tos/use-registries-in-build-farm/#how-do-i-log-in-to-pull-images-that-require-authentication
 # If bin/ contains binaries of different arch, you may remove them so the container can install their arch.
 .PHONY: test
-test: vet envtest ## Run Go linter and unit tests and check Go code format and if api and bundle folders are up to date.
+test: vet envtest ## Run unit tests; run Go linters checks; and check if api and bundle folders are up to date
 	KUBEBUILDER_ASSETS="$(ENVTESTPATH)" go test -mod=mod $(shell go list -mod=mod ./... | grep -v /tests/e2e) -coverprofile cover.out
-	@make fmt-isupdated
+	@make lint
 	@make api-isupdated
 	@make bundle-isupdated
-
-.PHONY: fmt-isupdated
-fmt-isupdated: TEMP:= $(shell mktemp -d)
-fmt-isupdated:
-	@cp -r ./ $(TEMP) && cd $(TEMP) && make fmt && cd - && diff -ruN . $(TEMP)/ && echo "Go code is formatted" || (echo "Go code is not formatted, run 'make fmt' to format" && exit 1)
-	@chmod -R 777 $(TEMP) && rm -rf $(TEMP)
 
 .PHONY: api-isupdated
 api-isupdated: TEMP:= $(shell mktemp -d)
@@ -536,3 +530,38 @@ test-e2e-cleanup: login-required
 	$(OC_CLI) delete restore -n $(OADP_TEST_NAMESPACE) --all --wait=false
 	for restore_name in $(shell $(OC_CLI) get restore -n $(OADP_TEST_NAMESPACE) -o name);do $(OC_CLI) patch "$$restore_name" -n $(OADP_TEST_NAMESPACE) -p '{"metadata":{"finalizers":null}}' --type=merge;done
 	rm -rf $(SETTINGS_TMP)
+
+## Location to install dependencies to
+LOCALBIN ?= $(shell pwd)/bin
+$(LOCALBIN):
+	mkdir -p $(LOCALBIN)
+
+GOLANGCI_LINT = $(LOCALBIN)/golangci-lint-$(GOLANGCI_LINT_VERSION)
+GOLANGCI_LINT_VERSION ?= v1.56.2
+
+.PHONY: golangci-lint
+golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
+$(GOLANGCI_LINT): $(LOCALBIN)
+	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,${GOLANGCI_LINT_VERSION})
+
+# go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
+# $1 - target path with name of binary with version
+# $2 - package url which can be installed
+# $3 - specific version of package
+define go-install-tool
+@[ -f $(1) ] || { \
+set -e; \
+package=$(2)@$(3) ;\
+echo "Downloading $${package}" ;\
+GOBIN=$(LOCALBIN) go install $${package} ;\
+mv "$$(echo "$(1)" | sed "s/-$(3)$$//")" $(1) ;\
+}
+endef
+
+.PHONY: lint
+lint: golangci-lint ## Run Go linters checks against all project's Go files.
+	$(GOLANGCI_LINT) run
+
+.PHONY: lint-fix
+lint-fix: golangci-lint ## Fix Go linters issues.
+	$(GOLANGCI_LINT) run --fix

--- a/Makefile
+++ b/Makefile
@@ -542,13 +542,13 @@ GOLANGCI_LINT_VERSION ?= v1.56.2
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
-	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,${GOLANGCI_LINT_VERSION})
+	$(call go-install-tool-with-version,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,${GOLANGCI_LINT_VERSION})
 
-# go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
+# go-install-tool-with-version will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary with version
 # $2 - package url which can be installed
 # $3 - specific version of package
-define go-install-tool
+define go-install-tool-with-version
 @[ -f $(1) ] || { \
 set -e; \
 package=$(2)@$(3) ;\

--- a/Makefile
+++ b/Makefile
@@ -531,32 +531,11 @@ test-e2e-cleanup: login-required
 	for restore_name in $(shell $(OC_CLI) get restore -n $(OADP_TEST_NAMESPACE) -o name);do $(OC_CLI) patch "$$restore_name" -n $(OADP_TEST_NAMESPACE) -p '{"metadata":{"finalizers":null}}' --type=merge;done
 	rm -rf $(SETTINGS_TMP)
 
-## Location to install dependencies to
-LOCALBIN ?= $(shell pwd)/bin
-$(LOCALBIN):
-	mkdir -p $(LOCALBIN)
-
-GOLANGCI_LINT = $(LOCALBIN)/golangci-lint-$(GOLANGCI_LINT_VERSION)
-GOLANGCI_LINT_VERSION ?= v1.56.2
+GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
 
 .PHONY: golangci-lint
-golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
-$(GOLANGCI_LINT): $(LOCALBIN)
-	$(call go-install-tool-with-version,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,${GOLANGCI_LINT_VERSION})
-
-# go-install-tool-with-version will 'go install' any package with custom target and name of binary, if it doesn't exist
-# $1 - target path with name of binary with version
-# $2 - package url which can be installed
-# $3 - specific version of package
-define go-install-tool-with-version
-@[ -f $(1) ] || { \
-set -e; \
-package=$(2)@$(3) ;\
-echo "Downloading $${package}" ;\
-GOBIN=$(LOCALBIN) go install -mod=mod $${package} ;\
-mv "$$(echo "$(1)" | sed "s/-$(3)$$//")" $(1) ;\
-}
-endef
+golangci-lint: ## Download golangci-lint locally if necessary.
+	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint@v1.56.2)
 
 .PHONY: lint
 lint: golangci-lint ## Run Go linters checks against all project's Go files.

--- a/Makefile
+++ b/Makefile
@@ -535,7 +535,7 @@ GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
 
 .PHONY: golangci-lint
 golangci-lint: ## Download golangci-lint locally if necessary.
-	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint@v1.56.2)
+	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint@v1.55.2)
 
 .PHONY: lint
 lint: golangci-lint ## Run Go linters checks against all project's Go files.

--- a/api/v1alpha1/oadp_types.go
+++ b/api/v1alpha1/oadp_types.go
@@ -19,11 +19,12 @@ package v1alpha1
 import (
 	"time"
 
-	"github.com/openshift/oadp-operator/pkg/common"
-	"github.com/openshift/oadp-operator/pkg/velero/server"
 	velero "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/oadp-operator/pkg/common"
+	"github.com/openshift/oadp-operator/pkg/velero/server"
 )
 
 // Conditions

--- a/controllers/bsl.go
+++ b/controllers/bsl.go
@@ -5,14 +5,20 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
+<<<<<<< HEAD
 	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
 	"github.com/openshift/oadp-operator/pkg/common"
 	"github.com/openshift/oadp-operator/pkg/storage/aws"
+=======
+>>>>>>> 9a85d2f (feat: Add golangci-lint)
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
+	"github.com/openshift/oadp-operator/pkg/common"
 )
 
 func (r *DPAReconciler) ValidateBackupStorageLocations(dpa oadpv1alpha1.DataProtectionApplication) (bool, error) {

--- a/controllers/bsl.go
+++ b/controllers/bsl.go
@@ -5,12 +5,6 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-<<<<<<< HEAD
-	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
-	"github.com/openshift/oadp-operator/pkg/common"
-	"github.com/openshift/oadp-operator/pkg/storage/aws"
-=======
->>>>>>> 9a85d2f (feat: Add golangci-lint)
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -19,6 +13,7 @@ import (
 
 	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
 	"github.com/openshift/oadp-operator/pkg/common"
+	"github.com/openshift/oadp-operator/pkg/storage/aws"
 )
 
 func (r *DPAReconciler) ValidateBackupStorageLocations(dpa oadpv1alpha1.DataProtectionApplication) (bool, error) {

--- a/controllers/bsl_test.go
+++ b/controllers/bsl_test.go
@@ -6,13 +6,10 @@ import (
 	"reflect"
 	"testing"
 
-	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
-
 	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
-	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -21,6 +18,8 @@ import (
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
 )
 
 // A bucket that region can be automatically discovered
@@ -1636,7 +1635,7 @@ func TestDPAReconciler_ensureBackupLocationHasVeleroOrCloudStorage(t *testing.T)
 								Provider: "aws",
 							},
 							CloudStorage: &oadpv1alpha1.CloudStorageLocation{
-								CloudStorageRef: v1.LocalObjectReference{
+								CloudStorageRef: corev1.LocalObjectReference{
 									Name: "foo",
 								},
 							},
@@ -1903,8 +1902,8 @@ func TestDPAReconciler_ReconcileBackupStorageLocations(t *testing.T) {
 			Namespace: "test-ns",
 		},
 		Spec: oadpv1alpha1.CloudStorageSpec{
-			CreationSecret: v1.SecretKeySelector{
-				LocalObjectReference: v1.LocalObjectReference{
+			CreationSecret: corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{
 					Name: "cloud-credentials",
 				},
 				Key: "credentials",
@@ -1955,11 +1954,11 @@ func TestDPAReconciler_ReconcileBackupStorageLocations(t *testing.T) {
 					BackupLocations: []oadpv1alpha1.BackupLocation{
 						{
 							CloudStorage: &oadpv1alpha1.CloudStorageLocation{
-								CloudStorageRef: v1.LocalObjectReference{
+								CloudStorageRef: corev1.LocalObjectReference{
 									Name: "test-cs",
 								},
-								Credential: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Credential: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "cloud-credentials",
 									},
 									Key: "credentials",
@@ -2054,8 +2053,8 @@ func TestDPAReconciler_ReconcileBackupStorageLocations(t *testing.T) {
 											Prefix: "test-prefix",
 										},
 									},
-									Credential: &v1.SecretKeySelector{
-										LocalObjectReference: v1.LocalObjectReference{
+									Credential: &corev1.SecretKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "cloud-credentials",
 										},
 										Key: "credentials",
@@ -2087,8 +2086,8 @@ func TestDPAReconciler_ReconcileBackupStorageLocations(t *testing.T) {
 							Prefix: "test-prefix",
 						},
 					},
-					Credential: &v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					Credential: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "cloud-credentials",
 						},
 						Key: "credentials",
@@ -2108,11 +2107,11 @@ func TestDPAReconciler_ReconcileBackupStorageLocations(t *testing.T) {
 						BackupLocations: []oadpv1alpha1.BackupLocation{
 							{
 								CloudStorage: &oadpv1alpha1.CloudStorageLocation{
-									CloudStorageRef: v1.LocalObjectReference{
+									CloudStorageRef: corev1.LocalObjectReference{
 										Name: "test-cs",
 									},
-									Credential: &v1.SecretKeySelector{
-										LocalObjectReference: v1.LocalObjectReference{
+									Credential: &corev1.SecretKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "cloud-credentials",
 										},
 										Key: "credentials",
@@ -2137,8 +2136,8 @@ func TestDPAReconciler_ReconcileBackupStorageLocations(t *testing.T) {
 					},
 					Spec: oadpv1alpha1.CloudStorageSpec{
 						Provider: "aws",
-						CreationSecret: v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						CreationSecret: corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "cloud-credentials",
 							},
 							Key: "credentials",
@@ -2245,11 +2244,11 @@ func TestDPAReconciler_ReconcileBackupStorageLocations(t *testing.T) {
 						BackupLocations: []oadpv1alpha1.BackupLocation{
 							{
 								CloudStorage: &oadpv1alpha1.CloudStorageLocation{
-									CloudStorageRef: v1.LocalObjectReference{
+									CloudStorageRef: corev1.LocalObjectReference{
 										Name: "test-cs",
 									},
-									Credential: &v1.SecretKeySelector{
-										LocalObjectReference: v1.LocalObjectReference{
+									Credential: &corev1.SecretKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "cloud-credentials",
 										},
 										Key: "credentials",
@@ -2275,8 +2274,8 @@ func TestDPAReconciler_ReconcileBackupStorageLocations(t *testing.T) {
 					},
 					Spec: oadpv1alpha1.CloudStorageSpec{
 						Provider: "aws",
-						CreationSecret: v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						CreationSecret: corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "cloud-credentials",
 							},
 							Key: "credentials",

--- a/controllers/bucket_controller.go
+++ b/controllers/bucket_controller.go
@@ -3,26 +3,27 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"github.com/openshift/oadp-operator/pkg/common"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"os"
 	"strconv"
 	"time"
 
 	"github.com/go-logr/logr"
-	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
-	bucketpkg "github.com/openshift/oadp-operator/pkg/bucket"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
+	bucketpkg "github.com/openshift/oadp-operator/pkg/bucket"
+	"github.com/openshift/oadp-operator/pkg/common"
 )
 
 const (
@@ -56,14 +57,14 @@ type BucketReconciler struct {
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.9.2/pkg/reconcile
 func (b BucketReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	b.Log = log.FromContext(ctx)
-	log := b.Log.WithValues("bucket", req.NamespacedName)
+	logger := b.Log.WithValues("bucket", req.NamespacedName)
 	result := ctrl.Result{}
 	// Set reconciler context + name
 
 	bucket := oadpv1alpha1.CloudStorage{}
 
 	if err := b.Client.Get(ctx, req.NamespacedName, &bucket); err != nil {
-		log.Error(err, "unable to fetch bucket CR")
+		logger.Error(err, "unable to fetch bucket CR")
 		return result, nil
 	}
 
@@ -94,16 +95,16 @@ func (b BucketReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		if shouldDelete && bucket.DeletionTimestamp != nil {
 			deleted, err := clnt.Delete()
 			if err != nil {
-				log.Error(err, "unable to delete bucket")
+				logger.Error(err, "unable to delete bucket")
 				b.EventRecorder.Event(&bucket, corev1.EventTypeWarning, "UnableToDeleteBucket", fmt.Sprintf("unable to delete bucket: %v", bucket.Spec.Name))
 				return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 			}
 			if !deleted {
-				log.Info("unable to delete bucket for unknown reason")
+				logger.Info("unable to delete bucket for unknown reason")
 				b.EventRecorder.Event(&bucket, corev1.EventTypeWarning, "UnableToDeleteBucketUnknown", fmt.Sprintf("unable to delete bucket: %v", bucket.Spec.Name))
 				return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 			}
-			log.Info("bucket deleted")
+			logger.Info("bucket deleted")
 			b.EventRecorder.Event(&bucket, corev1.EventTypeNormal, "BucketDeleted", fmt.Sprintf("bucket %v deleted", bucket.Spec.Name))
 
 			//Removing oadpFinalizerBucket from bucket.Finalizers
@@ -118,11 +119,11 @@ func (b BucketReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	var ok bool
 	if common.CCOWorkflow() {
 		// wait for the credential request to be processed and the secret to be created
-		log.Info(fmt.Sprintf("Following standardized STS workflow, waiting for for the credential request to be processed and provision the secret"))
+		logger.Info(fmt.Sprintf("Following standardized STS workflow, waiting for for the credential request to be processed and provision the secret"))
 		installNS := os.Getenv("WATCH_NAMESPACE")
 		_, err = b.WaitForSecret(installNS, VeleroAWSSecretName)
 		if err != nil {
-			log.Error(err, "unable to fetch secert created by CCO")
+			logger.Error(err, "unable to fetch secert created by CCO")
 			return result, err
 		}
 	}
@@ -131,20 +132,20 @@ func (b BucketReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		// Handle Creation if not exist.
 		created, err := clnt.Create()
 		if !created {
-			log.Info("unable to create object bucket")
+			logger.Info("unable to create object bucket")
 			b.EventRecorder.Event(&bucket, corev1.EventTypeWarning, "BucketNotCreated", fmt.Sprintf("unable to create bucket: %v", err))
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 		}
 		if err != nil {
 			//TODO: LOG/EVENT THE MESSAGE
-			log.Error(err, "Error while creating event")
+			logger.Error(err, "Error while creating event")
 			return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
 		}
 		b.EventRecorder.Event(&bucket, corev1.EventTypeNormal, "BucketCreated", fmt.Sprintf("bucket %v has been created", bucket.Spec.Name))
 	}
 	if err != nil {
 		// Bucket may be created but something else went wrong.
-		log.Error(err, "unable to determine if bucket exists.")
+		logger.Error(err, "unable to determine if bucket exists.")
 		b.EventRecorder.Event(&bucket, corev1.EventTypeWarning, "BucketNotFound", fmt.Sprintf("unable to find bucket: %v", err))
 		return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
 	}

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -1,9 +1,10 @@
 package controllers
 
 import (
-	"github.com/openshift/oadp-operator/pkg/common"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/pointer"
+
+	"github.com/openshift/oadp-operator/pkg/common"
 )
 
 // setting defaults to avoid emitting update events

--- a/controllers/monitor.go
+++ b/controllers/monitor.go
@@ -4,11 +4,12 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
 )
 
 func (r *DPAReconciler) ReconcileVeleroMetricsSVC(log logr.Logger) (bool, error) {

--- a/controllers/monitor_test.go
+++ b/controllers/monitor_test.go
@@ -7,8 +7,6 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
-	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
-	"github.com/openshift/oadp-operator/pkg/common"
 	monitor "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -21,6 +19,9 @@ import (
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
+	"github.com/openshift/oadp-operator/pkg/common"
 )
 
 func getSchemeForFakeClientForMonitor() (*runtime.Scheme, error) {

--- a/controllers/nodeagent.go
+++ b/controllers/nodeagent.go
@@ -6,13 +6,9 @@ import (
 	"os"
 	"reflect"
 
-	"github.com/openshift/oadp-operator/pkg/common"
+	"github.com/go-logr/logr"
 	"github.com/operator-framework/operator-lib/proxy"
 	"github.com/vmware-tanzu/velero/pkg/install"
-
-	"github.com/go-logr/logr"
-	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
-	"github.com/openshift/oadp-operator/pkg/credentials"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -22,6 +18,10 @@ import (
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
+	"github.com/openshift/oadp-operator/pkg/common"
+	"github.com/openshift/oadp-operator/pkg/credentials"
 )
 
 const (

--- a/controllers/nodeagent_test.go
+++ b/controllers/nodeagent_test.go
@@ -7,24 +7,22 @@ import (
 	"reflect"
 	"testing"
 
-	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/apimachinery/pkg/util/intstr"
-
+	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
-
-	"github.com/go-logr/logr"
-	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
-	"github.com/openshift/oadp-operator/pkg/common"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
+	"github.com/openshift/oadp-operator/pkg/common"
 )
 
 func TestDPAReconciler_ReconcileNodeAgentDaemonset(t *testing.T) {
@@ -151,60 +149,60 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 						Type: appsv1.RollingUpdateDaemonSetStrategyType,
 					},
 					Selector: nodeAgentLabelSelector,
-					Template: v1.PodTemplateSpec{
+					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
 								"component": common.Velero,
 								"name":      common.NodeAgent,
 							},
 						},
-						Spec: v1.PodSpec{
+						Spec: corev1.PodSpec{
 							NodeSelector:       dpa.Spec.Configuration.NodeAgent.PodConfig.NodeSelector,
 							ServiceAccountName: common.Velero,
-							SecurityContext: &v1.PodSecurityContext{
+							SecurityContext: &corev1.PodSecurityContext{
 								RunAsUser:          pointer.Int64(0),
 								SupplementalGroups: dpa.Spec.Configuration.NodeAgent.SupplementalGroups,
 							},
-							Volumes: []v1.Volume{
+							Volumes: []corev1.Volume{
 								// Cloud Provider volumes are dynamically added in the for loop below
 								{
 									Name: HostPods,
-									VolumeSource: v1.VolumeSource{
-										HostPath: &v1.HostPathVolumeSource{
+									VolumeSource: corev1.VolumeSource{
+										HostPath: &corev1.HostPathVolumeSource{
 											Path: fsPvHostPath,
 										},
 									},
 								},
 								{
 									Name: HostPlugins,
-									VolumeSource: v1.VolumeSource{
-										HostPath: &v1.HostPathVolumeSource{
+									VolumeSource: corev1.VolumeSource{
+										HostPath: &corev1.HostPathVolumeSource{
 											Path: "/var/lib/kubelet/plugins",
 										},
 									},
 								},
 								{
 									Name: "scratch",
-									VolumeSource: v1.VolumeSource{
-										EmptyDir: &v1.EmptyDirVolumeSource{},
+									VolumeSource: corev1.VolumeSource{
+										EmptyDir: &corev1.EmptyDirVolumeSource{},
 									},
 								},
 								{
 									Name: "certs",
-									VolumeSource: v1.VolumeSource{
-										EmptyDir: &v1.EmptyDirVolumeSource{},
+									VolumeSource: corev1.VolumeSource{
+										EmptyDir: &corev1.EmptyDirVolumeSource{},
 									},
 								},
 							},
 							Tolerations: dpa.Spec.Configuration.NodeAgent.PodConfig.Tolerations,
-							Containers: []v1.Container{
+							Containers: []corev1.Container{
 								{
 									Name: common.NodeAgent,
-									SecurityContext: &v1.SecurityContext{
+									SecurityContext: &corev1.SecurityContext{
 										Privileged: pointer.Bool(true),
 									},
 									Image:           getVeleroImage(&dpa),
-									ImagePullPolicy: v1.PullAlways,
+									ImagePullPolicy: corev1.PullAlways,
 									Command: []string{
 										"/velero",
 									},
@@ -212,7 +210,7 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 										common.NodeAgent,
 										"server",
 									},
-									VolumeMounts: []v1.VolumeMount{
+									VolumeMounts: []corev1.VolumeMount{
 										{
 											Name:             HostPods,
 											MountPath:        "/host_pods",
@@ -238,19 +236,19 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 											corev1.ResourceMemory: resource.MustParse("128Mi"),
 										},
 									},
-									Env: []v1.EnvVar{
+									Env: []corev1.EnvVar{
 										{
 											Name: "NODE_NAME",
-											ValueFrom: &v1.EnvVarSource{
-												FieldRef: &v1.ObjectFieldSelector{
+											ValueFrom: &corev1.EnvVarSource{
+												FieldRef: &corev1.ObjectFieldSelector{
 													FieldPath: "spec.nodeName",
 												},
 											},
 										},
 										{
 											Name: "VELERO_NAMESPACE",
-											ValueFrom: &v1.EnvVarSource{
-												FieldRef: &v1.ObjectFieldSelector{
+											ValueFrom: &corev1.EnvVarSource{
+												FieldRef: &corev1.ObjectFieldSelector{
 													FieldPath: "metadata.namespace",
 												},
 											},
@@ -307,60 +305,60 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 						Type: appsv1.RollingUpdateDaemonSetStrategyType,
 					},
 					Selector: nodeAgentLabelSelector,
-					Template: v1.PodTemplateSpec{
+					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
 								"component": common.Velero,
 								"name":      common.NodeAgent,
 							},
 						},
-						Spec: v1.PodSpec{
+						Spec: corev1.PodSpec{
 							NodeSelector:       dpa.Spec.Configuration.NodeAgent.PodConfig.NodeSelector,
 							ServiceAccountName: common.Velero,
-							SecurityContext: &v1.PodSecurityContext{
+							SecurityContext: &corev1.PodSecurityContext{
 								RunAsUser:          pointer.Int64(0),
 								SupplementalGroups: dpa.Spec.Configuration.NodeAgent.SupplementalGroups,
 							},
-							Volumes: []v1.Volume{
+							Volumes: []corev1.Volume{
 								// Cloud Provider volumes are dynamically added in the for loop below
 								{
 									Name: HostPods,
-									VolumeSource: v1.VolumeSource{
-										HostPath: &v1.HostPathVolumeSource{
+									VolumeSource: corev1.VolumeSource{
+										HostPath: &corev1.HostPathVolumeSource{
 											Path: fsPvHostPath,
 										},
 									},
 								},
 								{
 									Name: HostPlugins,
-									VolumeSource: v1.VolumeSource{
-										HostPath: &v1.HostPathVolumeSource{
+									VolumeSource: corev1.VolumeSource{
+										HostPath: &corev1.HostPathVolumeSource{
 											Path: "/var/lib/kubelet/plugins",
 										},
 									},
 								},
 								{
 									Name: "scratch",
-									VolumeSource: v1.VolumeSource{
-										EmptyDir: &v1.EmptyDirVolumeSource{},
+									VolumeSource: corev1.VolumeSource{
+										EmptyDir: &corev1.EmptyDirVolumeSource{},
 									},
 								},
 								{
 									Name: "certs",
-									VolumeSource: v1.VolumeSource{
-										EmptyDir: &v1.EmptyDirVolumeSource{},
+									VolumeSource: corev1.VolumeSource{
+										EmptyDir: &corev1.EmptyDirVolumeSource{},
 									},
 								},
 							},
 							Tolerations: dpa.Spec.Configuration.NodeAgent.PodConfig.Tolerations,
-							Containers: []v1.Container{
+							Containers: []corev1.Container{
 								{
 									Name: common.NodeAgent,
-									SecurityContext: &v1.SecurityContext{
+									SecurityContext: &corev1.SecurityContext{
 										Privileged: pointer.Bool(true),
 									},
 									Image:           getVeleroImage(&dpa),
-									ImagePullPolicy: v1.PullAlways,
+									ImagePullPolicy: corev1.PullAlways,
 									Command: []string{
 										"/velero",
 									},
@@ -368,7 +366,7 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 										"node-agent",
 										"server",
 									},
-									VolumeMounts: []v1.VolumeMount{
+									VolumeMounts: []corev1.VolumeMount{
 										{
 											Name:             HostPods,
 											MountPath:        "/host_pods",
@@ -394,19 +392,19 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 											corev1.ResourceMemory: resource.MustParse("128Mi"),
 										},
 									},
-									Env: []v1.EnvVar{
+									Env: []corev1.EnvVar{
 										{
 											Name: "NODE_NAME",
-											ValueFrom: &v1.EnvVarSource{
-												FieldRef: &v1.ObjectFieldSelector{
+											ValueFrom: &corev1.EnvVarSource{
+												FieldRef: &corev1.ObjectFieldSelector{
 													FieldPath: "spec.nodeName",
 												},
 											},
 										},
 										{
 											Name: "VELERO_NAMESPACE",
-											ValueFrom: &v1.EnvVarSource{
-												FieldRef: &v1.ObjectFieldSelector{
+											ValueFrom: &corev1.EnvVarSource{
+												FieldRef: &corev1.ObjectFieldSelector{
 													FieldPath: "metadata.namespace",
 												},
 											},
@@ -468,7 +466,7 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 						Type: appsv1.RollingUpdateDaemonSetStrategyType,
 					},
 					Selector: nodeAgentLabelSelector,
-					Template: v1.PodTemplateSpec{
+					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
 								"component":      common.Velero,
@@ -476,53 +474,53 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 								"nodeAgentLabel": "this is a label",
 							},
 						},
-						Spec: v1.PodSpec{
+						Spec: corev1.PodSpec{
 							NodeSelector:       dpa.Spec.Configuration.NodeAgent.PodConfig.NodeSelector,
 							ServiceAccountName: common.Velero,
-							SecurityContext: &v1.PodSecurityContext{
+							SecurityContext: &corev1.PodSecurityContext{
 								RunAsUser:          pointer.Int64(0),
 								SupplementalGroups: dpa.Spec.Configuration.NodeAgent.SupplementalGroups,
 							},
-							Volumes: []v1.Volume{
+							Volumes: []corev1.Volume{
 								// Cloud Provider volumes are dynamically added in the for loop below
 								{
 									Name: HostPods,
-									VolumeSource: v1.VolumeSource{
-										HostPath: &v1.HostPathVolumeSource{
+									VolumeSource: corev1.VolumeSource{
+										HostPath: &corev1.HostPathVolumeSource{
 											Path: fsPvHostPath,
 										},
 									},
 								},
 								{
 									Name: HostPlugins,
-									VolumeSource: v1.VolumeSource{
-										HostPath: &v1.HostPathVolumeSource{
+									VolumeSource: corev1.VolumeSource{
+										HostPath: &corev1.HostPathVolumeSource{
 											Path: "/var/lib/kubelet/plugins",
 										},
 									},
 								},
 								{
 									Name: "scratch",
-									VolumeSource: v1.VolumeSource{
-										EmptyDir: &v1.EmptyDirVolumeSource{},
+									VolumeSource: corev1.VolumeSource{
+										EmptyDir: &corev1.EmptyDirVolumeSource{},
 									},
 								},
 								{
 									Name: "certs",
-									VolumeSource: v1.VolumeSource{
-										EmptyDir: &v1.EmptyDirVolumeSource{},
+									VolumeSource: corev1.VolumeSource{
+										EmptyDir: &corev1.EmptyDirVolumeSource{},
 									},
 								},
 							},
 							Tolerations: dpa.Spec.Configuration.NodeAgent.PodConfig.Tolerations,
-							Containers: []v1.Container{
+							Containers: []corev1.Container{
 								{
 									Name: common.NodeAgent,
-									SecurityContext: &v1.SecurityContext{
+									SecurityContext: &corev1.SecurityContext{
 										Privileged: pointer.Bool(true),
 									},
 									Image:           getVeleroImage(&dpa),
-									ImagePullPolicy: v1.PullAlways,
+									ImagePullPolicy: corev1.PullAlways,
 									Command: []string{
 										"/velero",
 									},
@@ -530,7 +528,7 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 										common.NodeAgent,
 										"server",
 									},
-									VolumeMounts: []v1.VolumeMount{
+									VolumeMounts: []corev1.VolumeMount{
 										{
 											Name:             HostPods,
 											MountPath:        "/host_pods",
@@ -556,19 +554,19 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 											corev1.ResourceMemory: resource.MustParse("128Mi"),
 										},
 									},
-									Env: []v1.EnvVar{
+									Env: []corev1.EnvVar{
 										{
 											Name: "NODE_NAME",
-											ValueFrom: &v1.EnvVarSource{
-												FieldRef: &v1.ObjectFieldSelector{
+											ValueFrom: &corev1.EnvVarSource{
+												FieldRef: &corev1.ObjectFieldSelector{
 													FieldPath: "spec.nodeName",
 												},
 											},
 										},
 										{
 											Name: "VELERO_NAMESPACE",
-											ValueFrom: &v1.EnvVarSource{
-												FieldRef: &v1.ObjectFieldSelector{
+											ValueFrom: &corev1.EnvVarSource{
+												FieldRef: &corev1.ObjectFieldSelector{
 													FieldPath: "metadata.namespace",
 												},
 											},
@@ -657,70 +655,70 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 						Type: appsv1.RollingUpdateDaemonSetStrategyType,
 					},
 					Selector: nodeAgentLabelSelector,
-					Template: v1.PodTemplateSpec{
+					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
 								"component": common.Velero,
 								"name":      common.NodeAgent,
 							},
 						},
-						Spec: v1.PodSpec{
+						Spec: corev1.PodSpec{
 							NodeSelector: map[string]string{
 								"foo": "bar",
 							},
 							ServiceAccountName: common.Velero,
-							SecurityContext: &v1.PodSecurityContext{
+							SecurityContext: &corev1.PodSecurityContext{
 								RunAsUser:          pointer.Int64(0),
 								SupplementalGroups: dpa.Spec.Configuration.NodeAgent.SupplementalGroups,
 							},
-							Volumes: []v1.Volume{
+							Volumes: []corev1.Volume{
 								// Cloud Provider volumes are dynamically added in the for loop below
 								{
 									Name: HostPods,
-									VolumeSource: v1.VolumeSource{
-										HostPath: &v1.HostPathVolumeSource{
+									VolumeSource: corev1.VolumeSource{
+										HostPath: &corev1.HostPathVolumeSource{
 											Path: fsPvHostPath,
 										},
 									},
 								},
 								{
 									Name: HostPlugins,
-									VolumeSource: v1.VolumeSource{
-										HostPath: &v1.HostPathVolumeSource{
+									VolumeSource: corev1.VolumeSource{
+										HostPath: &corev1.HostPathVolumeSource{
 											Path: "/var/lib/kubelet/plugins",
 										},
 									},
 								},
 								{
 									Name: "scratch",
-									VolumeSource: v1.VolumeSource{
-										EmptyDir: &v1.EmptyDirVolumeSource{},
+									VolumeSource: corev1.VolumeSource{
+										EmptyDir: &corev1.EmptyDirVolumeSource{},
 									},
 								},
 								{
 									Name: "certs",
-									VolumeSource: v1.VolumeSource{
-										EmptyDir: &v1.EmptyDirVolumeSource{},
+									VolumeSource: corev1.VolumeSource{
+										EmptyDir: &corev1.EmptyDirVolumeSource{},
 									},
 								},
 								{
 									Name: "cloud-credentials",
-									VolumeSource: v1.VolumeSource{
-										Secret: &v1.SecretVolumeSource{
+									VolumeSource: corev1.VolumeSource{
+										Secret: &corev1.SecretVolumeSource{
 											SecretName: "cloud-credentials",
 										},
 									},
 								},
 							},
 							Tolerations: dpa.Spec.Configuration.NodeAgent.PodConfig.Tolerations,
-							Containers: []v1.Container{
+							Containers: []corev1.Container{
 								{
 									Name: common.NodeAgent,
-									SecurityContext: &v1.SecurityContext{
+									SecurityContext: &corev1.SecurityContext{
 										Privileged: pointer.Bool(true),
 									},
 									Image:           getVeleroImage(&dpa),
-									ImagePullPolicy: v1.PullAlways,
+									ImagePullPolicy: corev1.PullAlways,
 									Command: []string{
 										"/velero",
 									},
@@ -728,7 +726,7 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 										common.NodeAgent,
 										"server",
 									},
-									VolumeMounts: []v1.VolumeMount{
+									VolumeMounts: []corev1.VolumeMount{
 										{
 											Name:             HostPods,
 											MountPath:        "/host_pods",
@@ -758,19 +756,19 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 											corev1.ResourceMemory: resource.MustParse("128Mi"),
 										},
 									},
-									Env: []v1.EnvVar{
+									Env: []corev1.EnvVar{
 										{
 											Name: "NODE_NAME",
-											ValueFrom: &v1.EnvVarSource{
-												FieldRef: &v1.ObjectFieldSelector{
+											ValueFrom: &corev1.EnvVarSource{
+												FieldRef: &corev1.ObjectFieldSelector{
 													FieldPath: "spec.nodeName",
 												},
 											},
 										},
 										{
 											Name: "VELERO_NAMESPACE",
-											ValueFrom: &v1.EnvVarSource{
-												FieldRef: &v1.ObjectFieldSelector{
+											ValueFrom: &corev1.EnvVarSource{
+												FieldRef: &corev1.ObjectFieldSelector{
 													FieldPath: "metadata.namespace",
 												},
 											},
@@ -841,70 +839,70 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 						Type: appsv1.RollingUpdateDaemonSetStrategyType,
 					},
 					Selector: nodeAgentLabelSelector,
-					Template: v1.PodTemplateSpec{
+					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
 								"component": common.Velero,
 								"name":      common.NodeAgent,
 							},
 						},
-						Spec: v1.PodSpec{
+						Spec: corev1.PodSpec{
 							NodeSelector: map[string]string{
 								"foo": "bar",
 							},
 							ServiceAccountName: common.Velero,
-							SecurityContext: &v1.PodSecurityContext{
+							SecurityContext: &corev1.PodSecurityContext{
 								RunAsUser:          pointer.Int64(0),
 								SupplementalGroups: dpa.Spec.Configuration.NodeAgent.SupplementalGroups,
 							},
-							Volumes: []v1.Volume{
+							Volumes: []corev1.Volume{
 								// Cloud Provider volumes are dynamically added in the for loop below
 								{
 									Name: HostPods,
-									VolumeSource: v1.VolumeSource{
-										HostPath: &v1.HostPathVolumeSource{
+									VolumeSource: corev1.VolumeSource{
+										HostPath: &corev1.HostPathVolumeSource{
 											Path: fsPvHostPath,
 										},
 									},
 								},
 								{
 									Name: HostPlugins,
-									VolumeSource: v1.VolumeSource{
-										HostPath: &v1.HostPathVolumeSource{
+									VolumeSource: corev1.VolumeSource{
+										HostPath: &corev1.HostPathVolumeSource{
 											Path: "/var/lib/kubelet/plugins",
 										},
 									},
 								},
 								{
 									Name: "scratch",
-									VolumeSource: v1.VolumeSource{
-										EmptyDir: &v1.EmptyDirVolumeSource{},
+									VolumeSource: corev1.VolumeSource{
+										EmptyDir: &corev1.EmptyDirVolumeSource{},
 									},
 								},
 								{
 									Name: "certs",
-									VolumeSource: v1.VolumeSource{
-										EmptyDir: &v1.EmptyDirVolumeSource{},
+									VolumeSource: corev1.VolumeSource{
+										EmptyDir: &corev1.EmptyDirVolumeSource{},
 									},
 								},
 								{
 									Name: "cloud-credentials",
-									VolumeSource: v1.VolumeSource{
-										Secret: &v1.SecretVolumeSource{
+									VolumeSource: corev1.VolumeSource{
+										Secret: &corev1.SecretVolumeSource{
 											SecretName: "cloud-credentials",
 										},
 									},
 								},
 							},
 							Tolerations: dpa.Spec.Configuration.NodeAgent.PodConfig.Tolerations,
-							Containers: []v1.Container{
+							Containers: []corev1.Container{
 								{
 									Name: common.NodeAgent,
-									SecurityContext: &v1.SecurityContext{
+									SecurityContext: &corev1.SecurityContext{
 										Privileged: pointer.Bool(true),
 									},
 									Image:           getVeleroImage(&dpa),
-									ImagePullPolicy: v1.PullAlways,
+									ImagePullPolicy: corev1.PullAlways,
 									Command: []string{
 										"/velero",
 									},
@@ -912,7 +910,7 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 										common.NodeAgent,
 										"server",
 									},
-									VolumeMounts: []v1.VolumeMount{
+									VolumeMounts: []corev1.VolumeMount{
 										{
 											Name:             HostPods,
 											MountPath:        "/host_pods",
@@ -946,19 +944,19 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 											corev1.ResourceMemory: resource.MustParse("256Mi"),
 										},
 									},
-									Env: []v1.EnvVar{
+									Env: []corev1.EnvVar{
 										{
 											Name: "NODE_NAME",
-											ValueFrom: &v1.EnvVarSource{
-												FieldRef: &v1.ObjectFieldSelector{
+											ValueFrom: &corev1.EnvVarSource{
+												FieldRef: &corev1.ObjectFieldSelector{
 													FieldPath: "spec.nodeName",
 												},
 											},
 										},
 										{
 											Name: "VELERO_NAMESPACE",
-											ValueFrom: &v1.EnvVarSource{
-												FieldRef: &v1.ObjectFieldSelector{
+											ValueFrom: &corev1.EnvVarSource{
+												FieldRef: &corev1.ObjectFieldSelector{
 													FieldPath: "metadata.namespace",
 												},
 											},
@@ -1024,70 +1022,70 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 						Type: appsv1.RollingUpdateDaemonSetStrategyType,
 					},
 					Selector: nodeAgentLabelSelector,
-					Template: v1.PodTemplateSpec{
+					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
 								"component": common.Velero,
 								"name":      common.NodeAgent,
 							},
 						},
-						Spec: v1.PodSpec{
+						Spec: corev1.PodSpec{
 							NodeSelector: map[string]string{
 								"foo": "bar",
 							},
 							ServiceAccountName: common.Velero,
-							SecurityContext: &v1.PodSecurityContext{
+							SecurityContext: &corev1.PodSecurityContext{
 								RunAsUser:          pointer.Int64(0),
 								SupplementalGroups: dpa.Spec.Configuration.NodeAgent.SupplementalGroups,
 							},
-							Volumes: []v1.Volume{
+							Volumes: []corev1.Volume{
 								// Cloud Provider volumes are dynamically added in the for loop below
 								{
 									Name: HostPods,
-									VolumeSource: v1.VolumeSource{
-										HostPath: &v1.HostPathVolumeSource{
+									VolumeSource: corev1.VolumeSource{
+										HostPath: &corev1.HostPathVolumeSource{
 											Path: fsPvHostPath,
 										},
 									},
 								},
 								{
 									Name: HostPlugins,
-									VolumeSource: v1.VolumeSource{
-										HostPath: &v1.HostPathVolumeSource{
+									VolumeSource: corev1.VolumeSource{
+										HostPath: &corev1.HostPathVolumeSource{
 											Path: "/var/lib/kubelet/plugins",
 										},
 									},
 								},
 								{
 									Name: "scratch",
-									VolumeSource: v1.VolumeSource{
-										EmptyDir: &v1.EmptyDirVolumeSource{},
+									VolumeSource: corev1.VolumeSource{
+										EmptyDir: &corev1.EmptyDirVolumeSource{},
 									},
 								},
 								{
 									Name: "certs",
-									VolumeSource: v1.VolumeSource{
-										EmptyDir: &v1.EmptyDirVolumeSource{},
+									VolumeSource: corev1.VolumeSource{
+										EmptyDir: &corev1.EmptyDirVolumeSource{},
 									},
 								},
 								{
 									Name: "cloud-credentials",
-									VolumeSource: v1.VolumeSource{
-										Secret: &v1.SecretVolumeSource{
+									VolumeSource: corev1.VolumeSource{
+										Secret: &corev1.SecretVolumeSource{
 											SecretName: "cloud-credentials",
 										},
 									},
 								},
 							},
 							Tolerations: dpa.Spec.Configuration.NodeAgent.PodConfig.Tolerations,
-							Containers: []v1.Container{
+							Containers: []corev1.Container{
 								{
 									Name: common.NodeAgent,
-									SecurityContext: &v1.SecurityContext{
+									SecurityContext: &corev1.SecurityContext{
 										Privileged: pointer.Bool(true),
 									},
 									Image:           getVeleroImage(&dpa),
-									ImagePullPolicy: v1.PullAlways,
+									ImagePullPolicy: corev1.PullAlways,
 									Command: []string{
 										"/velero",
 									},
@@ -1095,7 +1093,7 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 										common.NodeAgent,
 										"server",
 									},
-									VolumeMounts: []v1.VolumeMount{
+									VolumeMounts: []corev1.VolumeMount{
 										{
 											Name:             HostPods,
 											MountPath:        "/host_pods",
@@ -1128,19 +1126,19 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 											corev1.ResourceMemory: resource.MustParse("128Mi"),
 										},
 									},
-									Env: []v1.EnvVar{
+									Env: []corev1.EnvVar{
 										{
 											Name: "NODE_NAME",
-											ValueFrom: &v1.EnvVarSource{
-												FieldRef: &v1.ObjectFieldSelector{
+											ValueFrom: &corev1.EnvVarSource{
+												FieldRef: &corev1.ObjectFieldSelector{
 													FieldPath: "spec.nodeName",
 												},
 											},
 										},
 										{
 											Name: "VELERO_NAMESPACE",
-											ValueFrom: &v1.EnvVarSource{
-												FieldRef: &v1.ObjectFieldSelector{
+											ValueFrom: &corev1.EnvVarSource{
+												FieldRef: &corev1.ObjectFieldSelector{
 													FieldPath: "metadata.namespace",
 												},
 											},
@@ -1206,70 +1204,70 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 						Type: appsv1.RollingUpdateDaemonSetStrategyType,
 					},
 					Selector: nodeAgentLabelSelector,
-					Template: v1.PodTemplateSpec{
+					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
 								"component": common.Velero,
 								"name":      common.NodeAgent,
 							},
 						},
-						Spec: v1.PodSpec{
+						Spec: corev1.PodSpec{
 							NodeSelector: map[string]string{
 								"foo": "bar",
 							},
 							ServiceAccountName: common.Velero,
-							SecurityContext: &v1.PodSecurityContext{
+							SecurityContext: &corev1.PodSecurityContext{
 								RunAsUser:          pointer.Int64(0),
 								SupplementalGroups: dpa.Spec.Configuration.NodeAgent.SupplementalGroups,
 							},
-							Volumes: []v1.Volume{
+							Volumes: []corev1.Volume{
 								// Cloud Provider volumes are dynamically added in the for loop below
 								{
 									Name: HostPods,
-									VolumeSource: v1.VolumeSource{
-										HostPath: &v1.HostPathVolumeSource{
+									VolumeSource: corev1.VolumeSource{
+										HostPath: &corev1.HostPathVolumeSource{
 											Path: fsPvHostPath,
 										},
 									},
 								},
 								{
 									Name: HostPlugins,
-									VolumeSource: v1.VolumeSource{
-										HostPath: &v1.HostPathVolumeSource{
+									VolumeSource: corev1.VolumeSource{
+										HostPath: &corev1.HostPathVolumeSource{
 											Path: "/var/lib/kubelet/plugins",
 										},
 									},
 								},
 								{
 									Name: "scratch",
-									VolumeSource: v1.VolumeSource{
-										EmptyDir: &v1.EmptyDirVolumeSource{},
+									VolumeSource: corev1.VolumeSource{
+										EmptyDir: &corev1.EmptyDirVolumeSource{},
 									},
 								},
 								{
 									Name: "certs",
-									VolumeSource: v1.VolumeSource{
-										EmptyDir: &v1.EmptyDirVolumeSource{},
+									VolumeSource: corev1.VolumeSource{
+										EmptyDir: &corev1.EmptyDirVolumeSource{},
 									},
 								},
 								{
 									Name: "cloud-credentials",
-									VolumeSource: v1.VolumeSource{
-										Secret: &v1.SecretVolumeSource{
+									VolumeSource: corev1.VolumeSource{
+										Secret: &corev1.SecretVolumeSource{
 											SecretName: "cloud-credentials",
 										},
 									},
 								},
 							},
 							Tolerations: dpa.Spec.Configuration.NodeAgent.PodConfig.Tolerations,
-							Containers: []v1.Container{
+							Containers: []corev1.Container{
 								{
 									Name: common.NodeAgent,
-									SecurityContext: &v1.SecurityContext{
+									SecurityContext: &corev1.SecurityContext{
 										Privileged: pointer.Bool(true),
 									},
 									Image:           getVeleroImage(&dpa),
-									ImagePullPolicy: v1.PullAlways,
+									ImagePullPolicy: corev1.PullAlways,
 									Command: []string{
 										"/velero",
 									},
@@ -1277,7 +1275,7 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 										common.NodeAgent,
 										"server",
 									},
-									VolumeMounts: []v1.VolumeMount{
+									VolumeMounts: []corev1.VolumeMount{
 										{
 											Name:             HostPods,
 											MountPath:        "/host_pods",
@@ -1307,19 +1305,19 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 											corev1.ResourceMemory: resource.MustParse("128Mi"),
 										},
 									},
-									Env: []v1.EnvVar{
+									Env: []corev1.EnvVar{
 										{
 											Name: "NODE_NAME",
-											ValueFrom: &v1.EnvVarSource{
-												FieldRef: &v1.ObjectFieldSelector{
+											ValueFrom: &corev1.EnvVarSource{
+												FieldRef: &corev1.ObjectFieldSelector{
 													FieldPath: "spec.nodeName",
 												},
 											},
 										},
 										{
 											Name: "VELERO_NAMESPACE",
-											ValueFrom: &v1.EnvVarSource{
-												FieldRef: &v1.ObjectFieldSelector{
+											ValueFrom: &corev1.EnvVarSource{
+												FieldRef: &corev1.ObjectFieldSelector{
 													FieldPath: "metadata.namespace",
 												},
 											},
@@ -1385,70 +1383,70 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 						Type: appsv1.RollingUpdateDaemonSetStrategyType,
 					},
 					Selector: nodeAgentLabelSelector,
-					Template: v1.PodTemplateSpec{
+					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
 								"component": common.Velero,
 								"name":      common.NodeAgent,
 							},
 						},
-						Spec: v1.PodSpec{
+						Spec: corev1.PodSpec{
 							NodeSelector: map[string]string{
 								"foo": "bar",
 							},
 							ServiceAccountName: common.Velero,
-							SecurityContext: &v1.PodSecurityContext{
+							SecurityContext: &corev1.PodSecurityContext{
 								RunAsUser:          pointer.Int64(0),
 								SupplementalGroups: dpa.Spec.Configuration.NodeAgent.SupplementalGroups,
 							},
-							Volumes: []v1.Volume{
+							Volumes: []corev1.Volume{
 								// Cloud Provider volumes are dynamically added in the for loop below
 								{
 									Name: HostPods,
-									VolumeSource: v1.VolumeSource{
-										HostPath: &v1.HostPathVolumeSource{
+									VolumeSource: corev1.VolumeSource{
+										HostPath: &corev1.HostPathVolumeSource{
 											Path: fsPvHostPath,
 										},
 									},
 								},
 								{
 									Name: HostPlugins,
-									VolumeSource: v1.VolumeSource{
-										HostPath: &v1.HostPathVolumeSource{
+									VolumeSource: corev1.VolumeSource{
+										HostPath: &corev1.HostPathVolumeSource{
 											Path: "/var/lib/kubelet/plugins",
 										},
 									},
 								},
 								{
 									Name: "scratch",
-									VolumeSource: v1.VolumeSource{
-										EmptyDir: &v1.EmptyDirVolumeSource{},
+									VolumeSource: corev1.VolumeSource{
+										EmptyDir: &corev1.EmptyDirVolumeSource{},
 									},
 								},
 								{
 									Name: "certs",
-									VolumeSource: v1.VolumeSource{
-										EmptyDir: &v1.EmptyDirVolumeSource{},
+									VolumeSource: corev1.VolumeSource{
+										EmptyDir: &corev1.EmptyDirVolumeSource{},
 									},
 								},
 								{
 									Name: "cloud-credentials",
-									VolumeSource: v1.VolumeSource{
-										Secret: &v1.SecretVolumeSource{
+									VolumeSource: corev1.VolumeSource{
+										Secret: &corev1.SecretVolumeSource{
 											SecretName: "cloud-credentials",
 										},
 									},
 								},
 							},
 							Tolerations: dpa.Spec.Configuration.NodeAgent.PodConfig.Tolerations,
-							Containers: []v1.Container{
+							Containers: []corev1.Container{
 								{
 									Name: common.NodeAgent,
-									SecurityContext: &v1.SecurityContext{
+									SecurityContext: &corev1.SecurityContext{
 										Privileged: pointer.Bool(true),
 									},
 									Image:           getVeleroImage(&dpa),
-									ImagePullPolicy: v1.PullAlways,
+									ImagePullPolicy: corev1.PullAlways,
 									Command: []string{
 										"/velero",
 									},
@@ -1456,7 +1454,7 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 										common.NodeAgent,
 										"server",
 									},
-									VolumeMounts: []v1.VolumeMount{
+									VolumeMounts: []corev1.VolumeMount{
 										{
 											Name:             HostPods,
 											MountPath:        "/host_pods",
@@ -1489,19 +1487,19 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 											corev1.ResourceMemory: resource.MustParse("128Mi"),
 										},
 									},
-									Env: []v1.EnvVar{
+									Env: []corev1.EnvVar{
 										{
 											Name: "NODE_NAME",
-											ValueFrom: &v1.EnvVarSource{
-												FieldRef: &v1.ObjectFieldSelector{
+											ValueFrom: &corev1.EnvVarSource{
+												FieldRef: &corev1.ObjectFieldSelector{
 													FieldPath: "spec.nodeName",
 												},
 											},
 										},
 										{
 											Name: "VELERO_NAMESPACE",
-											ValueFrom: &v1.EnvVarSource{
-												FieldRef: &v1.ObjectFieldSelector{
+											ValueFrom: &corev1.EnvVarSource{
+												FieldRef: &corev1.ObjectFieldSelector{
 													FieldPath: "metadata.namespace",
 												},
 											},
@@ -1567,70 +1565,70 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 						Type: appsv1.RollingUpdateDaemonSetStrategyType,
 					},
 					Selector: nodeAgentLabelSelector,
-					Template: v1.PodTemplateSpec{
+					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
 								"component": common.Velero,
 								"name":      common.NodeAgent,
 							},
 						},
-						Spec: v1.PodSpec{
+						Spec: corev1.PodSpec{
 							NodeSelector: map[string]string{
 								"foo": "bar",
 							},
 							ServiceAccountName: common.Velero,
-							SecurityContext: &v1.PodSecurityContext{
+							SecurityContext: &corev1.PodSecurityContext{
 								RunAsUser:          pointer.Int64(0),
 								SupplementalGroups: dpa.Spec.Configuration.NodeAgent.SupplementalGroups,
 							},
-							Volumes: []v1.Volume{
+							Volumes: []corev1.Volume{
 								// Cloud Provider volumes are dynamically added in the for loop below
 								{
 									Name: HostPods,
-									VolumeSource: v1.VolumeSource{
-										HostPath: &v1.HostPathVolumeSource{
+									VolumeSource: corev1.VolumeSource{
+										HostPath: &corev1.HostPathVolumeSource{
 											Path: fsPvHostPath,
 										},
 									},
 								},
 								{
 									Name: HostPlugins,
-									VolumeSource: v1.VolumeSource{
-										HostPath: &v1.HostPathVolumeSource{
+									VolumeSource: corev1.VolumeSource{
+										HostPath: &corev1.HostPathVolumeSource{
 											Path: "/var/lib/kubelet/plugins",
 										},
 									},
 								},
 								{
 									Name: "scratch",
-									VolumeSource: v1.VolumeSource{
-										EmptyDir: &v1.EmptyDirVolumeSource{},
+									VolumeSource: corev1.VolumeSource{
+										EmptyDir: &corev1.EmptyDirVolumeSource{},
 									},
 								},
 								{
 									Name: "certs",
-									VolumeSource: v1.VolumeSource{
-										EmptyDir: &v1.EmptyDirVolumeSource{},
+									VolumeSource: corev1.VolumeSource{
+										EmptyDir: &corev1.EmptyDirVolumeSource{},
 									},
 								},
 								{
 									Name: "cloud-credentials",
-									VolumeSource: v1.VolumeSource{
-										Secret: &v1.SecretVolumeSource{
+									VolumeSource: corev1.VolumeSource{
+										Secret: &corev1.SecretVolumeSource{
 											SecretName: "cloud-credentials",
 										},
 									},
 								},
 							},
 							Tolerations: dpa.Spec.Configuration.NodeAgent.PodConfig.Tolerations,
-							Containers: []v1.Container{
+							Containers: []corev1.Container{
 								{
 									Name: common.NodeAgent,
-									SecurityContext: &v1.SecurityContext{
+									SecurityContext: &corev1.SecurityContext{
 										Privileged: pointer.Bool(true),
 									},
 									Image:           getVeleroImage(&dpa),
-									ImagePullPolicy: v1.PullAlways,
+									ImagePullPolicy: corev1.PullAlways,
 									Command: []string{
 										"/velero",
 									},
@@ -1638,7 +1636,7 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 										common.NodeAgent,
 										"server",
 									},
-									VolumeMounts: []v1.VolumeMount{
+									VolumeMounts: []corev1.VolumeMount{
 										{
 											Name:             HostPods,
 											MountPath:        "/host_pods",
@@ -1668,19 +1666,19 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 											corev1.ResourceMemory: resource.MustParse("256Mi"),
 										},
 									},
-									Env: []v1.EnvVar{
+									Env: []corev1.EnvVar{
 										{
 											Name: "NODE_NAME",
-											ValueFrom: &v1.EnvVarSource{
-												FieldRef: &v1.ObjectFieldSelector{
+											ValueFrom: &corev1.EnvVarSource{
+												FieldRef: &corev1.ObjectFieldSelector{
 													FieldPath: "spec.nodeName",
 												},
 											},
 										},
 										{
 											Name: "VELERO_NAMESPACE",
-											ValueFrom: &v1.EnvVarSource{
-												FieldRef: &v1.ObjectFieldSelector{
+											ValueFrom: &corev1.EnvVarSource{
+												FieldRef: &corev1.ObjectFieldSelector{
 													FieldPath: "metadata.namespace",
 												},
 											},
@@ -1710,7 +1708,7 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 							NodeAgent: &oadpv1alpha1.NodeAgentConfig{
 								NodeAgentCommonFields: oadpv1alpha1.NodeAgentCommonFields{
 									PodConfig: &oadpv1alpha1.PodConfig{
-										Tolerations: []v1.Toleration{
+										Tolerations: []corev1.Toleration{
 											{
 												Key:      "key1",
 												Operator: "Equal",
@@ -1746,59 +1744,59 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 						Type: appsv1.RollingUpdateDaemonSetStrategyType,
 					},
 					Selector: nodeAgentLabelSelector,
-					Template: v1.PodTemplateSpec{
+					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
 								"component": common.Velero,
 								"name":      common.NodeAgent,
 							},
 						},
-						Spec: v1.PodSpec{
+						Spec: corev1.PodSpec{
 							ServiceAccountName: common.Velero,
-							SecurityContext: &v1.PodSecurityContext{
+							SecurityContext: &corev1.PodSecurityContext{
 								RunAsUser:          pointer.Int64(0),
 								SupplementalGroups: dpa.Spec.Configuration.NodeAgent.SupplementalGroups,
 							},
-							Volumes: []v1.Volume{
+							Volumes: []corev1.Volume{
 								// Cloud Provider volumes are dynamically added in the for loop below
 								{
 									Name: HostPods,
-									VolumeSource: v1.VolumeSource{
-										HostPath: &v1.HostPathVolumeSource{
+									VolumeSource: corev1.VolumeSource{
+										HostPath: &corev1.HostPathVolumeSource{
 											Path: fsPvHostPath,
 										},
 									},
 								},
 								{
 									Name: HostPlugins,
-									VolumeSource: v1.VolumeSource{
-										HostPath: &v1.HostPathVolumeSource{
+									VolumeSource: corev1.VolumeSource{
+										HostPath: &corev1.HostPathVolumeSource{
 											Path: "/var/lib/kubelet/plugins",
 										},
 									},
 								},
 								{
 									Name: "scratch",
-									VolumeSource: v1.VolumeSource{
-										EmptyDir: &v1.EmptyDirVolumeSource{},
+									VolumeSource: corev1.VolumeSource{
+										EmptyDir: &corev1.EmptyDirVolumeSource{},
 									},
 								},
 								{
 									Name: "certs",
-									VolumeSource: v1.VolumeSource{
-										EmptyDir: &v1.EmptyDirVolumeSource{},
+									VolumeSource: corev1.VolumeSource{
+										EmptyDir: &corev1.EmptyDirVolumeSource{},
 									},
 								},
 								{
 									Name: "cloud-credentials",
-									VolumeSource: v1.VolumeSource{
-										Secret: &v1.SecretVolumeSource{
+									VolumeSource: corev1.VolumeSource{
+										Secret: &corev1.SecretVolumeSource{
 											SecretName: "cloud-credentials",
 										},
 									},
 								},
 							},
-							Tolerations: []v1.Toleration{
+							Tolerations: []corev1.Toleration{
 								{
 									Key:      "key1",
 									Operator: "Equal",
@@ -1806,14 +1804,14 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 									Effect:   "NoSchedule",
 								},
 							},
-							Containers: []v1.Container{
+							Containers: []corev1.Container{
 								{
 									Name: common.NodeAgent,
-									SecurityContext: &v1.SecurityContext{
+									SecurityContext: &corev1.SecurityContext{
 										Privileged: pointer.Bool(true),
 									},
 									Image:           getVeleroImage(&dpa),
-									ImagePullPolicy: v1.PullAlways,
+									ImagePullPolicy: corev1.PullAlways,
 									Command: []string{
 										"/velero",
 									},
@@ -1821,7 +1819,7 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 										common.NodeAgent,
 										"server",
 									},
-									VolumeMounts: []v1.VolumeMount{
+									VolumeMounts: []corev1.VolumeMount{
 										{
 											Name:             HostPods,
 											MountPath:        "/host_pods",
@@ -1851,19 +1849,19 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 											corev1.ResourceMemory: resource.MustParse("128Mi"),
 										},
 									},
-									Env: []v1.EnvVar{
+									Env: []corev1.EnvVar{
 										{
 											Name: "NODE_NAME",
-											ValueFrom: &v1.EnvVarSource{
-												FieldRef: &v1.ObjectFieldSelector{
+											ValueFrom: &corev1.EnvVarSource{
+												FieldRef: &corev1.ObjectFieldSelector{
 													FieldPath: "spec.nodeName",
 												},
 											},
 										},
 										{
 											Name: "VELERO_NAMESPACE",
-											ValueFrom: &v1.EnvVarSource{
-												FieldRef: &v1.ObjectFieldSelector{
+											ValueFrom: &corev1.EnvVarSource{
+												FieldRef: &corev1.ObjectFieldSelector{
 													FieldPath: "metadata.namespace",
 												},
 											},
@@ -1920,68 +1918,68 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 						Type: appsv1.RollingUpdateDaemonSetStrategyType,
 					},
 					Selector: nodeAgentLabelSelector,
-					Template: v1.PodTemplateSpec{
+					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
 								"component": common.Velero,
 								"name":      common.NodeAgent,
 							},
 						},
-						Spec: v1.PodSpec{
+						Spec: corev1.PodSpec{
 							NodeSelector:       dpa.Spec.Configuration.NodeAgent.PodConfig.NodeSelector,
 							ServiceAccountName: common.Velero,
-							SecurityContext: &v1.PodSecurityContext{
+							SecurityContext: &corev1.PodSecurityContext{
 								RunAsUser:          pointer.Int64(0),
 								SupplementalGroups: dpa.Spec.Configuration.NodeAgent.SupplementalGroups,
 							},
-							Volumes: []v1.Volume{
+							Volumes: []corev1.Volume{
 								// Cloud Provider volumes are dynamically added in the for loop below
 								{
 									Name: HostPods,
-									VolumeSource: v1.VolumeSource{
-										HostPath: &v1.HostPathVolumeSource{
+									VolumeSource: corev1.VolumeSource{
+										HostPath: &corev1.HostPathVolumeSource{
 											Path: fsPvHostPath,
 										},
 									},
 								},
 								{
 									Name: HostPlugins,
-									VolumeSource: v1.VolumeSource{
-										HostPath: &v1.HostPathVolumeSource{
+									VolumeSource: corev1.VolumeSource{
+										HostPath: &corev1.HostPathVolumeSource{
 											Path: "/var/lib/kubelet/plugins",
 										},
 									},
 								},
 								{
 									Name: "scratch",
-									VolumeSource: v1.VolumeSource{
-										EmptyDir: &v1.EmptyDirVolumeSource{},
+									VolumeSource: corev1.VolumeSource{
+										EmptyDir: &corev1.EmptyDirVolumeSource{},
 									},
 								},
 								{
 									Name: "certs",
-									VolumeSource: v1.VolumeSource{
-										EmptyDir: &v1.EmptyDirVolumeSource{},
+									VolumeSource: corev1.VolumeSource{
+										EmptyDir: &corev1.EmptyDirVolumeSource{},
 									},
 								},
 								{
 									Name: "cloud-credentials",
-									VolumeSource: v1.VolumeSource{
-										Secret: &v1.SecretVolumeSource{
+									VolumeSource: corev1.VolumeSource{
+										Secret: &corev1.SecretVolumeSource{
 											SecretName: "cloud-credentials",
 										},
 									},
 								},
 							},
 							Tolerations: dpa.Spec.Configuration.NodeAgent.PodConfig.Tolerations,
-							Containers: []v1.Container{
+							Containers: []corev1.Container{
 								{
 									Name: common.NodeAgent,
-									SecurityContext: &v1.SecurityContext{
+									SecurityContext: &corev1.SecurityContext{
 										Privileged: pointer.Bool(true),
 									},
 									Image:           getVeleroImage(&dpa),
-									ImagePullPolicy: v1.PullAlways,
+									ImagePullPolicy: corev1.PullAlways,
 									Command: []string{
 										"/velero",
 									},
@@ -1989,7 +1987,7 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 										common.NodeAgent,
 										"server",
 									},
-									VolumeMounts: []v1.VolumeMount{
+									VolumeMounts: []corev1.VolumeMount{
 										{
 											Name:             HostPods,
 											MountPath:        "/host_pods",
@@ -2019,19 +2017,19 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 											corev1.ResourceMemory: resource.MustParse("128Mi"),
 										},
 									},
-									Env: []v1.EnvVar{
+									Env: []corev1.EnvVar{
 										{
 											Name: "NODE_NAME",
-											ValueFrom: &v1.EnvVarSource{
-												FieldRef: &v1.ObjectFieldSelector{
+											ValueFrom: &corev1.EnvVarSource{
+												FieldRef: &corev1.ObjectFieldSelector{
 													FieldPath: "spec.nodeName",
 												},
 											},
 										},
 										{
 											Name: "VELERO_NAMESPACE",
-											ValueFrom: &v1.EnvVarSource{
-												FieldRef: &v1.ObjectFieldSelector{
+											ValueFrom: &corev1.EnvVarSource{
+												FieldRef: &corev1.ObjectFieldSelector{
 													FieldPath: "metadata.namespace",
 												},
 											},
@@ -2079,8 +2077,8 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 										S3URL:                 "https://sr-url-aws-domain.com",
 										InsecureSkipTLSVerify: "false",
 									},
-									Credential: &v1.SecretKeySelector{
-										LocalObjectReference: v1.LocalObjectReference{
+									Credential: &corev1.SecretKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "cloud-credentials",
 										},
 									},
@@ -2107,7 +2105,7 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 						Type: appsv1.RollingUpdateDaemonSetStrategyType,
 					},
 					Selector: nodeAgentLabelSelector,
-					Template: v1.PodTemplateSpec{
+					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
 								"component": common.Velero,
@@ -2117,53 +2115,53 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 								"test-annotation": "awesome annotation",
 							},
 						},
-						Spec: v1.PodSpec{
+						Spec: corev1.PodSpec{
 							NodeSelector:       dpa.Spec.Configuration.NodeAgent.PodConfig.NodeSelector,
 							ServiceAccountName: common.Velero,
-							SecurityContext: &v1.PodSecurityContext{
+							SecurityContext: &corev1.PodSecurityContext{
 								RunAsUser:          pointer.Int64(0),
 								SupplementalGroups: dpa.Spec.Configuration.NodeAgent.SupplementalGroups,
 							},
-							Volumes: []v1.Volume{
+							Volumes: []corev1.Volume{
 								// Cloud Provider volumes are dynamically added in the for loop below
 								{
 									Name: HostPods,
-									VolumeSource: v1.VolumeSource{
-										HostPath: &v1.HostPathVolumeSource{
+									VolumeSource: corev1.VolumeSource{
+										HostPath: &corev1.HostPathVolumeSource{
 											Path: fsPvHostPath,
 										},
 									},
 								},
 								{
 									Name: HostPlugins,
-									VolumeSource: v1.VolumeSource{
-										HostPath: &v1.HostPathVolumeSource{
+									VolumeSource: corev1.VolumeSource{
+										HostPath: &corev1.HostPathVolumeSource{
 											Path: "/var/lib/kubelet/plugins",
 										},
 									},
 								},
 								{
 									Name: "scratch",
-									VolumeSource: v1.VolumeSource{
-										EmptyDir: &v1.EmptyDirVolumeSource{},
+									VolumeSource: corev1.VolumeSource{
+										EmptyDir: &corev1.EmptyDirVolumeSource{},
 									},
 								},
 								{
 									Name: "certs",
-									VolumeSource: v1.VolumeSource{
-										EmptyDir: &v1.EmptyDirVolumeSource{},
+									VolumeSource: corev1.VolumeSource{
+										EmptyDir: &corev1.EmptyDirVolumeSource{},
 									},
 								},
 							},
 							Tolerations: dpa.Spec.Configuration.NodeAgent.PodConfig.Tolerations,
-							Containers: []v1.Container{
+							Containers: []corev1.Container{
 								{
 									Name: common.NodeAgent,
-									SecurityContext: &v1.SecurityContext{
+									SecurityContext: &corev1.SecurityContext{
 										Privileged: pointer.Bool(true),
 									},
 									Image:           getVeleroImage(&dpa),
-									ImagePullPolicy: v1.PullAlways,
+									ImagePullPolicy: corev1.PullAlways,
 									Command: []string{
 										"/velero",
 									},
@@ -2171,7 +2169,7 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 										common.NodeAgent,
 										"server",
 									},
-									VolumeMounts: []v1.VolumeMount{
+									VolumeMounts: []corev1.VolumeMount{
 										{
 											Name:             HostPods,
 											MountPath:        "/host_pods",
@@ -2197,19 +2195,19 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 											corev1.ResourceMemory: resource.MustParse("128Mi"),
 										},
 									},
-									Env: []v1.EnvVar{
+									Env: []corev1.EnvVar{
 										{
 											Name: "NODE_NAME",
-											ValueFrom: &v1.EnvVarSource{
-												FieldRef: &v1.ObjectFieldSelector{
+											ValueFrom: &corev1.EnvVarSource{
+												FieldRef: &corev1.ObjectFieldSelector{
 													FieldPath: "spec.nodeName",
 												},
 											},
 										},
 										{
 											Name: "VELERO_NAMESPACE",
-											ValueFrom: &v1.EnvVarSource{
-												FieldRef: &v1.ObjectFieldSelector{
+											ValueFrom: &corev1.EnvVarSource{
+												FieldRef: &corev1.ObjectFieldSelector{
 													FieldPath: "metadata.namespace",
 												},
 											},
@@ -2260,12 +2258,12 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 							"test-annotation": "awesome annotation",
 						},
 						PodDnsPolicy: "None",
-						PodDnsConfig: v1.PodDNSConfig{
+						PodDnsConfig: corev1.PodDNSConfig{
 							Nameservers: []string{
 								"1.1.1.1",
 								"8.8.8.8",
 							},
-							Options: []v1.PodDNSConfigOption{
+							Options: []corev1.PodDNSConfigOption{
 								{
 									Name:  "ndots",
 									Value: pointer.String("2"),
@@ -2292,7 +2290,7 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 						Type: appsv1.RollingUpdateDaemonSetStrategyType,
 					},
 					Selector: nodeAgentLabelSelector,
-					Template: v1.PodTemplateSpec{
+					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
 								"component": common.Velero,
@@ -2302,20 +2300,20 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 								"test-annotation": "awesome annotation",
 							},
 						},
-						Spec: v1.PodSpec{
+						Spec: corev1.PodSpec{
 							NodeSelector:       dpa.Spec.Configuration.NodeAgent.PodConfig.NodeSelector,
 							ServiceAccountName: common.Velero,
-							SecurityContext: &v1.PodSecurityContext{
+							SecurityContext: &corev1.PodSecurityContext{
 								RunAsUser:          pointer.Int64(0),
 								SupplementalGroups: dpa.Spec.Configuration.NodeAgent.SupplementalGroups,
 							},
 							DNSPolicy: "None",
-							DNSConfig: &v1.PodDNSConfig{
+							DNSConfig: &corev1.PodDNSConfig{
 								Nameservers: []string{
 									"1.1.1.1",
 									"8.8.8.8",
 								},
-								Options: []v1.PodDNSConfigOption{
+								Options: []corev1.PodDNSConfigOption{
 									{
 										Name:  "ndots",
 										Value: pointer.String("2"),
@@ -2325,54 +2323,54 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 									},
 								},
 							},
-							Volumes: []v1.Volume{
+							Volumes: []corev1.Volume{
 								// Cloud Provider volumes are dynamically added in the for loop below
 								{
 									Name: HostPods,
-									VolumeSource: v1.VolumeSource{
-										HostPath: &v1.HostPathVolumeSource{
+									VolumeSource: corev1.VolumeSource{
+										HostPath: &corev1.HostPathVolumeSource{
 											Path: fsPvHostPath,
 										},
 									},
 								},
 								{
 									Name: HostPlugins,
-									VolumeSource: v1.VolumeSource{
-										HostPath: &v1.HostPathVolumeSource{
+									VolumeSource: corev1.VolumeSource{
+										HostPath: &corev1.HostPathVolumeSource{
 											Path: "/var/lib/kubelet/plugins",
 										},
 									},
 								},
 								{
 									Name: "scratch",
-									VolumeSource: v1.VolumeSource{
-										EmptyDir: &v1.EmptyDirVolumeSource{},
+									VolumeSource: corev1.VolumeSource{
+										EmptyDir: &corev1.EmptyDirVolumeSource{},
 									},
 								},
 								{
 									Name: "certs",
-									VolumeSource: v1.VolumeSource{
-										EmptyDir: &v1.EmptyDirVolumeSource{},
+									VolumeSource: corev1.VolumeSource{
+										EmptyDir: &corev1.EmptyDirVolumeSource{},
 									},
 								},
 								{
 									Name: "cloud-credentials",
-									VolumeSource: v1.VolumeSource{
-										Secret: &v1.SecretVolumeSource{
+									VolumeSource: corev1.VolumeSource{
+										Secret: &corev1.SecretVolumeSource{
 											SecretName: "cloud-credentials",
 										},
 									},
 								},
 							},
 							Tolerations: dpa.Spec.Configuration.NodeAgent.PodConfig.Tolerations,
-							Containers: []v1.Container{
+							Containers: []corev1.Container{
 								{
 									Name: common.NodeAgent,
-									SecurityContext: &v1.SecurityContext{
+									SecurityContext: &corev1.SecurityContext{
 										Privileged: pointer.Bool(true),
 									},
 									Image:           getVeleroImage(&dpa),
-									ImagePullPolicy: v1.PullAlways,
+									ImagePullPolicy: corev1.PullAlways,
 									Command: []string{
 										"/velero",
 									},
@@ -2380,7 +2378,7 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 										common.NodeAgent,
 										"server",
 									},
-									VolumeMounts: []v1.VolumeMount{
+									VolumeMounts: []corev1.VolumeMount{
 										{
 											Name:             HostPods,
 											MountPath:        "/host_pods",
@@ -2410,19 +2408,19 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 											corev1.ResourceMemory: resource.MustParse("128Mi"),
 										},
 									},
-									Env: []v1.EnvVar{
+									Env: []corev1.EnvVar{
 										{
 											Name: "NODE_NAME",
-											ValueFrom: &v1.EnvVarSource{
-												FieldRef: &v1.ObjectFieldSelector{
+											ValueFrom: &corev1.EnvVarSource{
+												FieldRef: &corev1.ObjectFieldSelector{
 													FieldPath: "spec.nodeName",
 												},
 											},
 										},
 										{
 											Name: "VELERO_NAMESPACE",
-											ValueFrom: &v1.EnvVarSource{
-												FieldRef: &v1.ObjectFieldSelector{
+											ValueFrom: &corev1.EnvVarSource{
+												FieldRef: &corev1.ObjectFieldSelector{
 													FieldPath: "metadata.namespace",
 												},
 											},
@@ -2492,14 +2490,14 @@ func TestDPAReconciler_updateFsRestoreHelperCM(t *testing.T) {
 
 	tests := []struct {
 		name                  string
-		fsRestoreHelperCM     *v1.ConfigMap
+		fsRestoreHelperCM     *corev1.ConfigMap
 		dpa                   *oadpv1alpha1.DataProtectionApplication
 		wantErr               bool
-		wantFsRestoreHelperCM *v1.ConfigMap
+		wantFsRestoreHelperCM *corev1.ConfigMap
 	}{
 		{
 			name: "Given DPA CR instance, appropriate NodeAgent restore helper cm is created",
-			fsRestoreHelperCM: &v1.ConfigMap{
+			fsRestoreHelperCM: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      FsRestoreHelperCM,
 					Namespace: "test-ns",
@@ -2507,7 +2505,7 @@ func TestDPAReconciler_updateFsRestoreHelperCM(t *testing.T) {
 			},
 			dpa:     &oadpv1alpha1.DataProtectionApplication{},
 			wantErr: false,
-			wantFsRestoreHelperCM: &v1.ConfigMap{
+			wantFsRestoreHelperCM: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      FsRestoreHelperCM,
 					Namespace: "test-ns",

--- a/controllers/predicate.go
+++ b/controllers/predicate.go
@@ -1,11 +1,12 @@
 package controllers
 
 import (
-	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
 )
 
 func veleroPredicate(scheme *runtime.Scheme) predicate.Predicate {

--- a/controllers/registry.go
+++ b/controllers/registry.go
@@ -7,23 +7,21 @@ import (
 	"regexp"
 	"strings"
 
-	"k8s.io/apimachinery/pkg/labels"
-
-	"github.com/openshift/oadp-operator/pkg/credentials"
-	"k8s.io/apimachinery/pkg/types"
-
 	"github.com/go-logr/logr"
 	routev1 "github.com/openshift/api/route/v1"
-	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
-	"github.com/openshift/oadp-operator/pkg/common"
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
+	"github.com/openshift/oadp-operator/pkg/common"
+	"github.com/openshift/oadp-operator/pkg/credentials"
 )
 
 // Registry Env var keys

--- a/controllers/registry_test.go
+++ b/controllers/registry_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
-	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -14,6 +13,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
+
+	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
 )
 
 func getSchemeForFakeClientForRegistry() (*runtime.Scheme, error) {

--- a/controllers/restore_resource_version_priority.go
+++ b/controllers/restore_resource_version_priority.go
@@ -3,10 +3,11 @@ package controllers
 import (
 	"fmt"
 
-	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
 )
 
 const (

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -29,7 +29,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
-	//+kubebuilder:scaffold:imports
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -20,8 +20,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -38,37 +38,37 @@ var k8sClient client.Client
 var testEnv *envtest.Environment
 
 func TestAPIs(t *testing.T) {
-	RegisterFailHandler(Fail)
+	gomega.RegisterFailHandler(ginkgo.Fail)
 
-	RunSpecs(t, "Controller Suite")
+	ginkgo.RunSpecs(t, "Controller Suite")
 }
 
-var _ = BeforeSuite(func() {
-	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+var _ = ginkgo.BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(ginkgo.GinkgoWriter), zap.UseDevMode(true)))
 
-	By("bootstrapping test environment")
+	ginkgo.By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths:     []string{filepath.Join("..", "config", "crd", "bases")},
 		ErrorIfCRDPathMissing: true,
 	}
 
 	cfg, err := testEnv.Start()
-	Expect(err).NotTo(HaveOccurred())
-	Expect(cfg).NotTo(BeNil())
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	gomega.Expect(cfg).NotTo(gomega.BeNil())
 
 	err = oadpv1alpha1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	//+kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
-	Expect(err).NotTo(HaveOccurred())
-	Expect(k8sClient).NotTo(BeNil())
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	gomega.Expect(k8sClient).NotTo(gomega.BeNil())
 
 }, 60)
 
-var _ = AfterSuite(func() {
-	By("tearing down the test environment")
+var _ = ginkgo.AfterSuite(func() {
+	ginkgo.By("tearing down the test environment")
 	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 })

--- a/controllers/validator.go
+++ b/controllers/validator.go
@@ -7,6 +7,7 @@ import (
 
 	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/go-logr/logr"
+
 	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
 	"github.com/openshift/oadp-operator/pkg/credentials"
 )

--- a/controllers/validator_test.go
+++ b/controllers/validator_test.go
@@ -4,8 +4,7 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
-	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
-	v1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	"github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -13,6 +12,8 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
 )
 
 func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {

--- a/controllers/velero.go
+++ b/controllers/velero.go
@@ -7,29 +7,27 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/vmware-tanzu/velero/pkg/util/boolptr"
-
+	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
-	"github.com/openshift/oadp-operator/pkg/credentials"
 	"github.com/operator-framework/operator-lib/proxy"
 	"github.com/sirupsen/logrus"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/util/intstr"
-
-	"github.com/go-logr/logr"
-	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
-	"github.com/openshift/oadp-operator/pkg/common"
 	"github.com/vmware-tanzu/velero/pkg/install"
+	"github.com/vmware-tanzu/velero/pkg/util/boolptr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
-
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
+	"github.com/openshift/oadp-operator/pkg/common"
+	"github.com/openshift/oadp-operator/pkg/credentials"
 )
 
 const (

--- a/controllers/velero_test.go
+++ b/controllers/velero_test.go
@@ -10,10 +10,6 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
-	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
-	oadpClient "github.com/openshift/oadp-operator/pkg/client"
-	"github.com/openshift/oadp-operator/pkg/common"
-	"github.com/openshift/oadp-operator/pkg/velero/server"
 	"github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -25,6 +21,11 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
+	oadpclient "github.com/openshift/oadp-operator/pkg/client"
+	"github.com/openshift/oadp-operator/pkg/common"
+	"github.com/openshift/oadp-operator/pkg/velero/server"
 )
 
 const (
@@ -4117,7 +4118,7 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 			r := DPAReconciler{
 				Client: fakeClient,
 			}
-			oadpClient.SetClient(fakeClient)
+			oadpclient.SetClient(fakeClient)
 			if tt.testProxy {
 				os.Setenv(proxyEnvKey, proxyEnvValue)
 				defer os.Unsetenv(proxyEnvKey)

--- a/controllers/vsl.go
+++ b/controllers/vsl.go
@@ -6,12 +6,13 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
-	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
-	"github.com/openshift/oadp-operator/pkg/credentials"
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
+	"github.com/openshift/oadp-operator/pkg/credentials"
 )
 
 // provider specific object storage

--- a/controllers/vsl_test.go
+++ b/controllers/vsl_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
-	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -13,6 +12,8 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
 )
 
 func TestDPAReconciler_ValidateVolumeSnapshotLocation(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -23,36 +23,36 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/openshift/oadp-operator/pkg/common"
-	monitor "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/discovery"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
-	client "sigs.k8s.io/controller-runtime/pkg/client"
 
-	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
-	// to ensure that exec-entrypoint and run can make use of them.
-	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	"k8s.io/client-go/rest"
 
 	routev1 "github.com/openshift/api/route/v1"
 	security "github.com/openshift/api/security/v1"
-	"github.com/openshift/oadp-operator/controllers"
+	monitor "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
+	// to ensure that exec-entrypoint and run can make use of them.
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	//+kubebuilder:scaffold:imports
 	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
+	"github.com/openshift/oadp-operator/controllers"
+	"github.com/openshift/oadp-operator/pkg/common"
 	"github.com/openshift/oadp-operator/pkg/leaderelection"
 )
 
@@ -306,7 +306,7 @@ func DoesCRDExist(CRDGroupVersion, CRDName string, kubeconf *rest.Config) (bool,
 
 // CreateCredRequest WITP : WebIdentityTokenPath
 func CreateCredRequest(roleARN string, WITP string, secretNS string, kubeconf *rest.Config) error {
-	client, err := client.New(kubeconf, client.Options{})
+	clientInstance, err := client.New(kubeconf, client.Options{})
 	if err != nil {
 		setupLog.Error(err, "unable to create client")
 	}
@@ -349,7 +349,7 @@ func CreateCredRequest(roleARN string, WITP string, secretNS string, kubeconf *r
 		},
 	}
 
-	if err := client.Create(context.Background(), credRequest); err != nil {
+	if err := clientInstance.Create(context.Background(), credRequest); err != nil {
 		setupLog.Error(err, "unable to create credentials request resource")
 	}
 

--- a/main.go
+++ b/main.go
@@ -23,10 +23,6 @@ import (
 	"fmt"
 	"os"
 
-	"k8s.io/apimachinery/pkg/types"
-
-	"k8s.io/client-go/rest"
-
 	routev1 "github.com/openshift/api/route/v1"
 	security "github.com/openshift/api/security/v1"
 	monitor "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -37,6 +33,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes"
@@ -44,6 +41,7 @@ import (
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"

--- a/main_test.go
+++ b/main_test.go
@@ -20,8 +20,8 @@ import (
 	"context"
 	"testing"
 
-	coreV1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
@@ -80,7 +80,7 @@ func TestAddPodSecurityPrivilegedLabels(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create a new namespace with the existing labels
-			namespace := coreV1.Namespace{
+			namespace := corev1.Namespace{
 				ObjectMeta: v1.ObjectMeta{
 					Name:   testNamespaceName,
 					Labels: tt.existingLabels,

--- a/pkg/bucket/aws.go
+++ b/pkg/bucket/aws.go
@@ -8,8 +8,9 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
-	"github.com/openshift/oadp-operator/api/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openshift/oadp-operator/api/v1alpha1"
 )
 
 type awsBucketClient struct {

--- a/pkg/bucket/client.go
+++ b/pkg/bucket/client.go
@@ -4,15 +4,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/openshift/oadp-operator/pkg/common"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 
-	"github.com/openshift/oadp-operator/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openshift/oadp-operator/api/v1alpha1"
+	"github.com/openshift/oadp-operator/pkg/common"
 )
 
 var (

--- a/pkg/credentials/credentials.go
+++ b/pkg/credentials/credentials.go
@@ -6,15 +6,15 @@ import (
 	"os"
 	"strings"
 
-	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
-
-	"github.com/openshift/oadp-operator/pkg/client"
-	"github.com/openshift/oadp-operator/pkg/common"
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+
+	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
+	"github.com/openshift/oadp-operator/pkg/client"
+	"github.com/openshift/oadp-operator/pkg/common"
 )
 
 type DefaultPluginFields struct {

--- a/pkg/credentials/credentials_test.go
+++ b/pkg/credentials/credentials_test.go
@@ -5,12 +5,13 @@ import (
 	"os"
 	"testing"
 
-	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
-	"github.com/openshift/oadp-operator/pkg/client"
-	"github.com/openshift/oadp-operator/pkg/common"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
+	"github.com/openshift/oadp-operator/pkg/client"
+	"github.com/openshift/oadp-operator/pkg/common"
 )
 
 func TestCredentials_getPluginImage(t *testing.T) {

--- a/pkg/leaderelection/leaderelection.go
+++ b/pkg/leaderelection/leaderelection.go
@@ -3,16 +3,17 @@ package leaderelection
 import (
 	"context"
 	"fmt"
-	configv1 "github.com/openshift/api/config/v1"
 	"io/ioutil"
+	"math"
+	"strings"
+	"time"
+
+	configv1 "github.com/openshift/api/config/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
-	"math"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"strings"
-	"time"
 )
 
 const infraResourceName = "cluster"
@@ -106,14 +107,14 @@ func GetClusterInfraStatus(restClient *rest.Config) (*configv1.InfrastructureSta
 	if err != nil {
 		return nil, err
 	}
-	client, err := client.New(restClient, client.Options{})
+	clientInstance, err := client.New(restClient, client.Options{})
 	if err != nil {
 		return nil, err
 	}
 
 	infra := &configv1.Infrastructure{}
 	key := types.NamespacedName{Name: infraResourceName}
-	if err = client.Get(context.TODO(), key, infra); err != nil {
+	if err = clientInstance.Get(context.TODO(), key, infra); err != nil {
 		return nil, err
 	}
 

--- a/pkg/storage/aws/s3.go
+++ b/pkg/storage/aws/s3.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"context"
-
 	"errors"
 
 	"github.com/aws/aws-sdk-go/aws/endpoints"
@@ -21,7 +20,7 @@ func BucketRegionIsDiscoverable(bucket string) bool {
 func GetBucketRegion(bucket string) (string, error) {
 	var region string
 
-	session, err := session.NewSession()
+	sessionInstance, err := session.NewSession()
 	if err != nil {
 		// return "", errors.WithStack(err) // don't need stack trace, not inside velero-plugin
 		return "", err
@@ -29,7 +28,7 @@ func GetBucketRegion(bucket string) (string, error) {
 
 	for _, partition := range endpoints.DefaultPartitions() {
 		for regionHint := range partition.Regions() {
-			region, _ = s3manager.GetBucketRegion(context.Background(), session, bucket, regionHint)
+			region, _ = s3manager.GetBucketRegion(context.Background(), sessionInstance, bucket, regionHint)
 
 			// we only need to try a single region hint per partition, so break after the first
 			break

--- a/pkg/velero/server/args.go
+++ b/pkg/velero/server/args.go
@@ -5,10 +5,11 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/openshift/oadp-operator/pkg/klog"
-	"github.com/openshift/oadp-operator/pkg/velero/client"
 	"github.com/sirupsen/logrus"
 	"github.com/vmware-tanzu/velero/pkg/util/boolptr"
+
+	"github.com/openshift/oadp-operator/pkg/klog"
+	"github.com/openshift/oadp-operator/pkg/velero/client"
 )
 
 // VeleroServerArgs are the arguments that are passed to the Velero server

--- a/pkg/velero/server/config.go
+++ b/pkg/velero/server/config.go
@@ -4,7 +4,7 @@ import (
 	"time"
 
 	"github.com/vmware-tanzu/velero/pkg/client"
-	vServer "github.com/vmware-tanzu/velero/pkg/cmd/server"
+	veleroserver "github.com/vmware-tanzu/velero/pkg/cmd/server"
 )
 
 // This package is used to store ServerConfig struct and note information about flags for velero server and how they are set.
@@ -89,4 +89,4 @@ type ServerConfig struct {
 	MaxConcurrentK8SConnections *int `json:"max-concurrent-k8s-connections,omitempty"`
 }
 
-var VeleroServerCommand = vServer.NewCommand(client.NewFactory("velero-server", client.VeleroConfig{})).Flags()
+var VeleroServerCommand = veleroserver.NewCommand(client.NewFactory("velero-server", client.VeleroConfig{})).Flags()

--- a/tests/e2e/backup_restore_suite_test.go
+++ b/tests/e2e/backup_restore_suite_test.go
@@ -10,32 +10,32 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	ginkgov2 "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	k8serror "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	. "github.com/openshift/oadp-operator/tests/e2e/lib"
+	"github.com/openshift/oadp-operator/tests/e2e/lib"
 )
 
 type VerificationFunction func(client.Client, string) error
 
-type appVerificationFunction func(bool, bool, BackupRestoreType) VerificationFunction
+type appVerificationFunction func(bool, bool, lib.BackupRestoreType) VerificationFunction
 
 // TODO duplications with mongoready
 func mongoready(preBackupState bool, twoVol bool) VerificationFunction {
 	return VerificationFunction(func(ocClient client.Client, namespace string) error {
-		Eventually(IsDCReady(ocClient, namespace, "todolist"), timeoutMultiplier*time.Minute*10, time.Second*10).Should(BeTrue())
-		exists, err := DoesSCCExist(ocClient, "mongo-persistent-scc")
+		gomega.Eventually(lib.IsDCReady(ocClient, namespace, "todolist"), timeoutMultiplier*time.Minute*10, time.Second*10).Should(gomega.BeTrue())
+		exists, err := lib.DoesSCCExist(ocClient, "mongo-persistent-scc")
 		if err != nil {
 			return err
 		}
 		if !exists {
 			return errors.New("did not find Mongo scc")
 		}
-		err = VerifyBackupRestoreData(runTimeClientForSuiteRun, kubernetesClientForSuiteRun, kubeConfig, artifact_dir, namespace, "todolist-route", "todolist", "todolist", preBackupState, false)
+		err = lib.VerifyBackupRestoreData(runTimeClientForSuiteRun, kubernetesClientForSuiteRun, kubeConfig, artifact_dir, namespace, "todolist-route", "todolist", "todolist", preBackupState, false)
 		return err
 	})
 }
@@ -44,15 +44,15 @@ func mysqlReady(preBackupState bool, twoVol bool) VerificationFunction {
 	return VerificationFunction(func(ocClient client.Client, namespace string) error {
 		log.Printf("checking for the NAMESPACE: %s", namespace)
 		// This test confirms that SCC restore logic in our plugin is working
-		Eventually(IsDeploymentReady(ocClient, namespace, "mysql"), timeoutMultiplier*time.Minute*10, time.Second*10).Should(BeTrue())
-		exists, err := DoesSCCExist(ocClient, "mysql-persistent-scc")
+		gomega.Eventually(lib.IsDeploymentReady(ocClient, namespace, "mysql"), timeoutMultiplier*time.Minute*10, time.Second*10).Should(gomega.BeTrue())
+		exists, err := lib.DoesSCCExist(ocClient, "mysql-persistent-scc")
 		if err != nil {
 			return err
 		}
 		if !exists {
 			return errors.New("did not find MYSQL scc")
 		}
-		err = VerifyBackupRestoreData(runTimeClientForSuiteRun, kubernetesClientForSuiteRun, kubeConfig, artifact_dir, namespace, "todolist-route", "todolist", "todolist", preBackupState, twoVol)
+		err = lib.VerifyBackupRestoreData(runTimeClientForSuiteRun, kubernetesClientForSuiteRun, kubeConfig, artifact_dir, namespace, "todolist-route", "todolist", "todolist", preBackupState, twoVol)
 		return err
 	})
 }
@@ -62,7 +62,7 @@ type BackupRestoreCase struct {
 	PvcSuffixName                string
 	ApplicationNamespace         string
 	Name                         string
-	BackupRestoreType            BackupRestoreType
+	BackupRestoreType            lib.BackupRestoreType
 	PreBackupVerify              VerificationFunction
 	PostRestoreVerify            VerificationFunction
 	AppReadyDelay                time.Duration
@@ -74,27 +74,27 @@ func runBackupAndRestore(brCase BackupRestoreCase, expectedErr error, updateLast
 	updateLastBRcase(brCase)
 
 	err := dpaCR.Build(brCase.BackupRestoreType)
-	Expect(err).NotTo(HaveOccurred())
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	//updateLastInstallingNamespace(dpaCR.Namespace)
 	updateLastInstallTime()
 
 	err = dpaCR.CreateOrUpdate(runTimeClientForSuiteRun, &dpaCR.CustomResource.Spec)
-	Expect(err).NotTo(HaveOccurred())
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	log.Printf("Waiting for velero pod to be running")
-	Eventually(AreVeleroPodsRunning(kubernetesClientForSuiteRun, namespace), timeoutMultiplier*time.Minute*3, time.Second*5).Should(BeTrue())
+	gomega.Eventually(lib.AreVeleroPodsRunning(kubernetesClientForSuiteRun, namespace), timeoutMultiplier*time.Minute*3, time.Second*5).Should(gomega.BeTrue())
 
-	if brCase.BackupRestoreType == RESTIC || brCase.BackupRestoreType == KOPIA || brCase.BackupRestoreType == CSIDataMover {
+	if brCase.BackupRestoreType == lib.RESTIC || brCase.BackupRestoreType == lib.KOPIA || brCase.BackupRestoreType == lib.CSIDataMover {
 		log.Printf("Waiting for Node Agent pods to be running")
-		Eventually(AreNodeAgentPodsRunning(kubernetesClientForSuiteRun, namespace), timeoutMultiplier*time.Minute*3, time.Second*5).Should(BeTrue())
+		gomega.Eventually(lib.AreNodeAgentPodsRunning(kubernetesClientForSuiteRun, namespace), timeoutMultiplier*time.Minute*3, time.Second*5).Should(gomega.BeTrue())
 	}
-	if brCase.BackupRestoreType == CSI || brCase.BackupRestoreType == CSIDataMover {
+	if brCase.BackupRestoreType == lib.CSI || brCase.BackupRestoreType == lib.CSIDataMover {
 		if provider == "aws" || provider == "ibmcloud" || provider == "gcp" || provider == "azure" {
 			log.Printf("Creating VolumeSnapshotClass for CSI backuprestore of %s", brCase.Name)
 			snapshotClassPath := fmt.Sprintf("./sample-applications/snapclass-csi/%s.yaml", provider)
-			err = InstallApplication(dpaCR.Client, snapshotClassPath)
-			Expect(err).ToNot(HaveOccurred())
+			err = lib.InstallApplication(dpaCR.Client, snapshotClassPath)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		}
 	}
 
@@ -109,9 +109,9 @@ func runBackupAndRestore(brCase BackupRestoreCase, expectedErr error, updateLast
 	// install app
 	updateLastInstallTime()
 	log.Printf("Installing application for case %s", brCase.Name)
-	err = InstallApplication(dpaCR.Client, brCase.ApplicationTemplate)
-	Expect(err).ToNot(HaveOccurred())
-	if brCase.BackupRestoreType == CSI || brCase.BackupRestoreType == CSIDataMover {
+	err = lib.InstallApplication(dpaCR.Client, brCase.ApplicationTemplate)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	if brCase.BackupRestoreType == lib.CSI || brCase.BackupRestoreType == lib.CSIDataMover {
 		log.Printf("Creating pvc for case %s", brCase.Name)
 		var pvcName string
 		var pvcPath string
@@ -128,81 +128,81 @@ func runBackupAndRestore(brCase BackupRestoreCase, expectedErr error, updateLast
 
 		pvcPath = fmt.Sprintf(pvcPathFormat, brCase.ApplicationNamespace, pvcName)
 
-		err = InstallApplication(dpaCR.Client, pvcPath)
-		Expect(err).ToNot(HaveOccurred())
+		err = lib.InstallApplication(dpaCR.Client, pvcPath)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 	}
 
 	// wait for pods to be running
-	Eventually(AreAppBuildsReady(dpaCR.Client, brCase.ApplicationNamespace), timeoutMultiplier*time.Minute*5, time.Second*5).Should(BeTrue())
-	Eventually(AreApplicationPodsRunning(kubernetesClientForSuiteRun, brCase.ApplicationNamespace), timeoutMultiplier*time.Minute*9, time.Second*5).Should(BeTrue())
+	gomega.Eventually(lib.AreAppBuildsReady(dpaCR.Client, brCase.ApplicationNamespace), timeoutMultiplier*time.Minute*5, time.Second*5).Should(gomega.BeTrue())
+	gomega.Eventually(lib.AreApplicationPodsRunning(kubernetesClientForSuiteRun, brCase.ApplicationNamespace), timeoutMultiplier*time.Minute*9, time.Second*5).Should(gomega.BeTrue())
 
 	// Run optional custom verification
 	log.Printf("Running pre-backup function for case %s", brCase.Name)
 	err = brCase.PreBackupVerify(dpaCR.Client, brCase.ApplicationNamespace)
-	Expect(err).ToNot(HaveOccurred())
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-	nsRequiresResticDCWorkaround, err := NamespaceRequiresResticDCWorkaround(dpaCR.Client, brCase.ApplicationNamespace)
-	Expect(err).ToNot(HaveOccurred())
+	nsRequiresResticDCWorkaround, err := lib.NamespaceRequiresResticDCWorkaround(dpaCR.Client, brCase.ApplicationNamespace)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 	// TODO this should be a function, not an arbitrary sleep
 	log.Printf("Sleeping for %v to allow application to be ready for case %s", brCase.AppReadyDelay, brCase.Name)
 	time.Sleep(brCase.AppReadyDelay)
 	// create backup
 	log.Printf("Creating backup %s for case %s", backupName, brCase.Name)
-	backup, err := CreateBackupForNamespaces(dpaCR.Client, namespace, backupName, []string{brCase.ApplicationNamespace}, brCase.BackupRestoreType == RESTIC || brCase.BackupRestoreType == KOPIA, brCase.BackupRestoreType == CSIDataMover)
-	Expect(err).ToNot(HaveOccurred())
+	backup, err := lib.CreateBackupForNamespaces(dpaCR.Client, namespace, backupName, []string{brCase.ApplicationNamespace}, brCase.BackupRestoreType == lib.RESTIC || brCase.BackupRestoreType == lib.KOPIA, brCase.BackupRestoreType == lib.CSIDataMover)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 	// wait for backup to not be running
-	Eventually(IsBackupDone(dpaCR.Client, namespace, backupName), timeoutMultiplier*time.Minute*20, time.Second*10).Should(BeTrue())
+	gomega.Eventually(lib.IsBackupDone(dpaCR.Client, namespace, backupName), timeoutMultiplier*time.Minute*20, time.Second*10).Should(gomega.BeTrue())
 	// TODO only log on fail?
-	describeBackup := DescribeBackup(veleroClientForSuiteRun, csiClientForSuiteRun, dpaCR.Client, backup)
-	GinkgoWriter.Println(describeBackup)
+	describeBackup := lib.DescribeBackup(veleroClientForSuiteRun, csiClientForSuiteRun, dpaCR.Client, backup)
+	ginkgov2.GinkgoWriter.Println(describeBackup)
 
-	backupLogs := BackupLogs(kubernetesClientForSuiteRun, dpaCR.Client, backup)
-	backupErrorLogs := BackupErrorLogs(kubernetesClientForSuiteRun, dpaCR.Client, backup)
+	backupLogs := lib.BackupLogs(kubernetesClientForSuiteRun, dpaCR.Client, backup)
+	backupErrorLogs := lib.BackupErrorLogs(kubernetesClientForSuiteRun, dpaCR.Client, backup)
 	accumulatedTestLogs = append(accumulatedTestLogs, describeBackup, backupLogs)
 
-	Expect(backupErrorLogs).Should(Equal([]string{}))
+	gomega.Expect(backupErrorLogs).Should(gomega.Equal([]string{}))
 
 	// check if backup succeeded
-	succeeded, err := IsBackupCompletedSuccessfully(kubernetesClientForSuiteRun, dpaCR.Client, backup)
-	Expect(err).ToNot(HaveOccurred())
-	Expect(succeeded).To(Equal(true))
+	succeeded, err := lib.IsBackupCompletedSuccessfully(kubernetesClientForSuiteRun, dpaCR.Client, backup)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	gomega.Expect(succeeded).To(gomega.Equal(true))
 	log.Printf("Backup for case %s succeeded", brCase.Name)
 
-	if brCase.BackupRestoreType == CSI {
+	if brCase.BackupRestoreType == lib.CSI {
 		// wait for volume snapshot to be Ready
-		Eventually(AreVolumeSnapshotsReady(dpaCR.Client, backupName), timeoutMultiplier*time.Minute*4, time.Second*10).Should(BeTrue())
+		gomega.Eventually(lib.AreVolumeSnapshotsReady(dpaCR.Client, backupName), timeoutMultiplier*time.Minute*4, time.Second*10).Should(gomega.BeTrue())
 	}
 
 	// uninstall app
 	log.Printf("Uninstalling app for case %s", brCase.Name)
-	err = UninstallApplication(dpaCR.Client, brCase.ApplicationTemplate)
-	Expect(err).ToNot(HaveOccurred())
+	err = lib.UninstallApplication(dpaCR.Client, brCase.ApplicationTemplate)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 	// Wait for namespace to be deleted
-	Eventually(IsNamespaceDeleted(kubernetesClientForSuiteRun, brCase.ApplicationNamespace), timeoutMultiplier*time.Minute*4, time.Second*5).Should(BeTrue())
+	gomega.Eventually(lib.IsNamespaceDeleted(kubernetesClientForSuiteRun, brCase.ApplicationNamespace), timeoutMultiplier*time.Minute*4, time.Second*5).Should(gomega.BeTrue())
 
 	updateLastInstallTime()
 	// run restore
 	log.Printf("Creating restore %s for case %s", restoreName, brCase.Name)
-	restore, err := CreateRestoreFromBackup(dpaCR.Client, namespace, backupName, restoreName)
-	Expect(err).ToNot(HaveOccurred())
-	Eventually(IsRestoreDone(dpaCR.Client, namespace, restoreName), timeoutMultiplier*time.Minute*60, time.Second*10).Should(BeTrue())
+	restore, err := lib.CreateRestoreFromBackup(dpaCR.Client, namespace, backupName, restoreName)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	gomega.Eventually(lib.IsRestoreDone(dpaCR.Client, namespace, restoreName), timeoutMultiplier*time.Minute*60, time.Second*10).Should(gomega.BeTrue())
 	// TODO only log on fail?
-	describeRestore := DescribeRestore(veleroClientForSuiteRun, dpaCR.Client, restore)
-	GinkgoWriter.Println(describeRestore)
+	describeRestore := lib.DescribeRestore(veleroClientForSuiteRun, dpaCR.Client, restore)
+	ginkgov2.GinkgoWriter.Println(describeRestore)
 
-	restoreLogs := RestoreLogs(kubernetesClientForSuiteRun, dpaCR.Client, restore)
-	restoreErrorLogs := RestoreErrorLogs(kubernetesClientForSuiteRun, dpaCR.Client, restore)
+	restoreLogs := lib.RestoreLogs(kubernetesClientForSuiteRun, dpaCR.Client, restore)
+	restoreErrorLogs := lib.RestoreErrorLogs(kubernetesClientForSuiteRun, dpaCR.Client, restore)
 	accumulatedTestLogs = append(accumulatedTestLogs, describeRestore, restoreLogs)
 
-	Expect(restoreErrorLogs).Should(Equal([]string{}))
+	gomega.Expect(restoreErrorLogs).Should(gomega.Equal([]string{}))
 
 	// Check if restore succeeded
-	succeeded, err = IsRestoreCompletedSuccessfully(kubernetesClientForSuiteRun, dpaCR.Client, namespace, restoreName)
-	Expect(err).ToNot(HaveOccurred())
-	Expect(succeeded).To(Equal(true))
+	succeeded, err = lib.IsRestoreCompletedSuccessfully(kubernetesClientForSuiteRun, dpaCR.Client, namespace, restoreName)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	gomega.Expect(succeeded).To(gomega.Equal(true))
 
 	if nsRequiresResticDCWorkaround {
 		// We run the dc-post-restore.sh script for both restic and
@@ -211,48 +211,48 @@ func runBackupAndRestore(brCase BackupRestoreCase, expectedErr error, updateLast
 		// The script is designed to work with labels set by the
 		// openshift-velero-plugin and can be run without pre-conditions.
 		log.Printf("Running dc-post-restore.sh script.")
-		err = RunDcPostRestoreScript(restoreName)
-		Expect(err).ToNot(HaveOccurred())
+		err = lib.RunDcPostRestoreScript(restoreName)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 	}
 
 	// verify app is running
-	Eventually(AreAppBuildsReady(dpaCR.Client, brCase.ApplicationNamespace), timeoutMultiplier*time.Minute*3, time.Second*5).Should(BeTrue())
-	Eventually(AreApplicationPodsRunning(kubernetesClientForSuiteRun, brCase.ApplicationNamespace), timeoutMultiplier*time.Minute*9, time.Second*5).Should(BeTrue())
+	gomega.Eventually(lib.AreAppBuildsReady(dpaCR.Client, brCase.ApplicationNamespace), timeoutMultiplier*time.Minute*3, time.Second*5).Should(gomega.BeTrue())
+	gomega.Eventually(lib.AreApplicationPodsRunning(kubernetesClientForSuiteRun, brCase.ApplicationNamespace), timeoutMultiplier*time.Minute*9, time.Second*5).Should(gomega.BeTrue())
 
 	// Run optional custom verification
 	log.Printf("Running post-restore function for case %s", brCase.Name)
 	err = brCase.PostRestoreVerify(dpaCR.Client, brCase.ApplicationNamespace)
-	Expect(err).ToNot(HaveOccurred())
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 }
 
-func tearDownBackupAndRestore(brCase BackupRestoreCase, installTime time.Time, report SpecReport) {
+func tearDownBackupAndRestore(brCase BackupRestoreCase, installTime time.Time, report ginkgov2.SpecReport) {
 	log.Println("Post backup and restore state: ", report.State.String())
 	knownFlake = false
 	logString := strings.Join(accumulatedTestLogs, "\n")
-	CheckIfFlakeOccured(logString, &knownFlake)
+	lib.CheckIfFlakeOccured(logString, &knownFlake)
 	accumulatedTestLogs = nil
 
 	if report.Failed() {
 		// print namespace error events for app namespace
 		if brCase.ApplicationNamespace != "" {
-			GinkgoWriter.Println("Printing app namespace events")
-			PrintNamespaceEventsAfterTime(kubernetesClientForSuiteRun, brCase.ApplicationNamespace, installTime)
+			ginkgov2.GinkgoWriter.Println("Printing app namespace events")
+			lib.PrintNamespaceEventsAfterTime(kubernetesClientForSuiteRun, brCase.ApplicationNamespace, installTime)
 		}
-		GinkgoWriter.Println("Printing oadp namespace events")
-		PrintNamespaceEventsAfterTime(kubernetesClientForSuiteRun, namespace, installTime)
+		ginkgov2.GinkgoWriter.Println("Printing oadp namespace events")
+		lib.PrintNamespaceEventsAfterTime(kubernetesClientForSuiteRun, namespace, installTime)
 		baseReportDir := artifact_dir + "/" + report.LeafNodeText
 		err := os.MkdirAll(baseReportDir, 0755)
-		Expect(err).NotTo(HaveOccurred())
-		err = SavePodLogs(kubernetesClientForSuiteRun, namespace, baseReportDir)
-		Expect(err).NotTo(HaveOccurred())
-		err = SavePodLogs(kubernetesClientForSuiteRun, brCase.ApplicationNamespace, baseReportDir)
-		Expect(err).NotTo(HaveOccurred())
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = lib.SavePodLogs(kubernetesClientForSuiteRun, namespace, baseReportDir)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = lib.SavePodLogs(kubernetesClientForSuiteRun, brCase.ApplicationNamespace, baseReportDir)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	}
-	if brCase.BackupRestoreType == CSI || brCase.BackupRestoreType == CSIDataMover {
+	if brCase.BackupRestoreType == lib.CSI || brCase.BackupRestoreType == lib.CSIDataMover {
 		log.Printf("Deleting VolumeSnapshot for CSI backuprestore of %s", brCase.Name)
 		snapshotClassPath := fmt.Sprintf("./sample-applications/snapclass-csi/%s.yaml", provider)
-		err := UninstallApplication(dpaCR.Client, snapshotClassPath)
-		Expect(err).ToNot(HaveOccurred())
+		err := lib.UninstallApplication(dpaCR.Client, snapshotClassPath)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 	}
 	err := dpaCR.Client.Delete(context.Background(), &corev1.Namespace{ObjectMeta: v1.ObjectMeta{
 		Name:      brCase.ApplicationNamespace,
@@ -261,14 +261,14 @@ func tearDownBackupAndRestore(brCase BackupRestoreCase, installTime time.Time, r
 	if k8serror.IsNotFound(err) {
 		err = nil
 	}
-	Expect(err).ToNot(HaveOccurred())
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 	err = dpaCR.Delete(runTimeClientForSuiteRun)
-	Expect(err).ToNot(HaveOccurred())
-	Eventually(IsNamespaceDeleted(kubernetesClientForSuiteRun, brCase.ApplicationNamespace), timeoutMultiplier*time.Minute*2, time.Second*5).Should(BeTrue())
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	gomega.Eventually(lib.IsNamespaceDeleted(kubernetesClientForSuiteRun, brCase.ApplicationNamespace), timeoutMultiplier*time.Minute*2, time.Second*5).Should(gomega.BeTrue())
 }
 
-var _ = Describe("Backup and restore tests", func() {
+var _ = ginkgov2.Describe("Backup and restore tests", func() {
 	var lastBRCase BackupRestoreCase
 	var lastInstallTime time.Time
 	updateLastBRcase := func(brCase BackupRestoreCase) {
@@ -278,96 +278,96 @@ var _ = Describe("Backup and restore tests", func() {
 		lastInstallTime = time.Now()
 	}
 
-	var _ = AfterEach(func(ctx SpecContext) {
+	var _ = ginkgov2.AfterEach(func(ctx ginkgov2.SpecContext) {
 		tearDownBackupAndRestore(lastBRCase, lastInstallTime, ctx.SpecReport())
 	})
 
-	DescribeTable("Backup and restore applications",
+	ginkgov2.DescribeTable("Backup and restore applications",
 		func(brCase BackupRestoreCase, expectedErr error) {
-			if CurrentSpecReport().NumAttempts > 1 && !knownFlake {
-				Fail("No known FLAKE found in a previous run, marking test as failed.")
+			if ginkgov2.CurrentSpecReport().NumAttempts > 1 && !knownFlake {
+				ginkgov2.Fail("No known FLAKE found in a previous run, marking test as failed.")
 			}
 			runBackupAndRestore(brCase, expectedErr, updateLastBRcase, updateLastInstallTime)
 		},
-		Entry("MySQL application CSI", FlakeAttempts(flakeAttempts), BackupRestoreCase{
+		ginkgov2.Entry("MySQL application CSI", ginkgov2.FlakeAttempts(flakeAttempts), BackupRestoreCase{
 			ApplicationTemplate:  "./sample-applications/mysql-persistent/mysql-persistent-csi.yaml",
 			ApplicationNamespace: "mysql-persistent",
 			Name:                 "mysql-csi-e2e",
-			BackupRestoreType:    CSI,
+			BackupRestoreType:    lib.CSI,
 			PreBackupVerify:      mysqlReady(true, false),
 			PostRestoreVerify:    mysqlReady(false, false),
 		}, nil),
-		Entry("Mongo application CSI", FlakeAttempts(flakeAttempts), BackupRestoreCase{
+		ginkgov2.Entry("Mongo application CSI", ginkgov2.FlakeAttempts(flakeAttempts), BackupRestoreCase{
 			ApplicationTemplate:  "./sample-applications/mongo-persistent/mongo-persistent-csi.yaml",
 			ApplicationNamespace: "mongo-persistent",
 			Name:                 "mongo-csi-e2e",
-			BackupRestoreType:    CSI,
+			BackupRestoreType:    lib.CSI,
 			PreBackupVerify:      mongoready(true, false),
 			PostRestoreVerify:    mongoready(false, false),
 		}, nil),
-		Entry("MySQL application two Vol CSI", FlakeAttempts(flakeAttempts), BackupRestoreCase{
+		ginkgov2.Entry("MySQL application two Vol CSI", ginkgov2.FlakeAttempts(flakeAttempts), BackupRestoreCase{
 			ApplicationTemplate:  fmt.Sprintf("./sample-applications/mysql-persistent/mysql-persistent-twovol-csi.yaml"),
 			ApplicationNamespace: "mysql-persistent",
 			Name:                 "mysql-twovol-csi-e2e",
-			BackupRestoreType:    CSI,
+			BackupRestoreType:    lib.CSI,
 			AppReadyDelay:        30 * time.Second,
 			PreBackupVerify:      mysqlReady(true, true),
 			PostRestoreVerify:    mysqlReady(false, true),
 		}, nil),
-		Entry("Mongo application RESTIC", FlakeAttempts(flakeAttempts), BackupRestoreCase{
+		ginkgov2.Entry("Mongo application RESTIC", ginkgov2.FlakeAttempts(flakeAttempts), BackupRestoreCase{
 			ApplicationTemplate:  "./sample-applications/mongo-persistent/mongo-persistent.yaml",
 			ApplicationNamespace: "mongo-persistent",
 			Name:                 "mongo-restic-e2e",
-			BackupRestoreType:    RESTIC,
+			BackupRestoreType:    lib.RESTIC,
 			PreBackupVerify:      mongoready(true, false),
 			PostRestoreVerify:    mongoready(false, false),
 		}, nil),
-		Entry("MySQL application RESTIC", FlakeAttempts(flakeAttempts), BackupRestoreCase{
+		ginkgov2.Entry("MySQL application RESTIC", ginkgov2.FlakeAttempts(flakeAttempts), BackupRestoreCase{
 			ApplicationTemplate:  "./sample-applications/mysql-persistent/mysql-persistent.yaml",
 			ApplicationNamespace: "mysql-persistent",
 			Name:                 "mysql-restic-e2e",
-			BackupRestoreType:    RESTIC,
+			BackupRestoreType:    lib.RESTIC,
 			PreBackupVerify:      mysqlReady(true, false),
 			PostRestoreVerify:    mysqlReady(false, false),
 		}, nil),
-		Entry("Mongo application KOPIA", FlakeAttempts(flakeAttempts), BackupRestoreCase{
+		ginkgov2.Entry("Mongo application KOPIA", ginkgov2.FlakeAttempts(flakeAttempts), BackupRestoreCase{
 			ApplicationTemplate:  "./sample-applications/mongo-persistent/mongo-persistent.yaml",
 			ApplicationNamespace: "mongo-persistent",
 			Name:                 "mongo-kopia-e2e",
-			BackupRestoreType:    KOPIA,
+			BackupRestoreType:    lib.KOPIA,
 			PreBackupVerify:      mongoready(true, false),
 			PostRestoreVerify:    mongoready(false, false),
 		}, nil),
-		Entry("MySQL application KOPIA", FlakeAttempts(flakeAttempts), BackupRestoreCase{
+		ginkgov2.Entry("MySQL application KOPIA", ginkgov2.FlakeAttempts(flakeAttempts), BackupRestoreCase{
 			ApplicationTemplate:  "./sample-applications/mysql-persistent/mysql-persistent.yaml",
 			ApplicationNamespace: "mysql-persistent",
 			Name:                 "mysql-kopia-e2e",
-			BackupRestoreType:    KOPIA,
+			BackupRestoreType:    lib.KOPIA,
 			PreBackupVerify:      mysqlReady(true, false),
 			PostRestoreVerify:    mysqlReady(false, false),
 		}, nil),
-		Entry("Mongo application DATAMOVER", FlakeAttempts(flakeAttempts), BackupRestoreCase{
+		ginkgov2.Entry("Mongo application DATAMOVER", ginkgov2.FlakeAttempts(flakeAttempts), BackupRestoreCase{
 			ApplicationTemplate:  "./sample-applications/mongo-persistent/mongo-persistent-csi.yaml",
 			ApplicationNamespace: "mongo-persistent",
 			Name:                 "mongo-datamover-e2e",
-			BackupRestoreType:    CSIDataMover,
+			BackupRestoreType:    lib.CSIDataMover,
 			PreBackupVerify:      mongoready(true, false),
 			PostRestoreVerify:    mongoready(false, false),
 		}, nil),
-		Entry("MySQL application DATAMOVER", FlakeAttempts(flakeAttempts), BackupRestoreCase{
+		ginkgov2.Entry("MySQL application DATAMOVER", ginkgov2.FlakeAttempts(flakeAttempts), BackupRestoreCase{
 			ApplicationTemplate:  "./sample-applications/mysql-persistent/mysql-persistent-csi.yaml",
 			ApplicationNamespace: "mysql-persistent",
 			Name:                 "mysql-datamover-e2e",
-			BackupRestoreType:    CSIDataMover,
+			BackupRestoreType:    lib.CSIDataMover,
 			PreBackupVerify:      mysqlReady(true, false),
 			PostRestoreVerify:    mysqlReady(false, false),
 		}, nil),
-		Entry("Mongo application BlockDevice DATAMOVER", FlakeAttempts(flakeAttempts), BackupRestoreCase{
+		ginkgov2.Entry("Mongo application BlockDevice DATAMOVER", ginkgov2.FlakeAttempts(flakeAttempts), BackupRestoreCase{
 			ApplicationTemplate:  "./sample-applications/mongo-persistent/mongo-persistent-block.yaml",
 			PvcSuffixName:        "-block-mode",
 			ApplicationNamespace: "mongo-persistent",
 			Name:                 "mongo-blockdevice-e2e",
-			BackupRestoreType:    CSIDataMover,
+			BackupRestoreType:    lib.CSIDataMover,
 			PreBackupVerify:      mongoready(true, false),
 			PostRestoreVerify:    mongoready(false, false),
 		}, nil),

--- a/tests/e2e/backup_restore_suite_test.go
+++ b/tests/e2e/backup_restore_suite_test.go
@@ -12,11 +12,12 @@ import (
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/openshift/oadp-operator/tests/e2e/lib"
 	corev1 "k8s.io/api/core/v1"
 	k8serror "k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	. "github.com/openshift/oadp-operator/tests/e2e/lib"
 )
 
 type VerificationFunction func(client.Client, string) error

--- a/tests/e2e/dpa_deployment_suite_test.go
+++ b/tests/e2e/dpa_deployment_suite_test.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	ginkgov2 "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
 	velero "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -17,13 +17,13 @@ import (
 	"k8s.io/utils/pointer"
 
 	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
-	. "github.com/openshift/oadp-operator/tests/e2e/lib"
+	"github.com/openshift/oadp-operator/tests/e2e/lib"
 )
 
-var _ = Describe("Configuration testing for DPA Custom Resource", func() {
-	providerFromDPA := Dpa.Spec.BackupLocations[0].Velero.Provider
-	bucket := Dpa.Spec.BackupLocations[0].Velero.ObjectStorage.Bucket
-	bslConfig := Dpa.Spec.BackupLocations[0].Velero.Config
+var _ = ginkgov2.Describe("Configuration testing for DPA Custom Resource", func() {
+	providerFromDPA := lib.Dpa.Spec.BackupLocations[0].Velero.Provider
+	bucket := lib.Dpa.Spec.BackupLocations[0].Velero.ObjectStorage.Bucket
+	bslConfig := lib.Dpa.Spec.BackupLocations[0].Velero.Config
 	bslCredential := corev1.SecretKeySelector{
 		LocalObjectReference: corev1.LocalObjectReference{
 			Name: "bsl-cloud-credentials-" + provider,
@@ -33,7 +33,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 
 	type InstallCase struct {
 		Name               string
-		BRestoreType       BackupRestoreType
+		BRestoreType       lib.BackupRestoreType
 		DpaSpec            *oadpv1alpha1.DataProtectionApplicationSpec
 		TestCarriageReturn bool
 		WantError          bool
@@ -44,32 +44,32 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 
 	var lastInstallingApplicationNamespace string
 	var lastInstallTime time.Time
-	var _ = AfterEach(func(ctx SpecContext) {
+	var _ = ginkgov2.AfterEach(func(ctx ginkgov2.SpecContext) {
 		report := ctx.SpecReport()
 		if report.Failed() {
 			baseReportDir := artifact_dir + "/" + report.LeafNodeText
 			err := os.MkdirAll(baseReportDir, 0755)
-			Expect(err).NotTo(HaveOccurred())
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			// print namespace error events for app namespace
 			if lastInstallingApplicationNamespace != "" {
-				PrintNamespaceEventsAfterTime(kubernetesClientForSuiteRun, lastInstallingApplicationNamespace, lastInstallTime)
+				lib.PrintNamespaceEventsAfterTime(kubernetesClientForSuiteRun, lastInstallingApplicationNamespace, lastInstallTime)
 			}
-			err = SavePodLogs(kubernetesClientForSuiteRun, lastInstallingApplicationNamespace, baseReportDir)
-			Expect(err).NotTo(HaveOccurred())
+			err = lib.SavePodLogs(kubernetesClientForSuiteRun, lastInstallingApplicationNamespace, baseReportDir)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			log.Printf("Running must gather for failed deployment test - " + report.LeafNodeText)
-			err = RunMustGather(oc_cli, baseReportDir+"/must-gather")
+			err = lib.RunMustGather(oc_cli, baseReportDir+"/must-gather")
 			if err != nil {
 				log.Printf("Failed to run must gather: " + err.Error())
 			}
 		}
 	})
-	DescribeTable("Updating custom resource with new configuration",
+	ginkgov2.DescribeTable("Updating custom resource with new configuration",
 		func(installCase InstallCase, expectedErr error) {
 			//TODO: Calling dpaCR.build() is the old pattern.
 			//Change it later to make sure all the spec values are passed for every test case,
 			// instead of assigning the values in advance to the DPA CR
 			err := dpaCR.Build(installCase.BRestoreType)
-			Expect(err).NotTo(HaveOccurred())
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			if len(installCase.DpaSpec.BackupLocations) > 0 {
 				if installCase.DpaSpec.BackupLocations[0].Velero.Credential == nil {
 					installCase.DpaSpec.BackupLocations[0].Velero.Credential = &bslCredential
@@ -86,67 +86,67 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 			lastInstallingApplicationNamespace = dpaCR.Namespace
 			lastInstallTime = time.Now()
 			err = dpaCR.CreateOrUpdate(runTimeClientForSuiteRun, installCase.DpaSpec)
-			Expect(err).ToNot(HaveOccurred())
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			// sleep to accommodate throttled CI environment
 			// TODO this should be a function, not an arbitrary sleep
 			time.Sleep(20 * time.Second)
 			// Capture logs right after DPA is reconciled for diffing after one minute.
-			Eventually(dpaCR.GetNoErr(runTimeClientForSuiteRun).Status.Conditions[0].Type, timeoutMultiplier*time.Minute*3, time.Second*5).Should(Equal("Reconciled"))
+			gomega.Eventually(dpaCR.GetNoErr(runTimeClientForSuiteRun).Status.Conditions[0].Type, timeoutMultiplier*time.Minute*3, time.Second*5).Should(gomega.Equal("Reconciled"))
 			if installCase.WantError {
 				log.Printf("Test case expected to error. Waiting for the error to show in DPA Status")
-				Eventually(dpaCR.GetNoErr(runTimeClientForSuiteRun).Status.Conditions[0].Status, timeoutMultiplier*time.Minute*3, time.Second*5).Should(Equal(metav1.ConditionFalse))
-				Eventually(dpaCR.GetNoErr(runTimeClientForSuiteRun).Status.Conditions[0].Reason, timeoutMultiplier*time.Minute*3, time.Second*5).Should(Equal("Error"))
-				Eventually(dpaCR.GetNoErr(runTimeClientForSuiteRun).Status.Conditions[0].Message, timeoutMultiplier*time.Minute*3, time.Second*5).Should(Equal(expectedErr.Error()))
+				gomega.Eventually(dpaCR.GetNoErr(runTimeClientForSuiteRun).Status.Conditions[0].Status, timeoutMultiplier*time.Minute*3, time.Second*5).Should(gomega.Equal(metav1.ConditionFalse))
+				gomega.Eventually(dpaCR.GetNoErr(runTimeClientForSuiteRun).Status.Conditions[0].Reason, timeoutMultiplier*time.Minute*3, time.Second*5).Should(gomega.Equal("Error"))
+				gomega.Eventually(dpaCR.GetNoErr(runTimeClientForSuiteRun).Status.Conditions[0].Message, timeoutMultiplier*time.Minute*3, time.Second*5).Should(gomega.Equal(expectedErr.Error()))
 				return
 			}
 			timeReconciled := time.Now()
-			adpLogsAtReconciled, err := GetOpenShiftADPLogs(kubernetesClientForSuiteRun, dpaCR.Namespace)
-			Expect(err).NotTo(HaveOccurred())
+			adpLogsAtReconciled, err := lib.GetOpenShiftADPLogs(kubernetesClientForSuiteRun, dpaCR.Namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			log.Printf("Waiting for velero pod to be running")
-			Eventually(AreVeleroPodsRunning(kubernetesClientForSuiteRun, namespace), timeoutMultiplier*time.Minute*3, time.Second*5).Should(BeTrue())
+			gomega.Eventually(lib.AreVeleroPodsRunning(kubernetesClientForSuiteRun, namespace), timeoutMultiplier*time.Minute*3, time.Second*5).Should(gomega.BeTrue())
 			dpa, err := dpaCR.Get(runTimeClientForSuiteRun)
-			Expect(err).NotTo(HaveOccurred())
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			if len(dpa.Spec.BackupLocations) > 0 {
 				log.Printf("Checking for bsl spec")
 				for _, bsl := range dpa.Spec.BackupLocations {
 					// Check if bsl matches the spec
-					Expect(DoesBSLSpecMatchesDpa(namespace, *bsl.Velero, installCase.DpaSpec)).To(BeTrue())
+					gomega.Expect(lib.DoesBSLSpecMatchesDpa(namespace, *bsl.Velero, installCase.DpaSpec)).To(gomega.BeTrue())
 				}
 			}
 			if len(dpa.Spec.SnapshotLocations) > 0 {
 				log.Printf("Checking for vsl spec")
 				for _, vsl := range dpa.Spec.SnapshotLocations {
-					Expect(DoesVSLSpecMatchesDpa(namespace, *vsl.Velero, installCase.DpaSpec)).To(BeTrue())
+					gomega.Expect(lib.DoesVSLSpecMatchesDpa(namespace, *vsl.Velero, installCase.DpaSpec)).To(gomega.BeTrue())
 				}
 			}
 
 			// Check for velero tolerances
 			if len(dpa.Spec.Configuration.Velero.PodConfig.Tolerations) > 0 {
 				log.Printf("Checking for velero tolerances")
-				Eventually(VerifyVeleroTolerations(kubernetesClientForSuiteRun, namespace, dpa.Spec.Configuration.Velero.PodConfig.Tolerations), timeoutMultiplier*time.Minute*3, time.Second*5).Should(BeTrue())
+				gomega.Eventually(lib.VerifyVeleroTolerations(kubernetesClientForSuiteRun, namespace, dpa.Spec.Configuration.Velero.PodConfig.Tolerations), timeoutMultiplier*time.Minute*3, time.Second*5).Should(gomega.BeTrue())
 			}
 
 			// check for velero resource allocations
 			if dpa.Spec.Configuration.Velero.PodConfig.ResourceAllocations.Requests != nil {
 				log.Printf("Checking for velero resource allocation requests")
-				Eventually(VerifyVeleroResourceRequests(kubernetesClientForSuiteRun, namespace, dpa.Spec.Configuration.Velero.PodConfig.ResourceAllocations.Requests), timeoutMultiplier*time.Minute*3, time.Second*5).Should(BeTrue())
+				gomega.Eventually(lib.VerifyVeleroResourceRequests(kubernetesClientForSuiteRun, namespace, dpa.Spec.Configuration.Velero.PodConfig.ResourceAllocations.Requests), timeoutMultiplier*time.Minute*3, time.Second*5).Should(gomega.BeTrue())
 			}
 
 			if dpa.Spec.Configuration.Velero.PodConfig.ResourceAllocations.Limits != nil {
 				log.Printf("Checking for velero resource allocation limits")
-				Eventually(VerifyVeleroResourceLimits(kubernetesClientForSuiteRun, namespace, dpa.Spec.Configuration.Velero.PodConfig.ResourceAllocations.Limits), timeoutMultiplier*time.Minute*3, time.Second*5).Should(BeTrue())
+				gomega.Eventually(lib.VerifyVeleroResourceLimits(kubernetesClientForSuiteRun, namespace, dpa.Spec.Configuration.Velero.PodConfig.ResourceAllocations.Limits), timeoutMultiplier*time.Minute*3, time.Second*5).Should(gomega.BeTrue())
 			}
 
 			//restic installation with new and deprecated options
 			if dpa.Spec.Configuration.Restic != nil && *dpa.Spec.Configuration.Restic.Enable {
 				log.Printf("Waiting for restic pods to be running")
-				Eventually(AreNodeAgentPodsRunning(kubernetesClientForSuiteRun, namespace), timeoutMultiplier*time.Minute*4, time.Second*5).Should(BeTrue())
+				gomega.Eventually(lib.AreNodeAgentPodsRunning(kubernetesClientForSuiteRun, namespace), timeoutMultiplier*time.Minute*4, time.Second*5).Should(gomega.BeTrue())
 			} else if dpa.Spec.Configuration.NodeAgent != nil && *dpa.Spec.Configuration.NodeAgent.Enable {
 				log.Printf("Waiting for NodeAgent pods to be running")
-				Eventually(AreNodeAgentPodsRunning(kubernetesClientForSuiteRun, namespace), timeoutMultiplier*time.Minute*4, time.Second*5).Should(BeTrue())
+				gomega.Eventually(lib.AreNodeAgentPodsRunning(kubernetesClientForSuiteRun, namespace), timeoutMultiplier*time.Minute*4, time.Second*5).Should(gomega.BeTrue())
 			} else {
 				log.Printf("Waiting for NodeAgent daemonset to be deleted")
-				Eventually(IsNodeAgentDaemonsetDeleted(kubernetesClientForSuiteRun, namespace), timeoutMultiplier*time.Minute*4, time.Second*5).Should(BeTrue())
+				gomega.Eventually(lib.IsNodeAgentDaemonsetDeleted(kubernetesClientForSuiteRun, namespace), timeoutMultiplier*time.Minute*4, time.Second*5).Should(gomega.BeTrue())
 			}
 
 			// check defaultPlugins
@@ -154,7 +154,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 			if len(dpa.Spec.Configuration.Velero.DefaultPlugins) > 0 {
 				log.Printf("Checking for default plugins")
 				for _, plugin := range dpa.Spec.Configuration.Velero.DefaultPlugins {
-					Eventually(DoesPluginExist(kubernetesClientForSuiteRun, namespace, plugin), timeoutMultiplier*time.Minute*6, time.Second*5).Should(BeTrue())
+					gomega.Eventually(lib.DoesPluginExist(kubernetesClientForSuiteRun, namespace, plugin), timeoutMultiplier*time.Minute*6, time.Second*5).Should(gomega.BeTrue())
 				}
 			}
 
@@ -163,7 +163,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 			if len(dpa.Spec.Configuration.Velero.CustomPlugins) > 0 {
 				log.Printf("Checking for custom plugins")
 				for _, plugin := range dpa.Spec.Configuration.Velero.CustomPlugins {
-					Eventually(DoesCustomPluginExist(kubernetesClientForSuiteRun, namespace, plugin), timeoutMultiplier*time.Minute*6, time.Second*5).Should(BeTrue())
+					gomega.Eventually(lib.DoesCustomPluginExist(kubernetesClientForSuiteRun, namespace, plugin), timeoutMultiplier*time.Minute*6, time.Second*5).Should(gomega.BeTrue())
 				}
 			}
 
@@ -171,39 +171,39 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 			if dpa.Spec.Configuration.Restic != nil && dpa.Spec.Configuration.Restic.PodConfig != nil {
 				for key, value := range dpa.Spec.Configuration.Restic.PodConfig.NodeSelector {
 					log.Printf("Waiting for restic daemonSet to get node selector")
-					Eventually(NodeAgentDaemonSetHasNodeSelector(kubernetesClientForSuiteRun, namespace, key, value), timeoutMultiplier*time.Minute*6, time.Second*5).Should(BeTrue())
+					gomega.Eventually(lib.NodeAgentDaemonSetHasNodeSelector(kubernetesClientForSuiteRun, namespace, key, value), timeoutMultiplier*time.Minute*6, time.Second*5).Should(gomega.BeTrue())
 				}
 			}
 			log.Printf("Waiting for nodeAgent daemonSet to have nodeSelector")
 			if dpa.Spec.Configuration.NodeAgent != nil && dpa.Spec.Configuration.NodeAgent.PodConfig != nil {
 				for key, value := range dpa.Spec.Configuration.NodeAgent.PodConfig.NodeSelector {
 					log.Printf("Waiting for NodeAgent daemonSet to get node selector")
-					Eventually(NodeAgentDaemonSetHasNodeSelector(kubernetesClientForSuiteRun, namespace, key, value), timeoutMultiplier*time.Minute*6, time.Second*5).Should(BeTrue())
+					gomega.Eventually(lib.NodeAgentDaemonSetHasNodeSelector(kubernetesClientForSuiteRun, namespace, key, value), timeoutMultiplier*time.Minute*6, time.Second*5).Should(gomega.BeTrue())
 				}
 			}
 			// wait at least 1 minute after reconciled
-			Eventually(func() bool {
+			gomega.Eventually(func() bool {
 				//has it been at least 1 minute since reconciled?
 				log.Printf("Waiting for 1 minute after reconciled: %v elapsed", time.Since(timeReconciled).String())
 				return time.Now().After(timeReconciled.Add(time.Minute))
-			}, timeoutMultiplier*time.Minute*5, time.Second*5).Should(BeTrue())
-			adpLogsAfterOneMinute, err := GetOpenShiftADPLogs(kubernetesClientForSuiteRun, dpaCR.Namespace)
-			Expect(err).NotTo(HaveOccurred())
+			}, timeoutMultiplier*time.Minute*5, time.Second*5).Should(gomega.BeTrue())
+			adpLogsAfterOneMinute, err := lib.GetOpenShiftADPLogs(kubernetesClientForSuiteRun, dpaCR.Namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			// We expect adp logs to be the same after 1 minute
 			adpLogsDiff := cmp.Diff(adpLogsAtReconciled, adpLogsAfterOneMinute)
 			// If registry deployment were deleted after CR update, we expect to see a new log entry, ignore that.
 			// We also ignore case where deprecated restic entry was used
 			if !strings.Contains(adpLogsDiff, "Registry Deployment deleted") && !strings.Contains(adpLogsDiff, "(Deprecation Warning) Use nodeAgent instead of restic, which is deprecated and will be removed with the OADP 1.4") {
-				Expect(adpLogsDiff).To(Equal(""))
+				gomega.Expect(adpLogsDiff).To(gomega.Equal(""))
 			}
 		},
-		Entry("Default velero CR", InstallCase{
+		ginkgov2.Entry("Default velero CR", InstallCase{
 			Name:         "default-cr",
-			BRestoreType: RESTIC,
+			BRestoreType: lib.RESTIC,
 			DpaSpec: &oadpv1alpha1.DataProtectionApplicationSpec{
 				Configuration: &oadpv1alpha1.ApplicationConfig{
 					Velero: &oadpv1alpha1.VeleroConfig{
-						DefaultPlugins: Dpa.Spec.Configuration.Velero.DefaultPlugins,
+						DefaultPlugins: lib.Dpa.Spec.Configuration.Velero.DefaultPlugins,
 						PodConfig:      &oadpv1alpha1.PodConfig{},
 					},
 					Restic: &oadpv1alpha1.ResticConfig{
@@ -222,7 +222,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 							StorageType: velero.StorageType{
 								ObjectStorage: &velero.ObjectStorageLocation{
 									Bucket: bucket,
-									Prefix: VeleroPrefix,
+									Prefix: lib.VeleroPrefix,
 								},
 							},
 							Credential: &bslCredential,
@@ -232,14 +232,14 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 			},
 			WantError: false,
 		}, nil),
-		Entry("Default velero CR, test carriage return", InstallCase{
+		ginkgov2.Entry("Default velero CR, test carriage return", InstallCase{
 			Name:               "default-cr",
-			BRestoreType:       RESTIC,
+			BRestoreType:       lib.RESTIC,
 			TestCarriageReturn: true,
 			DpaSpec: &oadpv1alpha1.DataProtectionApplicationSpec{
 				Configuration: &oadpv1alpha1.ApplicationConfig{
 					Velero: &oadpv1alpha1.VeleroConfig{
-						DefaultPlugins: Dpa.Spec.Configuration.Velero.DefaultPlugins,
+						DefaultPlugins: lib.Dpa.Spec.Configuration.Velero.DefaultPlugins,
 						PodConfig:      &oadpv1alpha1.PodConfig{},
 					},
 					Restic: &oadpv1alpha1.ResticConfig{
@@ -258,7 +258,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 							StorageType: velero.StorageType{
 								ObjectStorage: &velero.ObjectStorageLocation{
 									Bucket: bucket,
-									Prefix: VeleroPrefix,
+									Prefix: lib.VeleroPrefix,
 								},
 							},
 							Credential: &bslCredential,
@@ -268,16 +268,16 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 			},
 			WantError: false,
 		}, nil),
-		Entry("Adding Velero custom plugin", InstallCase{
+		ginkgov2.Entry("Adding Velero custom plugin", InstallCase{
 			Name:         "default-cr-velero-custom-plugin",
-			BRestoreType: RESTIC,
+			BRestoreType: lib.RESTIC,
 			DpaSpec: &oadpv1alpha1.DataProtectionApplicationSpec{
 				Configuration: &oadpv1alpha1.ApplicationConfig{
 					Velero: &oadpv1alpha1.VeleroConfig{
 						PodConfig: &oadpv1alpha1.PodConfig{},
 						DefaultPlugins: append([]oadpv1alpha1.DefaultPlugin{
 							oadpv1alpha1.DefaultPluginCSI,
-						}, Dpa.Spec.Configuration.Velero.DefaultPlugins...),
+						}, lib.Dpa.Spec.Configuration.Velero.DefaultPlugins...),
 						CustomPlugins: []oadpv1alpha1.CustomPlugin{
 							{
 								Name:  "encryption-plugin",
@@ -302,7 +302,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 							StorageType: velero.StorageType{
 								ObjectStorage: &velero.ObjectStorageLocation{
 									Bucket: bucket,
-									Prefix: VeleroPrefix,
+									Prefix: lib.VeleroPrefix,
 								},
 							},
 							Credential: &bslCredential,
@@ -312,9 +312,9 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 			},
 			WantError: false,
 		}, nil),
-		Entry("Adding Velero resource allocations", InstallCase{
+		ginkgov2.Entry("Adding Velero resource allocations", InstallCase{
 			Name:         "default-cr-velero-resource-alloc",
-			BRestoreType: RESTIC,
+			BRestoreType: lib.RESTIC,
 			DpaSpec: &oadpv1alpha1.DataProtectionApplicationSpec{
 				Configuration: &oadpv1alpha1.ApplicationConfig{
 					Velero: &oadpv1alpha1.VeleroConfig{
@@ -332,7 +332,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 						},
 						DefaultPlugins: append([]oadpv1alpha1.DefaultPlugin{
 							oadpv1alpha1.DefaultPluginCSI,
-						}, Dpa.Spec.Configuration.Velero.DefaultPlugins...),
+						}, lib.Dpa.Spec.Configuration.Velero.DefaultPlugins...),
 					},
 					Restic: &oadpv1alpha1.ResticConfig{
 						NodeAgentCommonFields: oadpv1alpha1.NodeAgentCommonFields{
@@ -351,7 +351,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 							StorageType: velero.StorageType{
 								ObjectStorage: &velero.ObjectStorageLocation{
 									Bucket: bucket,
-									Prefix: VeleroPrefix,
+									Prefix: lib.VeleroPrefix,
 								},
 							},
 							Credential: &bslCredential,
@@ -361,9 +361,9 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 			},
 			WantError: false,
 		}, nil),
-		Entry("Provider plugin", InstallCase{
+		ginkgov2.Entry("Provider plugin", InstallCase{
 			Name:         "default-cr-aws-plugin",
-			BRestoreType: RESTIC,
+			BRestoreType: lib.RESTIC,
 			DpaSpec: &oadpv1alpha1.DataProtectionApplicationSpec{
 				Configuration: &oadpv1alpha1.ApplicationConfig{
 					Velero: &oadpv1alpha1.VeleroConfig{
@@ -399,7 +399,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 							StorageType: velero.StorageType{
 								ObjectStorage: &velero.ObjectStorageLocation{
 									Bucket: bucket,
-									Prefix: VeleroPrefix,
+									Prefix: lib.VeleroPrefix,
 								},
 							},
 							Credential: &bslCredential,
@@ -409,14 +409,14 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 			},
 			WantError: false,
 		}, nil),
-		Entry("DPA CR with bsl and vsl", InstallCase{
+		ginkgov2.Entry("DPA CR with bsl and vsl", InstallCase{
 			Name:         "default-cr-bsl-vsl",
-			BRestoreType: RESTIC,
+			BRestoreType: lib.RESTIC,
 			DpaSpec: &oadpv1alpha1.DataProtectionApplicationSpec{
 				Configuration: &oadpv1alpha1.ApplicationConfig{
 					Velero: &oadpv1alpha1.VeleroConfig{
 						PodConfig:      &oadpv1alpha1.PodConfig{},
-						DefaultPlugins: Dpa.Spec.Configuration.Velero.DefaultPlugins,
+						DefaultPlugins: lib.Dpa.Spec.Configuration.Velero.DefaultPlugins,
 					},
 					Restic: &oadpv1alpha1.ResticConfig{
 						NodeAgentCommonFields: oadpv1alpha1.NodeAgentCommonFields{
@@ -425,7 +425,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 						},
 					},
 				},
-				SnapshotLocations: Dpa.Spec.SnapshotLocations,
+				SnapshotLocations: lib.Dpa.Spec.SnapshotLocations,
 				BackupLocations: []oadpv1alpha1.BackupLocation{
 					{
 						Velero: &velero.BackupStorageLocationSpec{
@@ -435,7 +435,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 							StorageType: velero.StorageType{
 								ObjectStorage: &velero.ObjectStorageLocation{
 									Bucket: bucket,
-									Prefix: VeleroPrefix,
+									Prefix: lib.VeleroPrefix,
 								},
 							},
 							Credential: &bslCredential,
@@ -445,14 +445,14 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 			},
 			WantError: false,
 		}, nil),
-		Entry("Default velero CR with restic disabled", InstallCase{
+		ginkgov2.Entry("Default velero CR with restic disabled", InstallCase{
 			Name:         "default-cr-no-restic",
-			BRestoreType: RESTIC,
+			BRestoreType: lib.RESTIC,
 			DpaSpec: &oadpv1alpha1.DataProtectionApplicationSpec{
 				Configuration: &oadpv1alpha1.ApplicationConfig{
 					Velero: &oadpv1alpha1.VeleroConfig{
 						PodConfig:      &oadpv1alpha1.PodConfig{},
-						DefaultPlugins: Dpa.Spec.Configuration.Velero.DefaultPlugins,
+						DefaultPlugins: lib.Dpa.Spec.Configuration.Velero.DefaultPlugins,
 					},
 					Restic: &oadpv1alpha1.ResticConfig{
 						NodeAgentCommonFields: oadpv1alpha1.NodeAgentCommonFields{
@@ -470,7 +470,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 							StorageType: velero.StorageType{
 								ObjectStorage: &velero.ObjectStorageLocation{
 									Bucket: bucket,
-									Prefix: VeleroPrefix,
+									Prefix: lib.VeleroPrefix,
 								},
 							},
 							Credential: &bslCredential,
@@ -480,16 +480,16 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 			},
 			WantError: false,
 		}, nil),
-		Entry("Adding CSI plugin", InstallCase{
+		ginkgov2.Entry("Adding CSI plugin", InstallCase{
 			Name:         "default-cr-csi",
-			BRestoreType: RESTIC,
+			BRestoreType: lib.RESTIC,
 			DpaSpec: &oadpv1alpha1.DataProtectionApplicationSpec{
 				Configuration: &oadpv1alpha1.ApplicationConfig{
 					Velero: &oadpv1alpha1.VeleroConfig{
 						PodConfig: &oadpv1alpha1.PodConfig{},
 						DefaultPlugins: append([]oadpv1alpha1.DefaultPlugin{
 							oadpv1alpha1.DefaultPluginCSI,
-						}, Dpa.Spec.Configuration.Velero.DefaultPlugins...),
+						}, lib.Dpa.Spec.Configuration.Velero.DefaultPlugins...),
 					},
 					Restic: &oadpv1alpha1.ResticConfig{
 						NodeAgentCommonFields: oadpv1alpha1.NodeAgentCommonFields{
@@ -507,7 +507,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 							StorageType: velero.StorageType{
 								ObjectStorage: &velero.ObjectStorageLocation{
 									Bucket: bucket,
-									Prefix: VeleroPrefix,
+									Prefix: lib.VeleroPrefix,
 								},
 							},
 							Credential: &bslCredential,
@@ -517,9 +517,9 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 			},
 			WantError: false,
 		}, nil),
-		Entry("Set restic node selector", InstallCase{
+		ginkgov2.Entry("Set restic node selector", InstallCase{
 			Name:         "default-cr-node-selector",
-			BRestoreType: RESTIC,
+			BRestoreType: lib.RESTIC,
 			DpaSpec: &oadpv1alpha1.DataProtectionApplicationSpec{
 				BackupLocations: []oadpv1alpha1.BackupLocation{
 					{
@@ -530,7 +530,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 							StorageType: velero.StorageType{
 								ObjectStorage: &velero.ObjectStorageLocation{
 									Bucket: bucket,
-									Prefix: VeleroPrefix,
+									Prefix: lib.VeleroPrefix,
 								},
 							},
 							Credential: &bslCredential,
@@ -540,7 +540,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 				Configuration: &oadpv1alpha1.ApplicationConfig{
 					Velero: &oadpv1alpha1.VeleroConfig{
 						PodConfig:      &oadpv1alpha1.PodConfig{},
-						DefaultPlugins: Dpa.Spec.Configuration.Velero.DefaultPlugins,
+						DefaultPlugins: lib.Dpa.Spec.Configuration.Velero.DefaultPlugins,
 					},
 					Restic: &oadpv1alpha1.ResticConfig{
 						NodeAgentCommonFields: oadpv1alpha1.NodeAgentCommonFields{
@@ -556,9 +556,9 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 			},
 			WantError: false,
 		}, nil),
-		Entry("Enable tolerations", InstallCase{
+		ginkgov2.Entry("Enable tolerations", InstallCase{
 			Name:         "default-cr-tolerations",
-			BRestoreType: RESTIC,
+			BRestoreType: lib.RESTIC,
 			DpaSpec: &oadpv1alpha1.DataProtectionApplicationSpec{
 				BackupLocations: []oadpv1alpha1.BackupLocation{
 					{
@@ -569,7 +569,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 							StorageType: velero.StorageType{
 								ObjectStorage: &velero.ObjectStorageLocation{
 									Bucket: bucket,
-									Prefix: VeleroPrefix,
+									Prefix: lib.VeleroPrefix,
 								},
 							},
 							Credential: &bslCredential,
@@ -579,7 +579,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 				Configuration: &oadpv1alpha1.ApplicationConfig{
 					Velero: &oadpv1alpha1.VeleroConfig{
 						PodConfig:      &oadpv1alpha1.PodConfig{},
-						DefaultPlugins: Dpa.Spec.Configuration.Velero.DefaultPlugins,
+						DefaultPlugins: lib.Dpa.Spec.Configuration.Velero.DefaultPlugins,
 					},
 					Restic: &oadpv1alpha1.ResticConfig{
 						NodeAgentCommonFields: oadpv1alpha1.NodeAgentCommonFields{
@@ -600,15 +600,15 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 			},
 			WantError: false,
 		}, nil),
-		Entry("NoDefaultBackupLocation", InstallCase{
+		ginkgov2.Entry("NoDefaultBackupLocation", InstallCase{
 			Name:         "default-cr-node-selector",
-			BRestoreType: RESTIC,
+			BRestoreType: lib.RESTIC,
 			DpaSpec: &oadpv1alpha1.DataProtectionApplicationSpec{
 				Configuration: &oadpv1alpha1.ApplicationConfig{
 					Velero: &oadpv1alpha1.VeleroConfig{
 						PodConfig:               &oadpv1alpha1.PodConfig{},
 						NoDefaultBackupLocation: true,
-						DefaultPlugins:          Dpa.Spec.Configuration.Velero.DefaultPlugins,
+						DefaultPlugins:          lib.Dpa.Spec.Configuration.Velero.DefaultPlugins,
 					},
 					Restic: &oadpv1alpha1.ResticConfig{
 						NodeAgentCommonFields: oadpv1alpha1.NodeAgentCommonFields{
@@ -621,9 +621,9 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 			},
 			WantError: false,
 		}, nil),
-		Entry("AWS Without Region No S3ForcePathStyle with BackupImages false should succeed", Label("aws", "ibmcloud"), InstallCase{
+		ginkgov2.Entry("AWS Without Region No S3ForcePathStyle with BackupImages false should succeed", ginkgov2.Label("aws", "ibmcloud"), InstallCase{
 			Name:         "default-no-region-no-s3forcepathstyle",
-			BRestoreType: RESTIC,
+			BRestoreType: lib.RESTIC,
 			DpaSpec: &oadpv1alpha1.DataProtectionApplicationSpec{
 				BackupImages: pointer.Bool(false),
 				BackupLocations: []oadpv1alpha1.BackupLocation{
@@ -634,7 +634,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 							StorageType: velero.StorageType{
 								ObjectStorage: &velero.ObjectStorageLocation{
 									Bucket: bucket,
-									Prefix: VeleroPrefix,
+									Prefix: lib.VeleroPrefix,
 								},
 							},
 							Credential: &bslCredential,
@@ -653,9 +653,9 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 			},
 			WantError: false,
 		}, nil),
-		Entry("AWS With Region And S3ForcePathStyle should succeed", Label("aws", "ibmcloud"), InstallCase{
+		ginkgov2.Entry("AWS With Region And S3ForcePathStyle should succeed", ginkgov2.Label("aws", "ibmcloud"), InstallCase{
 			Name:         "default-with-region-and-s3forcepathstyle",
-			BRestoreType: RESTIC,
+			BRestoreType: lib.RESTIC,
 			DpaSpec: &oadpv1alpha1.DataProtectionApplicationSpec{
 				BackupLocations: []oadpv1alpha1.BackupLocation{
 					{
@@ -670,7 +670,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 							StorageType: velero.StorageType{
 								ObjectStorage: &velero.ObjectStorageLocation{
 									Bucket: bucket,
-									Prefix: VeleroPrefix,
+									Prefix: lib.VeleroPrefix,
 								},
 							},
 							Credential: &bslCredential,
@@ -689,9 +689,9 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 			},
 			WantError: false,
 		}, nil),
-		Entry("AWS Without Region And S3ForcePathStyle true should fail", Label("aws", "ibmcloud"), InstallCase{
+		ginkgov2.Entry("AWS Without Region And S3ForcePathStyle true should fail", ginkgov2.Label("aws", "ibmcloud"), InstallCase{
 			Name:         "default-with-region-and-s3forcepathstyle",
-			BRestoreType: RESTIC,
+			BRestoreType: lib.RESTIC,
 			DpaSpec: &oadpv1alpha1.DataProtectionApplicationSpec{
 				BackupLocations: []oadpv1alpha1.BackupLocation{
 					{
@@ -704,7 +704,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 							StorageType: velero.StorageType{
 								ObjectStorage: &velero.ObjectStorageLocation{
 									Bucket: bucket,
-									Prefix: VeleroPrefix,
+									Prefix: lib.VeleroPrefix,
 								},
 							},
 							Credential: &bslCredential,
@@ -723,9 +723,9 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 			},
 			WantError: true,
 		}, fmt.Errorf("region for AWS backupstoragelocation not automatically discoverable. Please set the region in the backupstoragelocation config")),
-		Entry("unsupportedOverrides should succeed", Label("aws", "ibmcloud"), InstallCase{
+		ginkgov2.Entry("unsupportedOverrides should succeed", ginkgov2.Label("aws", "ibmcloud"), InstallCase{
 			Name:         "valid-unsupported-overrides",
-			BRestoreType: RESTIC,
+			BRestoreType: lib.RESTIC,
 			DpaSpec: &oadpv1alpha1.DataProtectionApplicationSpec{
 				BackupLocations: []oadpv1alpha1.BackupLocation{
 					{
@@ -740,7 +740,7 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 							StorageType: velero.StorageType{
 								ObjectStorage: &velero.ObjectStorageLocation{
 									Bucket: bucket,
-									Prefix: VeleroPrefix,
+									Prefix: lib.VeleroPrefix,
 								},
 							},
 							Credential: &bslCredential,
@@ -764,49 +764,49 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 		}, nil),
 	)
 
-	DescribeTable("DPA / Restic Deletion test",
+	ginkgov2.DescribeTable("DPA / Restic Deletion test",
 		func(installCase deletionCase) {
 			log.Printf("Building dpa with restic")
-			err := dpaCR.Build(RESTIC)
-			Expect(err).NotTo(HaveOccurred())
+			err := dpaCR.Build(lib.RESTIC)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			log.Printf("Creating dpa with restic")
 			err = dpaCR.CreateOrUpdate(runTimeClientForSuiteRun, &dpaCR.CustomResource.Spec)
-			Expect(err).NotTo(HaveOccurred())
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			log.Printf("Waiting for velero pod with restic to be running")
-			Eventually(AreVeleroPodsRunning(kubernetesClientForSuiteRun, namespace), timeoutMultiplier*time.Minute*3, time.Second*5).Should(BeTrue())
+			gomega.Eventually(lib.AreVeleroPodsRunning(kubernetesClientForSuiteRun, namespace), timeoutMultiplier*time.Minute*3, time.Second*5).Should(gomega.BeTrue())
 			log.Printf("Deleting dpa with restic")
 			err = dpaCR.Delete(runTimeClientForSuiteRun)
 			if installCase.WantError {
-				Expect(err).To(HaveOccurred())
+				gomega.Expect(err).To(gomega.HaveOccurred())
 			} else {
-				Expect(err).NotTo(HaveOccurred())
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				log.Printf("Checking no velero pods with restic are running")
-				Eventually(AreVeleroPodsRunning(kubernetesClientForSuiteRun, namespace), timeoutMultiplier*time.Minute*3, time.Second*5).ShouldNot(BeTrue())
+				gomega.Eventually(lib.AreVeleroPodsRunning(kubernetesClientForSuiteRun, namespace), timeoutMultiplier*time.Minute*3, time.Second*5).ShouldNot(gomega.BeTrue())
 			}
 		},
-		Entry("Should succeed", deletionCase{WantError: false}),
+		ginkgov2.Entry("Should succeed", deletionCase{WantError: false}),
 	)
 
-	DescribeTable("DPA / Kopia Deletion test",
+	ginkgov2.DescribeTable("DPA / Kopia Deletion test",
 		func(installCase deletionCase) {
 			log.Printf("Building dpa with kopia")
-			err := dpaCR.Build(KOPIA)
-			Expect(err).NotTo(HaveOccurred())
+			err := dpaCR.Build(lib.KOPIA)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			log.Printf("Creating dpa with kopia")
 			err = dpaCR.CreateOrUpdate(runTimeClientForSuiteRun, &dpaCR.CustomResource.Spec)
-			Expect(err).NotTo(HaveOccurred())
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			log.Printf("Waiting for velero pod with kopia to be running")
-			Eventually(AreVeleroPodsRunning(kubernetesClientForSuiteRun, namespace), timeoutMultiplier*time.Minute*3, time.Second*5).Should(BeTrue())
+			gomega.Eventually(lib.AreVeleroPodsRunning(kubernetesClientForSuiteRun, namespace), timeoutMultiplier*time.Minute*3, time.Second*5).Should(gomega.BeTrue())
 			log.Printf("Deleting dpa with kopia")
 			err = dpaCR.Delete(runTimeClientForSuiteRun)
 			if installCase.WantError {
-				Expect(err).To(HaveOccurred())
+				gomega.Expect(err).To(gomega.HaveOccurred())
 			} else {
-				Expect(err).NotTo(HaveOccurred())
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				log.Printf("Checking no velero pods with kopia are running")
-				Eventually(AreVeleroPodsRunning(kubernetesClientForSuiteRun, namespace), timeoutMultiplier*time.Minute*3, time.Second*5).ShouldNot(BeTrue())
+				gomega.Eventually(lib.AreVeleroPodsRunning(kubernetesClientForSuiteRun, namespace), timeoutMultiplier*time.Minute*3, time.Second*5).ShouldNot(gomega.BeTrue())
 			}
 		},
-		Entry("Should succeed", deletionCase{WantError: false}),
+		ginkgov2.Entry("Should succeed", deletionCase{WantError: false}),
 	)
 })

--- a/tests/e2e/dpa_deployment_suite_test.go
+++ b/tests/e2e/dpa_deployment_suite_test.go
@@ -7,17 +7,17 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
-	. "github.com/openshift/oadp-operator/tests/e2e/lib"
 	velero "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
+
+	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
+	. "github.com/openshift/oadp-operator/tests/e2e/lib"
 )
 
 var _ = Describe("Configuration testing for DPA Custom Resource", func() {

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -12,13 +12,14 @@ import (
 	snapshotv1client "github.com/kubernetes-csi/external-snapshotter/client/v4/clientset/versioned"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/openshift/oadp-operator/tests/e2e/lib"
-	veleroClientset "github.com/vmware-tanzu/velero/pkg/generated/clientset/versioned"
+	veleroclientset "github.com/vmware-tanzu/velero/pkg/generated/clientset/versioned"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
+
+	. "github.com/openshift/oadp-operator/tests/e2e/lib"
 )
 
 // Common vars obtained from flags passed in ginkgo.
@@ -102,7 +103,7 @@ func TestOADPE2E(t *testing.T) {
 
 var kubernetesClientForSuiteRun *kubernetes.Clientset
 var runTimeClientForSuiteRun client.Client
-var veleroClientForSuiteRun veleroClientset.Interface
+var veleroClientForSuiteRun veleroclientset.Interface
 var csiClientForSuiteRun *snapshotv1client.Clientset
 var dynamicClientForSuiteRun dynamic.Interface
 var dpaCR *DpaCustomResource
@@ -129,7 +130,7 @@ var _ = BeforeSuite(func() {
 	runTimeClientForSuiteRun, err = client.New(kubeConfig, client.Options{})
 	Expect(err).NotTo(HaveOccurred())
 
-	veleroClientForSuiteRun, err = veleroClientset.NewForConfig(kubeConfig)
+	veleroClientForSuiteRun, err = veleroclientset.NewForConfig(kubeConfig)
 	Expect(err).NotTo(HaveOccurred())
 
 	csiClientForSuiteRun, err = snapshotv1client.NewForConfig(kubeConfig)

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -10,8 +10,8 @@ import (
 	"time"
 
 	snapshotv1client "github.com/kubernetes-csi/external-snapshotter/client/v4/clientset/versioned"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	ginkgov2 "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
 	veleroclientset "github.com/vmware-tanzu/velero/pkg/generated/clientset/versioned"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
@@ -19,7 +19,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
-	. "github.com/openshift/oadp-operator/tests/e2e/lib"
+	"github.com/openshift/oadp-operator/tests/e2e/lib"
 )
 
 // Common vars obtained from flags passed in ginkgo.
@@ -92,13 +92,13 @@ func init() {
 
 func TestOADPE2E(t *testing.T) {
 	flag.Parse()
-	errString := LoadDpaSettingsFromJson(settings)
+	errString := lib.LoadDpaSettingsFromJson(settings)
 	if errString != "" {
 		t.Fatalf(errString)
 	}
 
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "OADP E2E using velero prefix: "+VeleroPrefix)
+	gomega.RegisterFailHandler(ginkgov2.Fail)
+	ginkgov2.RunSpecs(t, "OADP E2E using velero prefix: "+lib.VeleroPrefix)
 }
 
 var kubernetesClientForSuiteRun *kubernetes.Clientset
@@ -106,17 +106,17 @@ var runTimeClientForSuiteRun client.Client
 var veleroClientForSuiteRun veleroclientset.Interface
 var csiClientForSuiteRun *snapshotv1client.Clientset
 var dynamicClientForSuiteRun dynamic.Interface
-var dpaCR *DpaCustomResource
+var dpaCR *lib.DpaCustomResource
 var knownFlake bool
 var accumulatedTestLogs []string
 var kubeConfig *rest.Config
 
-var _ = BeforeSuite(func() {
+var _ = ginkgov2.BeforeSuite(func() {
 	// TODO create logger (hh:mm:ss message) to be used by all functions
 	flag.Parse()
-	errString := LoadDpaSettingsFromJson(settings)
+	errString := lib.LoadDpaSettingsFromJson(settings)
 	if errString != "" {
-		Expect(errors.New(errString)).NotTo(HaveOccurred())
+		gomega.Expect(errors.New(errString)).NotTo(gomega.HaveOccurred())
 	}
 
 	var err error
@@ -125,55 +125,55 @@ var _ = BeforeSuite(func() {
 	kubeConfig.Burst = 100
 
 	kubernetesClientForSuiteRun, err = kubernetes.NewForConfig(kubeConfig)
-	Expect(err).NotTo(HaveOccurred())
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	runTimeClientForSuiteRun, err = client.New(kubeConfig, client.Options{})
-	Expect(err).NotTo(HaveOccurred())
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	veleroClientForSuiteRun, err = veleroclientset.NewForConfig(kubeConfig)
-	Expect(err).NotTo(HaveOccurred())
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	csiClientForSuiteRun, err = snapshotv1client.NewForConfig(kubeConfig)
-	Expect(err).NotTo(HaveOccurred())
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	dynamicClientForSuiteRun, err = dynamic.NewForConfig(kubeConfig)
-	Expect(err).NotTo(HaveOccurred())
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	dpaCR = &DpaCustomResource{
+	dpaCR = &lib.DpaCustomResource{
 		Namespace: namespace,
 		Provider:  provider,
 	}
-	dpaCR.CustomResource = Dpa
+	dpaCR.CustomResource = lib.Dpa
 	dpaCR.Name = "ts-" + instanceName
 
-	bslCredFileData, err := ReadFile(bslCredFile)
-	Expect(err).NotTo(HaveOccurred())
-	err = CreateCredentialsSecret(kubernetesClientForSuiteRun, bslCredFileData, namespace, "bsl-cloud-credentials-"+provider)
-	Expect(err).NotTo(HaveOccurred())
-	err = CreateCredentialsSecret(
+	bslCredFileData, err := lib.ReadFile(bslCredFile)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	err = lib.CreateCredentialsSecret(kubernetesClientForSuiteRun, bslCredFileData, namespace, "bsl-cloud-credentials-"+provider)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	err = lib.CreateCredentialsSecret(
 		kubernetesClientForSuiteRun,
-		ReplaceSecretDataNewLineWithCarriageReturn(bslCredFileData),
+		lib.ReplaceSecretDataNewLineWithCarriageReturn(bslCredFileData),
 		namespace, "bsl-cloud-credentials-"+provider+"-with-carriage-return",
 	)
-	Expect(err).NotTo(HaveOccurred())
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	vslCredFileData, err := ReadFile(vslCredFile)
-	Expect(err).NotTo(HaveOccurred())
-	err = CreateCredentialsSecret(kubernetesClientForSuiteRun, vslCredFileData, namespace, credSecretRef)
-	Expect(err).NotTo(HaveOccurred())
+	vslCredFileData, err := lib.ReadFile(vslCredFile)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	err = lib.CreateCredentialsSecret(kubernetesClientForSuiteRun, vslCredFileData, namespace, credSecretRef)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	dpaCR.SetClient(runTimeClientForSuiteRun)
-	Expect(DoesNamespaceExist(kubernetesClientForSuiteRun, namespace)).Should(BeTrue())
+	gomega.Expect(lib.DoesNamespaceExist(kubernetesClientForSuiteRun, namespace)).Should(gomega.BeTrue())
 })
 
-var _ = AfterSuite(func() {
+var _ = ginkgov2.AfterSuite(func() {
 	log.Printf("Deleting Velero CR")
-	err := DeleteSecret(kubernetesClientForSuiteRun, namespace, credSecretRef)
-	Expect(err).ToNot(HaveOccurred())
-	err = DeleteSecret(kubernetesClientForSuiteRun, namespace, "bsl-cloud-credentials-"+provider)
-	Expect(err).ToNot(HaveOccurred())
-	err = DeleteSecret(kubernetesClientForSuiteRun, namespace, "bsl-cloud-credentials-"+provider+"-with-carriage-return")
-	Expect(err).ToNot(HaveOccurred())
+	err := lib.DeleteSecret(kubernetesClientForSuiteRun, namespace, credSecretRef)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	err = lib.DeleteSecret(kubernetesClientForSuiteRun, namespace, "bsl-cloud-credentials-"+provider)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	err = lib.DeleteSecret(kubernetesClientForSuiteRun, namespace, "bsl-cloud-credentials-"+provider+"-with-carriage-return")
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 	err = dpaCR.Delete(runTimeClientForSuiteRun)
-	Expect(err).ToNot(HaveOccurred())
-	Eventually(dpaCR.IsDeleted(runTimeClientForSuiteRun), timeoutMultiplier*time.Minute*2, time.Second*5).Should(BeTrue())
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	gomega.Eventually(dpaCR.IsDeleted(runTimeClientForSuiteRun), timeoutMultiplier*time.Minute*2, time.Second*5).Should(gomega.BeTrue())
 })

--- a/tests/e2e/lib/apps.go
+++ b/tests/e2e/lib/apps.go
@@ -62,12 +62,12 @@ func InstallApplicationWithRetries(ocClient client.Client, file string, retries 
 		return err
 	}
 	for _, resource := range obj.Items {
-		labels := resource.GetLabels()
-		if labels == nil {
-			labels = make(map[string]string)
+		resourceLabels := resource.GetLabels()
+		if resourceLabels == nil {
+			resourceLabels = make(map[string]string)
 		}
-		labels[e2eAppLabelKey] = "true"
-		resource.SetLabels(labels)
+		resourceLabels[e2eAppLabelKey] = "true"
+		resource.SetLabels(resourceLabels)
 		resourceCreate := resource.DeepCopy()
 		err = nil // reset error for each resource
 		for i := 0; i < retries; i++ {
@@ -92,13 +92,13 @@ func InstallApplicationWithRetries(ocClient client.Client, file string, retries 
 					resource.SetDeletionTimestamp(clusterResource.GetDeletionTimestamp())
 					resource.SetFinalizers(clusterResource.GetFinalizers())
 					// append cluster labels to existing labels if they don't already exist
-					labels := resource.GetLabels()
-					if labels == nil {
-						labels = make(map[string]string)
+					resourceLabels := resource.GetLabels()
+					if resourceLabels == nil {
+						resourceLabels = make(map[string]string)
 					}
 					for k, v := range clusterResource.GetLabels() {
-						if _, exists := labels[k]; !exists {
-							labels[k] = v
+						if _, exists := resourceLabels[k]; !exists {
+							resourceLabels[k] = v
 						}
 					}
 				}

--- a/tests/e2e/lib/common_helpers.go
+++ b/tests/e2e/lib/common_helpers.go
@@ -6,7 +6,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
-	"net/url"
+	neturl "net/url"
 	"os"
 	"os/exec"
 	"strings"
@@ -175,7 +175,7 @@ func convertJsonStringToURLParams(payload string) (string, error) {
 		return "", err
 	}
 
-	params := url.Values{}
+	params := neturl.Values{}
 	for key, value := range data {
 		params.Add(key, fmt.Sprintf("%v", value))
 	}

--- a/tests/e2e/lib/dpa_helpers.go
+++ b/tests/e2e/lib/dpa_helpers.go
@@ -17,8 +17,6 @@ import (
 	buildv1 "github.com/openshift/api/build/v1"
 	security "github.com/openshift/api/security/v1"
 	templatev1 "github.com/openshift/api/template/v1"
-	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
-	"github.com/openshift/oadp-operator/pkg/common"
 	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	velero "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
@@ -31,6 +29,9 @@ import (
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
+
+	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
+	"github.com/openshift/oadp-operator/pkg/common"
 )
 
 type BackupRestoreType string
@@ -262,19 +263,19 @@ func (v *DpaCustomResource) Delete(c client.Client) error {
 	return err
 }
 
-func (v *DpaCustomResource) SetClient(client client.Client) error {
-	oadpv1alpha1.AddToScheme(client.Scheme())
-	velero.AddToScheme(client.Scheme())
-	appsv1.AddToScheme(client.Scheme())
-	corev1.AddToScheme(client.Scheme())
-	templatev1.AddToScheme(client.Scheme())
-	security.AddToScheme(client.Scheme())
-	volumesnapshotv1.AddToScheme(client.Scheme())
-	buildv1.AddToScheme(client.Scheme())
-	operatorsv1alpha1.AddToScheme(client.Scheme())
-	operatorsv1.AddToScheme(client.Scheme())
+func (v *DpaCustomResource) SetClient(c client.Client) error {
+	oadpv1alpha1.AddToScheme(c.Scheme())
+	velero.AddToScheme(c.Scheme())
+	appsv1.AddToScheme(c.Scheme())
+	corev1.AddToScheme(c.Scheme())
+	templatev1.AddToScheme(c.Scheme())
+	security.AddToScheme(c.Scheme())
+	volumesnapshotv1.AddToScheme(c.Scheme())
+	buildv1.AddToScheme(c.Scheme())
+	operatorsv1alpha1.AddToScheme(c.Scheme())
+	operatorsv1.AddToScheme(c.Scheme())
 
-	v.Client = client
+	v.Client = c
 	return nil
 }
 

--- a/tests/e2e/lib/dpa_helpers.go
+++ b/tests/e2e/lib/dpa_helpers.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
-	. "github.com/onsi/ginkgo/v2"
+	ginkgov2 "github.com/onsi/ginkgo/v2"
 	appsv1 "github.com/openshift/api/apps/v1"
 	buildv1 "github.com/openshift/api/build/v1"
 	security "github.com/openshift/api/security/v1"
@@ -382,7 +382,7 @@ func DoesBSLSpecMatchesDpa(namespace string, bsl velero.BackupStorageLocationSpe
 				bsl.Config = make(map[string]string)
 			}
 			if !reflect.DeepEqual(bsl, *b.Velero) {
-				GinkgoWriter.Print(cmp.Diff(bsl, *b.Velero))
+				ginkgov2.GinkgoWriter.Print(cmp.Diff(bsl, *b.Velero))
 				return false, errors.New("given Velero bsl does not match the deployed velero bsl")
 			}
 		}
@@ -403,7 +403,7 @@ func DoesVSLSpecMatchesDpa(namespace string, vslspec velero.VolumeSnapshotLocati
 			vslspec.Config = make(map[string]string)
 		}
 		if reflect.DeepEqual(vslspec, *v.Velero) {
-			GinkgoWriter.Print(cmp.Diff(vslspec, *v.Velero))
+			ginkgov2.GinkgoWriter.Print(cmp.Diff(vslspec, *v.Velero))
 			return true, nil
 		}
 	}

--- a/tests/e2e/lib/nodeagent_helpers.go
+++ b/tests/e2e/lib/nodeagent_helpers.go
@@ -5,12 +5,13 @@ import (
 	"log"
 	"time"
 
-	"github.com/openshift/oadp-operator/pkg/common"
 	appsv1 "k8s.io/api/apps/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
+
+	"github.com/openshift/oadp-operator/pkg/common"
 )
 
 func HasCorrectNumNodeAgentPods(c *kubernetes.Clientset, namespace string) wait.ConditionFunc {

--- a/tests/e2e/lib/plugins_helpers.go
+++ b/tests/e2e/lib/plugins_helpers.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"log"
 
-	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
-	"github.com/openshift/oadp-operator/pkg/credentials"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
+	"github.com/openshift/oadp-operator/pkg/credentials"
 )
 
 func (d *DpaCustomResource) RemoveVeleroPlugin(c client.Client, string, instanceName string, pluginValues []oadpv1alpha1.DefaultPlugin, removedPlugin string) error {

--- a/tests/e2e/lib/velero_helpers.go
+++ b/tests/e2e/lib/velero_helpers.go
@@ -18,7 +18,7 @@ import (
 	"github.com/vmware-tanzu/velero/pkg/cmd/util/downloadrequest"
 	"github.com/vmware-tanzu/velero/pkg/cmd/util/output"
 	"github.com/vmware-tanzu/velero/pkg/features"
-	veleroClientset "github.com/vmware-tanzu/velero/pkg/generated/clientset/versioned"
+	veleroclientset "github.com/vmware-tanzu/velero/pkg/generated/clientset/versioned"
 	"github.com/vmware-tanzu/velero/pkg/label"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,7 +27,7 @@ import (
 )
 
 // https://github.com/vmware-tanzu/velero/blob/11bfe82342c9f54c63f40d3e97313ce763b446f2/pkg/cmd/cli/backup/describe.go#L77-L111
-func DescribeBackup(veleroClient veleroClientset.Interface, csiClient *snapshotv1client.Clientset, ocClient client.Client, backup velero.Backup) (backupDescription string) {
+func DescribeBackup(veleroClient veleroclientset.Interface, csiClient *snapshotv1client.Clientset, ocClient client.Client, backup velero.Backup) (backupDescription string) {
 	err := ocClient.Get(context.Background(), client.ObjectKey{
 		Namespace: backup.Namespace,
 		Name:      backup.Name,
@@ -72,7 +72,7 @@ func DescribeBackup(veleroClient veleroClientset.Interface, csiClient *snapshotv
 }
 
 // https://github.com/vmware-tanzu/velero/blob/11bfe82342c9f54c63f40d3e97313ce763b446f2/pkg/cmd/cli/restore/describe.go#L72-L78
-func DescribeRestore(veleroClient veleroClientset.Interface, ocClient client.Client, restore velero.Restore) string {
+func DescribeRestore(veleroClient veleroclientset.Interface, ocClient client.Client, restore velero.Restore) string {
 	err := ocClient.Get(context.Background(), client.ObjectKey{
 		Namespace: restore.Namespace,
 		Name:      restore.Name,

--- a/tests/e2e/lib/virt_storage_helpers.go
+++ b/tests/e2e/lib/virt_storage_helpers.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"

--- a/tests/e2e/must-gather_suite_test.go
+++ b/tests/e2e/must-gather_suite_test.go
@@ -6,13 +6,13 @@ import (
 	"strings"
 	"time"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	ginkgov2 "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
 
-	. "github.com/openshift/oadp-operator/tests/e2e/lib"
+	"github.com/openshift/oadp-operator/tests/e2e/lib"
 )
 
-var _ = Describe("Backup and restore tests with must-gather", func() {
+var _ = ginkgov2.Describe("Backup and restore tests with must-gather", func() {
 	var lastBRCase BackupRestoreCase
 	var lastInstallTime time.Time
 	updateLastBRcase := func(brCase BackupRestoreCase) {
@@ -22,40 +22,40 @@ var _ = Describe("Backup and restore tests with must-gather", func() {
 		lastInstallTime = time.Now()
 	}
 
-	var _ = AfterEach(func(ctx SpecContext) {
+	var _ = ginkgov2.AfterEach(func(ctx ginkgov2.SpecContext) {
 		tearDownBackupAndRestore(lastBRCase, lastInstallTime, ctx.SpecReport())
 	})
 
-	DescribeTable("Backup and restore applications and run must-gather",
+	ginkgov2.DescribeTable("Backup and restore applications and run must-gather",
 		func(brCase BackupRestoreCase, expectedErr error) {
-			if CurrentSpecReport().NumAttempts > 1 && !knownFlake {
-				Fail("No known FLAKE found in a previous run, marking test as failed.")
+			if ginkgov2.CurrentSpecReport().NumAttempts > 1 && !knownFlake {
+				ginkgov2.Fail("No known FLAKE found in a previous run, marking test as failed.")
 			}
 			runBackupAndRestore(brCase, expectedErr, updateLastBRcase, updateLastInstallTime)
 
 			// TODO look for duplications in tearDownBackupAndRestore
 			baseReportDir := artifact_dir + "/" + brCase.Name
 			err := os.MkdirAll(baseReportDir, 0755)
-			Expect(err).NotTo(HaveOccurred())
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			log.Printf("Running must gather for backup/restore test - " + "")
-			err = RunMustGather(oc_cli, baseReportDir+"/must-gather")
+			err = lib.RunMustGather(oc_cli, baseReportDir+"/must-gather")
 			if err != nil {
 				log.Printf("Failed to run must gather: " + err.Error())
 			}
-			Expect(err).ToNot(HaveOccurred())
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			// get dirs in must-gather dir
 			dirEntries, err := os.ReadDir(baseReportDir + "/must-gather")
-			Expect(err).ToNot(HaveOccurred())
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			clusterDir := ""
 			for _, dirEntry := range dirEntries {
 				if dirEntry.IsDir() && strings.HasPrefix(dirEntry.Name(), "quay-io") {
 					mustGatherImageDir := baseReportDir + "/must-gather/" + dirEntry.Name()
 					// extract must-gather.tar.gz
-					err = ExtractTarGz(mustGatherImageDir, "must-gather.tar.gz")
-					Expect(err).ToNot(HaveOccurred())
+					err = lib.ExtractTarGz(mustGatherImageDir, "must-gather.tar.gz")
+					gomega.Expect(err).ToNot(gomega.HaveOccurred())
 					mustGatherDir := mustGatherImageDir + "/must-gather"
 					clusters, err := os.ReadDir(mustGatherDir + "/clusters")
-					Expect(err).ToNot(HaveOccurred())
+					gomega.Expect(err).ToNot(gomega.HaveOccurred())
 					for _, cluster := range clusters {
 						if cluster.IsDir() {
 							clusterDir = mustGatherDir + "/clusters/" + cluster.Name()
@@ -66,19 +66,19 @@ var _ = Describe("Backup and restore tests with must-gather", func() {
 			if len(brCase.MustGatherFiles) > 0 && clusterDir != "" {
 				for _, file := range brCase.MustGatherFiles {
 					_, err := os.Stat(clusterDir + "/" + file)
-					Expect(err).ToNot(HaveOccurred())
+					gomega.Expect(err).ToNot(gomega.HaveOccurred())
 				}
 			}
 			if brCase.MustGatherValidationFunction != nil && clusterDir != "" {
 				err = (*brCase.MustGatherValidationFunction)(clusterDir)
-				Expect(err).ToNot(HaveOccurred())
+				gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			}
 		},
-		Entry("Mongo application DATAMOVER", FlakeAttempts(flakeAttempts), BackupRestoreCase{
+		ginkgov2.Entry("Mongo application DATAMOVER", ginkgov2.FlakeAttempts(flakeAttempts), BackupRestoreCase{
 			ApplicationTemplate:  "./sample-applications/mongo-persistent/mongo-persistent-csi.yaml",
 			ApplicationNamespace: "mongo-persistent",
 			Name:                 "mongo-datamover-e2e",
-			BackupRestoreType:    CSIDataMover,
+			BackupRestoreType:    lib.CSIDataMover,
 			PreBackupVerify:      mongoready(true, false),
 			PostRestoreVerify:    mongoready(false, false),
 			MustGatherFiles: []string{

--- a/tests/e2e/must-gather_suite_test.go
+++ b/tests/e2e/must-gather_suite_test.go
@@ -8,6 +8,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	. "github.com/openshift/oadp-operator/tests/e2e/lib"
 )
 

--- a/tests/e2e/subscription_suite_test.go
+++ b/tests/e2e/subscription_suite_test.go
@@ -7,10 +7,11 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/openshift/oadp-operator/tests/e2e/lib"
 	operators "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/pointer"
+
+	. "github.com/openshift/oadp-operator/tests/e2e/lib"
 )
 
 var _ = Describe("Subscription Config Suite Test", func() {

--- a/tests/e2e/subscription_suite_test.go
+++ b/tests/e2e/subscription_suite_test.go
@@ -5,98 +5,98 @@ import (
 	"log"
 	"time"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	ginkgov2 "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
 	operators "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/pointer"
 
-	. "github.com/openshift/oadp-operator/tests/e2e/lib"
+	"github.com/openshift/oadp-operator/tests/e2e/lib"
 )
 
-var _ = Describe("Subscription Config Suite Test", func() {
+var _ = ginkgov2.Describe("Subscription Config Suite Test", func() {
 	type SubscriptionConfigTestCase struct {
 		operators.SubscriptionConfig
 		failureExpected *bool
-		stream          StreamSource
+		stream          lib.StreamSource
 	}
 
-	var _ = AfterEach(func() {
+	var _ = ginkgov2.AfterEach(func() {
 		err := dpaCR.Delete(runTimeClientForSuiteRun)
-		Expect(err).ToNot(HaveOccurred())
-		Eventually(dpaCR.IsDeleted(runTimeClientForSuiteRun), timeoutMultiplier*time.Minute*2, time.Second*5).Should(BeTrue())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		gomega.Eventually(dpaCR.IsDeleted(runTimeClientForSuiteRun), timeoutMultiplier*time.Minute*2, time.Second*5).Should(gomega.BeTrue())
 	})
 
-	DescribeTable("Proxy test table",
+	ginkgov2.DescribeTable("Proxy test table",
 		func(testCase SubscriptionConfigTestCase) {
 			log.Printf("Getting Operator Subscription")
-			s, err := dpaCR.GetOperatorSubscription(runTimeClientForSuiteRun, StreamSource(stream))
-			Expect(err).To(BeNil())
+			s, err := dpaCR.GetOperatorSubscription(runTimeClientForSuiteRun, lib.StreamSource(stream))
+			gomega.Expect(err).To(gomega.BeNil())
 			log.Printf("Setting test case subscription config")
 			s.Spec.Config = &testCase.SubscriptionConfig
 			log.Printf("Updating Subscription")
 			err = dpaCR.Client.Update(context.Background(), s.Subscription)
-			Expect(err).To(BeNil())
-			Eventually(s.CsvIsInstalling, time.Minute*1, time.Second*5).WithArguments(runTimeClientForSuiteRun).Should(BeTrue())
+			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Eventually(s.CsvIsInstalling, time.Minute*1, time.Second*5).WithArguments(runTimeClientForSuiteRun).Should(gomega.BeTrue())
 
 			// get csv from installplan from subscription
 			log.Printf("Wait for CSV to be succeeded")
 			if testCase.failureExpected != nil && *testCase.failureExpected {
-				Consistently(s.CsvIsReady, time.Minute*2, time.Second*5).WithArguments(runTimeClientForSuiteRun).Should(BeFalse())
+				gomega.Consistently(s.CsvIsReady, time.Minute*2, time.Second*5).WithArguments(runTimeClientForSuiteRun).Should(gomega.BeFalse())
 				// TODO read error message instead?
 			} else {
-				Eventually(s.CsvIsReady, time.Minute*15, time.Second*5).WithArguments(runTimeClientForSuiteRun).Should(BeTrue())
+				gomega.Eventually(s.CsvIsReady, time.Minute*15, time.Second*5).WithArguments(runTimeClientForSuiteRun).Should(gomega.BeTrue())
 
 				log.Printf("Creating test Velero")
-				err := dpaCR.Build(CSI)
-				Expect(err).NotTo(HaveOccurred())
+				err := dpaCR.Build(lib.CSI)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				//also test restic
 				dpaCR.CustomResource.Spec.Configuration.NodeAgent.Enable = pointer.BoolPtr(true)
 				dpaCR.CustomResource.Spec.Configuration.NodeAgent.UploaderType = "restic"
 				err = dpaCR.CreateOrUpdate(runTimeClientForSuiteRun, &dpaCR.CustomResource.Spec)
-				Expect(err).NotTo(HaveOccurred())
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				log.Printf("Getting velero object")
 				velero, err := dpaCR.Get(runTimeClientForSuiteRun)
-				Expect(err).NotTo(HaveOccurred())
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				log.Printf("Waiting for velero pod to be running")
-				Eventually(AreVeleroPodsRunning(kubernetesClientForSuiteRun, namespace), timeoutMultiplier*time.Minute*3, time.Second*5).Should(BeTrue())
+				gomega.Eventually(lib.AreVeleroPodsRunning(kubernetesClientForSuiteRun, namespace), timeoutMultiplier*time.Minute*3, time.Second*5).Should(gomega.BeTrue())
 				if velero.Spec.Configuration.NodeAgent.Enable != nil && *velero.Spec.Configuration.NodeAgent.Enable {
 					log.Printf("Waiting for Node Agent pods to be running")
-					Eventually(AreNodeAgentPodsRunning(kubernetesClientForSuiteRun, namespace), timeoutMultiplier*time.Minute*3, time.Second*5).Should(BeTrue())
+					gomega.Eventually(lib.AreNodeAgentPodsRunning(kubernetesClientForSuiteRun, namespace), timeoutMultiplier*time.Minute*3, time.Second*5).Should(gomega.BeTrue())
 				}
 				if s.Spec.Config != nil && s.Spec.Config.Env != nil {
 					// get pod env vars
 					log.Printf("Getting deployments")
-					vd, err := GetVeleroDeploymentList(kubernetesClientForSuiteRun, namespace)
-					Expect(err).NotTo(HaveOccurred())
+					vd, err := lib.GetVeleroDeploymentList(kubernetesClientForSuiteRun, namespace)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 					log.Printf("Getting daemonsets")
-					nads, err := GetNodeAgentDaemonsetList(kubernetesClientForSuiteRun, namespace)
-					Expect(err).NotTo(HaveOccurred())
+					nads, err := lib.GetNodeAgentDaemonsetList(kubernetesClientForSuiteRun, namespace)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 					for _, env := range s.Spec.Config.Env {
 						for _, deployment := range vd.Items {
 							log.Printf("Checking env vars are passed to deployment " + deployment.Name)
 							for _, container := range deployment.Spec.Template.Spec.Containers {
 								log.Printf("Checking env vars are passed to container " + container.Name)
-								Expect(container.Env).To(ContainElement(env))
+								gomega.Expect(container.Env).To(gomega.ContainElement(env))
 							}
 						}
 						for _, daemonset := range nads.Items {
 							log.Printf("Checking env vars are passed to daemonset " + daemonset.Name)
 							for _, container := range daemonset.Spec.Template.Spec.Containers {
 								log.Printf("Checking env vars are passed to container " + container.Name)
-								Expect(container.Env).To(ContainElement(env))
+								gomega.Expect(container.Env).To(gomega.ContainElement(env))
 							}
 						}
 					}
 				}
 				log.Printf("Deleting test Velero")
 				err = dpaCR.Delete(runTimeClientForSuiteRun)
-				Expect(err).ToNot(HaveOccurred())
+				gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			}
 
 		},
-		Entry("HTTP_PROXY set", SubscriptionConfigTestCase{
+		ginkgov2.Entry("HTTP_PROXY set", SubscriptionConfigTestCase{
 			SubscriptionConfig: operators.SubscriptionConfig{
 				Env: []corev1.EnvVar{
 					{
@@ -106,7 +106,7 @@ var _ = Describe("Subscription Config Suite Test", func() {
 				},
 			},
 		}),
-		Entry("NO_PROXY set", SubscriptionConfigTestCase{
+		ginkgov2.Entry("NO_PROXY set", SubscriptionConfigTestCase{
 			SubscriptionConfig: operators.SubscriptionConfig{
 				Env: []corev1.EnvVar{
 					{
@@ -116,7 +116,7 @@ var _ = Describe("Subscription Config Suite Test", func() {
 				},
 			},
 		}),
-		Entry("HTTPS_PROXY set", SubscriptionConfigTestCase{
+		ginkgov2.Entry("HTTPS_PROXY set", SubscriptionConfigTestCase{
 			SubscriptionConfig: operators.SubscriptionConfig{
 				Env: []corev1.EnvVar{
 					{
@@ -130,7 +130,7 @@ var _ = Describe("Subscription Config Suite Test", func() {
 		}),
 		// Leave this as last entry to reset config
 		// TODO move this to after each
-		Entry("Config unset", SubscriptionConfigTestCase{
+		ginkgov2.Entry("Config unset", SubscriptionConfigTestCase{
 			SubscriptionConfig: operators.SubscriptionConfig{},
 		}),
 	)

--- a/tests/e2e/virt_backup_restore_suite_test.go
+++ b/tests/e2e/virt_backup_restore_suite_test.go
@@ -7,10 +7,10 @@ import (
 	"strings"
 	"time"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	ginkgov2 "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
 
-	. "github.com/openshift/oadp-operator/tests/e2e/lib"
+	"github.com/openshift/oadp-operator/tests/e2e/lib"
 )
 
 func getLatestCirrosImageURL() (string, error) {
@@ -34,35 +34,35 @@ func getLatestCirrosImageURL() (string, error) {
 	return imageURL, nil
 }
 
-var _ = Describe("VM backup and restore tests", Ordered, func() {
-	var v *VirtOperator
+var _ = ginkgov2.Describe("VM backup and restore tests", ginkgov2.Ordered, func() {
+	var v *lib.VirtOperator
 	var err error
 	wasInstalledFromTest := false
 
-	var _ = BeforeAll(func() {
+	var _ = ginkgov2.BeforeAll(func() {
 		dpaCR.CustomResource.Name = "dummyDPA"
 		dpaCR.CustomResource.Namespace = "openshift-adp"
 
-		v, err = GetVirtOperator(runTimeClientForSuiteRun, kubernetesClientForSuiteRun, dynamicClientForSuiteRun)
-		Expect(err).To(BeNil())
-		Expect(v).ToNot(BeNil())
+		v, err = lib.GetVirtOperator(runTimeClientForSuiteRun, kubernetesClientForSuiteRun, dynamicClientForSuiteRun)
+		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(v).ToNot(gomega.BeNil())
 
 		if !v.IsVirtInstalled() {
 			err = v.EnsureVirtInstallation()
-			Expect(err).To(BeNil())
+			gomega.Expect(err).To(gomega.BeNil())
 			wasInstalledFromTest = true
 		}
 
 		err = v.EnsureEmulation(10 * time.Second)
-		Expect(err).To(BeNil())
+		gomega.Expect(err).To(gomega.BeNil())
 
 		url, err := getLatestCirrosImageURL()
-		Expect(err).To(BeNil())
+		gomega.Expect(err).To(gomega.BeNil())
 		err = v.EnsureDataVolumeFromUrl("openshift-cnv", "cirros-dv", url, "128Mi", 5*time.Minute)
-		Expect(err).To(BeNil())
+		gomega.Expect(err).To(gomega.BeNil())
 	})
 
-	var _ = AfterAll(func() {
+	var _ = ginkgov2.AfterAll(func() {
 		v.RemoveDataVolume("openshift-cnv", "cirros-dv", 2*time.Minute)
 
 		if v != nil && wasInstalledFromTest {
@@ -70,21 +70,21 @@ var _ = Describe("VM backup and restore tests", Ordered, func() {
 		}
 	})
 
-	It("should verify virt installation", Label("virt"), func() {
+	ginkgov2.It("should verify virt installation", ginkgov2.Label("virt"), func() {
 		installed := v.IsVirtInstalled()
-		Expect(installed).To(BeTrue())
+		gomega.Expect(installed).To(gomega.BeTrue())
 	})
 
-	It("should create and boot a virtual machine", Label("virt"), func() {
+	ginkgov2.It("should create and boot a virtual machine", ginkgov2.Label("virt"), func() {
 		namespace := "openshift-cnv"
 		source := "cirros-dv"
 		name := "cirros-vm"
 
 		err := v.CloneDisk(namespace, source, name, 5*time.Minute)
-		Expect(err).To(BeNil())
+		gomega.Expect(err).To(gomega.BeNil())
 
 		err = v.CreateVm(namespace, name, source, 5*time.Minute)
-		Expect(err).To(BeNil())
+		gomega.Expect(err).To(gomega.BeNil())
 
 		v.RemoveVm(namespace, name, 2*time.Minute)
 		v.RemoveDataVolume(namespace, name, 2*time.Minute)

--- a/tests/e2e/virt_backup_restore_suite_test.go
+++ b/tests/e2e/virt_backup_restore_suite_test.go
@@ -9,6 +9,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	. "github.com/openshift/oadp-operator/tests/e2e/lib"
 )
 


### PR DESCRIPTION
Add more linting checks to project with `golangci-lint`. This PR fixes issues related to imports in the code.

`.golangci.yaml` is similar to the one proposed at https://github.com/vmware-tanzu/velero/pull/7194

## Test

Run `golangci-lint` with new `make lint` and `make lint-fix` commands.

## TODO

All go files changes where related to imports errors (with the help of `make lint-fix` command). There are still a lot of issues to be resolved in the code, but they will be fixed by categories in follow up PRs.