### PR TITLE
OADP-2982: Test VMs from YAML templates

### DIFF
--- a/tests/e2e/lib/virt_storage_helpers.go
+++ b/tests/e2e/lib/virt_storage_helpers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -322,4 +323,28 @@ func (v *VirtOperator) CloneDisk(sourceNamespace, sourceName, cloneNamespace, cl
 	}
 
 	return nil
+}
+
+// Create a DataVolume from a sample YAML template. The namespace argument
+// should match a subdirectory under sample-applications/virtual-machines, and
+// the name argument should match a .yaml file in that directory, for example:
+//
+//	sample-applications/virtual-machines/cirros-test/cirros-test-disk.yaml
+//
+// This file should create a DataVolume with the following annotations set:
+//
+//	cdi.kubevirt.io/storage.bind.immediate.requested: ""
+//	cdi.kubevirt.io/storage.deleteAfterCompletion: "false"
+//
+// This function will then wait for that DataVolume to be marked "Succeeded".
+func (v *VirtOperator) CreateDiskFromYaml(namespace, name string, timeout time.Duration) error {
+	if err := InstallApplication(v.Client, filepath.Join("sample-applications", "virtual-machines", namespace, name+".yaml")); err != nil {
+		return fmt.Errorf("failed to create DataVolume %s/%s: %w", namespace, name, err)
+	}
+
+	err := wait.PollImmediate(5*time.Second, timeout, func() (bool, error) {
+		return v.checkDataVolumeReady(namespace, name), nil
+	})
+
+	return err
 }

--- a/tests/e2e/lib/virt_storage_helpers.go
+++ b/tests/e2e/lib/virt_storage_helpers.go
@@ -329,9 +329,9 @@ func (v *VirtOperator) CloneDisk(sourceNamespace, sourceName, cloneNamespace, cl
 // should match a subdirectory under sample-applications/virtual-machines, and
 // the name argument should match a .yaml file in that directory, for example:
 //
-//	sample-applications/virtual-machines/cirros-test/cirros-test-disk.yaml
+//	sample-applications/virtual-machines/example-vm-test/example-vm-test-disk.yaml
 //
-// This file should create a DataVolume with the following annotations set:
+// This file must specify a DataVolume with the following annotations set:
 //
 //	cdi.kubevirt.io/storage.bind.immediate.requested: ""
 //	cdi.kubevirt.io/storage.deleteAfterCompletion: "false"

--- a/tests/e2e/sample-applications/virtual-machines/cirros-test-vm/cirros-vm.yaml
+++ b/tests/e2e/sample-applications/virtual-machines/cirros-test-vm/cirros-vm.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: kubevirt.io/v1
+    kind: VirtualMachine
+    metadata:
+      name: cirros-vm
+      namespace: cirros-test-vm
+    spec:
+      running: true
+      template:
+        spec:
+          domain:
+            devices:
+              disks:
+              - disk:
+                  bus: virtio
+                name: rootdisk
+            resources:
+              requests:
+                cpu: 1
+                memory: 256Mi
+          volumes:
+          - name: rootdisk
+            persistentVolumeClaim:
+              claimName: cirros-vm

--- a/tests/e2e/sample-applications/virtual-machines/cirros-test/cirros-test-disk.yaml
+++ b/tests/e2e/sample-applications/virtual-machines/cirros-test/cirros-test-disk.yaml
@@ -7,6 +7,12 @@ items:
       name: cirros-test-disk
       namespace: cirros-test
       annotations:
+        # The test code wants to watch a DataVolume for the status of a download
+        # or clone. CDI defaults to deleting a DataVolume some time after it is
+        # done, so the test might miss the status. Add the deleteAfterCompletion
+        # annotation to avoid this. Also, add the bind.immediate.requested
+        # annotation so that CDI does not wait for a VM to start before binding
+        # to a PV and doing the download/clone.
         cdi.kubevirt.io/storage.bind.immediate.requested: ""
         cdi.kubevirt.io/storage.deleteAfterCompletion: "false"
     spec:

--- a/tests/e2e/sample-applications/virtual-machines/cirros-test/cirros-test-disk.yaml
+++ b/tests/e2e/sample-applications/virtual-machines/cirros-test/cirros-test-disk.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: cdi.kubevirt.io/v1beta1
+    kind: DataVolume
+    metadata:
+      name: cirros-test-disk
+      namespace: cirros-test
+      annotations:
+        cdi.kubevirt.io/storage.bind.immediate.requested: ""
+        cdi.kubevirt.io/storage.deleteAfterCompletion: "false"
+    spec:
+      source:
+        pvc:
+          name: cirros-dv
+          namespace: openshift-cnv
+      pvc:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 128Mi

--- a/tests/e2e/sample-applications/virtual-machines/cirros-test/cirros-test-vm.yaml
+++ b/tests/e2e/sample-applications/virtual-machines/cirros-test/cirros-test-vm.yaml
@@ -4,8 +4,8 @@ items:
   - apiVersion: kubevirt.io/v1
     kind: VirtualMachine
     metadata:
-      name: cirros-vm
-      namespace: cirros-test-vm
+      name: cirros-test-vm
+      namespace: cirros-test
     spec:
       running: true
       template:
@@ -23,4 +23,4 @@ items:
           volumes:
           - name: rootdisk
             persistentVolumeClaim:
-              claimName: cirros-vm
+              claimName: cirros-test-disk

--- a/tests/e2e/virt_backup_restore_suite_test.go
+++ b/tests/e2e/virt_backup_restore_suite_test.go
@@ -54,7 +54,7 @@ func runVmBackupAndRestore(brCase VmBackupRestoreCase, expectedErr error, update
 	err = v.CloneDisk(brCase.SourceNamespace, brCase.Source, brCase.Namespace, brCase.Name, 5*time.Minute)
 	gomega.Expect(err).To(gomega.BeNil())
 
-	err = v.CreateVm(brCase.Namespace, brCase.Name, brCase.Source, 5*time.Minute)
+	err = v.CreateVm(brCase.Namespace, brCase.Name, 5*time.Minute)
 	gomega.Expect(err).To(gomega.BeNil())
 
 	// Remove the Data Volume, but keep the PVC attached to the VM

--- a/tests/e2e/virt_backup_restore_suite_test.go
+++ b/tests/e2e/virt_backup_restore_suite_test.go
@@ -53,14 +53,28 @@ func runVmBackupAndRestore(brCase VmBackupRestoreCase, expectedErr error, update
 	err := lib.CreateNamespace(v.Clientset, brCase.Namespace)
 	gomega.Expect(err).To(gomega.BeNil())
 
-	// Create VM disk, defaults to clone of CirrOS image
+	// Create a standalone VM disk. This defaults to cloning the CirrOS image.
+	// This uses a DataVolume so import and clone progress can be monitored.
+	// Behavioral notes: CDI will garbage collect DataVolumes if they are not
+	// attached to anything, so this disk needs to include the annotation
+	// storage.deleteAfterCompletion in order to keep it around long enough to
+	// attach to a VM. CDI also waits until the DataVolume is attached to
+	// something before running whatever import process it has been asked to
+	// run, so this disk also needs the storage.bind.immediate.requested
+	// annotation to get it to start the cloning process.
 	err = v.CreateDiskFromYaml(brCase.Namespace, diskName, 5*time.Minute)
 	gomega.Expect(err).To(gomega.BeNil())
 
 	err = v.CreateVm(brCase.Namespace, vmName, 5*time.Minute)
 	gomega.Expect(err).To(gomega.BeNil())
 
-	// Remove the Data Volume, but keep the PVC attached to the VM
+	// Remove the Data Volume, but keep the PVC attached to the VM. The
+	// DataVolume must be removed before backing up, because otherwise the
+	// restore process might try to follow the instructions in the spec. For
+	// example, a DataVolume that lists a cloned PVC will get restored in the
+	// same state, and attempt to clone the PVC again after restore. The
+	// DataVolume also needs to be detached from the VM, so that the VM restore
+	// does not try to use the DataVolume that was deleted.
 	err = v.DetachPvc(brCase.Namespace, diskName, 2*time.Minute)
 	gomega.Expect(err).To(gomega.BeNil())
 	err = v.RemoveDataVolume(brCase.Namespace, diskName, 2*time.Minute)


### PR DESCRIPTION
Allow creation of disks and VMs from YAML files in the E2E sample-applications directory, instead of directly from code. This does not change the initial CirrOS download, because of the code that does active retrieval of the latest version. But the test VM and its disk are now created from YAML.