### PR TITLE
OADP-3504: imagePullPolicy based on image having or not digest

### DIFF
--- a/controllers/nodeagent.go
+++ b/controllers/nodeagent.go
@@ -330,7 +330,12 @@ func (r *DPAReconciler) customizeNodeAgentDaemonset(dpa *oadpv1alpha1.DataProtec
 			Privileged: pointer.Bool(true),
 		}
 
-		nodeAgentContainer.ImagePullPolicy = common.GetImagePullPolicy(getVeleroImage(dpa))
+		imagePullPolicy, err := common.GetImagePullPolicy(getVeleroImage(dpa))
+		if err != nil {
+			r.Log.Error(err, "imagePullPolicy regex failed")
+		}
+
+		nodeAgentContainer.ImagePullPolicy = imagePullPolicy
 		setContainerDefaults(nodeAgentContainer)
 	}
 

--- a/controllers/nodeagent.go
+++ b/controllers/nodeagent.go
@@ -330,7 +330,7 @@ func (r *DPAReconciler) customizeNodeAgentDaemonset(dpa *oadpv1alpha1.DataProtec
 			Privileged: pointer.Bool(true),
 		}
 
-		nodeAgentContainer.ImagePullPolicy = corev1.PullAlways
+		nodeAgentContainer.ImagePullPolicy = common.GetImagePullPolicy(getVeleroImage(dpa))
 		setContainerDefaults(nodeAgentContainer)
 	}
 

--- a/controllers/nonadmin_controller.go
+++ b/controllers/nonadmin_controller.go
@@ -158,14 +158,14 @@ func ensureRequiredSpecs(deploymentObject *appsv1.Deployment, image string) {
 		deploymentObject.Spec.Template.Spec.Containers = []corev1.Container{{
 			Name:            nonAdminObjectName,
 			Image:           image,
-			ImagePullPolicy: corev1.PullAlways,
+			ImagePullPolicy: common.GetImagePullPolicy(image),
 			Env:             []corev1.EnvVar{namespaceEnvVar},
 		}}
 	} else {
 		for _, container := range deploymentObject.Spec.Template.Spec.Containers {
 			if container.Name == nonAdminObjectName {
 				container.Image = image
-				container.ImagePullPolicy = corev1.PullAlways
+				container.ImagePullPolicy = common.GetImagePullPolicy(image)
 				container.Env = []corev1.EnvVar{namespaceEnvVar}
 				break
 			}

--- a/controllers/nonadmin_controller_test.go
+++ b/controllers/nonadmin_controller_test.go
@@ -245,7 +245,7 @@ func TestEnsureRequiredLabels(t *testing.T) {
 
 func TestEnsureRequiredSpecs(t *testing.T) {
 	deployment := createTestDeployment("test-ensure-spec")
-	ensureRequiredSpecs(deployment, defaultNonAdminImage)
+	ensureRequiredSpecs(deployment, defaultNonAdminImage, corev1.PullAlways)
 	if *deployment.Spec.Replicas != 1 {
 		t.Errorf("Deployment has wrong number of replicas: %v", *deployment.Spec.Replicas)
 	}

--- a/controllers/velero.go
+++ b/controllers/velero.go
@@ -281,7 +281,7 @@ func (r *DPAReconciler) customizeVeleroDeployment(dpa *oadpv1alpha1.DataProtecti
 	}
 	//add any default init containers here if needed eg: setup-certificate-secret
 	// When you do this
-	// - please set the ImagePullPolicy to Always, and
+	// - please set the ImagePullPolicy to Always , and
 	// - please also update the test
 	if veleroDeployment.Spec.Template.Spec.InitContainers == nil {
 		veleroDeployment.Spec.Template.Spec.InitContainers = []corev1.Container{}
@@ -400,7 +400,7 @@ func (r *DPAReconciler) customizeVeleroContainer(dpa *oadpv1alpha1.DataProtectio
 			}
 		}
 	}
-	veleroContainer.ImagePullPolicy = corev1.PullAlways
+	veleroContainer.ImagePullPolicy = common.GetImagePullPolicy(getVeleroImage(dpa))
 	veleroContainer.VolumeMounts = append(veleroContainer.VolumeMounts,
 		corev1.VolumeMount{
 			Name:      "certs",

--- a/controllers/velero.go
+++ b/controllers/velero.go
@@ -279,9 +279,9 @@ func (r *DPAReconciler) customizeVeleroDeployment(dpa *oadpv1alpha1.DataProtecti
 			},
 		)
 	}
-	//add any default init containers here if needed eg: setup-certificate-secret
+	// add any default init containers here if needed eg: setup-certificate-secret
 	// When you do this
-	// - please set the ImagePullPolicy to Always , and
+	// - please use common.GetImagePullPolicy function to set the ImagePullPolicy, and
 	// - please also update the test
 	if veleroDeployment.Spec.Template.Spec.InitContainers == nil {
 		veleroDeployment.Spec.Template.Spec.InitContainers = []corev1.Container{}

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/vmware-tanzu/velero/pkg/restore"
@@ -213,4 +214,15 @@ func StripDefaultPorts(fromUrl string) (string, error) {
 		r.URL.Host = r.Host
 	}
 	return r.URL.String(), nil
+}
+
+// GetImagePullPolicy get imagePullPolicy for a container, based on its image.
+// If image contains a digest, use IfNotPresent; otherwise, Always.
+// Reference: https://github.com/distribution/distribution/blob/v2.7.1/reference/reference.go
+func GetImagePullPolicy(image string) corev1.PullPolicy {
+	if strings.Contains(image, "@") {
+		// If image contains a digest
+		return corev1.PullIfNotPresent
+	}
+	return corev1.PullAlways
 }

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -224,20 +224,18 @@ func GetImagePullPolicy(image string) (corev1.PullPolicy, error) {
 	sha256regex, err := regexp.Compile("@sha256:[a-f0-9]{64}")
 	if err != nil {
 		return corev1.PullAlways, err
-	} else {
-		if sha256regex.Match([]byte(image)) {
-			// image contains a sha256 digest
-			return corev1.PullIfNotPresent, nil
-		}
+	}
+	if sha256regex.Match([]byte(image)) {
+		// image contains a sha256 digest
+		return corev1.PullIfNotPresent, nil
 	}
 	sha512regex, err := regexp.Compile("@sha512:[a-f0-9]{128}")
 	if err != nil {
 		return corev1.PullAlways, err
-	} else {
-		if sha512regex.Match([]byte(image)) {
-			// image contains a sha512 digest
-			return corev1.PullIfNotPresent, nil
-		}
+	}
+	if sha512regex.Match([]byte(image)) {
+		// image contains a sha512 digest
+		return corev1.PullIfNotPresent, nil
 	}
 	return corev1.PullAlways, nil
 }

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -217,11 +217,11 @@ func StripDefaultPorts(fromUrl string) (string, error) {
 }
 
 // GetImagePullPolicy get imagePullPolicy for a container, based on its image.
-// If image contains a digest, use IfNotPresent; otherwise, Always.
+// If image contains a sha256 digest, use IfNotPresent; otherwise, Always.
 // Reference: https://github.com/distribution/distribution/blob/v2.7.1/reference/reference.go
 func GetImagePullPolicy(image string) corev1.PullPolicy {
-	if strings.Contains(image, "@") {
-		// If image contains a digest
+	if strings.Contains(image, "@sha256:") {
+		// If image contains a sha256 digest
 		return corev1.PullIfNotPresent
 	}
 	return corev1.PullAlways

--- a/pkg/common/common_test.go
+++ b/pkg/common/common_test.go
@@ -168,8 +168,23 @@ func TestGetImagePullPolicy(t *testing.T) {
 			result: corev1.PullIfNotPresent,
 		},
 		{
-			name:   "Image with non sha256 digest",
+			name:   "Image with wrong sha256 digest",
+			image:  "test.com/foo@sha256:123456789009876543211234566789009876543211234566789009876543211",
+			result: corev1.PullAlways,
+		},
+		{
+			name:   "Image with sha512 digest",
 			image:  "test.com/foo@sha512:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+			result: corev1.PullIfNotPresent,
+		},
+		{
+			name:   "Image with wrong sha512 digest",
+			image:  "test.com/foo@sha512:Ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+			result: corev1.PullAlways,
+		},
+		{
+			name:   "Image with non sha512 nor sha512 digest",
+			image:  "test.com/foo@sha256+b64u:LCa0a2j_xo_5m0U8HTBBNBNCLXBkg7-g-YpeiGJm564",
 			result: corev1.PullAlways,
 		},
 	}

--- a/pkg/common/common_test.go
+++ b/pkg/common/common_test.go
@@ -190,7 +190,10 @@ func TestGetImagePullPolicy(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			result := GetImagePullPolicy(test.image)
+			result, err := GetImagePullPolicy(test.image)
+			if err != nil {
+				t.Errorf("Error occurred in test: %s", err)
+			}
 			if result != test.result {
 				t.Errorf("Results differ: got '%v' but expected '%v'", result, test.result)
 			}

--- a/pkg/credentials/credentials.go
+++ b/pkg/credentials/credentials.go
@@ -28,7 +28,7 @@ type DefaultPluginFields struct {
 }
 
 const (
-	cloudFieldPath = "cloud"
+	CloudFieldPath = "cloud"
 )
 
 var (
@@ -136,7 +136,7 @@ func getKubeVirtPluginImage(dpa *oadpv1alpha1.DataProtectionApplication) string 
 	return os.Getenv("RELATED_IMAGE_KUBEVIRT_VELERO_PLUGIN")
 }
 
-func getPluginImage(pluginName string, dpa *oadpv1alpha1.DataProtectionApplication) string {
+func GetPluginImage(pluginName string, dpa *oadpv1alpha1.DataProtectionApplication) string {
 	switch pluginName {
 
 	case common.VeleroPluginForAWS:
@@ -213,7 +213,7 @@ func AppendCloudProviderVolumes(dpa *oadpv1alpha1.DataProtectionApplication, ds 
 					resticContainer.Env,
 					corev1.EnvVar{
 						Name:  cloudProviderMap.EnvCredentialsFile,
-						Value: cloudProviderMap.MountPath + "/" + cloudFieldPath,
+						Value: cloudProviderMap.MountPath + "/" + CloudFieldPath,
 					},
 				)
 			}
@@ -235,102 +235,6 @@ func AppendCloudProviderVolumes(dpa *oadpv1alpha1.DataProtectionApplication, ds 
 					},
 				)
 			}
-		}
-	}
-	return nil
-}
-
-// add plugin specific specs to velero deployment
-func AppendPluginSpecificSpecs(dpa *oadpv1alpha1.DataProtectionApplication, veleroDeployment *appsv1.Deployment, veleroContainer *corev1.Container, providerNeedsDefaultCreds map[string]bool, hasCloudStorage bool) error {
-
-	init_container_resources := veleroContainer.Resources
-
-	for _, plugin := range dpa.Spec.Configuration.Velero.DefaultPlugins {
-		if pluginSpecificMap, ok := PluginSpecificFields[plugin]; ok {
-			veleroDeployment.Spec.Template.Spec.InitContainers = append(
-				veleroDeployment.Spec.Template.Spec.InitContainers,
-				corev1.Container{
-					Image:                    getPluginImage(pluginSpecificMap.PluginName, dpa),
-					Name:                     pluginSpecificMap.PluginName,
-					ImagePullPolicy:          common.GetImagePullPolicy(getPluginImage(pluginSpecificMap.PluginName, dpa)),
-					Resources:                init_container_resources,
-					TerminationMessagePath:   "/dev/termination-log",
-					TerminationMessagePolicy: "File",
-					VolumeMounts: []corev1.VolumeMount{
-						{
-							MountPath: "/target",
-							Name:      "plugins",
-						},
-					},
-				})
-
-			pluginNeedsCheck, foundInBSLorVSL := providerNeedsDefaultCreds[string(plugin)]
-
-			if !foundInBSLorVSL && !hasCloudStorage {
-				pluginNeedsCheck = true
-			}
-
-			if !pluginSpecificMap.IsCloudProvider || !pluginNeedsCheck {
-				continue
-			}
-			if dpa.Spec.Configuration.Velero.NoDefaultBackupLocation &&
-				dpa.Spec.UnsupportedOverrides[oadpv1alpha1.OperatorTypeKey] != oadpv1alpha1.OperatorTypeMTC &&
-				pluginSpecificMap.IsCloudProvider {
-				continue
-			}
-			// set default secret name to use
-			secretName := pluginSpecificMap.SecretName
-			// append plugin specific volume mounts
-			if veleroContainer != nil {
-				veleroContainer.VolumeMounts = append(
-					veleroContainer.VolumeMounts,
-					corev1.VolumeMount{
-						Name:      secretName,
-						MountPath: pluginSpecificMap.MountPath,
-					})
-
-				// append plugin specific env vars
-				veleroContainer.Env = append(
-					veleroContainer.Env,
-					corev1.EnvVar{
-						Name:  pluginSpecificMap.EnvCredentialsFile,
-						Value: pluginSpecificMap.MountPath + "/" + cloudFieldPath,
-					})
-			}
-
-			// append plugin specific volumes
-			veleroDeployment.Spec.Template.Spec.Volumes = append(
-				veleroDeployment.Spec.Template.Spec.Volumes,
-				corev1.Volume{
-					Name: secretName,
-					VolumeSource: corev1.VolumeSource{
-						Secret: &corev1.SecretVolumeSource{
-							SecretName:  secretName,
-							DefaultMode: common.DefaultModePtr(),
-						},
-					},
-				})
-		}
-	}
-	// append custom plugin init containers
-	if dpa.Spec.Configuration.Velero.CustomPlugins != nil {
-		for _, plugin := range dpa.Spec.Configuration.Velero.CustomPlugins {
-			veleroDeployment.Spec.Template.Spec.InitContainers = append(
-				veleroDeployment.Spec.Template.Spec.InitContainers,
-				corev1.Container{
-					Image:                    plugin.Image,
-					Name:                     plugin.Name,
-					ImagePullPolicy:          common.GetImagePullPolicy(plugin.Image),
-					Resources:                init_container_resources,
-					TerminationMessagePath:   "/dev/termination-log",
-					TerminationMessagePolicy: "File",
-					VolumeMounts: []corev1.VolumeMount{
-						{
-							MountPath: "/target",
-							Name:      "plugins",
-						},
-					},
-				})
 		}
 	}
 	return nil

--- a/pkg/credentials/credentials.go
+++ b/pkg/credentials/credentials.go
@@ -252,7 +252,7 @@ func AppendPluginSpecificSpecs(dpa *oadpv1alpha1.DataProtectionApplication, vele
 				corev1.Container{
 					Image:                    getPluginImage(pluginSpecificMap.PluginName, dpa),
 					Name:                     pluginSpecificMap.PluginName,
-					ImagePullPolicy:          corev1.PullAlways,
+					ImagePullPolicy:          common.GetImagePullPolicy(getPluginImage(pluginSpecificMap.PluginName, dpa)),
 					Resources:                init_container_resources,
 					TerminationMessagePath:   "/dev/termination-log",
 					TerminationMessagePolicy: "File",
@@ -320,7 +320,7 @@ func AppendPluginSpecificSpecs(dpa *oadpv1alpha1.DataProtectionApplication, vele
 				corev1.Container{
 					Image:                    plugin.Image,
 					Name:                     plugin.Name,
-					ImagePullPolicy:          corev1.PullAlways,
+					ImagePullPolicy:          common.GetImagePullPolicy(plugin.Image),
 					Resources:                init_container_resources,
 					TerminationMessagePath:   "/dev/termination-log",
 					TerminationMessagePolicy: "File",

--- a/pkg/credentials/credentials_test.go
+++ b/pkg/credentials/credentials_test.go
@@ -364,7 +364,7 @@ func TestCredentials_getPluginImage(t *testing.T) {
 				os.Setenv(key, value)
 				defer os.Unsetenv(key)
 			}
-			gotImage := getPluginImage(tt.pluginName, tt.dpa)
+			gotImage := GetPluginImage(tt.pluginName, tt.dpa)
 			if gotImage != tt.wantImage {
 				t.Errorf("Expected plugin image %v did not match %v", tt.wantImage, gotImage)
 			}


### PR DESCRIPTION
## Why the changes were made

First part of linked JIRA issue. For OADP 1.3, change imagePullPolicy based on container image. If it contains a sha256 or sha 512 digest, use IfNotPresent; otherwise, Always. User can not change that value manually, reconcile loop will just update value.

> **Note:** in production, we already set OADP CSV to IfNotPresent. But it can be changed manually by user.

## How the changes were made

Run
```sh
grep -Inr 'ImagePullPolicy' . --exclude=\*_test.go
grep -Inr 'imagePullPolicy' .
```

## How to test the changes made

Run `make deploy-olm` on this branch and check imagePullPolicy when using different images. Update `RELATED_IMAGE_` environment variables in OADP CSV or use unsupportedOverrides to do that.

Change regex to something wrong to test logs.  
