### PR TITLE
[oadp-1.4] Fix OADP-3960: Split labels avoiding label key exceed allowed 63 chars

### DIFF
--- a/controllers/bsl.go
+++ b/controllers/bsl.go
@@ -118,8 +118,8 @@ func (r *DPAReconciler) ReconcileBackupStorageLocations(log logr.Logger) (bool, 
 		}
 		// Add the following labels to the bsl secret,
 		//	 1. oadpApi.OadpOperatorLabel: "True"
-		// 	 2. <namespace>.dataprotectionapplication: <name>
-		// which in turn will be used in th elabel handler to trigger the reconciliation loop
+		// 	 2. dataprotectionapplication.name: <name>
+		// which in turn will be used in the label handler to trigger the reconciliation loop
 
 		secretName, _ := r.getSecretNameAndKeyforBackupLocation(bslSpec)
 		_, err := r.UpdateCredentialsSecretLabels(secretName, dpa.Namespace, dpa.Name)
@@ -210,8 +210,8 @@ func (r *DPAReconciler) UpdateCredentialsSecretLabels(secretName string, namespa
 		secret.Labels[oadpv1alpha1.OadpOperatorLabel] = "True"
 		needPatch = true
 	}
-	if secret.Labels[namespace+".dataprotectionapplication"] != dpaName {
-		secret.Labels[namespace+".dataprotectionapplication"] = dpaName
+	if secret.Labels["dataprotectionapplication.name"] != dpaName {
+		secret.Labels["dataprotectionapplication.name"] = dpaName
 		needPatch = true
 	}
 	if needPatch {

--- a/controllers/dpa_controller.go
+++ b/controllers/dpa_controller.go
@@ -158,7 +158,7 @@ type labelHandler struct {
 func (l *labelHandler) Create(ctx context.Context, evt event.CreateEvent, q workqueue.RateLimitingInterface) {
 	// check for the label & add it to the queue
 	namespace := evt.Object.GetNamespace()
-	dpaname := evt.Object.GetLabels()[namespace+".dataprotectionapplication"]
+	dpaname := evt.Object.GetLabels()["dataprotectionapplication.name"]
 	if evt.Object.GetLabels()[oadpv1alpha1.OadpOperatorLabel] == "" || dpaname == "" {
 		return
 	}
@@ -172,7 +172,7 @@ func (l *labelHandler) Create(ctx context.Context, evt event.CreateEvent, q work
 func (l *labelHandler) Delete(ctx context.Context, evt event.DeleteEvent, q workqueue.RateLimitingInterface) {
 
 	namespace := evt.Object.GetNamespace()
-	dpaname := evt.Object.GetLabels()[namespace+".dataprotectionapplication"]
+	dpaname := evt.Object.GetLabels()["dataprotectionapplication.name"]
 	if evt.Object.GetLabels()[oadpv1alpha1.OadpOperatorLabel] == "" || dpaname == "" {
 		return
 	}
@@ -184,7 +184,7 @@ func (l *labelHandler) Delete(ctx context.Context, evt event.DeleteEvent, q work
 }
 func (l *labelHandler) Update(ctx context.Context, evt event.UpdateEvent, q workqueue.RateLimitingInterface) {
 	namespace := evt.ObjectNew.GetNamespace()
-	dpaname := evt.ObjectNew.GetLabels()[namespace+".dataprotectionapplication"]
+	dpaname := evt.ObjectNew.GetLabels()["dataprotectionapplication.name"]
 	if evt.ObjectNew.GetLabels()[oadpv1alpha1.OadpOperatorLabel] == "" || dpaname == "" {
 		return
 	}
@@ -197,7 +197,7 @@ func (l *labelHandler) Update(ctx context.Context, evt event.UpdateEvent, q work
 func (l *labelHandler) Generic(ctx context.Context, evt event.GenericEvent, q workqueue.RateLimitingInterface) {
 
 	namespace := evt.Object.GetNamespace()
-	dpaname := evt.Object.GetLabels()[namespace+".dataprotectionapplication"]
+	dpaname := evt.Object.GetLabels()["dataprotectionapplication.name"]
 	if evt.Object.GetLabels()[oadpv1alpha1.OadpOperatorLabel] == "" || dpaname == "" {
 		return
 	}

--- a/docs/design/watches.md
+++ b/docs/design/watches.md
@@ -4,10 +4,10 @@ The provider secret gets created independently by the user, and it is not part o
 
 ```
  1. oadpApi.OadpOperatorLabel: "True"
- 2. <namespace>.dataprotectionapplication: <name>
+ 2. dataprotectionapplication.name: <name>
 ```
 
-where `<namespace>` is the namespace where OADP operator is installed and `<name>` is the name of the DPA instance
+where `<name>` is the name of the DPA instance.
 
 # Current State
 


### PR DESCRIPTION
This is a cherry-pick of https://github.com/openshift/oadp-operator/pull/1392