### PR TITLE
[oadp-1.4] OADP-4213: Backport VM E2E tests to OADP-1.4.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ VELERO_INSTANCE_NAME ?= velero-test
 E2E_TIMEOUT_MULTIPLIER ?= 1
 ARTIFACT_DIR ?= /tmp
 OC_CLI = $(shell which oc)
+TEST_VIRT ?= false
 
 ifdef CLI_DIR
 	OC_CLI = ${CLI_DIR}/oc
@@ -485,9 +486,14 @@ install-ginkgo: # Make sure ginkgo is in $GOPATH/bin
 	go install -v -mod=mod github.com/onsi/ginkgo/v2/ginkgo
 
 OADP_BUCKET ?= $(shell cat $(OADP_BUCKET_FILE))
-TEST_FILTER := ($(shell echo '! aws && ! gcp && ! azure && ! ibmcloud' | \
-sed -r "s/[&]* [!] $(CLUSTER_TYPE)|[!] $(CLUSTER_TYPE) [&]*//")) || $(CLUSTER_TYPE)
+TEST_FILTER = (($(shell echo '! aws && ! gcp && ! azure && ! ibmcloud' | \
+sed -r "s/[&]* [!] $(CLUSTER_TYPE)|[!] $(CLUSTER_TYPE) [&]*//")) || $(CLUSTER_TYPE))
 #TEST_FILTER := $(shell echo '! aws && ! gcp && ! azure' | sed -r "s/[&]* [!] $(CLUSTER_TYPE)|[!] $(CLUSTER_TYPE) [&]*//")
+ifeq ($(TEST_VIRT),true)
+	TEST_FILTER += && (virt)
+else
+	TEST_FILTER += && (! virt)
+endif
 SETTINGS_TMP=/tmp/test-settings
 
 .PHONY: test-e2e-setup

--- a/docs/developer/testing/TESTING.md
+++ b/docs/developer/testing/TESTING.md
@@ -21,6 +21,7 @@ To get started, you need to provide the following **required** environment varia
 | `BSL_REGION` | The region of backupLocations | `us-east-1` | false |
 | `OADP_TEST_NAMESPACE` | The namespace where OADP operator is installed | `openshift-adp` | false |
 | `OPENSHIFT_CI` | Disable colored output from tests suite run | `true` | false |
+| `TEST_VIRT` | Exclusively run Virtual Machine backup/restore testing | `false` | false |
 
 The expected format for `OADP_CRED_FILE` and `CI_CRED_FILE` files is:
 ```

--- a/tests/e2e/backup_restore_suite_test.go
+++ b/tests/e2e/backup_restore_suite_test.go
@@ -15,7 +15,7 @@ import (
 	. "github.com/openshift/oadp-operator/tests/e2e/lib"
 	corev1 "k8s.io/api/core/v1"
 	k8serror "k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -57,21 +57,24 @@ func mysqlReady(preBackupState bool, twoVol bool, backupRestoreType BackupRestor
 }
 
 type BackupRestoreCase struct {
+	Namespace         string
+	Name              string
+	BackupRestoreType BackupRestoreType
+	PreBackupVerify   VerificationFunction
+	PostRestoreVerify VerificationFunction
+	SkipVerifyLogs    bool // TODO remove
+	BackupTimeout     time.Duration
+}
+
+type ApplicationBackupRestoreCase struct {
+	BackupRestoreCase
 	ApplicationTemplate          string
 	PvcSuffixName                string
-	ApplicationNamespace         string
-	Name                         string
-	BackupRestoreType            BackupRestoreType
-	PreBackupVerify              VerificationFunction
-	PostRestoreVerify            VerificationFunction
-	AppReadyDelay                time.Duration
 	MustGatherFiles              []string            // list of files expected in must-gather under quay.io.../clusters/clustername/... ie. "namespaces/openshift-adp/oadp.openshift.io/dpa-ts-example-velero/ts-example-velero.yml"
 	MustGatherValidationFunction *func(string) error // validation function for must-gather where string parameter is the path to "quay.io.../clusters/clustername/"
 }
 
-func runBackupAndRestore(brCase BackupRestoreCase, expectedErr error, updateLastBRcase func(brCase BackupRestoreCase), updateLastInstallTime func()) {
-	updateLastBRcase(brCase)
-
+func prepareBackupAndRestore(brCase BackupRestoreCase, updateLastInstallTime func()) (string, string) {
 	err := dpaCR.Build(brCase.BackupRestoreType)
 	Expect(err).NotTo(HaveOccurred())
 
@@ -105,10 +108,19 @@ func runBackupAndRestore(brCase BackupRestoreCase, expectedErr error, updateLast
 	backupName := fmt.Sprintf("%s-%s", brCase.Name, backupUid.String())
 	restoreName := fmt.Sprintf("%s-%s", brCase.Name, restoreUid.String())
 
+	return backupName, restoreName
+}
+
+func runApplicationBackupAndRestore(brCase ApplicationBackupRestoreCase, expectedErr error, updateLastBRcase func(brCase ApplicationBackupRestoreCase), updateLastInstallTime func()) {
+	updateLastBRcase(brCase)
+
+	// create DPA
+	backupName, restoreName := prepareBackupAndRestore(brCase.BackupRestoreCase, updateLastInstallTime)
+
 	// install app
 	updateLastInstallTime()
 	log.Printf("Installing application for case %s", brCase.Name)
-	err = InstallApplication(dpaCR.Client, brCase.ApplicationTemplate)
+	err := InstallApplication(dpaCR.Client, brCase.ApplicationTemplate)
 	Expect(err).ToNot(HaveOccurred())
 	if brCase.BackupRestoreType == CSI || brCase.BackupRestoreType == CSIDataMover {
 		log.Printf("Creating pvc for case %s", brCase.Name)
@@ -125,34 +137,62 @@ func runBackupAndRestore(brCase BackupRestoreCase, expectedErr error, updateLast
 			pvcPathFormat = "./sample-applications/%s/pvc-twoVol/%s.yaml"
 		}
 
-		pvcPath = fmt.Sprintf(pvcPathFormat, brCase.ApplicationNamespace, pvcName)
+		pvcPath = fmt.Sprintf(pvcPathFormat, brCase.Namespace, pvcName)
 
 		err = InstallApplication(dpaCR.Client, pvcPath)
 		Expect(err).ToNot(HaveOccurred())
 	}
 
 	// wait for pods to be running
-	Eventually(AreAppBuildsReady(dpaCR.Client, brCase.ApplicationNamespace), timeoutMultiplier*time.Minute*5, time.Second*5).Should(BeTrue())
-	Eventually(AreApplicationPodsRunning(kubernetesClientForSuiteRun, brCase.ApplicationNamespace), timeoutMultiplier*time.Minute*9, time.Second*5).Should(BeTrue())
+	Eventually(AreAppBuildsReady(dpaCR.Client, brCase.Namespace), timeoutMultiplier*time.Minute*5, time.Second*5).Should(BeTrue())
+	Eventually(AreApplicationPodsRunning(kubernetesClientForSuiteRun, brCase.Namespace), timeoutMultiplier*time.Minute*9, time.Second*5).Should(BeTrue())
+
+	// do the backup for real
+	nsRequiredResticDCWorkaround := runBackup(brCase.BackupRestoreCase, backupName)
+
+	// uninstall app
+	log.Printf("Uninstalling app for case %s", brCase.Name)
+	err = UninstallApplication(dpaCR.Client, brCase.ApplicationTemplate)
+	Expect(err).ToNot(HaveOccurred())
+
+	// Wait for namespace to be deleted
+	Eventually(IsNamespaceDeleted(kubernetesClientForSuiteRun, brCase.Namespace), timeoutMultiplier*time.Minute*4, time.Second*5).Should(BeTrue())
+
+	updateLastInstallTime()
+
+	// run restore
+	runRestore(brCase.BackupRestoreCase, backupName, restoreName, nsRequiredResticDCWorkaround)
+
+	// verify app is running
+	Eventually(AreAppBuildsReady(dpaCR.Client, brCase.Namespace), timeoutMultiplier*time.Minute*3, time.Second*5).Should(BeTrue())
+	Eventually(AreApplicationPodsRunning(kubernetesClientForSuiteRun, brCase.Namespace), timeoutMultiplier*time.Minute*9, time.Second*5).Should(BeTrue())
 
 	// Run optional custom verification
-	log.Printf("Running pre-backup function for case %s", brCase.Name)
-	err = brCase.PreBackupVerify(dpaCR.Client, brCase.ApplicationNamespace)
+	if brCase.PostRestoreVerify != nil {
+		log.Printf("Running post-restore function for case %s", brCase.Name)
+		err = brCase.PostRestoreVerify(dpaCR.Client, brCase.Namespace)
+		Expect(err).ToNot(HaveOccurred())
+	}
+}
+
+func runBackup(brCase BackupRestoreCase, backupName string) bool {
+	// Run optional custom verification
+	if brCase.PreBackupVerify != nil {
+		log.Printf("Running pre-backup function for case %s", brCase.Name)
+		err := brCase.PreBackupVerify(dpaCR.Client, brCase.Namespace)
+		Expect(err).ToNot(HaveOccurred())
+	}
+
+	nsRequiresResticDCWorkaround, err := NamespaceRequiresResticDCWorkaround(dpaCR.Client, brCase.Namespace)
 	Expect(err).ToNot(HaveOccurred())
 
-	nsRequiresResticDCWorkaround, err := NamespaceRequiresResticDCWorkaround(dpaCR.Client, brCase.ApplicationNamespace)
-	Expect(err).ToNot(HaveOccurred())
-
-	// TODO this should be a function, not an arbitrary sleep
-	log.Printf("Sleeping for %v to allow application to be ready for case %s", brCase.AppReadyDelay, brCase.Name)
-	time.Sleep(brCase.AppReadyDelay)
 	// create backup
 	log.Printf("Creating backup %s for case %s", backupName, brCase.Name)
-	backup, err := CreateBackupForNamespaces(dpaCR.Client, namespace, backupName, []string{brCase.ApplicationNamespace}, brCase.BackupRestoreType == RESTIC || brCase.BackupRestoreType == KOPIA, brCase.BackupRestoreType == CSIDataMover)
+	backup, err := CreateBackupForNamespaces(dpaCR.Client, namespace, backupName, []string{brCase.Namespace}, brCase.BackupRestoreType == RESTIC || brCase.BackupRestoreType == KOPIA, brCase.BackupRestoreType == CSIDataMover)
 	Expect(err).ToNot(HaveOccurred())
 
 	// wait for backup to not be running
-	Eventually(IsBackupDone(dpaCR.Client, namespace, backupName), timeoutMultiplier*time.Minute*20, time.Second*10).Should(BeTrue())
+	Eventually(IsBackupDone(dpaCR.Client, namespace, backupName), timeoutMultiplier*brCase.BackupTimeout, time.Second*10).Should(BeTrue())
 	// TODO only log on fail?
 	describeBackup := DescribeBackup(veleroClientForSuiteRun, csiClientForSuiteRun, dpaCR.Client, backup)
 	GinkgoWriter.Println(describeBackup)
@@ -161,7 +201,9 @@ func runBackupAndRestore(brCase BackupRestoreCase, expectedErr error, updateLast
 	backupErrorLogs := BackupErrorLogs(kubernetesClientForSuiteRun, dpaCR.Client, backup)
 	accumulatedTestLogs = append(accumulatedTestLogs, describeBackup, backupLogs)
 
-	Expect(backupErrorLogs).Should(Equal([]string{}))
+	if !brCase.SkipVerifyLogs {
+		Expect(backupErrorLogs).Should(Equal([]string{}))
+	}
 
 	// check if backup succeeded
 	succeeded, err := IsBackupCompletedSuccessfully(kubernetesClientForSuiteRun, dpaCR.Client, backup)
@@ -174,16 +216,10 @@ func runBackupAndRestore(brCase BackupRestoreCase, expectedErr error, updateLast
 		Eventually(AreVolumeSnapshotsReady(dpaCR.Client, backupName), timeoutMultiplier*time.Minute*4, time.Second*10).Should(BeTrue())
 	}
 
-	// uninstall app
-	log.Printf("Uninstalling app for case %s", brCase.Name)
-	err = UninstallApplication(dpaCR.Client, brCase.ApplicationTemplate)
-	Expect(err).ToNot(HaveOccurred())
+	return nsRequiresResticDCWorkaround
+}
 
-	// Wait for namespace to be deleted
-	Eventually(IsNamespaceDeleted(kubernetesClientForSuiteRun, brCase.ApplicationNamespace), timeoutMultiplier*time.Minute*4, time.Second*5).Should(BeTrue())
-
-	updateLastInstallTime()
-	// run restore
+func runRestore(brCase BackupRestoreCase, backupName, restoreName string, nsRequiresResticDCWorkaround bool) {
 	log.Printf("Creating restore %s for case %s", restoreName, brCase.Name)
 	restore, err := CreateRestoreFromBackup(dpaCR.Client, namespace, backupName, restoreName)
 	Expect(err).ToNot(HaveOccurred())
@@ -196,10 +232,12 @@ func runBackupAndRestore(brCase BackupRestoreCase, expectedErr error, updateLast
 	restoreErrorLogs := RestoreErrorLogs(kubernetesClientForSuiteRun, dpaCR.Client, restore)
 	accumulatedTestLogs = append(accumulatedTestLogs, describeRestore, restoreLogs)
 
-	Expect(restoreErrorLogs).Should(Equal([]string{}))
+	if !brCase.SkipVerifyLogs {
+		Expect(restoreErrorLogs).Should(Equal([]string{}))
+	}
 
 	// Check if restore succeeded
-	succeeded, err = IsRestoreCompletedSuccessfully(kubernetesClientForSuiteRun, dpaCR.Client, namespace, restoreName)
+	succeeded, err := IsRestoreCompletedSuccessfully(kubernetesClientForSuiteRun, dpaCR.Client, namespace, restoreName)
 	Expect(err).ToNot(HaveOccurred())
 	Expect(succeeded).To(Equal(true))
 
@@ -213,15 +251,6 @@ func runBackupAndRestore(brCase BackupRestoreCase, expectedErr error, updateLast
 		err = RunDcPostRestoreScript(restoreName)
 		Expect(err).ToNot(HaveOccurred())
 	}
-
-	// verify app is running
-	Eventually(AreAppBuildsReady(dpaCR.Client, brCase.ApplicationNamespace), timeoutMultiplier*time.Minute*3, time.Second*5).Should(BeTrue())
-	Eventually(AreApplicationPodsRunning(kubernetesClientForSuiteRun, brCase.ApplicationNamespace), timeoutMultiplier*time.Minute*9, time.Second*5).Should(BeTrue())
-
-	// Run optional custom verification
-	log.Printf("Running post-restore function for case %s", brCase.Name)
-	err = brCase.PostRestoreVerify(dpaCR.Client, brCase.ApplicationNamespace)
-	Expect(err).ToNot(HaveOccurred())
 }
 
 func tearDownBackupAndRestore(brCase BackupRestoreCase, installTime time.Time, report SpecReport) {
@@ -233,9 +262,9 @@ func tearDownBackupAndRestore(brCase BackupRestoreCase, installTime time.Time, r
 
 	if report.Failed() {
 		// print namespace error events for app namespace
-		if brCase.ApplicationNamespace != "" {
+		if brCase.Namespace != "" {
 			GinkgoWriter.Println("Printing app namespace events")
-			PrintNamespaceEventsAfterTime(kubernetesClientForSuiteRun, brCase.ApplicationNamespace, installTime)
+			PrintNamespaceEventsAfterTime(kubernetesClientForSuiteRun, brCase.Namespace, installTime)
 		}
 		GinkgoWriter.Println("Printing oadp namespace events")
 		PrintNamespaceEventsAfterTime(kubernetesClientForSuiteRun, namespace, installTime)
@@ -244,7 +273,7 @@ func tearDownBackupAndRestore(brCase BackupRestoreCase, installTime time.Time, r
 		Expect(err).NotTo(HaveOccurred())
 		err = SavePodLogs(kubernetesClientForSuiteRun, namespace, baseReportDir)
 		Expect(err).NotTo(HaveOccurred())
-		err = SavePodLogs(kubernetesClientForSuiteRun, brCase.ApplicationNamespace, baseReportDir)
+		err = SavePodLogs(kubernetesClientForSuiteRun, brCase.Namespace, baseReportDir)
 		Expect(err).NotTo(HaveOccurred())
 	}
 	if brCase.BackupRestoreType == CSI || brCase.BackupRestoreType == CSIDataMover {
@@ -253,9 +282,9 @@ func tearDownBackupAndRestore(brCase BackupRestoreCase, installTime time.Time, r
 		err := UninstallApplication(dpaCR.Client, snapshotClassPath)
 		Expect(err).ToNot(HaveOccurred())
 	}
-	err := dpaCR.Client.Delete(context.Background(), &corev1.Namespace{ObjectMeta: v1.ObjectMeta{
-		Name:      brCase.ApplicationNamespace,
-		Namespace: brCase.ApplicationNamespace,
+	err := dpaCR.Client.Delete(context.Background(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name:      brCase.Namespace,
+		Namespace: brCase.Namespace,
 	}}, &client.DeleteOptions{})
 	if k8serror.IsNotFound(err) {
 		err = nil
@@ -264,13 +293,13 @@ func tearDownBackupAndRestore(brCase BackupRestoreCase, installTime time.Time, r
 
 	err = dpaCR.Delete(runTimeClientForSuiteRun)
 	Expect(err).ToNot(HaveOccurred())
-	Eventually(IsNamespaceDeleted(kubernetesClientForSuiteRun, brCase.ApplicationNamespace), timeoutMultiplier*time.Minute*2, time.Second*5).Should(BeTrue())
+	Eventually(IsNamespaceDeleted(kubernetesClientForSuiteRun, brCase.Namespace), timeoutMultiplier*time.Minute*5, time.Second*5).Should(BeTrue())
 }
 
 var _ = Describe("Backup and restore tests", func() {
-	var lastBRCase BackupRestoreCase
+	var lastBRCase ApplicationBackupRestoreCase
 	var lastInstallTime time.Time
-	updateLastBRcase := func(brCase BackupRestoreCase) {
+	updateLastBRcase := func(brCase ApplicationBackupRestoreCase) {
 		lastBRCase = brCase
 	}
 	updateLastInstallTime := func() {
@@ -278,97 +307,126 @@ var _ = Describe("Backup and restore tests", func() {
 	}
 
 	var _ = AfterEach(func(ctx SpecContext) {
-		tearDownBackupAndRestore(lastBRCase, lastInstallTime, ctx.SpecReport())
+		tearDownBackupAndRestore(lastBRCase.BackupRestoreCase, lastInstallTime, ctx.SpecReport())
 	})
 
 	DescribeTable("Backup and restore applications",
-		func(brCase BackupRestoreCase, expectedErr error) {
+		func(brCase ApplicationBackupRestoreCase, expectedErr error) {
 			if CurrentSpecReport().NumAttempts > 1 && !knownFlake {
 				Fail("No known FLAKE found in a previous run, marking test as failed.")
 			}
-			runBackupAndRestore(brCase, expectedErr, updateLastBRcase, updateLastInstallTime)
+			runApplicationBackupAndRestore(brCase, expectedErr, updateLastBRcase, updateLastInstallTime)
 		},
-		Entry("MySQL application CSI", FlakeAttempts(flakeAttempts), BackupRestoreCase{
-			ApplicationTemplate:  "./sample-applications/mysql-persistent/mysql-persistent-csi.yaml",
-			ApplicationNamespace: "mysql-persistent",
-			Name:                 "mysql-csi-e2e",
-			BackupRestoreType:    CSI,
-			PreBackupVerify:      mysqlReady(true, false, CSI),
-			PostRestoreVerify:    mysqlReady(false, false, CSI),
+		Entry("MySQL application CSI", FlakeAttempts(flakeAttempts), ApplicationBackupRestoreCase{
+			ApplicationTemplate: "./sample-applications/mysql-persistent/mysql-persistent-csi.yaml",
+			BackupRestoreCase: BackupRestoreCase{
+				Namespace:         "mysql-persistent",
+				Name:              "mysql-csi-e2e",
+				BackupRestoreType: CSI,
+				PreBackupVerify:   mysqlReady(true, false, CSI),
+				PostRestoreVerify: mysqlReady(false, false, CSI),
+				BackupTimeout:     20 * time.Minute,
+			},
 		}, nil),
-		Entry("Mongo application CSI", FlakeAttempts(flakeAttempts), BackupRestoreCase{
-			ApplicationTemplate:  "./sample-applications/mongo-persistent/mongo-persistent-csi.yaml",
-			ApplicationNamespace: "mongo-persistent",
-			Name:                 "mongo-csi-e2e",
-			BackupRestoreType:    CSI,
-			PreBackupVerify:      mongoready(true, false, CSI),
-			PostRestoreVerify:    mongoready(false, false, CSI),
+		Entry("Mongo application CSI", FlakeAttempts(flakeAttempts), ApplicationBackupRestoreCase{
+			ApplicationTemplate: "./sample-applications/mongo-persistent/mongo-persistent-csi.yaml",
+			BackupRestoreCase: BackupRestoreCase{
+				Namespace:         "mongo-persistent",
+				Name:              "mongo-csi-e2e",
+				BackupRestoreType: CSI,
+				PreBackupVerify:   mongoready(true, false, CSI),
+				PostRestoreVerify: mongoready(false, false, CSI),
+				BackupTimeout:     20 * time.Minute,
+			},
 		}, nil),
-		Entry("MySQL application two Vol CSI", FlakeAttempts(flakeAttempts), BackupRestoreCase{
-			ApplicationTemplate:  fmt.Sprintf("./sample-applications/mysql-persistent/mysql-persistent-twovol-csi.yaml"),
-			ApplicationNamespace: "mysql-persistent",
-			Name:                 "mysql-twovol-csi-e2e",
-			BackupRestoreType:    CSI,
-			AppReadyDelay:        30 * time.Second,
-			PreBackupVerify:      mysqlReady(true, true, CSI),
-			PostRestoreVerify:    mysqlReady(false, true, CSI),
+		Entry("MySQL application two Vol CSI", FlakeAttempts(flakeAttempts), ApplicationBackupRestoreCase{
+			ApplicationTemplate: "./sample-applications/mysql-persistent/mysql-persistent-twovol-csi.yaml",
+			BackupRestoreCase: BackupRestoreCase{
+				Namespace:         "mysql-persistent",
+				Name:              "mysql-twovol-csi-e2e",
+				BackupRestoreType: CSI,
+				PreBackupVerify:   mysqlReady(true, true, CSI),
+				PostRestoreVerify: mysqlReady(false, true, CSI),
+				BackupTimeout:     20 * time.Minute,
+			},
 		}, nil),
-		Entry("Mongo application RESTIC", FlakeAttempts(flakeAttempts), BackupRestoreCase{
-			ApplicationTemplate:  "./sample-applications/mongo-persistent/mongo-persistent.yaml",
-			ApplicationNamespace: "mongo-persistent",
-			Name:                 "mongo-restic-e2e",
-			BackupRestoreType:    RESTIC,
-			PreBackupVerify:      mongoready(true, false, RESTIC),
-			PostRestoreVerify:    mongoready(false, false, RESTIC),
+		Entry("Mongo application RESTIC", FlakeAttempts(flakeAttempts), ApplicationBackupRestoreCase{
+			ApplicationTemplate: "./sample-applications/mongo-persistent/mongo-persistent.yaml",
+			BackupRestoreCase: BackupRestoreCase{
+				Namespace:         "mongo-persistent",
+				Name:              "mongo-restic-e2e",
+				BackupRestoreType: RESTIC,
+				PreBackupVerify:   mongoready(true, false, RESTIC),
+				PostRestoreVerify: mongoready(false, false, RESTIC),
+				BackupTimeout:     20 * time.Minute,
+			},
 		}, nil),
-		Entry("MySQL application RESTIC", FlakeAttempts(flakeAttempts), BackupRestoreCase{
-			ApplicationTemplate:  "./sample-applications/mysql-persistent/mysql-persistent.yaml",
-			ApplicationNamespace: "mysql-persistent",
-			Name:                 "mysql-restic-e2e",
-			BackupRestoreType:    RESTIC,
-			PreBackupVerify:      mysqlReady(true, false, RESTIC),
-			PostRestoreVerify:    mysqlReady(false, false, RESTIC),
+		Entry("MySQL application RESTIC", FlakeAttempts(flakeAttempts), ApplicationBackupRestoreCase{
+			ApplicationTemplate: "./sample-applications/mysql-persistent/mysql-persistent.yaml",
+			BackupRestoreCase: BackupRestoreCase{
+				Namespace:         "mysql-persistent",
+				Name:              "mysql-restic-e2e",
+				BackupRestoreType: RESTIC,
+				PreBackupVerify:   mysqlReady(true, false, RESTIC),
+				PostRestoreVerify: mysqlReady(false, false, RESTIC),
+				BackupTimeout:     20 * time.Minute,
+			},
 		}, nil),
-		Entry("Mongo application KOPIA", FlakeAttempts(flakeAttempts), BackupRestoreCase{
-			ApplicationTemplate:  "./sample-applications/mongo-persistent/mongo-persistent.yaml",
-			ApplicationNamespace: "mongo-persistent",
-			Name:                 "mongo-kopia-e2e",
-			BackupRestoreType:    KOPIA,
-			PreBackupVerify:      mongoready(true, false, KOPIA),
-			PostRestoreVerify:    mongoready(false, false, KOPIA),
+		Entry("Mongo application KOPIA", FlakeAttempts(flakeAttempts), ApplicationBackupRestoreCase{
+			ApplicationTemplate: "./sample-applications/mongo-persistent/mongo-persistent.yaml",
+			BackupRestoreCase: BackupRestoreCase{
+				Namespace:         "mongo-persistent",
+				Name:              "mongo-kopia-e2e",
+				BackupRestoreType: KOPIA,
+				PreBackupVerify:   mongoready(true, false, KOPIA),
+				PostRestoreVerify: mongoready(false, false, KOPIA),
+				BackupTimeout:     20 * time.Minute,
+			},
 		}, nil),
-		Entry("MySQL application KOPIA", FlakeAttempts(flakeAttempts), BackupRestoreCase{
-			ApplicationTemplate:  "./sample-applications/mysql-persistent/mysql-persistent.yaml",
-			ApplicationNamespace: "mysql-persistent",
-			Name:                 "mysql-kopia-e2e",
-			BackupRestoreType:    KOPIA,
-			PreBackupVerify:      mysqlReady(true, false, KOPIA),
-			PostRestoreVerify:    mysqlReady(false, false, KOPIA),
+		Entry("MySQL application KOPIA", FlakeAttempts(flakeAttempts), ApplicationBackupRestoreCase{
+			ApplicationTemplate: "./sample-applications/mysql-persistent/mysql-persistent.yaml",
+			BackupRestoreCase: BackupRestoreCase{
+				Namespace:         "mysql-persistent",
+				Name:              "mysql-kopia-e2e",
+				BackupRestoreType: KOPIA,
+				PreBackupVerify:   mysqlReady(true, false, KOPIA),
+				PostRestoreVerify: mysqlReady(false, false, KOPIA),
+				BackupTimeout:     20 * time.Minute,
+			},
 		}, nil),
-		Entry("Mongo application DATAMOVER", FlakeAttempts(flakeAttempts), BackupRestoreCase{
-			ApplicationTemplate:  "./sample-applications/mongo-persistent/mongo-persistent-csi.yaml",
-			ApplicationNamespace: "mongo-persistent",
-			Name:                 "mongo-datamover-e2e",
-			BackupRestoreType:    CSIDataMover,
-			PreBackupVerify:      mongoready(true, false, CSIDataMover),
-			PostRestoreVerify:    mongoready(false, false, CSIDataMover),
+		Entry("Mongo application DATAMOVER", FlakeAttempts(flakeAttempts), ApplicationBackupRestoreCase{
+			ApplicationTemplate: "./sample-applications/mongo-persistent/mongo-persistent-csi.yaml",
+			BackupRestoreCase: BackupRestoreCase{
+				Namespace:         "mongo-persistent",
+				Name:              "mongo-datamover-e2e",
+				BackupRestoreType: CSIDataMover,
+				PreBackupVerify:   mongoready(true, false, CSIDataMover),
+				PostRestoreVerify: mongoready(false, false, CSIDataMover),
+				BackupTimeout:     20 * time.Minute,
+			},
 		}, nil),
-		Entry("MySQL application DATAMOVER", FlakeAttempts(flakeAttempts), BackupRestoreCase{
-			ApplicationTemplate:  "./sample-applications/mysql-persistent/mysql-persistent-csi.yaml",
-			ApplicationNamespace: "mysql-persistent",
-			Name:                 "mysql-datamover-e2e",
-			BackupRestoreType:    CSIDataMover,
-			PreBackupVerify:      mysqlReady(true, false, CSIDataMover),
-			PostRestoreVerify:    mysqlReady(false, false, CSIDataMover),
+		Entry("MySQL application DATAMOVER", FlakeAttempts(flakeAttempts), ApplicationBackupRestoreCase{
+			ApplicationTemplate: "./sample-applications/mysql-persistent/mysql-persistent-csi.yaml",
+			BackupRestoreCase: BackupRestoreCase{
+				Namespace:         "mysql-persistent",
+				Name:              "mysql-datamover-e2e",
+				BackupRestoreType: CSIDataMover,
+				PreBackupVerify:   mysqlReady(true, false, CSIDataMover),
+				PostRestoreVerify: mysqlReady(false, false, CSIDataMover),
+				BackupTimeout:     20 * time.Minute,
+			},
 		}, nil),
-		Entry("Mongo application BlockDevice DATAMOVER", FlakeAttempts(flakeAttempts), BackupRestoreCase{
-			ApplicationTemplate:  "./sample-applications/mongo-persistent/mongo-persistent-block.yaml",
-			PvcSuffixName:        "-block-mode",
-			ApplicationNamespace: "mongo-persistent",
-			Name:                 "mongo-blockdevice-e2e",
-			BackupRestoreType:    CSIDataMover,
-			PreBackupVerify:      mongoready(true, false, CSIDataMover),
-			PostRestoreVerify:    mongoready(false, false, CSIDataMover),
+		Entry("Mongo application BlockDevice DATAMOVER", FlakeAttempts(flakeAttempts), ApplicationBackupRestoreCase{
+			ApplicationTemplate: "./sample-applications/mongo-persistent/mongo-persistent-block.yaml",
+			PvcSuffixName:       "-block-mode",
+			BackupRestoreCase: BackupRestoreCase{
+				Namespace:         "mongo-persistent",
+				Name:              "mongo-blockdevice-e2e",
+				BackupRestoreType: CSIDataMover,
+				PreBackupVerify:   mongoready(true, false, CSIDataMover),
+				PostRestoreVerify: mongoready(false, false, CSIDataMover),
+				BackupTimeout:     20 * time.Minute,
+			},
 		}, nil),
 	)
 })

--- a/tests/e2e/backup_restore_suite_test.go
+++ b/tests/e2e/backup_restore_suite_test.go
@@ -186,6 +186,13 @@ func runBackup(brCase BackupRestoreCase, backupName string) bool {
 	nsRequiresResticDCWorkaround, err := NamespaceRequiresResticDCWorkaround(dpaCR.Client, brCase.Namespace)
 	Expect(err).ToNot(HaveOccurred())
 
+	if strings.Contains(brCase.Name, "twovol") {
+		volumeSyncDelay := 30 * time.Second
+		log.Printf("Sleeping for %v to allow volume to be in sync with /tmp/log/ for case %s", volumeSyncDelay, brCase.Name)
+		// TODO this should be a function, not an arbitrary sleep
+		time.Sleep(volumeSyncDelay)
+	}
+
 	// create backup
 	log.Printf("Creating backup %s for case %s", backupName, brCase.Name)
 	backup, err := CreateBackupForNamespaces(dpaCR.Client, namespace, backupName, []string{brCase.Namespace}, brCase.BackupRestoreType == RESTIC || brCase.BackupRestoreType == KOPIA, brCase.BackupRestoreType == CSIDataMover)

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -15,6 +15,7 @@ import (
 	. "github.com/openshift/oadp-operator/tests/e2e/lib"
 	"github.com/openshift/oadp-operator/tests/e2e/utils"
 	veleroClientset "github.com/vmware-tanzu/velero/pkg/generated/clientset/versioned"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -103,6 +104,7 @@ var kubernetesClientForSuiteRun *kubernetes.Clientset
 var runTimeClientForSuiteRun client.Client
 var veleroClientForSuiteRun veleroClientset.Interface
 var csiClientForSuiteRun *snapshotv1client.Clientset
+var dynamicClientForSuiteRun dynamic.Interface
 var dpaCR *DpaCustomResource
 var knownFlake bool
 var accumulatedTestLogs []string
@@ -130,6 +132,9 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	csiClientForSuiteRun, err = snapshotv1client.NewForConfig(kubeConf)
+	Expect(err).NotTo(HaveOccurred())
+
+	dynamicClientForSuiteRun, err = dynamic.NewForConfig(kubeConf)
 	Expect(err).NotTo(HaveOccurred())
 
 	dpaCR = &DpaCustomResource{

--- a/tests/e2e/lib/dpa_helpers.go
+++ b/tests/e2e/lib/dpa_helpers.go
@@ -20,6 +20,7 @@ import (
 	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
 	"github.com/openshift/oadp-operator/pkg/common"
 	utils "github.com/openshift/oadp-operator/tests/e2e/utils"
+	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
 	operators "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	velero "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
@@ -272,6 +273,7 @@ func (v *DpaCustomResource) SetClient(client client.Client) error {
 	volumesnapshotv1.AddToScheme(client.Scheme())
 	buildv1.AddToScheme(client.Scheme())
 	operatorsv1alpha1.AddToScheme(client.Scheme())
+	operatorsv1.AddToScheme(client.Scheme())
 
 	v.Client = client
 	return nil

--- a/tests/e2e/lib/kube_helpers.go
+++ b/tests/e2e/lib/kube_helpers.go
@@ -16,6 +16,23 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+func CreateNamespace(clientset *kubernetes.Clientset, namespace string) error {
+	ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+	_, err := clientset.CoreV1().Namespaces().Create(context.Background(), &ns, metav1.CreateOptions{})
+	if apierrors.IsAlreadyExists(err) {
+		return nil
+	}
+	return err
+}
+
+func DeleteNamespace(clientset *kubernetes.Clientset, namespace string) error {
+	err := clientset.CoreV1().Namespaces().Delete(context.Background(), namespace, metav1.DeleteOptions{})
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	return err
+}
+
 func DoesNamespaceExist(clientset *kubernetes.Clientset, namespace string) (bool, error) {
 	_, err := clientset.CoreV1().Namespaces().Get(context.Background(), namespace, metav1.GetOptions{})
 	if err != nil {

--- a/tests/e2e/lib/virt_helpers.go
+++ b/tests/e2e/lib/virt_helpers.go
@@ -1,0 +1,754 @@
+package lib
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/version"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	emulationAnnotation = "kubevirt.kubevirt.io/jsonpatch"
+	useEmulation        = `[{"op": "add", "path": "/spec/configuration/developerConfiguration", "value": {"useEmulation": true}}]`
+)
+
+var packageManifestsGvr = schema.GroupVersionResource{
+	Group:    "packages.operators.coreos.com",
+	Resource: "packagemanifests",
+	Version:  "v1",
+}
+
+var hyperConvergedGvr = schema.GroupVersionResource{
+	Group:    "hco.kubevirt.io",
+	Resource: "hyperconvergeds",
+	Version:  "v1beta1",
+}
+
+var virtualMachineGvr = schema.GroupVersionResource{
+	Group:    "kubevirt.io",
+	Resource: "virtualmachines",
+	Version:  "v1",
+}
+
+var csvGvr = schema.GroupVersionResource{
+	Group:    "operators.coreos.com",
+	Resource: "clusterserviceversion",
+	Version:  "v1alpha1",
+}
+
+type VirtOperator struct {
+	Client    client.Client
+	Clientset *kubernetes.Clientset
+	Dynamic   dynamic.Interface
+	Namespace string
+	Csv       string
+	Version   *version.Version
+}
+
+// GetVirtOperator fills out a new VirtOperator
+func GetVirtOperator(client client.Client, clientset *kubernetes.Clientset, dynamicClient dynamic.Interface) (*VirtOperator, error) {
+	namespace := "openshift-cnv"
+
+	csv, version, err := getCsvFromPackageManifest(dynamicClient, "kubevirt-hyperconverged")
+	if err != nil {
+		log.Printf("Failed to get CSV from package manifest")
+		return nil, err
+	}
+
+	v := &VirtOperator{
+		Client:    client,
+		Clientset: clientset,
+		Dynamic:   dynamicClient,
+		Namespace: namespace,
+		Csv:       csv,
+		Version:   version,
+	}
+
+	return v, nil
+}
+
+// Helper to create an operator group object, common to installOperatorGroup
+// and removeOperatorGroup.
+func (v *VirtOperator) makeOperatorGroup() *operatorsv1.OperatorGroup {
+	return &operatorsv1.OperatorGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kubevirt-hyperconverged-group",
+			Namespace: v.Namespace,
+		},
+		Spec: operatorsv1.OperatorGroupSpec{
+			TargetNamespaces: []string{
+				v.Namespace,
+			},
+		},
+	}
+}
+
+// getCsvFromPackageManifest returns the current CSV from the first channel
+// in the given PackageManifest name. Uses the dynamic client because adding
+// the real PackageManifest API from OLM was actually more work than this.
+// Takes the name of the package manifest, and returns the currentCSV string,
+// like: kubevirt-hyperconverged-operator.v4.12.8
+// Also returns just the version (e.g. 4.12.8 from above) as a comparable
+// Version type, so it is easy to check against the current cluster version.
+func getCsvFromPackageManifest(dynamicClient dynamic.Interface, name string) (string, *version.Version, error) {
+	log.Println("Getting packagemanifest...")
+	unstructuredManifest, err := dynamicClient.Resource(packageManifestsGvr).Namespace("default").Get(context.Background(), name, v1.GetOptions{})
+	if err != nil {
+		log.Printf("Error getting packagemanifest %s: %v", name, err)
+		return "", nil, err
+	}
+
+	log.Println("Extracting channels...")
+	channels, ok, err := unstructured.NestedSlice(unstructuredManifest.UnstructuredContent(), "status", "channels")
+	if err != nil {
+		log.Printf("Error getting channels from packagemanifest: %v", err)
+		return "", nil, err
+	}
+	if !ok {
+		return "", nil, errors.New("failed to get channels list from " + name + " packagemanifest")
+	}
+	if len(channels) < 1 {
+		return "", nil, errors.New("no channels listed in package manifest " + name)
+	}
+
+	firstChannel, ok := channels[0].(map[string]interface{})
+	if !ok {
+		return "", nil, errors.New("failed to read first channel from package manifest " + name)
+	}
+
+	csv, ok, err := unstructured.NestedString(firstChannel, "currentCSV")
+	if err != nil {
+		return "", nil, err
+	}
+	if !ok {
+		return "", nil, errors.New("failed to get current CSV from " + name + " packagemanifest")
+	}
+	log.Printf("Current CSV is: %s", csv)
+
+	versionString, ok, err := unstructured.NestedString(firstChannel, "currentCSVDesc", "version")
+	if err != nil {
+		return "", nil, err
+	}
+	if !ok {
+		return "", nil, errors.New("failed to get current operator version from " + name + " packagemanifest")
+	}
+	log.Printf("Current operator version is: %s", versionString)
+
+	version, err := version.ParseGeneric(versionString)
+	if err != nil {
+		return "", nil, err
+	}
+
+	return csv, version, nil
+}
+
+// Checks the existence of the operator's target namespace
+func (v *VirtOperator) checkNamespace() bool {
+	// First check that the namespace exists
+	exists, _ := DoesNamespaceExist(v.Clientset, v.Namespace)
+	return exists
+}
+
+// Checks for the existence of the virtualization operator group
+func (v *VirtOperator) checkOperatorGroup() bool {
+	group := operatorsv1.OperatorGroup{}
+	err := v.Client.Get(context.TODO(), client.ObjectKey{Namespace: v.Namespace, Name: "kubevirt-hyperconverged-group"}, &group)
+	return err == nil
+}
+
+// Checks if there is a virtualization subscription
+func (v *VirtOperator) checkSubscription() bool {
+	subscription := operatorsv1alpha1.Subscription{}
+	err := v.Client.Get(context.TODO(), client.ObjectKey{Namespace: v.Namespace, Name: "hco-operatorhub"}, &subscription)
+	return err == nil
+}
+
+// Checks if the ClusterServiceVersion status has changed to ready
+func (v *VirtOperator) checkCsv() bool {
+	subscription, err := v.getOperatorSubscription()
+	if err != nil {
+		if err.Error() == "no subscription found" {
+			return false
+		}
+	}
+
+	return subscription.CsvIsReady(v.Client)
+}
+
+// CheckHco looks for a HyperConvergedOperator and returns whether or not its
+// health status field is "healthy". Uses dynamic client to avoid uprooting lots
+// of package dependencies, which should probably be fixed later.
+func (v *VirtOperator) checkHco() bool {
+	unstructuredHco, err := v.Dynamic.Resource(hyperConvergedGvr).Namespace(v.Namespace).Get(context.Background(), "kubevirt-hyperconverged", v1.GetOptions{})
+	if err != nil {
+		log.Printf("Error getting HCO: %v", err)
+		return false
+	}
+
+	health, ok, err := unstructured.NestedString(unstructuredHco.UnstructuredContent(), "status", "systemHealthStatus")
+	if err != nil {
+		log.Printf("Error getting HCO health: %v", err)
+		return false
+	}
+	if !ok {
+		log.Printf("HCO health field not populated yet")
+		return false
+	}
+	log.Printf("HCO health status is: %s", health)
+
+	return health == "healthy"
+}
+
+// Check if KVM emulation is enabled.
+func (v *VirtOperator) checkEmulation() bool {
+	hco, err := v.Dynamic.Resource(hyperConvergedGvr).Namespace("openshift-cnv").Get(context.Background(), "kubevirt-hyperconverged", v1.GetOptions{})
+	if err != nil {
+		return false
+	}
+	if hco == nil {
+		return false
+	}
+
+	// Look for JSON patcher annotation that enables emulation.
+	patcher, ok, err := unstructured.NestedString(hco.UnstructuredContent(), "metadata", "annotations", emulationAnnotation)
+	if err != nil {
+		log.Printf("Failed to get KVM emulation annotation from HCO: %v", err)
+		return false
+	}
+	if !ok {
+		log.Printf("No KVM emulation annotation (%s) listed on HCO!", emulationAnnotation)
+	}
+	if strings.Compare(patcher, useEmulation) == 0 {
+		return true
+	}
+
+	return false
+}
+
+// Creates the target virtualization namespace, likely openshift-cnv or kubevirt-hyperconverged
+func (v *VirtOperator) installNamespace() error {
+	err := v.Client.Create(context.Background(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: v.Namespace}})
+	if err != nil {
+		log.Printf("Failed to create namespace %s: %v", v.Namespace, err)
+		return err
+	}
+	return nil
+}
+
+// Creates the virtualization operator group
+func (v *VirtOperator) installOperatorGroup() error {
+	group := v.makeOperatorGroup()
+	err := v.Client.Create(context.Background(), group)
+	if err != nil {
+		if !strings.Contains(err.Error(), "already exists") {
+			log.Printf("Failed to create operator group: %v", err)
+			return err
+		}
+	}
+	return nil
+}
+
+// Creates the subscription, which triggers creation of the ClusterServiceVersion.
+func (v *VirtOperator) installSubscription() error {
+	subscription := &operatorsv1alpha1.Subscription{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "hco-operatorhub",
+			Namespace: v.Namespace,
+		},
+		Spec: &operatorsv1alpha1.SubscriptionSpec{
+			CatalogSource:          "redhat-operators",
+			CatalogSourceNamespace: "openshift-marketplace",
+			Package:                "kubevirt-hyperconverged",
+			Channel:                "stable",
+			StartingCSV:            v.Csv,
+			InstallPlanApproval:    operatorsv1alpha1.ApprovalAutomatic,
+		},
+	}
+	err := v.Client.Create(context.Background(), subscription)
+	if err != nil {
+		log.Printf("Failed to create subscription: %v", err)
+		return err
+	}
+
+	return nil
+}
+
+// Creates a HyperConverged Operator instance. Another dynamic client to avoid
+// bringing in the KubeVirt APIs for now.
+func (v *VirtOperator) installHco() error {
+	unstructuredHco := unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "hco.kubevirt.io/v1beta1",
+			"kind":       "HyperConverged",
+			"metadata": map[string]interface{}{
+				"name":      "kubevirt-hyperconverged",
+				"namespace": v.Namespace,
+			},
+			"spec": map[string]interface{}{},
+		},
+	}
+	_, err := v.Dynamic.Resource(hyperConvergedGvr).Namespace(v.Namespace).Create(context.Background(), &unstructuredHco, v1.CreateOptions{})
+	if err != nil {
+		log.Printf("Error creating HCO: %v", err)
+		return err
+	}
+
+	return nil
+}
+
+func (v *VirtOperator) configureEmulation() error {
+	hco, err := v.Dynamic.Resource(hyperConvergedGvr).Namespace("openshift-cnv").Get(context.Background(), "kubevirt-hyperconverged", v1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	if hco == nil {
+		return fmt.Errorf("could not find hyperconverged operator to set emulation annotation")
+	}
+
+	annotations, ok, err := unstructured.NestedMap(hco.UnstructuredContent(), "metadata", "annotations")
+	if err != nil {
+		return err
+	}
+	if !ok {
+		annotations = make(map[string]interface{})
+	}
+	annotations[emulationAnnotation] = useEmulation
+
+	if err := unstructured.SetNestedMap(hco.UnstructuredContent(), annotations, "metadata", "annotations"); err != nil {
+		return err
+	}
+
+	_, err = v.Dynamic.Resource(hyperConvergedGvr).Namespace("openshift-cnv").Update(context.Background(), hco, v1.UpdateOptions{})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Creates target namespace if needed, and waits for it to exist
+func (v *VirtOperator) ensureNamespace(timeout time.Duration) error {
+	if !v.checkNamespace() {
+		if err := v.installNamespace(); err != nil {
+			return err
+		}
+		err := wait.PollImmediate(time.Second, timeout, func() (bool, error) {
+			return v.checkNamespace(), nil
+		})
+		if err != nil {
+			return fmt.Errorf("timed out waiting to create namespace %s: %w", v.Namespace, err)
+		}
+	} else {
+		log.Printf("Namespace %s already present, no action required", v.Namespace)
+	}
+
+	return nil
+}
+
+// Creates operator group if needed, and waits for it to exist
+func (v *VirtOperator) ensureOperatorGroup(timeout time.Duration) error {
+	if !v.checkOperatorGroup() {
+		if err := v.installOperatorGroup(); err != nil {
+			return err
+		}
+		err := wait.PollImmediate(time.Second, timeout, func() (bool, error) {
+			return v.checkOperatorGroup(), nil
+		})
+		if err != nil {
+			return fmt.Errorf("timed out waiting to create operator group kubevirt-hyperconverged-group: %w", err)
+		}
+	} else {
+		log.Printf("Operator group already present, no action required")
+	}
+
+	return nil
+}
+
+// Creates the virtualization subscription if needed, and waits for it to exist
+func (v *VirtOperator) ensureSubscription(timeout time.Duration) error {
+	if !v.checkSubscription() {
+		if err := v.installSubscription(); err != nil {
+			return err
+		}
+		err := wait.PollImmediate(time.Second, timeout, func() (bool, error) {
+			return v.checkSubscription(), nil
+		})
+		if err != nil {
+			return fmt.Errorf("timed out waiting to create subscription: %w", err)
+		}
+	} else {
+		log.Printf("Subscription already created, no action required")
+	}
+
+	return nil
+}
+
+// Waits for the ClusterServiceVersion to go to ready, triggered by subscription
+func (v *VirtOperator) ensureCsv(timeout time.Duration) error {
+	err := wait.PollImmediate(5*time.Second, timeout, func() (bool, error) {
+		return v.checkCsv(), nil
+	})
+	if err != nil {
+		return fmt.Errorf("timed out waiting for CSV to become ready: %w", err)
+	}
+	return nil
+}
+
+// Creates HyperConverged Operator instance if needed, and waits for it to go healthy
+func (v *VirtOperator) ensureHco(timeout time.Duration) error {
+	if !v.checkHco() {
+		if err := v.installHco(); err != nil {
+			return err
+		}
+		err := wait.PollImmediate(5*time.Second, timeout, func() (bool, error) {
+			return v.checkHco(), nil
+		})
+		if err != nil {
+			return fmt.Errorf("timed out waiting to create HCO: %w", err)
+		}
+	} else {
+		log.Printf("HCO already created, no action required")
+	}
+
+	return nil
+}
+
+// Deletes the virtualization operator namespace (likely openshift-cnv).
+func (v *VirtOperator) removeNamespace() error {
+	err := v.Client.Delete(context.Background(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: v.Namespace}})
+	if err != nil {
+		log.Printf("Failed to delete namespace %s: %v", v.Namespace, err)
+		return err
+	}
+	return nil
+}
+
+// Deletes the virtualization operator group
+func (v *VirtOperator) removeOperatorGroup() error {
+	group := v.makeOperatorGroup()
+	err := v.Client.Delete(context.Background(), group)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Deletes the kubvirt subscription
+func (v *VirtOperator) removeSubscription() error {
+	subscription, err := v.getOperatorSubscription()
+	if err != nil {
+		return err
+	}
+	return subscription.Delete(v.Client)
+}
+
+// Deletes the virt ClusterServiceVersion
+func (v *VirtOperator) removeCsv() error {
+	return v.Dynamic.Resource(csvGvr).Namespace(v.Namespace).Delete(context.Background(), v.Csv, v1.DeleteOptions{})
+}
+
+// Deletes a HyperConverged Operator instance.
+func (v *VirtOperator) removeHco() error {
+	err := v.Dynamic.Resource(hyperConvergedGvr).Namespace(v.Namespace).Delete(context.Background(), "kubevirt-hyperconverged", v1.DeleteOptions{})
+	if err != nil {
+		log.Printf("Error deleting HCO: %v", err)
+		return err
+	}
+
+	return nil
+}
+
+// Makes sure the virtualization operator's namespace is removed.
+func (v *VirtOperator) ensureNamespaceRemoved(timeout time.Duration) error {
+	if !v.checkNamespace() {
+		log.Printf("Namespace %s already removed, no action required", v.Namespace)
+		return nil
+	}
+
+	if err := v.removeNamespace(); err != nil {
+		return err
+	}
+
+	err := wait.PollImmediate(5*time.Second, timeout, func() (bool, error) {
+		return !v.checkNamespace(), nil
+	})
+	if err != nil {
+		return fmt.Errorf("timed out waiting to delete namespace %s: %w", v.Namespace, err)
+	}
+
+	return nil
+}
+
+// Makes sure the operator group is removed.
+func (v *VirtOperator) ensureOperatorGroupRemoved(timeout time.Duration) error {
+	if !v.checkOperatorGroup() {
+		log.Printf("Operator group already removed, no action required")
+		return nil
+	}
+
+	if err := v.removeOperatorGroup(); err != nil {
+		return err
+	}
+
+	err := wait.PollImmediate(5*time.Second, timeout, func() (bool, error) {
+		return !v.checkOperatorGroup(), nil
+	})
+	if err != nil {
+		return fmt.Errorf("timed out waiting for operator group to be removed: %w", err)
+	}
+
+	return nil
+}
+
+// Deletes the subscription
+func (v *VirtOperator) ensureSubscriptionRemoved(timeout time.Duration) error {
+	if !v.checkSubscription() {
+		log.Printf("Subscription already removed, no action required")
+		return nil
+	}
+
+	if err := v.removeSubscription(); err != nil {
+		return err
+	}
+
+	err := wait.PollImmediate(5*time.Second, timeout, func() (bool, error) {
+		return !v.checkSubscription(), nil
+	})
+	if err != nil {
+		return fmt.Errorf("timed out waiting for subscription to be deleted: %w", err)
+	}
+	return nil
+}
+
+// Deletes the ClusterServiceVersion and waits for it to be removed
+func (v *VirtOperator) ensureCsvRemoved(timeout time.Duration) error {
+	if !v.checkCsv() {
+		log.Printf("CSV already removed, no action required")
+		return nil
+	}
+
+	if err := v.removeCsv(); err != nil {
+		return err
+	}
+
+	err := wait.PollImmediate(5*time.Second, timeout, func() (bool, error) {
+		return !v.checkCsv(), nil
+	})
+	if err != nil {
+		return fmt.Errorf("timed out waiting for CSV to be deleted: %w", err)
+	}
+	return nil
+}
+
+// Deletes the HyperConverged Operator instance and waits for it to be removed.
+func (v *VirtOperator) ensureHcoRemoved(timeout time.Duration) error {
+	if !v.checkHco() {
+		log.Printf("HCO already removed, no action required")
+		return nil
+	}
+
+	if err := v.removeHco(); err != nil {
+		return err
+	}
+
+	err := wait.PollImmediate(5*time.Second, timeout, func() (bool, error) {
+		return !v.checkHco(), nil
+	})
+
+	return err
+}
+
+func (v *VirtOperator) GetVmStatus(namespace, name string) (string, error) {
+	vm, err := v.Dynamic.Resource(virtualMachineGvr).Namespace(namespace).Get(context.Background(), name, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	status, ok, err := unstructured.NestedString(vm.UnstructuredContent(), "status", "printableStatus")
+	if err != nil {
+		return "", err
+	}
+	if ok {
+		log.Printf("VM %s/%s status is: %s", namespace, name, status)
+	}
+
+	return status, nil
+}
+
+func (v *VirtOperator) checkVmExists(namespace, name string) bool {
+	_, err := v.GetVmStatus(namespace, name)
+	return err == nil
+}
+
+func (v *VirtOperator) removeVm(namespace, name string) error {
+	if err := v.Dynamic.Resource(virtualMachineGvr).Namespace(namespace).Delete(context.TODO(), name, v1.DeleteOptions{}); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("error deleting VM %s/%s: %w", namespace, name, err)
+		}
+		log.Printf("VM %s/%s not found, delete not necessary.", namespace, name)
+	}
+
+	return nil
+}
+
+func (v *VirtOperator) ensureVmRemoval(namespace, name string, timeout time.Duration) error {
+	if !v.checkVmExists(namespace, name) {
+		log.Printf("VM %s/%s already removed, no action required", namespace, name)
+		return nil
+	}
+
+	if err := v.removeVm(namespace, name); err != nil {
+		return err
+	}
+
+	err := wait.PollImmediate(5*time.Second, timeout, func() (bool, error) {
+		return !v.checkVmExists(namespace, name), nil
+	})
+
+	return err
+}
+
+// Enable KVM emulation for use on cloud clusters that do not have direct
+// access to the host server's virtualization capabilities.
+func (v *VirtOperator) EnsureEmulation(timeout time.Duration) error {
+	if v.checkEmulation() {
+		log.Printf("KVM emulation already enabled, no work needed to turn it on.")
+		return nil
+	}
+
+	log.Printf("Enabling KVM emulation...")
+
+	// Retry if there are API server conflicts ("the object has been modified")
+	timeTaken := 0 * time.Second
+	err := wait.PollImmediate(5*time.Second, timeout, func() (bool, error) {
+		timeTaken += 5
+		innerErr := v.configureEmulation()
+		if innerErr != nil {
+			if apierrors.IsConflict(innerErr) {
+				log.Printf("HCO modification conflict, trying again...")
+				return false, nil // Conflict: try again
+			}
+			return false, innerErr // Anything else: give up
+		}
+		return innerErr == nil, nil
+	})
+	if err != nil {
+		return err
+	}
+
+	timeout = timeout - timeTaken
+	err = wait.PollImmediate(5*time.Second, timeout, func() (bool, error) {
+		return v.checkEmulation(), nil
+	})
+
+	return err
+}
+
+// IsVirtInstalled returns whether or not the OpenShift Virtualization operator
+// is installed and ready, by checking for a HyperConverged operator resource.
+func (v *VirtOperator) IsVirtInstalled() bool {
+	if !v.checkNamespace() {
+		return false
+	}
+
+	return v.checkHco()
+}
+
+// EnsureVirtInstallation makes sure the OpenShift Virtualization operator is
+// installed. This will install the operator if it is not already present.
+func (v *VirtOperator) EnsureVirtInstallation() error {
+	if v.IsVirtInstalled() {
+		log.Printf("Virtualization operator already installed, no action needed")
+		return nil
+	}
+
+	log.Printf("Creating virtualization namespace %s", v.Namespace)
+	if err := v.ensureNamespace(10 * time.Second); err != nil {
+		return err
+	}
+	log.Printf("Created namespace %s", v.Namespace)
+
+	log.Printf("Creating operator group kubevirt-hyperconverged-group")
+	if err := v.ensureOperatorGroup(10 * time.Second); err != nil {
+		return err
+	}
+	log.Println("Created operator group")
+
+	log.Printf("Creating virtualization operator subscription")
+	if err := v.ensureSubscription(10 * time.Second); err != nil {
+		return err
+	}
+	log.Println("Created subscription")
+
+	log.Printf("Waiting for ClusterServiceVersion")
+	if err := v.ensureCsv(5 * time.Minute); err != nil {
+		return err
+	}
+	log.Println("CSV ready")
+
+	log.Printf("Creating hyperconverged operator")
+	if err := v.ensureHco(5 * time.Minute); err != nil {
+		return err
+	}
+	log.Printf("Created HCO")
+
+	return nil
+}
+
+// EnsureVirtRemoval makes sure the virtualization operator is removed.
+func (v *VirtOperator) EnsureVirtRemoval() error {
+	log.Printf("Removing hyperconverged operator")
+	if err := v.ensureHcoRemoved(3 * time.Minute); err != nil {
+		return err
+	}
+	log.Printf("Removed HCO")
+
+	log.Printf("Deleting virtualization operator subscription")
+	if err := v.ensureSubscriptionRemoved(10 * time.Second); err != nil {
+		return err
+	}
+	log.Println("Deleted subscription")
+
+	log.Printf("Deleting ClusterServiceVersion")
+	if err := v.ensureCsvRemoved(2 * time.Minute); err != nil {
+		return err
+	}
+	log.Println("CSV removed")
+
+	log.Printf("Deleting operator group kubevirt-hyperconverged-group")
+	if err := v.ensureOperatorGroupRemoved(10 * time.Second); err != nil {
+		return err
+	}
+	log.Println("Deleted operator group")
+
+	log.Printf("Deleting virtualization namespace %s", v.Namespace)
+	if err := v.ensureNamespaceRemoved(3 * time.Minute); err != nil {
+		return err
+	}
+	log.Printf("Deleting namespace %s", v.Namespace)
+
+	return nil
+}
+
+// Remove a virtual machine, but leave its data volume.
+func (v *VirtOperator) RemoveVm(namespace, name string, timeout time.Duration) error {
+	log.Printf("Removing virtual machine %s/%s", namespace, name)
+	return v.ensureVmRemoval(namespace, name, timeout)
+}

--- a/tests/e2e/lib/virt_storage_helpers.go
+++ b/tests/e2e/lib/virt_storage_helpers.go
@@ -1,0 +1,205 @@
+package lib
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+var dataVolumeGVR = schema.GroupVersionResource{
+	Group:    "cdi.kubevirt.io",
+	Resource: "datavolumes",
+	Version:  "v1beta1",
+}
+
+var dataSourceGVR = schema.GroupVersionResource{
+	Group:    "cdi.kubevirt.io",
+	Resource: "datasources",
+	Version:  "v1beta1",
+}
+
+func (v *VirtOperator) getDataVolume(namespace, name string) (*unstructured.Unstructured, error) {
+	unstructuredDataVolume, err := v.Dynamic.Resource(dataVolumeGVR).Namespace(namespace).Get(context.Background(), name, metav1.GetOptions{})
+	return unstructuredDataVolume, err
+}
+
+func (v *VirtOperator) deleteDataVolume(namespace, name string) error {
+	return v.Dynamic.Resource(dataVolumeGVR).Namespace(namespace).Delete(context.Background(), name, metav1.DeleteOptions{})
+}
+
+func (v *VirtOperator) checkDataVolumeExists(namespace, name string) bool {
+	unstructuredDataVolume, err := v.getDataVolume(namespace, name)
+	if err != nil {
+		return false
+	}
+	return unstructuredDataVolume != nil
+}
+
+// Check the Status.Phase field of the given DataVolume, and make sure it is
+// marked "Succeeded".
+func (v *VirtOperator) checkDataVolumeReady(namespace, name string) bool {
+	unstructuredDataVolume, err := v.getDataVolume(namespace, name)
+	if err != nil {
+		log.Printf("Error getting DataVolume %s/%s: %v", namespace, name, err)
+		return false
+	}
+	if unstructuredDataVolume == nil {
+		return false
+	}
+	phase, ok, err := unstructured.NestedString(unstructuredDataVolume.UnstructuredContent(), "status", "phase")
+	if err != nil {
+		log.Printf("Error getting phase from DataVolume: %v", err)
+		return false
+	}
+	if !ok {
+		return false
+	}
+	log.Printf("Phase of DataVolume %s/%s: %s", namespace, name, phase)
+	return phase == "Succeeded"
+}
+
+// Create a DataVolume and ask it to fill itself with the contents of the given URL.
+// Also add annotations to immediately create and bind to a PersistentVolume,
+// and to avoid deleting the DataVolume after the PVC is all ready.
+func (v *VirtOperator) createDataVolumeFromUrl(namespace, name, url, size string) error {
+	unstructuredDataVolume := unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "cdi.kubevirt.io/v1beta1",
+			"kind":       "DataVolume",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": namespace,
+				"annotations": map[string]interface{}{
+					"cdi.kubevirt.io/storage.bind.immediate.requested": "",
+					"cdi.kubevirt.io/storage.deleteAfterCompletion":    "false",
+				},
+			},
+			"spec": map[string]interface{}{
+				"source": map[string]interface{}{
+					"http": map[string]interface{}{
+						"url": url,
+					},
+				},
+				"pvc": map[string]interface{}{
+					"accessModes": []string{
+						"ReadWriteOnce",
+					},
+					"resources": map[string]interface{}{
+						"requests": map[string]interface{}{
+							"storage": size,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := v.Dynamic.Resource(dataVolumeGVR).Namespace(namespace).Create(context.Background(), &unstructuredDataVolume, metav1.CreateOptions{})
+	if err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			return nil
+		}
+		if strings.Contains(err.Error(), "already exists") {
+			return nil
+		}
+		log.Printf("Error creating DataVolume: %v", err)
+		return err
+	}
+
+	return nil
+}
+
+// Create a DataVolume and wait for it to be ready.
+func (v *VirtOperator) EnsureDataVolumeFromUrl(namespace, name, url, size string, timeout time.Duration) error {
+	if !v.checkDataVolumeExists(namespace, name) {
+		if err := v.createDataVolumeFromUrl(namespace, name, url, size); err != nil {
+			return err
+		}
+		log.Printf("Created DataVolume %s/%s from %s", namespace, name, url)
+	} else {
+		log.Printf("DataVolume %s/%s already created, checking for readiness", namespace, name)
+	}
+
+	err := wait.PollImmediate(5*time.Second, timeout, func() (bool, error) {
+		return v.checkDataVolumeReady(namespace, name), nil
+	})
+	if err != nil {
+		return fmt.Errorf("timed out waiting for DataVolume %s/%s to go ready: %w", namespace, name, err)
+	}
+
+	log.Printf("DataVolume %s/%s ready", namespace, name)
+
+	return nil
+}
+
+// Delete a DataVolume and wait for it to go away.
+func (v *VirtOperator) RemoveDataVolume(namespace, name string, timeout time.Duration) error {
+	err := v.deleteDataVolume(namespace, name)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Printf("DataVolume %s/%s already removed", namespace, name)
+		} else {
+			return err
+		}
+	}
+
+	err = wait.PollImmediate(5*time.Second, timeout, func() (bool, error) {
+		return !v.checkDataVolumeExists(namespace, name), nil
+	})
+	if err != nil {
+		return fmt.Errorf("timed out waiting for DataVolume %s/%s to be deleted: %w", namespace, name, err)
+	}
+
+	log.Printf("DataVolume %s/%s cleaned up", namespace, name)
+
+	return nil
+}
+
+func (v *VirtOperator) RemoveDataSource(namespace, name string) error {
+	return v.Dynamic.Resource(dataSourceGVR).Namespace(namespace).Delete(context.Background(), name, metav1.DeleteOptions{})
+}
+
+// Create a DataSource from an existing PVC, with the same name and namespace.
+// This way, the PVC can be specified as a sourceRef in the VM spec.
+func (v *VirtOperator) CreateDataSourceFromPvc(namespace, name string) error {
+	unstructuredDataSource := unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "cdi.kubevirt.io/v1beta1",
+			"kind":       "DataSource",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"spec": map[string]interface{}{
+				"source": map[string]interface{}{
+					"pvc": map[string]interface{}{
+						"name":      name,
+						"namespace": namespace,
+					},
+				},
+			},
+		},
+	}
+
+	_, err := v.Dynamic.Resource(dataSourceGVR).Namespace(namespace).Create(context.Background(), &unstructuredDataSource, metav1.CreateOptions{})
+	if err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			return nil
+		}
+		if strings.Contains(err.Error(), "already exists") {
+			return nil
+		}
+		log.Printf("Error creating DataSource: %v", err)
+		return err
+	}
+
+	return nil
+}

--- a/tests/e2e/sample-applications/virtual-machines/cirros-test/cirros-test.yaml
+++ b/tests/e2e/sample-applications/virtual-machines/cirros-test/cirros-test.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: kubevirt.io/v1
+    kind: VirtualMachine
+    metadata:
+      name: cirros-test
+      namespace: cirros-test
+    spec:
+      dataVolumeTemplates:
+        - apiVersion: cdi.kubevirt.io/v1beta1
+          kind: DataVolume
+          metadata:
+            name: cirros-test-disk
+          spec:
+            sourceRef:
+              kind: DataSource
+              name: cirros
+              namespace: openshift-virtualization-os-images
+            storage:
+              resources:
+                requests:
+                  storage: 128Mi
+      running: true
+      template:
+        metadata:
+          annotations:
+            vm.kubevirt.io/flavor: tiny
+        spec:
+          domain:
+            devices:
+              disks:
+              - disk:
+                  bus: virtio
+                name: rootdisk
+            resources:
+              requests:
+                cpu: 1
+                memory: 256Mi
+          volumes:
+          - name: rootdisk
+            persistentVolumeClaim:
+              claimName: cirros-test-disk

--- a/tests/e2e/sample-applications/virtual-machines/fedora-todolist/fedora-todolist.yaml
+++ b/tests/e2e/sample-applications/virtual-machines/fedora-todolist/fedora-todolist.yaml
@@ -1,0 +1,312 @@
+apiVersion: v1
+kind: List
+items:
+  - kind: Namespace
+    apiVersion: v1
+    metadata:
+      name: mysql-persistent
+      labels:
+        app: mysql
+  - apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: mysql-persistent-sa
+      namespace: mysql-persistent
+      labels:
+        component: mysql-persistent
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: mysql
+      namespace: mysql-persistent
+      labels:
+        app: mysql
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 1Gi
+  - kind: SecurityContextConstraints
+    apiVersion: security.openshift.io/v1
+    metadata:
+      name: mysql-persistent-scc
+    allowPrivilegeEscalation: true
+    allowPrivilegedContainer: true
+    runAsUser:
+      type: RunAsAny
+    seLinuxContext:
+      type: RunAsAny
+    fsGroup:
+      type: RunAsAny
+    supplementalGroups:
+      type: RunAsAny
+    volumes:
+    - '*'
+    users:
+    - system:admin
+    - system:serviceaccount:mysql-persistent:mysql-persistent-sa
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        template.openshift.io/expose-uri: mariadb://{.spec.clusterIP}:{.spec.ports[?(.name=="mysql")].port}
+      name: mysql
+      namespace: mysql-persistent
+      labels:
+        app: mysql
+        service: mysql
+    spec:
+      ports:
+      - protocol: TCP
+        name: mysql
+        port: 3306
+      selector:
+        app: mysql
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations:
+        template.alpha.openshift.io/wait-for-ready: 'true'
+      name: mysql
+      namespace: mysql-persistent
+      labels:
+        e2e-app: "true"
+    spec:
+      selector:
+        matchLabels:
+          app: mysql
+      strategy:
+        type: Recreate
+      template:
+        metadata:
+          labels:
+            e2e-app: "true"
+            app: mysql
+            curl-tool: "true"
+        spec:
+          securityContext:
+            runAsNonRoot: true
+          serviceAccountName: mysql-persistent-sa
+          containers:
+          - image: registry.redhat.io/rhel8/mariadb-105:latest
+            name: mysql
+            securityContext:
+              privileged: false
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                - ALL
+              seccompProfile:
+                type: RuntimeDefault
+            env:
+              - name: MYSQL_USER
+                value: changeme
+              - name: MYSQL_PASSWORD
+                value: changeme
+              - name: MYSQL_ROOT_PASSWORD
+                value: root
+              - name: MYSQL_DATABASE
+                value: todolist
+            ports:
+            - containerPort: 3306
+              name: mysql
+            resources:
+              limits:
+                memory: 512Mi
+            volumeMounts:
+            - name: mysql-data
+              mountPath: /var/lib/mysql
+            livenessProbe:
+              tcpSocket:
+                port: mysql
+              initialDelaySeconds: 10
+              periodSeconds: 10
+              timeoutSeconds: 5
+            startupProbe:
+              exec:
+                command:
+                - /usr/bin/timeout
+                - 1s
+                - /usr/bin/mysql
+                - $(MYSQL_DATABASE)
+                - -h
+                - 127.0.0.1
+                - -u$(MYSQL_USER)
+                - -p$(MYSQL_PASSWORD)
+                - -e EXIT
+              initialDelaySeconds: 5
+              periodSeconds: 30
+              timeoutSeconds: 2
+              successThreshold: 1
+              failureThreshold: 40 # 40x30sec before restart pod
+            restartPolicy: Always
+          - image: docker.io/curlimages/curl:8.5.0
+            name: curl-tool
+            command: ["/bin/sleep", "infinity"]
+          volumes:
+          - name: mysql-data
+            persistentVolumeClaim:
+              claimName: mysql
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: todolist
+      namespace: mysql-persistent
+      labels:
+        app: todolist
+        service: todolist
+        e2e-app: "true"
+    spec:
+      ports:
+        - name: web
+          port: 8000
+          targetPort: 8000
+      selector:
+        app: todolist
+        service: todolist
+  - apiVersion: apps.openshift.io/v1
+    kind: DeploymentConfig
+    metadata:
+      name: todolist
+      namespace: mysql-persistent
+      labels:
+        app: todolist
+        service: todolist
+        e2e-app: "true"
+    spec:
+      replicas: 1
+      selector:
+        app: todolist
+        service: todolist
+      strategy:
+        type: Recreate
+      template:
+        metadata:
+          labels:
+            app: todolist
+            service: todolist
+            e2e-app: "true"
+        spec:
+          containers:
+          - name: todolist
+            image:  quay.io/rhn_engineering_whayutin/todolist-mariadb-go-2:latest
+            env:
+              - name: foo
+                value: bar
+            ports:
+              - containerPort: 8000
+                protocol: TCP
+          initContainers:
+          - name: init-myservice
+            image: docker.io/curlimages/curl:8.5.0
+            command: ['sh', '-c', 'sleep 10; until /usr/bin/nc -z -w 1 mysql 3306; do echo Trying to connect to mysql DB port; sleep 5; done; echo mysql DB port reachable']
+  - apiVersion: route.openshift.io/v1
+    kind: Route
+    metadata:
+      name: todolist-route
+      namespace: mysql-persistent
+    spec:
+      path: "/"
+      to:
+        kind: Service
+        name: todolist
+  - apiVersion: kubevirt.io/v1
+    kind: VirtualMachine
+    metadata:
+      name: fedora-todolist
+      namespace: mysql-persistent
+    spec:
+      dataVolumeTemplates:
+        - apiVersion: cdi.kubevirt.io/v1beta1
+          kind: DataVolume
+          metadata:
+            name: fedora-todolist-disk
+          spec:
+            sourceRef:
+              kind: DataSource
+              name: fedora
+              namespace: openshift-virtualization-os-images
+            storage:
+              resources:
+                requests:
+                  storage: 30Gi
+      running: true
+      template:
+        metadata:
+          annotations:
+            vm.kubevirt.io/flavor: tiny
+            vm.kubevirt.io/os: fedora
+            vm.kubevirt.io/workload: server
+        spec:
+          architecture: amd64
+          domain:
+            devices:
+              disks:
+                - disk:
+                    bus: virtio
+                  name: rootdisk
+                - disk:
+                    bus: virtio
+                  name: cloudinitdisk
+              interfaces:
+                - macAddress: '02:73:43:00:00:07'
+                  masquerade: {}
+                  model: virtio
+                  name: default
+              networkInterfaceMultiqueue: true
+              rng: {}
+            features:
+              acpi: {}
+              smm:
+                enabled: true
+            firmware:
+              bootloader:
+                efi: {}
+            machine:
+              type: pc-q35-rhel9.2.0
+            memory:
+              guest: 2Gi
+            resources: {}
+          networks:
+            - name: default
+              pod: {}
+          terminationGracePeriodSeconds: 180
+          volumes:
+            - dataVolume:
+                name: fedora-todolist-disk
+              name: rootdisk
+            - cloudInitConfigDrive:
+                userData: |-
+                  #cloud-config
+                  user: fedora
+                  password: dog8code
+                  chpasswd: { expire: False }
+                  user: test
+                  password: dog8code
+                  chpasswd: { expire: False }
+                  packages:
+                    - mariadb-server
+                    - unzip
+                    - wget
+                  runcmd:
+                    - systemctl stop firewalld
+                    - systemctl disable firewalld
+                    - systemctl start mariadb
+                    - systemctl enable mariadb
+                    - mysql -uroot -e "CREATE DATABASE todolist; USE todolist; CREATE USER 'test'@'localhost' IDENTIFIED BY 'test';"
+                    - mysql -uroot -e "grant all privileges on todolist.* to test@'localhost' identified by 'test'; FLUSH PRIVILEGES;"
+                    - pushd /home/test/
+                    - wget https://github.com/weshayutin/todolist-mariadb-go/releases/download/testing3/todolist-linux-amd64.zip
+                    - unzip todolist-linux-amd64.zip
+                    - chown -R test:test /home/test
+                    - semanage fcontext --add --type bin_t '/home/test/todolist-linux-amd64'
+                    - restorecon -Fv /home/test/todolist-linux-amd64
+                    - cp systemd/todolist-mariadb.service /etc/systemd/system/
+                    - popd
+                    - systemctl daemon-reload
+                    - systemctl start todolist-mariadb.service
+                    - systemctl enable todolist-mariadb.service
+                    - systemctl status todolist-mariadb.service
+                    - systemctl  disable  cloud-init
+              name: cloudinitdisk

--- a/tests/e2e/sample-applications/virtual-machines/fedora-todolist/fedora-todolist.yaml
+++ b/tests/e2e/sample-applications/virtual-machines/fedora-todolist/fedora-todolist.yaml
@@ -140,7 +140,6 @@ items:
               timeoutSeconds: 2
               successThreshold: 1
               failureThreshold: 40 # 40x30sec before restart pod
-            restartPolicy: Always
           - image: docker.io/curlimages/curl:8.5.0
             name: curl-tool
             command: ["/bin/sleep", "infinity"]

--- a/tests/e2e/subscription_suite_test.go
+++ b/tests/e2e/subscription_suite_test.go
@@ -19,7 +19,7 @@ var _ = Describe("Subscription Config Suite Test", func() {
 	type SubscriptionConfigTestCase struct {
 		operators.SubscriptionConfig
 		failureExpected *bool
-		stream          string
+		stream          StreamSource
 	}
 
 	var _ = AfterEach(func() {
@@ -31,7 +31,7 @@ var _ = Describe("Subscription Config Suite Test", func() {
 	DescribeTable("Proxy test table",
 		func(testCase SubscriptionConfigTestCase) {
 			log.Printf("Getting Operator Subscription")
-			s, err := dpaCR.GetOperatorSubscription(runTimeClientForSuiteRun, stream)
+			s, err := dpaCR.GetOperatorSubscription(runTimeClientForSuiteRun, StreamSource(stream))
 			Expect(err).To(BeNil())
 			log.Printf("Setting test case subscription config")
 			s.Spec.Config = &testCase.SubscriptionConfig

--- a/tests/e2e/virt_backup_restore_suite_test.go
+++ b/tests/e2e/virt_backup_restore_suite_test.go
@@ -1,0 +1,190 @@
+package e2e_test
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/openshift/oadp-operator/api/v1alpha1"
+	"github.com/openshift/oadp-operator/tests/e2e/lib"
+)
+
+func getLatestCirrosImageURL() (string, error) {
+	cirrosVersionURL := "https://download.cirros-cloud.net/version/released"
+
+	resp, err := http.Get(cirrosVersionURL)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	latestCirrosVersion := strings.TrimSpace(string(body))
+
+	imageURL := fmt.Sprintf("https://download.cirros-cloud.net/%s/cirros-%s-x86_64-disk.img", latestCirrosVersion, latestCirrosVersion)
+
+	return imageURL, nil
+}
+
+type VmBackupRestoreCase struct {
+	BackupRestoreCase
+	Template  string
+	InitDelay time.Duration
+}
+
+func runVmBackupAndRestore(brCase VmBackupRestoreCase, expectedErr error, updateLastBRcase func(brCase VmBackupRestoreCase), updateLastInstallTime func(), v *lib.VirtOperator) {
+	updateLastBRcase(brCase)
+
+	// Create DPA
+	backupName, restoreName := prepareBackupAndRestore(brCase.BackupRestoreCase, func() {})
+
+	err := lib.CreateNamespace(v.Clientset, brCase.Namespace)
+	Expect(err).To(BeNil())
+
+	err = lib.InstallApplication(v.Client, brCase.Template)
+	if err != nil {
+		fmt.Printf("Failed to install VM template %s: %v", brCase.Template, err)
+	}
+	Expect(err).To(BeNil())
+
+	// Wait for VM to start, then give some time for cloud-init to run.
+	// Afterward, run through the standard application verification to make sure
+	// the application itself is working correctly.
+	err = wait.PollImmediate(10*time.Second, 10*time.Minute, func() (bool, error) {
+		status, err := v.GetVmStatus(brCase.Namespace, brCase.Name)
+		return status == "Running", err
+	})
+	Expect(err).ToNot(HaveOccurred())
+
+	// TODO: find a better way to check for clout-init completion
+	if brCase.InitDelay > 0*time.Second {
+		log.Printf("Sleeping to wait for cloud-init to be ready...")
+		time.Sleep(brCase.InitDelay)
+	}
+
+	// Back up VM
+	nsRequiresResticDCWorkaround := runBackup(brCase.BackupRestoreCase, backupName)
+
+	// Delete everything in test namespace
+	err = v.RemoveVm(brCase.Namespace, brCase.Name, 2*time.Minute)
+	Expect(err).To(BeNil())
+	err = lib.DeleteNamespace(v.Clientset, brCase.Namespace)
+	Expect(err).To(BeNil())
+	Eventually(lib.IsNamespaceDeleted(kubernetesClientForSuiteRun, brCase.Namespace), timeoutMultiplier*time.Minute*5, time.Second*5).Should(BeTrue())
+
+	// Do restore
+	runRestore(brCase.BackupRestoreCase, backupName, restoreName, nsRequiresResticDCWorkaround)
+
+	// Run optional custom verification
+	if brCase.PostRestoreVerify != nil {
+		log.Printf("Running post-restore function for VM case %s", brCase.Name)
+		err = brCase.PostRestoreVerify(dpaCR.Client, brCase.Namespace)
+		Expect(err).ToNot(HaveOccurred())
+	}
+}
+
+var _ = Describe("VM backup and restore tests", Ordered, func() {
+	var v *lib.VirtOperator
+	var err error
+	wasInstalledFromTest := false
+	var lastBRCase VmBackupRestoreCase
+	var lastInstallTime time.Time
+	updateLastBRcase := func(brCase VmBackupRestoreCase) {
+		lastBRCase = brCase
+	}
+	updateLastInstallTime := func() {
+		lastInstallTime = time.Now()
+	}
+
+	var _ = BeforeAll(func() {
+		v, err = lib.GetVirtOperator(runTimeClientForSuiteRun, kubernetesClientForSuiteRun, dynamicClientForSuiteRun)
+		Expect(err).To(BeNil())
+		Expect(v).ToNot(BeNil())
+
+		if !v.IsVirtInstalled() {
+			err = v.EnsureVirtInstallation()
+			Expect(err).To(BeNil())
+			wasInstalledFromTest = true
+		}
+
+		err = v.EnsureEmulation(20 * time.Second)
+		Expect(err).To(BeNil())
+
+		url, err := getLatestCirrosImageURL()
+		Expect(err).To(BeNil())
+		err = v.EnsureDataVolumeFromUrl("openshift-virtualization-os-images", "cirros", url, "128Mi", 5*time.Minute)
+		Expect(err).To(BeNil())
+		err = v.CreateDataSourceFromPvc("openshift-virtualization-os-images", "cirros")
+		Expect(err).To(BeNil())
+
+		dpaCR.CustomResource.Spec.Configuration.Velero.DefaultPlugins = append(dpaCR.CustomResource.Spec.Configuration.Velero.DefaultPlugins, v1alpha1.DefaultPluginKubeVirt)
+	})
+
+	var _ = AfterAll(func() {
+		v.RemoveDataSource("openshift-virtualization-os-images", "cirros")
+		v.RemoveDataVolume("openshift-virtualization-os-images", "cirros", 2*time.Minute)
+
+		if v != nil && wasInstalledFromTest {
+			v.EnsureVirtRemoval()
+		}
+	})
+
+	var _ = AfterEach(func(ctx SpecContext) {
+		tearDownBackupAndRestore(lastBRCase.BackupRestoreCase, lastInstallTime, ctx.SpecReport())
+	})
+
+	DescribeTable("Backup and restore virtual machines",
+		func(brCase VmBackupRestoreCase, expectedError error) {
+			runVmBackupAndRestore(brCase, expectedError, updateLastBRcase, updateLastInstallTime, v)
+		},
+
+		Entry("no-application CSI datamover backup and restore, CirrOS VM", Label("virt"), VmBackupRestoreCase{
+			Template:  "./sample-applications/virtual-machines/cirros-test/cirros-test.yaml",
+			InitDelay: 2 * time.Minute, // Just long enough to get to login prompt, VM is marked running while kernel messages are still scrolling by
+			BackupRestoreCase: BackupRestoreCase{
+				Namespace:         "cirros-test",
+				Name:              "cirros-test",
+				SkipVerifyLogs:    true,
+				BackupRestoreType: lib.CSIDataMover,
+				BackupTimeout:     20 * time.Minute,
+			},
+		}, nil),
+
+		Entry("no-application CSI backup and restore, CirrOS VM", Label("virt"), VmBackupRestoreCase{
+			Template:  "./sample-applications/virtual-machines/cirros-test/cirros-test.yaml",
+			InitDelay: 2 * time.Minute, // Just long enough to get to login prompt, VM is marked running while kernel messages are still scrolling by
+			BackupRestoreCase: BackupRestoreCase{
+				Namespace:         "cirros-test",
+				Name:              "cirros-test",
+				SkipVerifyLogs:    true,
+				BackupRestoreType: lib.CSI,
+				BackupTimeout:     20 * time.Minute,
+			},
+		}, nil),
+
+		Entry("todolist CSI backup and restore, in a Fedora VM", Label("virt"), VmBackupRestoreCase{
+			Template:  "./sample-applications/virtual-machines/fedora-todolist/fedora-todolist.yaml",
+			InitDelay: 3 * time.Minute, // For cloud-init
+			BackupRestoreCase: BackupRestoreCase{
+				Namespace:         "mysql-persistent",
+				Name:              "fedora-todolist",
+				SkipVerifyLogs:    true,
+				BackupRestoreType: lib.CSI,
+				PreBackupVerify:   mysqlReady(true, false, lib.CSI),
+				PostRestoreVerify: mysqlReady(false, false, lib.CSI),
+				BackupTimeout:     45 * time.Minute,
+			},
+		}, nil),
+	)
+})


### PR DESCRIPTION
Pull the virtual machine tests into the 1.4 branch. I tried cherry-picking the merges from the original work, but there were enough conflicts and intermediate throwaway changes that it was actually smaller to flatten them all into one. (See [this temporary work branch](https://github.com/openshift/oadp-operator/compare/oadp-1.4...mrnold:oadp-operator:oadp-interim-1.4-vm-ci?expand=1).

## Why the changes were made

Addresses https://issues.redhat.com/browse/OADP-4213.

## How to test the changes made

`make TEST_VIRT=true test-e2e`
