### PR TITLE
Add Design for the unsupported arguments for the OADP

### DIFF
--- a/docs/design/unsupported-args-design.md
+++ b/docs/design/unsupported-args-design.md
@@ -1,0 +1,118 @@
+# Unsupported Arguments schema and common design
+Date: 2024-06-29
+
+## Abstract
+OADP allows to configure it's components parameters via number of DataProtectionApplication Schema.
+
+Unsupported arguments within the OADP operator are those that do not conform to the standard DataProtectionApplication Schema or are explicitly identified as unsupported or custom arguments.
+
+There is need to provide a common way for defining and managing unsupported arguments within the OADP operator for its' components such as velero server or node-agent arguments.
+
+## Background
+The OADP allows configuration of several predefined arguments via the DataProtectionApplication Schema. These parameters are carefully selected and tested to meet the highest quality standards. However, in some circumstances, there is a need to pass other parameters that may be under development, not yet fully tested, or specifically overriding the default ones.
+
+Over the past OADP releases, some implementations have provided access to extra arguments. However, there has been no standardization, and unknown to DataProtectionApplication Schema arguments were not allowed.
+
+## Goals
+- Define common way to allow passing extra arguments to various executables used by OADP.
+- Ensure the new common way do not interfere with already existing implementations.
+
+## Non Goals
+- Deprecate current ways of defining extra arguments.
+- Change precedences within current ways of defining extra arguments.
+- Validation of unsupported args, they are passed to the appropriate executables without any prior validation.
+
+## Design
+Unsupported arguments are defined as a `ConfigMap` within the same Namespace as OADP Operator.
+
+There may be multiple `ConfigMaps` for particular section of the OADP configuration.
+
+There are default naming convention for the `ConfigMaps`, however user may override those using `DPA` annotations.
+
+When ConfigMap is found, controller takes those values as the highest priority and replaces **all** of the other configuration options, even if they were defined within `DPA` schema for the section for which the `ConfigMap` was created.
+
+The Schema of an `ConfigMap` includes data that corresponds to the arguments passed to the relevant executable as in the below example:
+
+   ```
+   apiVersion: v1
+   kind: ConfigMap
+   metadata:
+     name: oadp-unsupported-velero-server-args
+     namespace: openshift-adp
+   data:
+     --default-volume-snapshot-locations: 'aws:backups-primary,azure:backups-secondary'
+     --log-level: 'debug'
+   ```
+
+If the name of the ConfigMap is recognized by the OADP controller it is consumed, otherwise user has to create DPA with the annotation pointing to a relevant ConfigMap as in the example:
+
+
+    ```yaml
+    kind: DataProtectionApplication
+    apiVersion: oadp.openshift.io/v1alpha1
+    metadata:
+    name: sample-dpa
+    namespace: openshift-adp
+    annotations:
+        custom.configmap.dpa/velero-server-args: 'oadp-unsupported-velero-server-args'
+    spec:
+        [...]
+    ```
+
+## Alternatives Considered
+ - Resource specific configuration / CRD options
+ 
+   The configuration data is directly integrated into the Custom Resource Definition (CRD). This is how currently some of the extra arguments are defined within OADP.
+
+   There is however schema enforcement, which is problematic, because it requires new release of OADP to include unknown or not available options.
+   
+   This approach also introduces more complexity as it requires logic to handle and validate each of the options. On top of that having CRD options introduces migration and upgrade problems requiring migration strategies to be taken into account for existing resources. 
+
+   Adding the unsupported arguments and options within CRD makes those options highly visible to the users and may encourage to use them.
+
+ - Annotations to include unsupported args directly
+   This mmethod allows easily to add args to existing resources, however they have size limitations, restricting the amount of data that can be stored and may have impact on the scenarios where limit is reached.
+
+   Annotations are also problematic to maintain when used for more complex types of configurations.
+
+   Sample custom unsupported args:
+
+    ```yaml
+    kind: DataProtectionApplication
+    apiVersion: oadp.openshift.io/v1alpha1
+    metadata:
+    name: sample-dpa
+    namespace: openshift-adp
+    annotations:
+        custom.configmap.dpa/velero-server-args: '{"arg_1":"val_1","arg2":"val2"}'
+        custom.configmap.dpa/node-agent-args: '{"arg_1":"val_1","arg_2":"val_2"}'
+    spec:
+        [...]
+    ```
+
+ - Labels to include unsupported args directly
+
+   This approach is similar to annotations, with all the pros/cons of them with additional cons of labels being designed for resource identification, querying, and organizing within clusters and not configurations.
+
+## Security Considerations
+Passing input data without validation may cause malformed configurations to be included.
+
+This design does not allow to store sensitive information within configuration, as it's using ConfigMaps and not Secrets.
+
+Proper RBAC access restriction to the relevant ConfigMaps is required to ensure least privilege is granted.
+
+## Compatibility
+This design is backwards compatible with previous unsupported arguments passed via DPA specification, however it takes precendence over them.
+
+This may lead to the situation where users will have running previous configurations that are not reflected with the OADP instances that are using new way of defining unsupported arguments.
+
+## Implementation
+The implementation will take place within OADP controller only, without changes to the DPA specification.
+
+Once ConfigMap(s) are discovered to be in the same Namespace as OADP their config will take precendence and replace all the other arguments passed to the executable as a simple string without any validations.
+
+## Open Issues
+ - Should we include the unsupported args in all cases when the ConfigMaps are found in the napespace or maybe only when annotations are within DPA?
+ - Naming convention for the annotations - currently it's not well defined
+ - We may consider using one ConfigMap instead of multiple ConfigMaps, but this will lock down it's schema and may lead to future issues with enabling other unsupported args.
+


### PR DESCRIPTION
Initial design to address [OADP-4159](https://issues.redhat.com//browse/OADP-4159)

Also may be included as part of [OADP-4110](https://issues.redhat.com//browse/OADP-4110) with PR #1396

## Why the changes were made

To design unsupported arguments.

## How to test the changes made

n/a it's a design.
One test was performed to create ConfigMap with `--` as key name.