### PR TITLE
remove restartPolicy for OCP 4.16

### DIFF
--- a/tests/e2e/sample-applications/virtual-machines/fedora-todolist/fedora-todolist.yaml
+++ b/tests/e2e/sample-applications/virtual-machines/fedora-todolist/fedora-todolist.yaml
@@ -140,7 +140,6 @@ items:
               timeoutSeconds: 2
               successThreshold: 1
               failureThreshold: 40 # 40x30sec before restart pod
-            restartPolicy: Always
           - image: docker.io/curlimages/curl:8.5.0
             name: curl-tool
             command: ["/bin/sleep", "infinity"]


### PR DESCRIPTION
* How to test Install Virt and deploy the fedora vm
Alternatively allow the e2e virt ci to hit it.

## Why the changes were made

4.16 deployments will fail if restartPolicy is defined

## How to test the changes made

 Install Virt and deploy the fedora vm
Alternatively allow the e2e virt ci to hit it.
