### PR TITLE
[oadp-1.4] remove restartPolicy for OCP 4.16

### DIFF
--- a/tests/e2e/sample-applications/mongo-persistent/mongo-persistent-block.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/mongo-persistent-block.yaml
@@ -147,7 +147,6 @@ items:
                 timeoutSeconds: 2
                 successThreshold: 1
                 failureThreshold: 40 # 40x30sec before restart pod
-              restartPolicy: Always
           volumes:
           - name: block-volume-pv
             persistentVolumeClaim:

--- a/tests/e2e/sample-applications/mongo-persistent/mongo-persistent-csi.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/mongo-persistent-csi.yaml
@@ -104,7 +104,6 @@ items:
               timeoutSeconds: 2
               successThreshold: 1
               failureThreshold: 40 # 40x30sec before restart pod
-            restartPolicy: Always
           volumes:
           - name: mongo-data
             persistentVolumeClaim:

--- a/tests/e2e/sample-applications/mongo-persistent/mongo-persistent.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/mongo-persistent.yaml
@@ -117,7 +117,6 @@ items:
               timeoutSeconds: 2
               successThreshold: 1
               failureThreshold: 40 # 40x30sec before restart pod
-            restartPolicy: Always
           volumes:
           - name: mongo-data
             persistentVolumeClaim:

--- a/tests/e2e/sample-applications/mysql-persistent/mysql-persistent-csi.yaml
+++ b/tests/e2e/sample-applications/mysql-persistent/mysql-persistent-csi.yaml
@@ -126,7 +126,6 @@ items:
               timeoutSeconds: 2
               successThreshold: 1
               failureThreshold: 40 # 40x30sec before restart pod
-            restartPolicy: Always
           volumes:
           - name: mysql-data
             persistentVolumeClaim:

--- a/tests/e2e/sample-applications/mysql-persistent/mysql-persistent-twovol-csi.yaml
+++ b/tests/e2e/sample-applications/mysql-persistent/mysql-persistent-twovol-csi.yaml
@@ -118,7 +118,6 @@ items:
               timeoutSeconds: 2
               successThreshold: 1
               failureThreshold: 40 # 40x30sec before restart pod
-            restartPolicy: Always
           volumes:
           - name: mysql-data
             persistentVolumeClaim:

--- a/tests/e2e/sample-applications/mysql-persistent/mysql-persistent.yaml
+++ b/tests/e2e/sample-applications/mysql-persistent/mysql-persistent.yaml
@@ -139,7 +139,6 @@ items:
               timeoutSeconds: 2
               successThreshold: 1
               failureThreshold: 40 # 40x30sec before restart pod
-            restartPolicy: Always
           volumes:
           - name: mysql-data
             persistentVolumeClaim:


### PR DESCRIPTION
## Why the changes were made

restartPolicy is no longer accepted in OCP 4.16, and it's not really needed

## How to test the changes made

cd tests/e2e/sample_apps and deploy on 4.16