### PR TITLE
fix: Unbreak must-gather Dockerfile

### DIFF
--- a/must-gather/Dockerfile
+++ b/must-gather/Dockerfile
@@ -20,7 +20,8 @@ FROM quay.io/openshift/origin-must-gather:latest AS builder
 
 FROM registry.access.redhat.com/ubi9-minimal:latest
 
-RUN microdnf -y install rsync tar gzip findutils
+RUN echo -ne "[centos-9-appstream]\nname = CentOS 9 (RPMs) - AppStream\nbaseurl = https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/\nenabled = 1\ngpgcheck = 0" > /etc/yum.repos.d/centos-9-appstream.repo
+RUN microdnf -y install rsync tar gzip graphviz findutils
 
 COPY --from=gobuilder /opt/app-root/src/go/bin/pprof /usr/bin/pprof
 COPY --from=builder /usr/bin/oc /usr/bin/oc

--- a/must-gather/Dockerfile
+++ b/must-gather/Dockerfile
@@ -20,7 +20,7 @@ FROM quay.io/openshift/origin-must-gather:latest AS builder
 
 FROM registry.access.redhat.com/ubi9-minimal:latest
 
-RUN microdnf -y install rsync tar gzip graphviz findutils
+RUN microdnf -y install rsync tar gzip findutils
 
 COPY --from=gobuilder /opt/app-root/src/go/bin/pprof /usr/bin/pprof
 COPY --from=builder /usr/bin/oc /usr/bin/oc


### PR DESCRIPTION
## Why the changes were made

Noticed `must-gather` Dockerfile does not build with the following error
```
 => ERROR [stage-3  2/10] RUN microdnf -y install rsync tar gzip graphviz findutils                                                                      7.1s
 => CACHED [konveyor-builder 2/3] WORKDIR /build                                                                                                         0.0s
 => CANCELED [konveyor-builder 3/3] RUN curl --location --output velero.tgz https://github.com/openshift/velero/archive/refs/heads/konveyor-dev.tar.gz   7.2s
------                                                                                                                                                        
 > [stage-3  2/10] RUN microdnf -y install rsync tar gzip graphviz findutils:                                                                                 
#0 0.540                                                                                                                                                      
#0 0.540 (microdnf:1): librhsm-WARNING **: 18:40:27.088: Found 0 entitlement certificates                                                                     
#0 0.541                                                                                                                                                      
#0 0.541 (microdnf:1): librhsm-WARNING **: 18:40:27.088: Found 0 entitlement certificates                                                                     
#0 0.646 Downloading metadata...                                                                                                                              
#0 1.147 Downloading metadata...                                                                                                                              
#0 5.035 Downloading metadata...                                                                                                                              
#0 7.025 error: No package matches 'graphviz'
------
Dockerfile:23
--------------------
  21 |     FROM registry.access.redhat.com/ubi9-minimal:latest
  22 |     
  23 | >>> RUN microdnf -y install rsync tar gzip graphviz findutils
  24 |     
  25 |     COPY --from=gobuilder /opt/app-root/src/go/bin/pprof /usr/bin/pprof
--------------------

```
This was probably introduced by https://github.com/openshift/oadp-operator/pull/1347

## How the changes were made

Just removed package that was erroring out.

## How to test the changes made

Build `must-gather` image. You can run
```sh
cd must-gather/
make run
```