### PR TITLE
fix: Increase subscription test timeout

### DIFF
--- a/tests/e2e/subscription_suite_test.go
+++ b/tests/e2e/subscription_suite_test.go
@@ -103,7 +103,7 @@ var _ = ginkgov2.Describe("Subscription Config Suite Test", func() {
 				velero, err := dpaCR.Get(runTimeClientForSuiteRun)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				log.Printf("Waiting for velero pod to be running")
-				gomega.Eventually(lib.AreVeleroPodsRunning(kubernetesClientForSuiteRun, namespace), timeoutMultiplier*time.Minute*1, time.Second*5).Should(gomega.BeTrue())
+				gomega.Eventually(lib.AreVeleroPodsRunning(kubernetesClientForSuiteRun, namespace), timeoutMultiplier*time.Minute*3, time.Second*5).Should(gomega.BeTrue())
 				if velero.Spec.Configuration.NodeAgent.Enable != nil && *velero.Spec.Configuration.NodeAgent.Enable {
 					log.Printf("Waiting for Node Agent pods to be running")
 					gomega.Eventually(lib.AreNodeAgentPodsRunning(kubernetesClientForSuiteRun, namespace), timeoutMultiplier*time.Minute*1, time.Second*5).Should(gomega.BeTrue())


### PR DESCRIPTION
## Why the changes were made

Noticed that this week one timeout happened https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_oadp-operator/1266/pull-ci-openshift-oadp-operator-master-4.13-e2e-test-azure/1767186600720076800/artifacts/e2e-test-azure/e2e/build-log.txt

## How the changes were made

Increased timeout back to what it was.

## How to test the changes made

Check documentation on how to run E2E tests locally and check CI logs.