### PR TITLE
fix MakeFile ,  permissions for rm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -389,7 +389,7 @@ deploy-olm: operator-sdk undeploy-olm ## Build current branch operator image, bu
 	cp -r . $(DEPLOY_TMP) && cd $(DEPLOY_TMP) && \
 	IMG=$(THIS_OPERATOR_IMAGE) BUNDLE_IMG=$(THIS_BUNDLE_IMAGE) \
 		make docker-build docker-push bundle bundle-build bundle-push; \
-	rm -rf $(DEPLOY_TMP)
+	chmod -R 777 ${DEPLOY_TMP} && rm -rf $(DEPLOY_TMP)
 	$(OPERATOR_SDK) run bundle --security-context-config restricted $(THIS_BUNDLE_IMAGE) --namespace $(OADP_TEST_NAMESPACE)
 
 .PHONY: undeploy-olm


### PR DESCRIPTION
Not sure why this isn't getting other folks, but OADP-1.4 branch hits it.

to test: make deploy-olm on oadp-1.4 two or more times

## Why the changes were made

After running make deploy-olm > 1 times I'm still hitting this

## How to test the changes made

execute make deploy-olm on Fedora 40 more than once :) 