### PR TITLE
fix:  Add golangci-lint linters - code simplification

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -86,14 +86,14 @@ linters:
     - exportloopref
     - gci
     # - ginkgolinter
-    # - goconst
+    - goconst
     - gofmt
     # - goheader
     - goprintffuncname
     # - gosec
-    # - gosimple
+    - gosimple
     # - govet
-    # - ineffassign
+    - ineffassign
     # - misspell
     - nakedret
     # - nilerr
@@ -103,9 +103,9 @@ linters:
     - revive
     # - staticcheck
     # - stylecheck
-    # - unconvert
-    # - unparam
-    # - unused
+    - unconvert
+    - unparam
+    - unused
     - usestdlibvars
   fast: false
 

--- a/controllers/bsl_test.go
+++ b/controllers/bsl_test.go
@@ -1491,7 +1491,7 @@ func TestDPAReconciler_ValidateBackupStorageLocations(t *testing.T) {
 				Client:  fakeClient,
 				Scheme:  fakeClient.Scheme(),
 				Log:     logr.Discard(),
-				Context: newContextForTest(tt.name),
+				Context: newContextForTest(),
 				NamespacedName: types.NamespacedName{
 					Namespace: tt.dpa.Namespace,
 					Name:      tt.dpa.Name,
@@ -1510,7 +1510,7 @@ func TestDPAReconciler_ValidateBackupStorageLocations(t *testing.T) {
 	}
 }
 
-func newContextForTest(name string) context.Context {
+func newContextForTest() context.Context {
 	return context.TODO()
 }
 
@@ -1984,7 +1984,7 @@ func TestDPAReconciler_ReconcileBackupStorageLocations(t *testing.T) {
 				Client:  fakeClient,
 				Scheme:  fakeClient.Scheme(),
 				Log:     logr.Discard(),
-				Context: newContextForTest(tt.name),
+				Context: newContextForTest(),
 				NamespacedName: types.NamespacedName{
 					Namespace: tt.dpa.Namespace,
 					Name:      tt.dpa.Name,
@@ -2321,7 +2321,7 @@ func TestDPAReconciler_ReconcileBackupStorageLocations(t *testing.T) {
 				Client:  fakeClient,
 				Scheme:  fakeClient.Scheme(),
 				Log:     logr.Discard(),
-				Context: newContextForTest(tt.name),
+				Context: newContextForTest(),
 				NamespacedName: types.NamespacedName{
 					Namespace: tt.objects[0].GetNamespace(),
 					Name:      tt.objects[0].GetName(),

--- a/controllers/bucket_controller.go
+++ b/controllers/bucket_controller.go
@@ -119,7 +119,7 @@ func (b BucketReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	var ok bool
 	if common.CCOWorkflow() {
 		// wait for the credential request to be processed and the secret to be created
-		logger.Info(fmt.Sprintf("Following standardized STS workflow, waiting for for the credential request to be processed and provision the secret"))
+		logger.Info("Following standardized STS workflow, waiting for for the credential request to be processed and provision the secret")
 		installNS := os.Getenv("WATCH_NAMESPACE")
 		_, err = b.WaitForSecret(installNS, VeleroAWSSecretName)
 		if err != nil {

--- a/controllers/dpa_controller.go
+++ b/controllers/dpa_controller.go
@@ -41,6 +41,7 @@ import (
 
 	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
 	oadpclient "github.com/openshift/oadp-operator/pkg/client"
+	"github.com/openshift/oadp-operator/pkg/common"
 )
 
 // DPAReconciler reconciles a Velero object
@@ -157,7 +158,7 @@ type labelHandler struct {
 func (l *labelHandler) Create(evt event.CreateEvent, q workqueue.RateLimitingInterface) {
 	// check for the label & add it to the queue
 	namespace := evt.Object.GetNamespace()
-	dpaname := evt.Object.GetLabels()[namespace+".dataprotectionapplication"]
+	dpaname := evt.Object.GetLabels()[namespace+common.DPASuffix]
 	if evt.Object.GetLabels()[oadpv1alpha1.OadpOperatorLabel] == "" || dpaname == "" {
 		return
 	}
@@ -171,7 +172,7 @@ func (l *labelHandler) Create(evt event.CreateEvent, q workqueue.RateLimitingInt
 func (l *labelHandler) Delete(evt event.DeleteEvent, q workqueue.RateLimitingInterface) {
 
 	namespace := evt.Object.GetNamespace()
-	dpaname := evt.Object.GetLabels()[namespace+".dataprotectionapplication"]
+	dpaname := evt.Object.GetLabels()[namespace+common.DPASuffix]
 	if evt.Object.GetLabels()[oadpv1alpha1.OadpOperatorLabel] == "" || dpaname == "" {
 		return
 	}
@@ -183,7 +184,7 @@ func (l *labelHandler) Delete(evt event.DeleteEvent, q workqueue.RateLimitingInt
 }
 func (l *labelHandler) Update(evt event.UpdateEvent, q workqueue.RateLimitingInterface) {
 	namespace := evt.ObjectNew.GetNamespace()
-	dpaname := evt.ObjectNew.GetLabels()[namespace+".dataprotectionapplication"]
+	dpaname := evt.ObjectNew.GetLabels()[namespace+common.DPASuffix]
 	if evt.ObjectNew.GetLabels()[oadpv1alpha1.OadpOperatorLabel] == "" || dpaname == "" {
 		return
 	}
@@ -196,7 +197,7 @@ func (l *labelHandler) Update(evt event.UpdateEvent, q workqueue.RateLimitingInt
 func (l *labelHandler) Generic(evt event.GenericEvent, q workqueue.RateLimitingInterface) {
 
 	namespace := evt.Object.GetNamespace()
-	dpaname := evt.Object.GetLabels()[namespace+".dataprotectionapplication"]
+	dpaname := evt.Object.GetLabels()[namespace+common.DPASuffix]
 	if evt.Object.GetLabels()[oadpv1alpha1.OadpOperatorLabel] == "" || dpaname == "" {
 		return
 	}

--- a/controllers/monitor_test.go
+++ b/controllers/monitor_test.go
@@ -152,7 +152,7 @@ func TestDPAReconciler_updateVeleroMetricsSVC(t *testing.T) {
 				Client:  fakeClient,
 				Scheme:  fakeClient.Scheme(),
 				Log:     logr.Discard(),
-				Context: newContextForTest(tt.name),
+				Context: newContextForTest(),
 				NamespacedName: types.NamespacedName{
 					Namespace: tt.svc.Namespace,
 					Name:      tt.svc.Name,
@@ -160,7 +160,7 @@ func TestDPAReconciler_updateVeleroMetricsSVC(t *testing.T) {
 				EventRecorder: record.NewFakeRecorder(10),
 			}
 
-			err = r.updateVeleroMetricsSVC(tt.svc, tt.dpa)
+			_ = r.updateVeleroMetricsSVC(tt.svc, tt.dpa)
 			if !reflect.DeepEqual(tt.wantVeleroMtricsSVC.Labels, tt.svc.Labels) {
 				t.Errorf("expected velero metrics svc labels to be %#v, got %#v", tt.wantVeleroMtricsSVC.Labels, tt.svc.Labels)
 			}

--- a/controllers/nodeagent_test.go
+++ b/controllers/nodeagent_test.go
@@ -2541,7 +2541,7 @@ func TestDPAReconciler_updateFsRestoreHelperCM(t *testing.T) {
 				Client:  fakeClient,
 				Scheme:  fakeClient.Scheme(),
 				Log:     logr.Discard(),
-				Context: newContextForTest(tt.name),
+				Context: newContextForTest(),
 				NamespacedName: types.NamespacedName{
 					Namespace: tt.dpa.Namespace,
 					Name:      tt.dpa.Name,

--- a/controllers/registry.go
+++ b/controllers/registry.go
@@ -66,87 +66,7 @@ const (
 	ResourceGroup         = "resourceGroup"
 )
 
-// creating skeleton for provider based env var map
-var cloudProviderEnvVarMap = map[string][]corev1.EnvVar{
-	"aws": {
-		{
-			Name:  RegistryStorageEnvVarKey,
-			Value: S3,
-		},
-		{
-			Name:  RegistryStorageS3AccesskeyEnvVarKey,
-			Value: "",
-		},
-		{
-			Name:  RegistryStorageS3BucketEnvVarKey,
-			Value: "",
-		},
-		{
-			Name:  RegistryStorageS3RegionEnvVarKey,
-			Value: "",
-		},
-		{
-			Name:  RegistryStorageS3SecretkeyEnvVarKey,
-			Value: "",
-		},
-		{
-			Name:  RegistryStorageS3RegionendpointEnvVarKey,
-			Value: "",
-		},
-		{
-			Name:  RegistryStorageS3SkipverifyEnvVarKey,
-			Value: "",
-		},
-	},
-	"azure": {
-		{
-			Name:  RegistryStorageEnvVarKey,
-			Value: Azure,
-		},
-		{
-			Name:  RegistryStorageAzureContainerEnvVarKey,
-			Value: "",
-		},
-		{
-			Name:  RegistryStorageAzureAccountnameEnvVarKey,
-			Value: "",
-		},
-		{
-			Name:  RegistryStorageAzureAccountkeyEnvVarKey,
-			Value: "",
-		},
-		{
-			Name:  RegistryStorageAzureAADEndpointEnvVarKey,
-			Value: "",
-		},
-		{
-			Name:  RegistryStorageAzureSPNClientIDEnvVarKey,
-			Value: "",
-		},
-		{
-			Name:  RegistryStorageAzureSPNClientSecretEnvVarKey,
-			Value: "",
-		},
-		{
-			Name:  RegistryStorageAzureSPNTenantIDEnvVarKey,
-			Value: "",
-		},
-	},
-	"gcp": {
-		{
-			Name:  RegistryStorageEnvVarKey,
-			Value: GCS,
-		},
-		{
-			Name:  RegistryStorageGCSBucket,
-			Value: "",
-		},
-		{
-			Name:  RegistryStorageGCSKeyfile,
-			Value: "",
-		},
-	},
-}
+const oadpPrefix = "oadp-"
 
 type azureCredentials struct {
 	subscriptionID     string
@@ -208,7 +128,7 @@ func (r *DPAReconciler) ReconcileRegistries(log logr.Logger) (bool, error) {
 }
 
 func registryName(bsl *velerov1.BackupStorageLocation) string {
-	return "oadp-" + bsl.Name + "-" + bsl.Spec.Provider + "-registry"
+	return oadpPrefix + bsl.Name + "-" + bsl.Spec.Provider + "-registry"
 }
 
 func (r *DPAReconciler) getProviderSecret(secretName string) (corev1.Secret, error) {
@@ -492,7 +412,7 @@ func (r *DPAReconciler) ReconcileRegistrySVCs(log logr.Logger) (bool, error) {
 		for _, bsl := range bslList.Items {
 			svc := corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "oadp-" + bsl.Name + "-" + bsl.Spec.Provider + "-registry-svc",
+					Name:      oadpPrefix + bsl.Name + "-" + bsl.Spec.Provider + "-registry-svc",
 					Namespace: r.NamespacedName.Namespace,
 				},
 			}
@@ -540,13 +460,13 @@ func (r *DPAReconciler) ReconcileRegistryRoutes(log logr.Logger) (bool, error) {
 		for _, bsl := range bslList.Items {
 			route := routev1.Route{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "oadp-" + bsl.Name + "-" + bsl.Spec.Provider + "-registry-route",
+					Name:      oadpPrefix + bsl.Name + "-" + bsl.Spec.Provider + "-registry-route",
 					Namespace: r.NamespacedName.Namespace,
 				},
 				Spec: routev1.RouteSpec{
 					To: routev1.RouteTargetReference{
 						Kind: "Service",
-						Name: "oadp-" + bsl.Name + "-" + bsl.Spec.Provider + "-registry-svc",
+						Name: oadpPrefix + bsl.Name + "-" + bsl.Spec.Provider + "-registry-svc",
 					},
 				},
 			}
@@ -631,7 +551,7 @@ func (r *DPAReconciler) ReconcileRegistrySecrets(log logr.Logger) (bool, error) 
 		}
 		secret := corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "oadp-" + bsl.Name + "-" + bsl.Spec.Provider + "-registry-secret",
+				Name:      oadpPrefix + bsl.Name + "-" + bsl.Spec.Provider + "-registry-secret",
 				Namespace: r.NamespacedName.Namespace,
 				Labels: map[string]string{
 					oadpv1alpha1.OadpOperatorLabel: "True",

--- a/controllers/registry_test.go
+++ b/controllers/registry_test.go
@@ -9,27 +9,11 @@ import (
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
 
 	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
 )
-
-func getSchemeForFakeClientForRegistry() (*runtime.Scheme, error) {
-	err := oadpv1alpha1.AddToScheme(scheme.Scheme)
-	if err != nil {
-		return nil, err
-	}
-
-	err = velerov1.AddToScheme(scheme.Scheme)
-	if err != nil {
-		return nil, err
-	}
-
-	return scheme.Scheme, nil
-}
 
 const (
 	testProfile            = "someProfile"
@@ -47,83 +31,55 @@ const (
 	testResourceGroup      = "someResourceGroup"
 )
 
+const (
+	awsAccessKeyId     = "aws_access_key_id="
+	awsSecretAccessKey = "aws_secret_access_key="
+)
+
 var (
 	secretData = map[string][]byte{
 		"cloud": []byte(
 			"\n[" + testBslProfile + "]\n" +
-				"aws_access_key_id=" + testBslAccessKey + "\n" +
-				"aws_secret_access_key=" + testBslSecretAccessKey +
+				awsAccessKeyId + testBslAccessKey + "\n" +
+				awsSecretAccessKey + testBslSecretAccessKey +
 				"\n[default]" + "\n" +
-				"aws_access_key_id=" + testAccessKey + "\n" +
-				"aws_secret_access_key=" + testSecretAccessKey +
+				awsAccessKeyId + testAccessKey + "\n" +
+				awsSecretAccessKey + testSecretAccessKey +
 				"\n[test-profile]\n" +
-				"aws_access_key_id=" + testAccessKey + "\n" +
-				"aws_secret_access_key=" + testSecretAccessKey,
+				awsAccessKeyId + testAccessKey + "\n" +
+				awsSecretAccessKey + testSecretAccessKey,
 		),
 	}
 	secretDataWithEqualInSecret = map[string][]byte{
 		"cloud": []byte(
 			"\n[" + testBslProfile + "]\n" +
-				"aws_access_key_id=" + testBslAccessKey + "\n" +
-				"aws_secret_access_key=" + testBslSecretAccessKey + "=" + testBslSecretAccessKey +
+				awsAccessKeyId + testBslAccessKey + "\n" +
+				awsSecretAccessKey + testBslSecretAccessKey + "=" + testBslSecretAccessKey +
 				"\n[default]" + "\n" +
-				"aws_access_key_id=" + testAccessKey + "\n" +
-				"aws_secret_access_key=" + testSecretAccessKey + "=" + testSecretAccessKey +
+				awsAccessKeyId + testAccessKey + "\n" +
+				awsSecretAccessKey + testSecretAccessKey + "=" + testSecretAccessKey +
 				"\n[test-profile]\n" +
-				"aws_access_key_id=" + testAccessKey + "\n" +
-				"aws_secret_access_key=" + testSecretAccessKey + "=" + testSecretAccessKey,
+				awsAccessKeyId + testAccessKey + "\n" +
+				awsSecretAccessKey + testSecretAccessKey + "=" + testSecretAccessKey,
 		),
 	}
 	secretDataWithCarriageReturnInSecret = map[string][]byte{
 		"cloud": []byte(
 			"\n[" + testBslProfile + "]\r\n" +
-				"aws_access_key_id=" + testBslAccessKey + "\n" +
-				"aws_secret_access_key=" + testBslSecretAccessKey + "=" + testBslSecretAccessKey +
+				awsAccessKeyId + testBslAccessKey + "\n" +
+				awsSecretAccessKey + testBslSecretAccessKey + "=" + testBslSecretAccessKey +
 				"\n[default]" + "\n" +
-				"aws_access_key_id=" + testAccessKey + "\n" +
-				"aws_secret_access_key=" + testSecretAccessKey + "=" + testSecretAccessKey +
+				awsAccessKeyId + testAccessKey + "\n" +
+				awsSecretAccessKey + testSecretAccessKey + "=" + testSecretAccessKey +
 				"\r\n[test-profile]\n" +
-				"aws_access_key_id=" + testAccessKey + "\r\n" +
-				"aws_secret_access_key=" + testSecretAccessKey + "=" + testSecretAccessKey,
-		),
-	}
-	secretDataWithMixedQuotesAndSpacesInSecret = map[string][]byte{
-		"cloud": []byte(
-			"\n[" + testBslProfile + "]\n" +
-				"aws_access_key_id =" + testBslAccessKey + "\n" +
-				" aws_secret_access_key=" + "\" " + testBslSecretAccessKey + "\"" +
-				"\n[default]" + "\n" +
-				" aws_access_key_id= " + testAccessKey + "\n" +
-				"aws_secret_access_key =" + "'" + testSecretAccessKey + " '" +
-				"\n[test-profile]\n" +
-				"aws_access_key_id =" + testAccessKey + "\n" +
-				"aws_secret_access_key=" + "\" " + testSecretAccessKey + "\"",
-		),
-	}
-	awsSecretDataWithMissingProfile = map[string][]byte{
-		"cloud": []byte(
-			"[default]" + "\n" +
-				"aws_access_key_id=" + testAccessKey + "\n" +
-				"aws_secret_access_key=" + testSecretAccessKey +
-				"\n[test-profile]\n" +
-				"aws_access_key_id=" + testAccessKey + "\n" +
-				"aws_secret_access_key=" + testSecretAccessKey,
+				awsAccessKeyId + testAccessKey + "\r\n" +
+				awsSecretAccessKey + testSecretAccessKey + "=" + testSecretAccessKey,
 		),
 	}
 	secretAzureData = map[string][]byte{
 		"cloud": []byte("[default]" + "\n" +
 			"AZURE_STORAGE_ACCOUNT_ACCESS_KEY=" + testStoragekey + "\n" +
 			"AZURE_CLOUD_NAME=" + testCloudName),
-	}
-	secretAzureServicePrincipalData = map[string][]byte{
-		"cloud": []byte("[default]" + "\n" +
-			"AZURE_STORAGE_ACCOUNT_ACCESS_KEY=" + testStoragekey + "\n" +
-			"AZURE_CLOUD_NAME=" + testCloudName + "\n" +
-			"AZURE_SUBSCRIPTION_ID=" + testSubscriptionID + "\n" +
-			"AZURE_TENANT_ID=" + testTenantID + "\n" +
-			"AZURE_CLIENT_ID=" + testClientID + "\n" +
-			"AZURE_CLIENT_SECRET=" + testClientSecret + "\n" +
-			"AZURE_RESOURCE_GROUP=" + testResourceGroup),
 	}
 	awsRegistrySecretData = map[string][]byte{
 		"access_key": []byte(testBslAccessKey),
@@ -137,19 +93,7 @@ var (
 		"subscription_id_key": []byte(""),
 		"tenant_id_key":       []byte(""),
 	}
-	azureRegistrySPSecretData = map[string][]byte{
-		"client_id_key":       []byte(testClientID),
-		"client_secret_key":   []byte(testClientSecret),
-		"resource_group_key":  []byte(testResourceGroup),
-		"storage_account_key": []byte(testStoragekey),
-		"subscription_id_key": []byte(testSubscriptionID),
-		"tenant_id_key":       []byte(testTenantID),
-	}
 )
-
-var testAWSEnvVar = cloudProviderEnvVarMap["aws"]
-var testAzureEnvVar = cloudProviderEnvVarMap["azure"]
-var testGCPEnvVar = cloudProviderEnvVarMap["gcp"]
 
 func TestDPAReconciler_getSecretNameAndKeyforBackupLocation(t *testing.T) {
 	tests := []struct {
@@ -265,7 +209,7 @@ func TestDPAReconciler_getSecretNameAndKeyforBackupLocation(t *testing.T) {
 				Client:        fakeClient,
 				Scheme:        fakeClient.Scheme(),
 				Log:           logr.Discard(),
-				Context:       newContextForTest(tt.name),
+				Context:       newContextForTest(),
 				EventRecorder: record.NewFakeRecorder(10),
 			}
 
@@ -363,7 +307,7 @@ func TestDPAReconciler_populateAWSRegistrySecret(t *testing.T) {
 				Client:  fakeClient,
 				Scheme:  fakeClient.Scheme(),
 				Log:     logr.Discard(),
-				Context: newContextForTest(tt.name),
+				Context: newContextForTest(),
 				NamespacedName: types.NamespacedName{
 					Namespace: tt.bsl.Namespace,
 					Name:      tt.bsl.Name,
@@ -372,7 +316,7 @@ func TestDPAReconciler_populateAWSRegistrySecret(t *testing.T) {
 			}
 			wantRegistrySecret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "oadp-" + tt.bsl.Name + "-" + tt.bsl.Spec.Provider + "-registry-secret",
+					Name:      oadpPrefix + tt.bsl.Name + "-" + tt.bsl.Spec.Provider + "-registry-secret",
 					Namespace: r.NamespacedName.Namespace,
 					Labels: map[string]string{
 						oadpv1alpha1.OadpOperatorLabel: "True",
@@ -453,7 +397,7 @@ func TestDPAReconciler_populateAzureRegistrySecret(t *testing.T) {
 				Client:  fakeClient,
 				Scheme:  fakeClient.Scheme(),
 				Log:     logr.Discard(),
-				Context: newContextForTest(tt.name),
+				Context: newContextForTest(),
 				NamespacedName: types.NamespacedName{
 					Namespace: tt.bsl.Namespace,
 					Name:      tt.bsl.Name,
@@ -462,7 +406,7 @@ func TestDPAReconciler_populateAzureRegistrySecret(t *testing.T) {
 			}
 			wantRegistrySecret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "oadp-" + tt.bsl.Name + "-" + tt.bsl.Spec.Provider + "-registry-secret",
+					Name:      oadpPrefix + tt.bsl.Name + "-" + tt.bsl.Spec.Provider + "-registry-secret",
 					Namespace: r.NamespacedName.Namespace,
 					Labels: map[string]string{
 						oadpv1alpha1.OadpOperatorLabel: "True",

--- a/controllers/validator.go
+++ b/controllers/validator.go
@@ -52,7 +52,7 @@ func (r *DPAReconciler) ValidateDataProtectionCR(log logr.Logger) (bool, error) 
 		return false, errors.New("only mtc operator type override is supported")
 	}
 
-	if _, err := r.ValidateVeleroPlugins(r.Log); err != nil {
+	if _, err := r.ValidateVeleroPlugins(); err != nil {
 		return false, err
 	}
 
@@ -66,13 +66,10 @@ func (r *DPAReconciler) ValidateDataProtectionCR(log logr.Logger) (bool, error) 
 	return true, nil
 }
 
-// empty struct to use as map value
-type empty struct{}
-
 // For later: Move this code into validator.go when more need for validation arises
 // TODO: if multiple default plugins exist, ensure we validate all of them.
 // Right now its sequential validation
-func (r *DPAReconciler) ValidateVeleroPlugins(log logr.Logger) (bool, error) {
+func (r *DPAReconciler) ValidateVeleroPlugins() (bool, error) {
 	dpa := oadpv1alpha1.DataProtectionApplication{}
 	if err := r.Get(r.Context, r.NamespacedName, &dpa); err != nil {
 		return false, err

--- a/controllers/validator_test.go
+++ b/controllers/validator_test.go
@@ -1371,7 +1371,7 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 			Client:  fakeClient,
 			Scheme:  fakeClient.Scheme(),
 			Log:     logr.Discard(),
-			Context: newContextForTest(tt.name),
+			Context: newContextForTest(),
 			NamespacedName: types.NamespacedName{
 				Namespace: tt.dpa.Namespace,
 				Name:      tt.dpa.Name,

--- a/controllers/velero_test.go
+++ b/controllers/velero_test.go
@@ -4386,7 +4386,7 @@ func Test_validateVeleroPlugins(t *testing.T) {
 			Client:  fakeClient,
 			Scheme:  fakeClient.Scheme(),
 			Log:     logr.Discard(),
-			Context: newContextForTest(tt.name),
+			Context: newContextForTest(),
 			NamespacedName: types.NamespacedName{
 				Namespace: tt.dpa.Namespace,
 				Name:      tt.dpa.Name,
@@ -4394,7 +4394,7 @@ func Test_validateVeleroPlugins(t *testing.T) {
 			EventRecorder: record.NewFakeRecorder(10),
 		}
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := r.ValidateVeleroPlugins(r.Log)
+			result, err := r.ValidateVeleroPlugins()
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ValidateVeleroPlugins() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/controllers/vsl.go
+++ b/controllers/vsl.go
@@ -60,13 +60,13 @@ func (r *DPAReconciler) LabelVSLSecrets(log logr.Logger) (bool, error) {
 		case "aws":
 			if vsl.Velero.Credential != nil {
 				secretName := vsl.Velero.Credential.Name
-				_, err := r.UpdateCredentialsSecretLabels(secretName, dpa.Namespace, dpa.Name)
+				err := r.UpdateCredentialsSecretLabels(secretName, dpa.Namespace, dpa.Name)
 				if err != nil {
 					return false, err
 				}
 			} else {
 				secretName := credentials.PluginSpecificFields[oadpv1alpha1.DefaultPluginAWS].SecretName
-				_, err := r.UpdateCredentialsSecretLabels(secretName, dpa.Namespace, dpa.Name)
+				err := r.UpdateCredentialsSecretLabels(secretName, dpa.Namespace, dpa.Name)
 				if err != nil {
 					return false, err
 				}
@@ -74,13 +74,13 @@ func (r *DPAReconciler) LabelVSLSecrets(log logr.Logger) (bool, error) {
 		case "gcp":
 			if vsl.Velero.Credential != nil {
 				secretName := vsl.Velero.Credential.Name
-				_, err := r.UpdateCredentialsSecretLabels(secretName, dpa.Namespace, dpa.Name)
+				err := r.UpdateCredentialsSecretLabels(secretName, dpa.Namespace, dpa.Name)
 				if err != nil {
 					return false, err
 				}
 			} else {
 				secretName := credentials.PluginSpecificFields[oadpv1alpha1.DefaultPluginGCP].SecretName
-				_, err := r.UpdateCredentialsSecretLabels(secretName, dpa.Namespace, dpa.Name)
+				err := r.UpdateCredentialsSecretLabels(secretName, dpa.Namespace, dpa.Name)
 				if err != nil {
 					return false, err
 				}
@@ -88,13 +88,13 @@ func (r *DPAReconciler) LabelVSLSecrets(log logr.Logger) (bool, error) {
 		case "azure":
 			if vsl.Velero.Credential != nil {
 				secretName := vsl.Velero.Credential.Name
-				_, err := r.UpdateCredentialsSecretLabels(secretName, dpa.Namespace, dpa.Name)
+				err := r.UpdateCredentialsSecretLabels(secretName, dpa.Namespace, dpa.Name)
 				if err != nil {
 					return false, err
 				}
 			} else {
 				secretName := credentials.PluginSpecificFields[oadpv1alpha1.DefaultPluginMicrosoftAzure].SecretName
-				_, err := r.UpdateCredentialsSecretLabels(secretName, dpa.Namespace, dpa.Name)
+				err := r.UpdateCredentialsSecretLabels(secretName, dpa.Namespace, dpa.Name)
 				if err != nil {
 					return false, err
 				}

--- a/controllers/vsl_test.go
+++ b/controllers/vsl_test.go
@@ -504,7 +504,7 @@ func TestDPAReconciler_ValidateVolumeSnapshotLocation(t *testing.T) {
 				Client:  fakeClient,
 				Scheme:  fakeClient.Scheme(),
 				Log:     logr.Discard(),
-				Context: newContextForTest(tt.name),
+				Context: newContextForTest(),
 				NamespacedName: types.NamespacedName{
 					Namespace: tt.dpa.Namespace,
 					Name:      tt.dpa.Name,
@@ -568,7 +568,7 @@ func TestDPAReconciler_ReconcileVolumeSnapshotLocations(t *testing.T) {
 				Client:  fakeClient,
 				Scheme:  fakeClient.Scheme(),
 				Log:     logr.Discard(),
-				Context: newContextForTest(tt.name),
+				Context: newContextForTest(),
 				NamespacedName: types.NamespacedName{
 					Namespace: tt.dpa.Namespace,
 					Name:      tt.dpa.Name,

--- a/main.go
+++ b/main.go
@@ -29,7 +29,6 @@ import (
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -142,12 +141,7 @@ func main() {
 		if credReqCRDExists {
 			// create cred request
 			setupLog.Info(fmt.Sprintf("Creating credentials request for role: %s, and WebIdentityTokenPath: %s", roleARN, WebIdentityTokenPath))
-			if err := CreateCredRequest(roleARN, WebIdentityTokenPath, watchNamespace, kubeconf); err != nil {
-				if !errors.IsAlreadyExists(err) {
-					setupLog.Error(err, "unable to create credRequest")
-					os.Exit(1)
-				}
-			}
+			CreateCredRequest(roleARN, WebIdentityTokenPath, watchNamespace, kubeconf)
 		}
 	}
 
@@ -303,7 +297,7 @@ func DoesCRDExist(CRDGroupVersion, CRDName string, kubeconf *rest.Config) (bool,
 }
 
 // CreateCredRequest WITP : WebIdentityTokenPath
-func CreateCredRequest(roleARN string, WITP string, secretNS string, kubeconf *rest.Config) error {
+func CreateCredRequest(roleARN string, WITP string, secretNS string, kubeconf *rest.Config) {
 	clientInstance, err := client.New(kubeconf, client.Options{})
 	if err != nil {
 		setupLog.Error(err, "unable to create client")
@@ -352,5 +346,4 @@ func CreateCredRequest(roleARN string, WITP string, secretNS string, kubeconf *r
 	}
 
 	setupLog.Info("Custom resource credentialsrequest created successfully")
-	return nil
 }

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -18,6 +18,7 @@ const (
 	OADPOperator               = "oadp-operator"
 	OADPOperatorVelero         = "oadp-operator-velero"
 	OADPOperatorServiceAccount = "openshift-adp-controller-manager"
+	DPASuffix                  = ".dataprotectionapplication"
 )
 
 var DefaultRestoreResourcePriorities = restore.Priorities{
@@ -144,7 +145,7 @@ func containsEnvVar(envVars []corev1.EnvVar, envVar corev1.EnvVar) bool {
 }
 
 func AppendUniqueValues[T comparable](slice []T, values ...T) []T {
-	if values == nil || len(values) == 0 {
+	if len(values) == 0 {
 		return slice
 	}
 	slice = append(slice, values...)
@@ -169,7 +170,7 @@ func RemoveDuplicateValues[T comparable](slice []T) []T {
 }
 
 func AppendTTMapAsCopy[T comparable](add ...map[T]T) map[T]T {
-	if add == nil || len(add) == 0 {
+	if len(add) == 0 {
 		return nil
 	}
 	base := map[T]T{}
@@ -192,10 +193,7 @@ func AppendTTMapAsCopy[T comparable](add ...map[T]T) map[T]T {
 // during installation via OLM
 func CCOWorkflow() bool {
 	roleARN := os.Getenv("ROLEARN")
-	if len(roleARN) > 0 {
-		return true
-	}
-	return false
+	return len(roleARN) > 0
 }
 
 // StripDefaultPorts removes port 80 from HTTP URLs and 443 from HTTPS URLs.

--- a/pkg/credentials/credentials.go
+++ b/pkg/credentials/credentials.go
@@ -259,7 +259,7 @@ func AppendCloudProviderVolumes(dpa *oadpv1alpha1.DataProtectionApplication, ds 
 }
 
 // add plugin specific specs to velero deployment
-func AppendPluginSpecificSpecs(dpa *oadpv1alpha1.DataProtectionApplication, veleroDeployment *appsv1.Deployment, veleroContainer *corev1.Container, providerNeedsDefaultCreds map[string]bool, hasCloudStorage bool) error {
+func AppendPluginSpecificSpecs(dpa *oadpv1alpha1.DataProtectionApplication, veleroDeployment *appsv1.Deployment, veleroContainer *corev1.Container, providerNeedsDefaultCreds map[string]bool, hasCloudStorage bool) {
 
 	init_container_resources := veleroContainer.Resources
 
@@ -351,7 +351,6 @@ func AppendPluginSpecificSpecs(dpa *oadpv1alpha1.DataProtectionApplication, vele
 				})
 		}
 	}
-	return nil
 }
 
 // TODO: remove duplicate func in registry.go - refactoring away registry.go later
@@ -429,11 +428,11 @@ func BslUsesShortLivedCredential(bls []oadpv1alpha1.BackupLocation, namespace st
 				return true, nil
 			}
 		}
-		secretName, secretKey, provider, config, err := GetSecretNameKeyConfigProviderForBackupLocation(blspec, namespace)
+		secretName, secretKey, provider, _, err := GetSecretNameKeyConfigProviderForBackupLocation(blspec, namespace)
 		if err != nil {
 			return false, err
 		}
-		ret, err = SecretContainsShortLivedCredential(secretName, secretKey, provider, namespace, config)
+		ret, err = SecretContainsShortLivedCredential(secretName, secretKey, provider, namespace)
 		if err != nil {
 			return false, err
 		}
@@ -444,7 +443,7 @@ func BslUsesShortLivedCredential(bls []oadpv1alpha1.BackupLocation, namespace st
 	return ret, err
 }
 
-func SecretContainsShortLivedCredential(secretName, secretKey, provider, namespace string, config map[string]string) (bool, error) {
+func SecretContainsShortLivedCredential(secretName, secretKey, provider, namespace string) (bool, error) {
 	switch provider {
 	case "aws":
 		// AWS credentials short lived are determined by enableSharedConfig

--- a/pkg/credentials/credentials_test.go
+++ b/pkg/credentials/credentials_test.go
@@ -535,7 +535,7 @@ func TestSecretContainsShortLivedCredential(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to create secret: %v", err)
 			}
-			if got, err := SecretContainsShortLivedCredential(secretName, secretKey, tt.args.provider, namespace, tt.args.config); got != tt.want {
+			if got, err := SecretContainsShortLivedCredential(secretName, secretKey, tt.args.provider, namespace); got != tt.want {
 				t.Errorf("SecretContainsShortLivedCredential() = %v, want %v", got, tt.want)
 			} else if err != nil && !tt.wantErr {
 				t.Errorf("SecretContainsShortLivedCredential() = %v, want %v", err, tt.wantErr)

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -148,12 +148,12 @@ var _ = ginkgov2.BeforeSuite(func() {
 
 	bslCredFileData, err := lib.ReadFile(bslCredFile)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	err = lib.CreateCredentialsSecret(kubernetesClientForSuiteRun, bslCredFileData, namespace, "bsl-cloud-credentials-"+provider)
+	err = lib.CreateCredentialsSecret(kubernetesClientForSuiteRun, bslCredFileData, namespace, lib.BSLCloudCredentialsPrefix+provider)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	err = lib.CreateCredentialsSecret(
 		kubernetesClientForSuiteRun,
 		lib.ReplaceSecretDataNewLineWithCarriageReturn(bslCredFileData),
-		namespace, "bsl-cloud-credentials-"+provider+"-with-carriage-return",
+		namespace, lib.BSLCloudCredentialsPrefix+provider+"-with-carriage-return",
 	)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -169,9 +169,9 @@ var _ = ginkgov2.AfterSuite(func() {
 	log.Printf("Deleting Velero CR")
 	err := lib.DeleteSecret(kubernetesClientForSuiteRun, namespace, credSecretRef)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
-	err = lib.DeleteSecret(kubernetesClientForSuiteRun, namespace, "bsl-cloud-credentials-"+provider)
+	err = lib.DeleteSecret(kubernetesClientForSuiteRun, namespace, lib.BSLCloudCredentialsPrefix+provider)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
-	err = lib.DeleteSecret(kubernetesClientForSuiteRun, namespace, "bsl-cloud-credentials-"+provider+"-with-carriage-return")
+	err = lib.DeleteSecret(kubernetesClientForSuiteRun, namespace, lib.BSLCloudCredentialsPrefix+provider+"-with-carriage-return")
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 	err = dpaCR.Delete(runTimeClientForSuiteRun)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())

--- a/tests/e2e/lib/apps.go
+++ b/tests/e2e/lib/apps.go
@@ -57,7 +57,7 @@ func InstallApplicationWithRetries(ocClient client.Client, file string, retries 
 	obj := &unstructured.UnstructuredList{}
 
 	dec := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
-	_, _, err = dec.Decode([]byte(template), nil, obj)
+	_, _, err = dec.Decode(template, nil, obj)
 	if err != nil {
 		return err
 	}
@@ -71,7 +71,6 @@ func InstallApplicationWithRetries(ocClient client.Client, file string, retries 
 		resourceCreate := resource.DeepCopy()
 		err = nil // reset error for each resource
 		for i := 0; i < retries; i++ {
-			err = nil // reset error for each retry
 			err = ocClient.Create(context.Background(), resourceCreate)
 			if apierrors.IsAlreadyExists(err) {
 				// if spec has changed for following kinds, update the resource
@@ -157,7 +156,7 @@ func UninstallApplication(ocClient client.Client, file string) error {
 	obj := &unstructured.UnstructuredList{}
 
 	dec := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
-	_, _, err = dec.Decode([]byte(template), nil, obj)
+	_, _, err = dec.Decode(template, nil, obj)
 	if err != nil {
 		return err
 	}
@@ -237,7 +236,7 @@ func AreVolumeSnapshotsReady(ocClient client.Client, backupName string) wait.Con
 			return false, nil
 		}
 		for _, v := range vList.Items {
-			log.Println(fmt.Sprintf("waiting for volume snapshot contents %s to be ready", v.Name))
+			log.Printf("waiting for volume snapshot contents %s to be ready", v.Name)
 			if v.Status.ReadyToUse == nil {
 				ginkgo.GinkgoWriter.Println("VolumeSnapshotContents Ready status not found for " + v.Name)
 				ginkgo.GinkgoWriter.Println(fmt.Sprintf("status: %v", v.Status))
@@ -599,7 +598,7 @@ func verifyVolume(requestParams *RequestParameters, volumeFile string, prebackup
 		log.Printf("Data came from volume-file\n %s", volumeBackupData)
 		log.Printf("Volume Data after restore\n %s", volData)
 		dataIsIn := bytes.Contains([]byte(volData), volumeBackupData)
-		if dataIsIn != true {
+		if !dataIsIn {
 			return errors.New("Backup data is not in Restore Data")
 		}
 	}

--- a/tests/e2e/lib/dpa_helpers.go
+++ b/tests/e2e/lib/dpa_helpers.go
@@ -52,10 +52,12 @@ type DpaCustomResource struct {
 	Provider          string
 }
 
+const BSLCloudCredentialsPrefix = "bsl-cloud-credentials-"
+
 var VeleroPrefix = "velero-e2e-" + string(uuid.NewUUID())
 var Dpa *oadpv1alpha1.DataProtectionApplication
 
-func (v *DpaCustomResource) Build(backupRestoreType BackupRestoreType) error {
+func (v *DpaCustomResource) Build(backupRestoreType BackupRestoreType) {
 	// Velero Instance creation spec with backupstorage location default to AWS. Would need to parameterize this later on to support multiple plugins.
 	dpaInstance := oadpv1alpha1.DataProtectionApplication{
 		TypeMeta: metav1.TypeMeta{
@@ -88,7 +90,7 @@ func (v *DpaCustomResource) Build(backupRestoreType BackupRestoreType) error {
 						Config:   v.CustomResource.Spec.BackupLocations[0].Velero.Config,
 						Credential: &corev1.SecretKeySelector{
 							LocalObjectReference: corev1.LocalObjectReference{
-								Name: "bsl-cloud-credentials-" + v.Provider,
+								Name: BSLCloudCredentialsPrefix + v.Provider,
 							},
 							Key: "cloud",
 						},
@@ -149,7 +151,6 @@ func (v *DpaCustomResource) Build(backupRestoreType BackupRestoreType) error {
 		// oadpv1alpha1.CSIPluginImageKey: "quay.io/emcmulla/csi-plugin:latest",
 	}
 	v.CustomResource = &dpaInstance
-	return nil
 }
 
 // if e2e, test/e2e is "." since context is tests/e2e/
@@ -369,7 +370,7 @@ func (v *DpaCustomResource) IsDeleted(c client.Client) wait.ConditionFunc {
 }
 
 // check if bsl matches the spec
-func DoesBSLSpecMatchesDpa(namespace string, bsl velero.BackupStorageLocationSpec, spec *oadpv1alpha1.DataProtectionApplicationSpec) (bool, error) {
+func DoesBSLSpecMatchesDpa(bsl velero.BackupStorageLocationSpec, spec *oadpv1alpha1.DataProtectionApplicationSpec) (bool, error) {
 	if len(spec.BackupLocations) == 0 {
 		return false, errors.New("no backup storage location configured. Expected BSL to be configured")
 	}
@@ -391,7 +392,7 @@ func DoesBSLSpecMatchesDpa(namespace string, bsl velero.BackupStorageLocationSpe
 }
 
 // check if vsl matches the spec
-func DoesVSLSpecMatchesDpa(namespace string, vslspec velero.VolumeSnapshotLocationSpec, spec *oadpv1alpha1.DataProtectionApplicationSpec) (bool, error) {
+func DoesVSLSpecMatchesDpa(vslspec velero.VolumeSnapshotLocationSpec, spec *oadpv1alpha1.DataProtectionApplicationSpec) (bool, error) {
 	if len(spec.SnapshotLocations) == 0 {
 		return false, errors.New("no volume storage location configured. Expected VSL to be configured")
 	}

--- a/tests/e2e/lib/ocp_common_helpers.go
+++ b/tests/e2e/lib/ocp_common_helpers.go
@@ -37,7 +37,7 @@ func GetRouteEndpointURL(ocClient client.Client, namespace, routeName string) (s
 	// Check if the route is accessible
 	log.Printf("Verifying if the service is accessible via: %s", routeEndpoint)
 	resp, err := IsURLReachable(routeEndpoint)
-	if err != nil || resp == false {
+	if err != nil || !resp {
 		return "", fmt.Errorf("Route endpoint not accessible: %v", err)
 	}
 

--- a/tests/e2e/lib/plugins_helpers.go
+++ b/tests/e2e/lib/plugins_helpers.go
@@ -7,35 +7,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
 	"github.com/openshift/oadp-operator/pkg/credentials"
 )
-
-func (d *DpaCustomResource) RemoveVeleroPlugin(c client.Client, string, instanceName string, pluginValues []oadpv1alpha1.DefaultPlugin, removedPlugin string) error {
-	err := d.SetClient(c)
-	if err != nil {
-		return err
-	}
-	dpa := &oadpv1alpha1.DataProtectionApplication{}
-	err = d.Client.Get(context.Background(), client.ObjectKey{
-		Namespace: d.Namespace,
-		Name:      d.Name,
-	}, dpa)
-	if err != nil {
-		return err
-	}
-	// remove plugin from default_plugins
-	dpa.Spec.Configuration.Velero.DefaultPlugins = pluginValues
-
-	err = d.Client.Update(context.Background(), dpa)
-	if err != nil {
-		return err
-	}
-	log.Printf("%s plugin has been removed\n", removedPlugin)
-	return nil
-}
 
 func DoesPluginExist(c *kubernetes.Clientset, namespace string, plugin oadpv1alpha1.DefaultPlugin) wait.ConditionFunc {
 	return func() (bool, error) {

--- a/tests/e2e/lib/virt_helpers.go
+++ b/tests/e2e/lib/virt_helpers.go
@@ -601,7 +601,7 @@ func (v *VirtOperator) checkVmStatus(namespace, name, expectedStatus string) boo
 	return status == expectedStatus
 }
 
-func (v *VirtOperator) createVm(namespace, name, source string) error {
+func (v *VirtOperator) createVm(namespace, name string) error {
 	unstructuredVm := unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": "kubevirt.io/v1",
@@ -664,8 +664,8 @@ func (v *VirtOperator) removeVm(namespace, name string) error {
 	return nil
 }
 
-func (v *VirtOperator) ensureVm(namespace, name, source string, timeout time.Duration) error {
-	if err := v.createVm(namespace, name, source); err != nil {
+func (v *VirtOperator) ensureVm(namespace, name string, timeout time.Duration) error {
+	if err := v.createVm(namespace, name); err != nil {
 		return fmt.Errorf("failed to create VM %s/%s: %w", namespace, name, err)
 	}
 
@@ -816,9 +816,9 @@ func (v *VirtOperator) EnsureVirtRemoval() error {
 }
 
 // Create a virtual machine from an existing PVC.
-func (v *VirtOperator) CreateVm(namespace, name, source string, timeout time.Duration) error {
+func (v *VirtOperator) CreateVm(namespace, name string, timeout time.Duration) error {
 	log.Printf("Creating virtual machine %s/%s", namespace, name)
-	return v.ensureVm(namespace, name, source, timeout)
+	return v.ensureVm(namespace, name, timeout)
 }
 
 // Remove a virtual machine, but leave its data volume.

--- a/tests/e2e/must-gather_suite_test.go
+++ b/tests/e2e/must-gather_suite_test.go
@@ -31,7 +31,7 @@ var _ = ginkgov2.Describe("Backup and restore tests with must-gather", func() {
 			if ginkgov2.CurrentSpecReport().NumAttempts > 1 && !knownFlake {
 				ginkgov2.Fail("No known FLAKE found in a previous run, marking test as failed.")
 			}
-			runApplicationBackupAndRestore(brCase, expectedErr, updateLastBRcase, updateLastInstallTime)
+			runApplicationBackupAndRestore(brCase, updateLastBRcase, updateLastInstallTime)
 
 			// TODO look for duplications in tearDownBackupAndRestore
 			baseReportDir := artifact_dir + "/" + brCase.Name
@@ -80,8 +80,8 @@ var _ = ginkgov2.Describe("Backup and restore tests with must-gather", func() {
 				Namespace:         "mongo-persistent",
 				Name:              "mongo-datamover-e2e",
 				BackupRestoreType: lib.CSIDataMover,
-				PreBackupVerify:   mongoready(true, false),
-				PostRestoreVerify: mongoready(false, false),
+				PreBackupVerify:   mongoready(true),
+				PostRestoreVerify: mongoready(false),
 			},
 			MustGatherFiles: []string{
 				"namespaces/" + namespace + "/oadp.openshift.io/dpa-ts-" + instanceName + "/ts-" + instanceName + ".yml",

--- a/tests/e2e/subscription_suite_test.go
+++ b/tests/e2e/subscription_suite_test.go
@@ -20,7 +20,6 @@ var _ = ginkgov2.Describe("Subscription Config Suite Test", func() {
 	type SubscriptionConfigTestCase struct {
 		operators.SubscriptionConfig
 		failureExpected *bool
-		stream          lib.StreamSource
 	}
 
 	var _ = ginkgov2.AfterEach(func() {
@@ -91,8 +90,7 @@ var _ = ginkgov2.Describe("Subscription Config Suite Test", func() {
 				gomega.Eventually(isLeaseReady, time.Minute*4, time.Second*5).Should(gomega.BeTrue())
 
 				log.Printf("Creating test Velero")
-				err = dpaCR.Build(lib.CSI)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				dpaCR.Build(lib.CSI)
 				//also test restic
 				dpaCR.CustomResource.Spec.Configuration.NodeAgent.Enable = pointer.BoolPtr(true)
 				dpaCR.CustomResource.Spec.Configuration.NodeAgent.UploaderType = "restic"

--- a/tests/e2e/virt_backup_restore_suite_test.go
+++ b/tests/e2e/virt_backup_restore_suite_test.go
@@ -41,7 +41,7 @@ type VmBackupRestoreCase struct {
 	SourceNamespace string
 }
 
-func runVmBackupAndRestore(brCase VmBackupRestoreCase, expectedErr error, updateLastBRcase func(brCase VmBackupRestoreCase), updateLastInstallTime func(), v *lib.VirtOperator) {
+func runVmBackupAndRestore(brCase VmBackupRestoreCase, updateLastBRcase func(brCase VmBackupRestoreCase), v *lib.VirtOperator) {
 	updateLastBRcase(brCase)
 
 	// Create DPA
@@ -54,7 +54,7 @@ func runVmBackupAndRestore(brCase VmBackupRestoreCase, expectedErr error, update
 	err = v.CloneDisk(brCase.SourceNamespace, brCase.Source, brCase.Namespace, brCase.Name, 5*time.Minute)
 	gomega.Expect(err).To(gomega.BeNil())
 
-	err = v.CreateVm(brCase.Namespace, brCase.Name, brCase.Source, 5*time.Minute)
+	err = v.CreateVm(brCase.Namespace, brCase.Name, 5*time.Minute)
 	gomega.Expect(err).To(gomega.BeNil())
 
 	// Remove the Data Volume, but keep the PVC attached to the VM
@@ -87,9 +87,6 @@ var _ = ginkgov2.Describe("VM backup and restore tests", ginkgov2.Ordered, func(
 	var lastInstallTime time.Time
 	updateLastBRcase := func(brCase VmBackupRestoreCase) {
 		lastBRCase = brCase
-	}
-	updateLastInstallTime := func() {
-		lastInstallTime = time.Now()
 	}
 
 	var _ = ginkgov2.BeforeAll(func() {
@@ -128,7 +125,7 @@ var _ = ginkgov2.Describe("VM backup and restore tests", ginkgov2.Ordered, func(
 
 	ginkgov2.DescribeTable("Backup and restore virtual machines",
 		func(brCase VmBackupRestoreCase, expectedError error) {
-			runVmBackupAndRestore(brCase, expectedError, updateLastBRcase, updateLastInstallTime, v)
+			runVmBackupAndRestore(brCase, updateLastBRcase, v)
 		},
 
 		ginkgov2.Entry("default virtual machine backup and restore", ginkgov2.Label("virt"), VmBackupRestoreCase{


### PR DESCRIPTION
## Why the changes were made

Add more linting checks to project with golangci-lint. This PR fixes issues related to code simplification. Continuation of https://github.com/openshift/oadp-operator/pull/1337

## How the changes were made

Uncommented related linters in `.golangci.yaml` file, ran `make lint-fix` to see/fix issues and manually fixed remaining ones.

## How to test the changes made

Run `golangci-lint` with `make lint` and `make lint-fix` commands.