### PR TITLE
fix: CI unit test (envtest version)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,7 +169,7 @@ ifeq ($(shell $(ENVTEST) list | grep $(ENVTEST_K8S_VERSION)),)
 	ENVTESTPATH = $(shell $(ENVTEST) --arch=amd64 use $(ENVTEST_K8S_VERSION) -p path)
 endif
 $(ENVTEST): ## Download envtest-setup locally if necessary.
-	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@latest)
+	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20240320141353-395cfc7486e6)
 
 .PHONY: envtest
 envtest: $(ENVTEST)


### PR DESCRIPTION
## Why the changes were made

Noted that CI unit-test are breaking. This PR fixes it.

## How the changes were made

Checked envtest latest release `go.mod` file
https://github.com/kubernetes-sigs/controller-runtime/blob/e08b286e313e0642b739c7c9bc1d31d7bb333d2f/tools/setup-envtest/go.mod#L3

Its format is not supported by Go version 1.20 (which is used by CI)

Changed latest to [last release with supported `go.mod` file for Go version 1.20](https://pkg.go.dev/sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20240320141353-395cfc7486e6)

## How to test the changes made

Run `make test` and check CI logs.