### PR TITLE
fix: update OADP version relation with plugins 

### DIFF
--- a/docs/developer/PROW_CI.md
+++ b/docs/developer/PROW_CI.md
@@ -42,7 +42,7 @@ The configuration for [OADP's Velero plugin for Microsoft Azure repo](https://gi
 - https://github.com/openshift/release/tree/master/ci-operator/config/openshift/velero-plugin-for-microsoft-azure
 - https://github.com/openshift/release/tree/master/ci-operator/jobs/openshift/velero-plugin-for-microsoft-azure
 
-The configuration for [OADP's Velero plugin for CSI repo](https://github.com/openshift/velero-plugin-for-csi) can be found in
+The configuration for [OADP's Velero plugin for CSI repo](https://github.com/openshift/velero-plugin-for-csi) can be found in (OADP < 1.4)
 - https://github.com/openshift/release/tree/master/core-services/prow/02_config/openshift/velero-plugin-for-csi
 - https://github.com/openshift/release/tree/master/ci-operator/config/openshift/velero-plugin-for-csi
 - https://github.com/openshift/release/tree/master/ci-operator/jobs/openshift/velero-plugin-for-csi

--- a/docs/developer/PROW_CI.md
+++ b/docs/developer/PROW_CI.md
@@ -52,7 +52,7 @@ The configuration for [OADP's restic repo](https://github.com/openshift/restic) 
 - https://github.com/openshift/release/tree/master/ci-operator/config/openshift/restic
 - https://github.com/openshift/release/tree/master/ci-operator/jobs/openshift/restic
 
-The configuration for [Non Admin repo](https://github.com/migtools/oadp-non-admin) can be found in (OADP >= 1.4)
+The configuration for [Non Admin repo](https://github.com/migtools/oadp-non-admin) can be found in (OADP >= 1.5)
 - https://github.com/openshift/release/tree/master/core-services/prow/02_config/migtools/oadp-non-admin
 - https://github.com/openshift/release/tree/master/ci-operator/config/migtools/oadp-non-admin
 - https://github.com/openshift/release/tree/master/ci-operator/jobs/migtools/oadp-non-admin


### PR DESCRIPTION
## Why the changes were made

Fix non admin schedule and csi plugin removed from OADP 1.4.

## How to test the changes made

Check that all necessary places were modified.
