### PR TITLE
OADP-4110: Add support for unsupported node-agent args

### DIFF
--- a/api/v1alpha1/oadp_types.go
+++ b/api/v1alpha1/oadp_types.go
@@ -160,6 +160,12 @@ type NodeAgentConfig struct {
 	// +kubebuilder:validation:Enum=restic;kopia
 	// +kubebuilder:validation:Required
 	UploaderType string `json:"uploaderType"`
+
+	// UnsupportedNodeAgentArgs accepts a string of server args and their values to be supplied to nodeagent daemon set
+	// each pair of server arg and value is comma separated if there are multiple args to be supplied
+	// This will replace and override any other args specified via DPA for the nodeagent
+	// +optional
+	UnsupportedNodeAgentArgs string `json:"unsupportedNodeAgentArgs,omitempty"`
 }
 
 // ResticConfig is the configuration for restic server

--- a/api/v1alpha1/oadp_types.go
+++ b/api/v1alpha1/oadp_types.go
@@ -161,9 +161,8 @@ type NodeAgentConfig struct {
 	// +kubebuilder:validation:Required
 	UploaderType string `json:"uploaderType"`
 
-	// UnsupportedNodeAgentArgs accepts a string of server args and their values to be supplied to nodeagent daemon set
-	// each pair of server arg and value is comma separated if there are multiple args to be supplied
-	// This will replace and override any other args specified via DPA for the nodeagent
+	// UnsupportedNodeAgentArgs accepts a string of server args and their values to be supplied to nodeagent daemon set,
+	// each pair of server arg and value should be comma separated if there are multiple args to be supplied
 	// +optional
 	UnsupportedNodeAgentArgs string `json:"unsupportedNodeAgentArgs,omitempty"`
 }

--- a/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
@@ -313,7 +313,7 @@ spec:
                           description: timeout defines the NodeAgent timeout, default value is 1h
                           type: string
                         unsupportedNodeAgentArgs:
-                          description: UnsupportedNodeAgentArgs accepts a string of server args to be supplied to nodeagent daemon set This will replace and override any other args specified via DPA for the nodeagent
+                          description: UnsupportedNodeAgentArgs accepts a string of server args and their values to be supplied to nodeagent daemon set, each pair of server arg and value should be comma separated if there are multiple args to be supplied
                           type: string
                         uploaderType:
                           description: The type of uploader to transfer the data of pod volumes, the supported values are 'restic' or 'kopia'

--- a/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
@@ -312,6 +312,9 @@ spec:
                         timeout:
                           description: timeout defines the NodeAgent timeout, default value is 1h
                           type: string
+                        unsupportedNodeAgentArgs:
+                          description: UnsupportedNodeAgentArgs accepts a string of server args to be supplied to nodeagent daemon set This will replace and override any other args specified via DPA for the nodeagent
+                          type: string
                         uploaderType:
                           description: The type of uploader to transfer the data of pod volumes, the supported values are 'restic' or 'kopia'
                           enum:

--- a/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
@@ -313,7 +313,7 @@ spec:
                           description: timeout defines the NodeAgent timeout, default value is 1h
                           type: string
                         unsupportedNodeAgentArgs:
-                          description: UnsupportedNodeAgentArgs accepts a string of server args to be supplied to nodeagent daemon set This will replace and override any other args specified via DPA for the nodeagent
+                          description: UnsupportedNodeAgentArgs accepts a string of server args and their values to be supplied to nodeagent daemon set, each pair of server arg and value should be comma separated if there are multiple args to be supplied
                           type: string
                         uploaderType:
                           description: The type of uploader to transfer the data of pod volumes, the supported values are 'restic' or 'kopia'

--- a/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
@@ -312,6 +312,9 @@ spec:
                         timeout:
                           description: timeout defines the NodeAgent timeout, default value is 1h
                           type: string
+                        unsupportedNodeAgentArgs:
+                          description: UnsupportedNodeAgentArgs accepts a string of server args to be supplied to nodeagent daemon set This will replace and override any other args specified via DPA for the nodeagent
+                          type: string
                         uploaderType:
                           description: The type of uploader to transfer the data of pod volumes, the supported values are 'restic' or 'kopia'
                           enum:

--- a/controllers/nodeagent.go
+++ b/controllers/nodeagent.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"strings"
 
 	"github.com/go-logr/logr"
 	"github.com/operator-framework/operator-lib/proxy"
@@ -328,6 +329,18 @@ func (r *DPAReconciler) customizeNodeAgentDaemonset(dpa *oadpv1alpha1.DataProtec
 
 		nodeAgentContainer.SecurityContext = &corev1.SecurityContext{
 			Privileged: pointer.Bool(true),
+		}
+
+		// append node agent server args if specified via UnsupportedNodeAgentArgs
+		if len(dpa.Spec.Configuration.NodeAgent.UnsupportedNodeAgentArgs) > 0 {
+			unsupportedArgs := strings.TrimSpace(dpa.Spec.Configuration.NodeAgent.UnsupportedNodeAgentArgs)
+			unsupportedArgsList := strings.Split(unsupportedArgs, ",")
+			for _, arg := range unsupportedArgsList {
+				arg = strings.TrimSpace(arg)
+				if arg != "" {
+					nodeAgentContainer.Args = append(nodeAgentContainer.Args, arg)
+				}
+			}
 		}
 
 		nodeAgentContainer.ImagePullPolicy = corev1.PullAlways


### PR DESCRIPTION
## Why the changes were made

<!-- Explain why this PR is important, what problems it fixes, link related issues -->

This PR 
- fixes [OADP-4110](https://issues.redhat.com//browse/OADP-4110) https://issues.redhat.com/browse/OADP-4110
- adds support for unsupported node-agent args via DPA
- this PR unblocks the customers when the DPA does not have server args parity with upstream Velero node-agent server args

## How to test the changes made

<!-- Explain how the changes introduced by this PR can be tested and verified, with commands and pictures -->

In order to test these changes:
- checkout the PR and use `make deploy-olm` command to install the operator and CRDs (make sure you do not have stale CRDs in cluster)
- create a valid sample DPA and add the following to spec (In this example we will try to supply 2 node-agent server args):
```
spec.nodeAgent.unsupportedNodeAgentArgs: "--data-mover-prepare-timeout=45m,--resource-timeout=15m"
``` 
- check the node-agent daemon set container args to verify the values supplied
- To cross verify you can use the image (`veleroImageFqin: quay.io/spampatt/velero:unsupp-node-agent-args`) and view node-agent logs for the arg values we supplied:
```
time="2024-05-22T18:50:48Z" level=info msg="Testing value for data-mover-prepare-timeout: 45m0s" logSource="pkg/cmd/cli/nodeagent/server.go:275"  
time="2024-05-22T18:50:48Z" level=info msg="Testing value for resource-timeout: 15m0s" logSource="pkg/cmd/cli/nodeagent/server.go:276"
```