### PR TITLE
Fix OADP-3960: Split labels avoiding label key exceed allowed 63 chars

### DIFF
--- a/controllers/bsl.go
+++ b/controllers/bsl.go
@@ -211,8 +211,12 @@ func (r *DPAReconciler) UpdateCredentialsSecretLabels(secretName string, namespa
 		secret.Labels[oadpv1alpha1.OadpOperatorLabel] = "True"
 		needPatch = true
 	}
-	if secret.Labels[namespace+".dataprotectionapplication"] != dpaName {
-		secret.Labels[namespace+".dataprotectionapplication"] = dpaName
+	if secret.Labels["dataprotectionapplication.name"] != dpaName {
+		secret.Labels["dataprotectionapplication.name"] = dpaName
+		needPatch = true
+	}
+	if secret.Labels["dataprotectionapplication.namespace"] != namespace {
+		secret.Labels["dataprotectionapplication.namespace"] = namespace
 		needPatch = true
 	}
 	if needPatch {

--- a/controllers/bsl.go
+++ b/controllers/bsl.go
@@ -119,8 +119,8 @@ func (r *DPAReconciler) ReconcileBackupStorageLocations(log logr.Logger) (bool, 
 		}
 		// Add the following labels to the bsl secret,
 		//	 1. oadpApi.OadpOperatorLabel: "True"
-		// 	 2. <namespace>.dataprotectionapplication: <name>
-		// which in turn will be used in th elabel handler to trigger the reconciliation loop
+		// 	 2. dataprotectionapplication.name: <name>
+		// which in turn will be used in the label handler to trigger the reconciliation loop
 
 		secretName, _ := r.getSecretNameAndKeyforBackupLocation(bslSpec)
 		_, err := r.UpdateCredentialsSecretLabels(secretName, dpa.Namespace, dpa.Name)
@@ -213,10 +213,6 @@ func (r *DPAReconciler) UpdateCredentialsSecretLabels(secretName string, namespa
 	}
 	if secret.Labels["dataprotectionapplication.name"] != dpaName {
 		secret.Labels["dataprotectionapplication.name"] = dpaName
-		needPatch = true
-	}
-	if secret.Labels["dataprotectionapplication.namespace"] != namespace {
-		secret.Labels["dataprotectionapplication.namespace"] = namespace
 		needPatch = true
 	}
 	if needPatch {

--- a/controllers/dpa_controller.go
+++ b/controllers/dpa_controller.go
@@ -157,8 +157,8 @@ type labelHandler struct {
 
 func (l *labelHandler) Create(evt event.CreateEvent, q workqueue.RateLimitingInterface) {
 	// check for the label & add it to the queue
-	namespace := evt.Object.GetNamespace()
-	dpaname := evt.Object.GetLabels()[namespace+".dataprotectionapplication"]
+	namespace := evt.Object.GetLabels()["dataprotectionapplication.namespace"]
+	dpaname := evt.Object.GetLabels()["dataprotectionapplication.name"]
 	if evt.Object.GetLabels()[oadpv1alpha1.OadpOperatorLabel] == "" || dpaname == "" {
 		return
 	}
@@ -171,8 +171,8 @@ func (l *labelHandler) Create(evt event.CreateEvent, q workqueue.RateLimitingInt
 }
 func (l *labelHandler) Delete(evt event.DeleteEvent, q workqueue.RateLimitingInterface) {
 
-	namespace := evt.Object.GetNamespace()
-	dpaname := evt.Object.GetLabels()[namespace+".dataprotectionapplication"]
+	namespace := evt.Object.GetLabels()["dataprotectionapplication.namespace"]
+	dpaname := evt.Object.GetLabels()["dataprotectionapplication.name"]
 	if evt.Object.GetLabels()[oadpv1alpha1.OadpOperatorLabel] == "" || dpaname == "" {
 		return
 	}
@@ -183,8 +183,8 @@ func (l *labelHandler) Delete(evt event.DeleteEvent, q workqueue.RateLimitingInt
 
 }
 func (l *labelHandler) Update(evt event.UpdateEvent, q workqueue.RateLimitingInterface) {
-	namespace := evt.ObjectNew.GetNamespace()
-	dpaname := evt.ObjectNew.GetLabels()[namespace+".dataprotectionapplication"]
+	namespace := evt.ObjectNew.GetLabels()["dataprotectionapplication.namespace"]
+	dpaname := evt.ObjectNew.GetLabels()["dataprotectionapplication.name"]
 	if evt.ObjectNew.GetLabels()[oadpv1alpha1.OadpOperatorLabel] == "" || dpaname == "" {
 		return
 	}
@@ -196,8 +196,8 @@ func (l *labelHandler) Update(evt event.UpdateEvent, q workqueue.RateLimitingInt
 }
 func (l *labelHandler) Generic(evt event.GenericEvent, q workqueue.RateLimitingInterface) {
 
-	namespace := evt.Object.GetNamespace()
-	dpaname := evt.Object.GetLabels()[namespace+".dataprotectionapplication"]
+	namespace := evt.Object.GetLabels()["dataprotectionapplication.namespace"]
+	dpaname := evt.Object.GetLabels()["dataprotectionapplication.name"]
 	if evt.Object.GetLabels()[oadpv1alpha1.OadpOperatorLabel] == "" || dpaname == "" {
 		return
 	}

--- a/controllers/dpa_controller.go
+++ b/controllers/dpa_controller.go
@@ -157,7 +157,7 @@ type labelHandler struct {
 
 func (l *labelHandler) Create(evt event.CreateEvent, q workqueue.RateLimitingInterface) {
 	// check for the label & add it to the queue
-	namespace := evt.Object.GetLabels()["dataprotectionapplication.namespace"]
+	namespace := evt.Object.GetNamespace()
 	dpaname := evt.Object.GetLabels()["dataprotectionapplication.name"]
 	if evt.Object.GetLabels()[oadpv1alpha1.OadpOperatorLabel] == "" || dpaname == "" {
 		return
@@ -171,7 +171,7 @@ func (l *labelHandler) Create(evt event.CreateEvent, q workqueue.RateLimitingInt
 }
 func (l *labelHandler) Delete(evt event.DeleteEvent, q workqueue.RateLimitingInterface) {
 
-	namespace := evt.Object.GetLabels()["dataprotectionapplication.namespace"]
+	namespace := evt.Object.GetNamespace()
 	dpaname := evt.Object.GetLabels()["dataprotectionapplication.name"]
 	if evt.Object.GetLabels()[oadpv1alpha1.OadpOperatorLabel] == "" || dpaname == "" {
 		return
@@ -183,7 +183,7 @@ func (l *labelHandler) Delete(evt event.DeleteEvent, q workqueue.RateLimitingInt
 
 }
 func (l *labelHandler) Update(evt event.UpdateEvent, q workqueue.RateLimitingInterface) {
-	namespace := evt.ObjectNew.GetLabels()["dataprotectionapplication.namespace"]
+	namespace := evt.ObjectNew.GetNamespace()
 	dpaname := evt.ObjectNew.GetLabels()["dataprotectionapplication.name"]
 	if evt.ObjectNew.GetLabels()[oadpv1alpha1.OadpOperatorLabel] == "" || dpaname == "" {
 		return
@@ -196,7 +196,7 @@ func (l *labelHandler) Update(evt event.UpdateEvent, q workqueue.RateLimitingInt
 }
 func (l *labelHandler) Generic(evt event.GenericEvent, q workqueue.RateLimitingInterface) {
 
-	namespace := evt.Object.GetLabels()["dataprotectionapplication.namespace"]
+	namespace := evt.Object.GetNamespace()
 	dpaname := evt.Object.GetLabels()["dataprotectionapplication.name"]
 	if evt.Object.GetLabels()[oadpv1alpha1.OadpOperatorLabel] == "" || dpaname == "" {
 		return

--- a/docs/design/watches.md
+++ b/docs/design/watches.md
@@ -4,7 +4,8 @@ The provider secret gets created independently by the user, and it is not part o
 
 ```
  1. oadpApi.OadpOperatorLabel: "True"
- 2. <namespace>.dataprotectionapplication: <name>
+ 2. dataprotectionapplication.namespace: <namespace>
+ 3. dataprotectionapplication.name: <name>
 ```
 
 where `<namespace>` is the namespace where OADP operator is installed and `<name>` is the name of the DPA instance

--- a/docs/design/watches.md
+++ b/docs/design/watches.md
@@ -4,11 +4,10 @@ The provider secret gets created independently by the user, and it is not part o
 
 ```
  1. oadpApi.OadpOperatorLabel: "True"
- 2. dataprotectionapplication.namespace: <namespace>
- 3. dataprotectionapplication.name: <name>
+ 2. dataprotectionapplication.name: <name>
 ```
 
-where `<namespace>` is the namespace where OADP operator is installed and `<name>` is the name of the DPA instance
+where `<name>` is the name of the DPA instance.
 
 # Current State
 


### PR DESCRIPTION
This PR should fix https://issues.redhat.com/browse/OADP-3960 by adding another label containing the namespace, while removing the namespace from the label key. 

Summary: Right now the operator labels the "cloud-credentials"-secret like `<namespace>.dataprotectionapplication=<name>`. If the operator is deployed in a namespace with more than 37 characters, the operation will fail, as the label key exceeds the allowed 63 char length limit.
- Both namespace-name and label-key may contain up to 63 chars [1].
- ".dataprotectionapplication" spends 26 chars.


[1] https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set