### PR TITLE
doc: Upgrade instructions from 1.3 to 1.4

### DIFF
--- a/docs/install_olm.md
+++ b/docs/install_olm.md
@@ -89,57 +89,57 @@ spec:
 
 ### Verify install
 
+* Verify the DPA has been reconciled successfully:
+
+  ```
+  oc get dpa dpa-sample -n openshift-adp -o jsonpath='{.status}'
+  ```
+
+  Example Output:
+  ```
+  {"conditions":[{"lastTransitionTime":"2023-10-27T01:23:57Z","message":"Reconcile complete","reason":"Complete","status":"True","type":"Reconciled"}]}
+  ```
+
+  **Note**: the `type` is set to `Reconciled` and `status` is set to `True`.
+
 * To verify all of the correct resources have been created, the following command
 `oc get all -n openshift-adp` should look similar to:
+  ```
+  NAME                                                    READY   STATUS    RESTARTS   AGE
+  pod/node-agent-9pjz9                                    1/1     Running   0          3d17h
+  pod/node-agent-fmn84                                    1/1     Running   0          3d17h
+  pod/node-agent-xw2dg                                    1/1     Running   0          3d17h
+  pod/openshift-adp-controller-manager-76b8bc8d7b-kgkcw   1/1     Running   0          3d17h
+  pod/velero-64475b8c5b-nh2qc                             1/1     Running   0          3d17h
 
-**Note**: The node-agent pods are labeled as `restic` in older installations.
+  NAME                                                       TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)    AGE
+  service/openshift-adp-controller-manager-metrics-service   ClusterIP   172.30.194.192   <none>        8443/TCP   3d17h
+  service/openshift-adp-velero-metrics-svc                   ClusterIP   172.30.190.174   <none>        8085/TCP   3d17h
 
-```
-NAME                                                    READY   STATUS    RESTARTS   AGE
-pod/node-agent-9pjz9                                    1/1     Running   0          3d17h
-pod/node-agent-fmn84                                    1/1     Running   0          3d17h
-pod/node-agent-xw2dg                                    1/1     Running   0          3d17h
-pod/openshift-adp-controller-manager-76b8bc8d7b-kgkcw   1/1     Running   0          3d17h
-pod/velero-64475b8c5b-nh2qc                             1/1     Running   0          3d17h
+  NAME                        DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
+  daemonset.apps/node-agent   3         3         3       3            3           <none>          3d17h
 
-NAME                                                       TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)    AGE
-service/openshift-adp-controller-manager-metrics-service   ClusterIP   172.30.194.192   <none>        8443/TCP   3d17h
-service/openshift-adp-velero-metrics-svc                   ClusterIP   172.30.190.174   <none>        8085/TCP   3d17h
+  NAME                                               READY   UP-TO-DATE   AVAILABLE   AGE
+  deployment.apps/openshift-adp-controller-manager   1/1     1            1           3d17h
+  deployment.apps/velero                             1/1     1            1           3d17h
 
-NAME                        DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
-daemonset.apps/node-agent   3         3         3       3            3           <none>          3d17h
+  NAME                                                          DESIRED   CURRENT   READY   AGE
+  replicaset.apps/openshift-adp-controller-manager-76b8bc8d7b   1         1         1       3d17h
+  replicaset.apps/openshift-adp-controller-manager-85fff975b8   0         0         0       3d17h
+  replicaset.apps/velero-64475b8c5b                             1         1         1       3d17h
+  replicaset.apps/velero-8b5bc54fd                              0         0         0       3d17h
+  replicaset.apps/velero-f5c9ffb66                              0         0         0       3d17h
+  ```
 
-NAME                                               READY   UP-TO-DATE   AVAILABLE   AGE
-deployment.apps/openshift-adp-controller-manager   1/1     1            1           3d17h
-deployment.apps/velero                             1/1     1            1           3d17h
+  **Note**: The node-agent Pods are created only if using `restic` or `kopia` in DPA.
 
-NAME                                                          DESIRED   CURRENT   READY   AGE
-replicaset.apps/openshift-adp-controller-manager-76b8bc8d7b   1         1         1       3d17h
-replicaset.apps/openshift-adp-controller-manager-85fff975b8   0         0         0       3d17h
-replicaset.apps/velero-64475b8c5b                             1         1         1       3d17h
-replicaset.apps/velero-8b5bc54fd                              0         0         0       3d17h
-replicaset.apps/velero-f5c9ffb66                              0         0         0       3d17h
+  **Note**: The node-agent Pods are labeled as `restic` in older installations.
 
-```
+* Verify the BackupStorageLocations
+  ```
+  oc get backupStorageLocation -n openshift-adp
+  NAME           PHASE       LAST VALIDATED   AGE     DEFAULT
+  dpa-sample-1   Available   1s               3d16h   true
+  ```
 
-* Verify the DPA has been reconciled:
-
-```
-oc get dpa dpa-sample -n openshift-adp -o jsonpath='{.status}'
-```
-
-Example Output:
-```
-{"conditions":[{"lastTransitionTime":"2023-10-27T01:23:57Z","message":"Reconcile complete","reason":"Complete","status":"True","type":"Reconciled"}]}
-```
-
-Note: the `type` is set to `Reconciled`
-
-* Verify the BackupStorageLocation
-```
-oc get backupStorageLocation -n openshift-adp
-NAME           PHASE       LAST VALIDATED   AGE     DEFAULT
-dpa-sample-1   Available   1s               3d16h   true
-```
-
-Note: the `PHASE` is in `Available`
+  **Note**: the `PHASE` set to `Available`.

--- a/docs/upgrade_1-3_to_1-4.md
+++ b/docs/upgrade_1-3_to_1-4.md
@@ -1,0 +1,53 @@
+# Upgrading from OADP 1.3
+
+> **NOTE:** Always upgrade to next minor version, do NOT skip versions. To update to higher version, please upgrade one channel at a time. Example: to upgrade from 1.1 to 1.3, upgrade first to 1.2, then to 1.3.
+
+## Changes from OADP 1.3 to 1.4
+
+- Velero was updated from version 1.12 to 1.14 (Changes reference: https://velero.io/docs/v1.13/upgrade-to-1.13/ https://velero.io/docs/v1.14/upgrade-to-1.14/)
+
+    From this update:
+
+    - TODO CSI?
+
+    - Velero changed client Burst and QPS defaults from 30 and 20 to 100 and 100, respectively. If you want to change these values, use new `spec.configuration.velero.client-burst` and `spec.configuration.velero.client-qps` fields.
+
+    - Non AWS object storages that use AWS plugin need a new `spec.backupLocations[].velero.config.checksumAlgorithm` field to be set in DPA to them to work in OADP 1.4.
+
+- TODO image pull policy override
+
+## Upgrade steps
+
+### Backup the DPA configuration
+
+Save your current DataProtectionApplication (DPA) CustomResource config, be sure to remember the values.
+
+For example:
+```
+oc get dpa -n openshift-adp -o yaml > dpa.orig.backup
+```
+
+### Upgrade the OADP Operator
+
+For general operator upgrade instructions please review the [OpenShift documentation](https://docs.openshift.com/container-platform/4.13/operators/admin/olm-upgrading-operators.html)
+* Change the Subscription for the OADP Operator from `stable-1.3` to `stable-1.4`
+* Allow time for the operator and containers to update and restart
+
+### Convert your DPA to the new version
+
+If you are using an object storage compatible with AWS (different then AWS itself) and using AWS plugin, you need to add new `spec.backupLocations[].velero.config.checksumAlgorithm` field with an empty string as value to your DPA. Example
+```diff
+ spec:
+   backupLocations:
+     - velero:
+         config:
+           profile: default
+           region: <region>
+           s3ForcePathStyle: 'true'
+           s3Url: <url>
++          checksumAlgorithm: ""
+```
+
+### Verify the upgrade
+
+Follow theses [basic install verification](../docs/install_olm.md#verify-install) to verify the installation.

--- a/docs/upgrade_1-3_to_1-4.md
+++ b/docs/upgrade_1-3_to_1-4.md
@@ -12,7 +12,9 @@
 
     - Velero changed client Burst and QPS defaults from 30 and 20 to 100 and 100, respectively.
 
-    - velero-plugin-for-aws updated default value of `spec.config.checksumAlgorithm` field in BackupStorageLocations (BSLs) from `""` (no checksum calculation) to `CRC32` (reference https://github.com/vmware-tanzu/velero-plugin-for-aws/blob/release-1.10/backupstoragelocation.md). For compatibility, OADP did not change default value of the field for BSLs created within DPA (and if you want to change it, use `spec.backupLocations[].velero.config.checksumAlgorithm` field). If your BSLs are created outside DPA, you may need to change value of the `spec.config.checksumAlgorithm` field in the BSLs. Some compatible S3 storages, like IBM, currently only work with `""` value.
+    - velero-plugin-for-aws updated default value of `spec.config.checksumAlgorithm` field in BackupStorageLocations (BSLs) from `""` (no checksum calculation) to `CRC32` algorithm (reference https://github.com/vmware-tanzu/velero-plugin-for-aws/blob/release-1.10/backupstoragelocation.md). The checksum algorithm types are known to work only with AWS. Several S3 providers require the md5sum to be disabled (setting checksum algorithm to `""`). Please confirm with your storage provider with regards to the md5sum algorithm support and configuration.
+
+        OADP 1.4 default value for BSLs created within DPA for this configuration is `""`, meaning the md5sum is not checked (which is consistent with OADP 1.3). For BSLs created within DPA, this can be updated by using `spec.backupLocations[].velero.config.checksumAlgorithm` field in the DPA. If your BSLs are created outside DPA, this configuration can be updated by using `spec.config.checksumAlgorithm` field in the BSLs.
 
 ## Upgrade steps
 
@@ -33,7 +35,7 @@ For general operator upgrade instructions please review the [OpenShift documenta
 
 ### Convert your DPA to the new version
 
-No changes.
+No DPA changes are required to upgrade from OADP 1.3 to 1.4.
 
 ### Verify the upgrade
 

--- a/docs/upgrade_1-3_to_1-4.md
+++ b/docs/upgrade_1-3_to_1-4.md
@@ -8,13 +8,11 @@
 
     From this update:
 
-    - TODO CSI?
+    - velero-plugin-for-csi code is now inside Velero code, which means, no init container is needed for the plugin anymore. No changes needed in DPA.
 
-    - Velero changed client Burst and QPS defaults from 30 and 20 to 100 and 100, respectively. If you want to change these values, use new `spec.configuration.velero.client-burst` and `spec.configuration.velero.client-qps` fields.
+    - Velero changed client Burst and QPS defaults from 30 and 20 to 100 and 100, respectively.
 
-    - Non AWS object storages that use AWS plugin need a new `spec.backupLocations[].velero.config.checksumAlgorithm` field to be set in DPA to them to work in OADP 1.4.
-
-- TODO image pull policy override
+    - velero-plugin-for-aws updated default value of `spec.config.checksumAlgorithm` field in BackupStorageLocations (BSLs) from `""` (no checksum calculation) to `CRC32` (reference https://github.com/vmware-tanzu/velero-plugin-for-aws/blob/release-1.10/backupstoragelocation.md). For compatibility, OADP did not change default value of the field for BSLs created within DPA (and if you want to change it, use `spec.backupLocations[].velero.config.checksumAlgorithm` field). If your BSLs are created outside DPA, you may need to change value of the `spec.config.checksumAlgorithm` field in the BSLs. Some compatible S3 storages, like IBM, currently only work with `""` value.
 
 ## Upgrade steps
 
@@ -35,19 +33,14 @@ For general operator upgrade instructions please review the [OpenShift documenta
 
 ### Convert your DPA to the new version
 
-If you are using an object storage compatible with AWS (different then AWS itself) and using AWS plugin, you need to add new `spec.backupLocations[].velero.config.checksumAlgorithm` field with an empty string as value to your DPA. Example
-```diff
- spec:
-   backupLocations:
-     - velero:
-         config:
-           profile: default
-           region: <region>
-           s3ForcePathStyle: 'true'
-           s3Url: <url>
-+          checksumAlgorithm: ""
-```
+No changes.
 
 ### Verify the upgrade
 
 Follow theses [basic install verification](../docs/install_olm.md#verify-install) to verify the installation.
+
+## Changes from OADP 1.4.0 to 1.4.1
+
+- If you want to change client Burst and QPS values, use new `spec.configuration.velero.client-burst` and `spec.configuration.velero.client-qps` fields.
+
+- TODO image pull policy override and default behavior


### PR DESCRIPTION
## Why the changes were made

Add steps to upgrade from OADP 1.3 to 1.4.

## How to test the changes made

Check if all changes were documented.

Check that all necessary changes were documented.

Test an upgrade following [upgrade test documentation](https://github.com/openshift/oadp-operator/blob/master/docs/developer/testing/test_oadp_version_upgrade.md).
