### PR TITLE
add datavolume and datasource template for humans

### DIFF
--- a/tests/e2e/sample-applications/virtual-machines/cirros-test/cirros-ds.yaml
+++ b/tests/e2e/sample-applications/virtual-machines/cirros-test/cirros-ds.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: cdi.kubevirt.io/v1beta1
+    kind: DataVolume
+    metadata:
+      annotations:
+        cdi.kubevirt.io/storage.bind.immediate.requested: ""
+        cdi.kubevirt.io/storage.deleteAfterCompletion: "false"
+      name: cirros
+      namespace: cirros-test
+    spec:
+      pvc:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 128Mi
+      source:
+        http:
+          url: https://download.cirros-cloud.net/0.6.2/cirros-0.6.2-x86_64-disk.img
+  - apiVersion: cdi.kubevirt.io/v1beta1
+    kind: DataSource
+    metadata:
+      name: cirros
+      namespace: cirros-test
+    spec:
+      source:
+        pvc:
+          name: cirros
+          namespace: cirros-test


### PR DESCRIPTION
## Why the changes were made
a nice to have for humans manually testing virt
and oadp together.

## How to test the changes made

* install virt operator
```
cd  oadp-operator/tests/e2e/sample-applications/virtual-machines/cirros-test/
oc create namespace cirros-test
oc create -f cirros-ds.yaml
# check for complete
oc create -f cirros-test.yaml
```
