### PR TITLE
fix: More YAML templates for E2E virt tests

### DIFF
--- a/tests/e2e/lib/virt_helpers.go
+++ b/tests/e2e/lib/virt_helpers.go
@@ -215,9 +215,11 @@ func (v *VirtOperator) checkEmulation() bool {
 	// TODO check if spec.configuration.developerConfiguration.useEmulation field is set to true in kubevirst object
 	hco, err := v.Dynamic.Resource(hyperConvergedGvr).Namespace(v.Namespace).Get(context.Background(), v.HyperConverged, metav1.GetOptions{})
 	if err != nil {
+		log.Printf("Failed to get hyperConverged: %v", err)
 		return false
 	}
 	if hco == nil {
+		log.Print("No hyperConverged found")
 		return false
 	}
 
@@ -229,12 +231,10 @@ func (v *VirtOperator) checkEmulation() bool {
 	}
 	if !ok {
 		log.Printf("No KVM emulation annotation (%s) listed on HCO!", emulationAnnotation)
-	}
-	if strings.Compare(patcher, useEmulation) == 0 {
-		return true
+		return false
 	}
 
-	return false
+	return strings.Compare(patcher, useEmulation) == 0
 }
 
 // Creates target namespace if needed, and waits for it to exist

--- a/tests/e2e/sample-applications/virtual-machines/data-volume.yaml
+++ b/tests/e2e/sample-applications/virtual-machines/data-volume.yaml
@@ -4,8 +4,8 @@ items:
   - apiVersion: cdi.kubevirt.io/v1beta1
     kind: DataVolume
     metadata:
-      name: cirros-test-disk
-      namespace: cirros-test
+      name: <<template-replace-1>>
+      namespace: <<template-replace-2>>
       annotations:
         # The test code wants to watch a DataVolume for the status of a download
         # or clone. CDI defaults to deleting a DataVolume some time after it is
@@ -16,10 +16,7 @@ items:
         cdi.kubevirt.io/storage.bind.immediate.requested: ""
         cdi.kubevirt.io/storage.deleteAfterCompletion: "false"
     spec:
-      source:
-        pvc:
-          name: cirros-dv
-          namespace: openshift-cnv
+      source: <<template-replace-3>>
       pvc:
         accessModes:
         - ReadWriteOnce

--- a/tests/e2e/sample-applications/virtual-machines/openshift-cnv/hyper-converged.yaml
+++ b/tests/e2e/sample-applications/virtual-machines/openshift-cnv/hyper-converged.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: hco.kubevirt.io/v1beta1
+    kind: HyperConverged
+    metadata:
+      name: kubevirt-hyperconverged
+      namespace: openshift-cnv
+      annotations:
+        # TODO this triggers Alert KubevirtHyperconvergedClusterOperatorUSModification: unsafe modification for
+        # the kubevirt.kubevirt.io/jsonpatch annotation in the HyperConverged resource.
+        kubevirt.kubevirt.io/jsonpatch: >
+          [{"op": "add", "path": "/spec/configuration/developerConfiguration", "value": {"useEmulation": true}}]
+    spec: {}

--- a/tests/e2e/sample-applications/virtual-machines/openshift-cnv/hyper-converged.yaml
+++ b/tests/e2e/sample-applications/virtual-machines/openshift-cnv/hyper-converged.yaml
@@ -9,6 +9,6 @@ items:
       annotations:
         # TODO this triggers Alert KubevirtHyperconvergedClusterOperatorUSModification: unsafe modification for
         # the kubevirt.kubevirt.io/jsonpatch annotation in the HyperConverged resource.
-        kubevirt.kubevirt.io/jsonpatch: >
+        kubevirt.kubevirt.io/jsonpatch: >-
           [{"op": "add", "path": "/spec/configuration/developerConfiguration", "value": {"useEmulation": true}}]
     spec: {}

--- a/tests/e2e/sample-applications/virtual-machines/openshift-cnv/openshift-virtualization.yaml
+++ b/tests/e2e/sample-applications/virtual-machines/openshift-cnv/openshift-virtualization.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: v1
+    kind: Namespace
+    metadata:
+      name: openshift-cnv
+  - apiVersion: operators.coreos.com/v1
+    kind: OperatorGroup
+    metadata:
+      name: kubevirt-hyperconverged-group
+      namespace: openshift-cnv
+    spec:
+      targetNamespaces:
+        - openshift-cnv
+  - apiVersion: operators.coreos.com/v1alpha1
+    kind: Subscription
+    metadata:
+      name: hco-operatorhub
+      namespace: openshift-cnv
+    spec:
+      source: redhat-operators
+      sourceNamespace: openshift-marketplace
+      name: kubevirt-hyperconverged
+      channel: "stable"
+      startingCSV: <<template-replace-1>>
+      installPlanApproval: Automatic


### PR DESCRIPTION
## Why the changes were made

Follow up for https://github.com/openshift/oadp-operator/pull/1359 to add more YAML templates.

~Blocked by https://github.com/openshift/oadp-operator/pull/1386~

## How the changes were made

Studied code to find and remove "YAML literals" from it. Added feature to replace strings in code in templates.

## How to test the changes made

If you have 4.14+ cluster, you can run E2E virt tests locally with `make TEST_VIRT=true test-e2e`

Check logs, they should not be less informative and readable as they were before this change.