### PR TITLE
Fix OADP-4274: Backups failing for S3 compatible storage providers due to AWS SDK upgrade

### DIFF
--- a/controllers/bsl.go
+++ b/controllers/bsl.go
@@ -252,6 +252,15 @@ func (r *DPAReconciler) updateBSLFromSpec(bsl *velerov1.BackupStorageLocation, d
 				bslSpec.Config["s3Url"] = s3Url
 			}
 		}
+
+		// Since the AWS SDK upgrade in velero-plugin-for-aws, data transfer to BSL bucket fails unless
+		// we specify the checksumAlgorithm. We will set it empty string if checksumAlgorithm is not specified by the user
+		// Setting it to an empty string will default to using the CRC32 algorithm for checksum calculation.
+		checksumAlgorithm := bslSpec.Config[checksumAlgorithm]
+		if len(s3Url) > 0 && len(checksumAlgorithm) == 0 {
+			bslSpec.Config["checksumAlgorithm"] = ""
+		}
+
 	}
 	bsl.Labels = map[string]string{
 		"app.kubernetes.io/name":     common.OADPOperatorVelero,

--- a/controllers/bsl.go
+++ b/controllers/bsl.go
@@ -236,7 +236,7 @@ func (r *DPAReconciler) updateBSLFromSpec(bsl *velerov1.BackupStorageLocation, d
 	// However, the registry deployment fails without a valid storage account key.
 	// This logic prevents the registry pods from being deployed if Azure SP is used as an auth mechanism.
 	registryDeployment := "True"
-	if bslSpec.Provider == "azure" {
+	if bslSpec.Provider == "azure" && bslSpec.Config != nil {
 		if len(bslSpec.Config["storageAccountKeyEnvVar"]) == 0 {
 			registryDeployment = "False"
 		}
@@ -245,7 +245,7 @@ func (r *DPAReconciler) updateBSLFromSpec(bsl *velerov1.BackupStorageLocation, d
 	// (80 for HTTP and 443 for HTTPS) before calculating a signature, and not
 	// all S3-compatible services do this. Remove the ports here to avoid 403
 	// errors from mismatched signatures.
-	if bslSpec.Provider == "aws" {
+	if bslSpec.Provider == "aws" && bslSpec.Config != nil {
 		s3Url := bslSpec.Config["s3Url"]
 		if len(s3Url) > 0 {
 			if s3Url, err = common.StripDefaultPorts(s3Url); err == nil {
@@ -261,7 +261,6 @@ func (r *DPAReconciler) updateBSLFromSpec(bsl *velerov1.BackupStorageLocation, d
 		if _, exists := bslSpec.Config[checksumAlgorithm]; !exists {
 			bslSpec.Config[checksumAlgorithm] = ""
 		}
-
 	}
 	bsl.Labels = map[string]string{
 		"app.kubernetes.io/name":     common.OADPOperatorVelero,

--- a/controllers/bsl.go
+++ b/controllers/bsl.go
@@ -254,9 +254,11 @@ func (r *DPAReconciler) updateBSLFromSpec(bsl *velerov1.BackupStorageLocation, d
 		}
 
 		// Since the AWS SDK upgrade in velero-plugin-for-aws, data transfer to BSL bucket fails unless
-		// we specify the checksumAlgorithm. We will set it empty string if checksumAlgorithm is not specified by the user
-		// Setting it to an empty string will default to using the CRC32 algorithm for checksum calculation.
-		if _, exists := bslSpec.Config[checksumAlgorithm]; len(s3Url) > 0 && !exists {
+		// if the chosen checksumAlgorithm doesn't work for the provider. Velero sets this to CRC32 if not
+		// chosen by the user. We will set it empty string if checksumAlgorithm is not specified by the user
+		// to bypass checksum calculation entirely. If your s3 provider supports checksum calculation,
+		// then you should specify this value in the config.
+		if _, exists := bslSpec.Config[checksumAlgorithm]; !exists {
 			bslSpec.Config[checksumAlgorithm] = ""
 		}
 

--- a/controllers/bsl.go
+++ b/controllers/bsl.go
@@ -257,7 +257,7 @@ func (r *DPAReconciler) updateBSLFromSpec(bsl *velerov1.BackupStorageLocation, d
 		// we specify the checksumAlgorithm. We will set it empty string if checksumAlgorithm is not specified by the user
 		// Setting it to an empty string will default to using the CRC32 algorithm for checksum calculation.
 		if _, exists := bslSpec.Config[checksumAlgorithm]; len(s3Url) > 0 && !exists {
-			bslSpec.Config["checksumAlgorithm"] = ""
+			bslSpec.Config[checksumAlgorithm] = ""
 		}
 
 	}

--- a/controllers/bsl.go
+++ b/controllers/bsl.go
@@ -256,8 +256,7 @@ func (r *DPAReconciler) updateBSLFromSpec(bsl *velerov1.BackupStorageLocation, d
 		// Since the AWS SDK upgrade in velero-plugin-for-aws, data transfer to BSL bucket fails unless
 		// we specify the checksumAlgorithm. We will set it empty string if checksumAlgorithm is not specified by the user
 		// Setting it to an empty string will default to using the CRC32 algorithm for checksum calculation.
-		checksumAlgorithm := bslSpec.Config[checksumAlgorithm]
-		if len(s3Url) > 0 && len(checksumAlgorithm) == 0 {
+		if _, exists := bslSpec.Config[checksumAlgorithm]; len(s3Url) > 0 && !exists {
 			bslSpec.Config["checksumAlgorithm"] = ""
 		}
 

--- a/controllers/bsl.go
+++ b/controllers/bsl.go
@@ -253,7 +253,7 @@ func (r *DPAReconciler) updateBSLFromSpec(bsl *velerov1.BackupStorageLocation, d
 			}
 		}
 
-		// Since the AWS SDK upgrade in velero-plugin-for-aws, data transfer to BSL bucket fails unless
+		// Since the AWS SDK upgrade in velero-plugin-for-aws, data transfer to BSL bucket fails
 		// if the chosen checksumAlgorithm doesn't work for the provider. Velero sets this to CRC32 if not
 		// chosen by the user. We will set it empty string if checksumAlgorithm is not specified by the user
 		// to bypass checksum calculation entirely. If your s3 provider supports checksum calculation,

--- a/controllers/bsl_test.go
+++ b/controllers/bsl_test.go
@@ -2065,6 +2065,9 @@ func TestDPAReconciler_ReconcileBackupStorageLocations(t *testing.T) {
 						{
 							Velero: &velerov1.BackupStorageLocationSpec{
 								Provider: "aws",
+								Config: map[string]string{
+									Region: "us-east-1",
+								},
 							},
 						},
 					},
@@ -2180,6 +2183,9 @@ func TestDPAReconciler_ReconcileBackupStorageLocations(t *testing.T) {
 							{
 								Velero: &velerov1.BackupStorageLocationSpec{
 									Provider: "aws",
+									Config: map[string]string{
+										Region: "us-east-1",
+									},
 									StorageType: velerov1.StorageType{
 										ObjectStorage: &velerov1.ObjectStorageLocation{
 											Prefix: "test-prefix",
@@ -2213,6 +2219,10 @@ func TestDPAReconciler_ReconcileBackupStorageLocations(t *testing.T) {
 				},
 				Spec: velerov1.BackupStorageLocationSpec{
 					Provider: "aws",
+					Config: map[string]string{
+						Region:            "us-east-1",
+						checksumAlgorithm: "",
+					},
 					StorageType: velerov1.StorageType{
 						ObjectStorage: &velerov1.ObjectStorageLocation{
 							Prefix: "test-prefix",
@@ -2313,6 +2323,9 @@ func TestDPAReconciler_ReconcileBackupStorageLocations(t *testing.T) {
 							{
 								Velero: &velerov1.BackupStorageLocationSpec{
 									Provider: "aws",
+									Config: map[string]string{
+										Region: "us-east-1",
+									},
 									StorageType: velerov1.StorageType{
 										ObjectStorage: &velerov1.ObjectStorageLocation{
 											Bucket: "test-bucket",
@@ -2348,6 +2361,10 @@ func TestDPAReconciler_ReconcileBackupStorageLocations(t *testing.T) {
 				},
 				Spec: velerov1.BackupStorageLocationSpec{
 					Provider: "aws",
+					Config: map[string]string{
+						Region:            "us-east-1",
+						checksumAlgorithm: "",
+					},
 					StorageType: velerov1.StorageType{
 						ObjectStorage: &velerov1.ObjectStorageLocation{
 							Prefix: "test-prefix",

--- a/controllers/bsl_test.go
+++ b/controllers/bsl_test.go
@@ -1591,7 +1591,8 @@ func TestDPAReconciler_updateBSLFromSpec(t *testing.T) {
 						},
 					},
 					Config: map[string]string{
-						Region: "test-region",
+						Region:            "test-region",
+						checksumAlgorithm: "",
 					},
 					Credential: &corev1.SecretKeySelector{
 						LocalObjectReference: corev1.LocalObjectReference{
@@ -1605,7 +1606,7 @@ func TestDPAReconciler_updateBSLFromSpec(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "checksumAlgorithm config is not specified by the user, add it as an empty string for s3-compatible BSL",
+			name: "checksumAlgorithm config is not specified by the user, add it as an empty string for BSL config",
 			bsl: &velerov1.BackupStorageLocation{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo-1",
@@ -1624,15 +1625,12 @@ func TestDPAReconciler_updateBSLFromSpec(t *testing.T) {
 								Provider: "aws",
 								StorageType: velerov1.StorageType{
 									ObjectStorage: &velerov1.ObjectStorageLocation{
-										Bucket: "test-noobaa-bucket",
+										Bucket: "test-aws-bucket",
 										Prefix: "velero",
 									},
 								},
 								Config: map[string]string{
-									Region:           "nooba",
-									Profile:          "nooba",
-									S3ForcePathStyle: "true",
-									S3URL:            "https://s3-compatible-storage-provider-like-noobaa-minio-etc.com",
+									Region: "test-region",
 								},
 								Credential: &corev1.SecretKeySelector{
 									LocalObjectReference: corev1.LocalObjectReference{
@@ -1672,15 +1670,12 @@ func TestDPAReconciler_updateBSLFromSpec(t *testing.T) {
 					Provider: "aws",
 					StorageType: velerov1.StorageType{
 						ObjectStorage: &velerov1.ObjectStorageLocation{
-							Bucket: "test-noobaa-bucket",
+							Bucket: "test-aws-bucket",
 							Prefix: "velero",
 						},
 					},
 					Config: map[string]string{
-						Region:            "nooba",
-						Profile:           "nooba",
-						S3ForcePathStyle:  "true",
-						S3URL:             "https://s3-compatible-storage-provider-like-noobaa-minio-etc.com",
+						Region:            "test-region",
 						checksumAlgorithm: "",
 					},
 					Credential: &corev1.SecretKeySelector{

--- a/controllers/bsl_test.go
+++ b/controllers/bsl_test.go
@@ -1519,6 +1519,7 @@ func TestDPAReconciler_updateBSLFromSpec(t *testing.T) {
 		name    string
 		bsl     *velerov1.BackupStorageLocation
 		dpa     *oadpv1alpha1.DataProtectionApplication
+		wantBSL *velerov1.BackupStorageLocation
 		wantErr bool
 	}{
 		{
@@ -1534,7 +1535,164 @@ func TestDPAReconciler_updateBSLFromSpec(t *testing.T) {
 					Name:      "foo",
 					Namespace: "bar",
 				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					BackupLocations: []oadpv1alpha1.BackupLocation{
+						{
+							Velero: &velerov1.BackupStorageLocationSpec{
+								Provider: "aws",
+								StorageType: velerov1.StorageType{
+									ObjectStorage: &velerov1.ObjectStorageLocation{
+										Bucket: "test-aws-bucket",
+										Prefix: "velero",
+									},
+								},
+								Config: map[string]string{
+									Region: "test-region",
+								},
+								Credential: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "cloud-credentials",
+									},
+									Key: "cloud",
+								},
+								Default: true,
+							},
+						},
+					},
+				},
 			},
+			wantBSL: &velerov1.BackupStorageLocation{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo-1",
+					Namespace: "bar",
+					Labels: map[string]string{
+						"app.kubernetes.io/name":     "oadp-operator-velero",
+						"app.kubernetes.io/instance": "foo" + "-1",
+						//"app.kubernetes.io/version":    "x.y.z",
+						"app.kubernetes.io/managed-by":       "oadp-operator",
+						"app.kubernetes.io/component":        "bsl",
+						oadpv1alpha1.OadpOperatorLabel:       "True",
+						oadpv1alpha1.RegistryDeploymentLabel: "True",
+					},
+					OwnerReferences: []metav1.OwnerReference{{
+						APIVersion:         oadpv1alpha1.SchemeBuilder.GroupVersion.String(),
+						Kind:               "DataProtectionApplication",
+						Name:               "foo",
+						Controller:         pointer.BoolPtr(true),
+						BlockOwnerDeletion: pointer.BoolPtr(true),
+					}},
+				},
+				Spec: velerov1.BackupStorageLocationSpec{
+					Provider: "aws",
+					StorageType: velerov1.StorageType{
+						ObjectStorage: &velerov1.ObjectStorageLocation{
+							Bucket: "test-aws-bucket",
+							Prefix: "velero",
+						},
+					},
+					Config: map[string]string{
+						Region: "test-region",
+					},
+					Credential: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "cloud-credentials",
+						},
+						Key: "cloud",
+					},
+					Default: true,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "checksumAlgorithm config is not specified by the user, add it as an empty string for s3-compatible BSL",
+			bsl: &velerov1.BackupStorageLocation{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo-1",
+					Namespace: "bar",
+				},
+			},
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "bar",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					BackupLocations: []oadpv1alpha1.BackupLocation{
+						{
+							Velero: &velerov1.BackupStorageLocationSpec{
+								Provider: "aws",
+								StorageType: velerov1.StorageType{
+									ObjectStorage: &velerov1.ObjectStorageLocation{
+										Bucket: "test-noobaa-bucket",
+										Prefix: "velero",
+									},
+								},
+								Config: map[string]string{
+									Region:           "nooba",
+									Profile:          "nooba",
+									S3ForcePathStyle: "true",
+									S3URL:            "https://s3-compatible-storage-provider-like-noobaa-minio-etc.com",
+								},
+								Credential: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "cloud-credentials",
+									},
+									Key: "cloud",
+								},
+								Default: true,
+							},
+						},
+					},
+				},
+			},
+
+			wantBSL: &velerov1.BackupStorageLocation{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo-1",
+					Namespace: "bar",
+					Labels: map[string]string{
+						"app.kubernetes.io/name":     "oadp-operator-velero",
+						"app.kubernetes.io/instance": "foo" + "-1",
+						//"app.kubernetes.io/version":    "x.y.z",
+						"app.kubernetes.io/managed-by":       "oadp-operator",
+						"app.kubernetes.io/component":        "bsl",
+						oadpv1alpha1.OadpOperatorLabel:       "True",
+						oadpv1alpha1.RegistryDeploymentLabel: "True",
+					},
+					OwnerReferences: []metav1.OwnerReference{{
+						APIVersion:         oadpv1alpha1.SchemeBuilder.GroupVersion.String(),
+						Kind:               "DataProtectionApplication",
+						Name:               "foo",
+						Controller:         pointer.BoolPtr(true),
+						BlockOwnerDeletion: pointer.BoolPtr(true),
+					}},
+				},
+				Spec: velerov1.BackupStorageLocationSpec{
+					Provider: "aws",
+					StorageType: velerov1.StorageType{
+						ObjectStorage: &velerov1.ObjectStorageLocation{
+							Bucket: "test-noobaa-bucket",
+							Prefix: "velero",
+						},
+					},
+					Config: map[string]string{
+						Region:            "nooba",
+						Profile:           "nooba",
+						S3ForcePathStyle:  "true",
+						S3URL:             "https://s3-compatible-storage-provider-like-noobaa-minio-etc.com",
+						checksumAlgorithm: "",
+					},
+					Credential: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "cloud-credentials",
+						},
+						Key: "cloud",
+					},
+					Default: true,
+				},
+			},
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {
@@ -1547,40 +1705,19 @@ func TestDPAReconciler_updateBSLFromSpec(t *testing.T) {
 				Scheme: scheme,
 			}
 
-			wantBSl := &velerov1.BackupStorageLocation{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "foo-1",
-					Namespace: "bar",
-					Labels: map[string]string{
-						"app.kubernetes.io/name":     "oadp-operator-velero",
-						"app.kubernetes.io/instance": tt.dpa.Name + "-1",
-						//"app.kubernetes.io/version":    "x.y.z",
-						"app.kubernetes.io/managed-by":       "oadp-operator",
-						"app.kubernetes.io/component":        "bsl",
-						oadpv1alpha1.OadpOperatorLabel:       "True",
-						oadpv1alpha1.RegistryDeploymentLabel: "True",
-					},
-					OwnerReferences: []metav1.OwnerReference{{
-						APIVersion:         oadpv1alpha1.SchemeBuilder.GroupVersion.String(),
-						Kind:               "DataProtectionApplication",
-						Name:               tt.dpa.Name,
-						UID:                tt.dpa.UID,
-						Controller:         pointer.BoolPtr(true),
-						BlockOwnerDeletion: pointer.BoolPtr(true),
-					}},
-				},
-			}
-
-			err = r.updateBSLFromSpec(tt.bsl, tt.dpa, tt.bsl.Spec)
+			err = r.updateBSLFromSpec(tt.bsl, tt.dpa, *tt.dpa.Spec.BackupLocations[0].Velero)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("updateBSLFromSpec() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(tt.bsl.Labels, wantBSl.Labels) {
-				t.Errorf("expected bsl labels to be %#v, got %#v", wantBSl.Labels, tt.bsl.Labels)
+			if !reflect.DeepEqual(tt.bsl.Labels, tt.wantBSL.Labels) {
+				t.Errorf("expected bsl labels to be %#v, got %#v", tt.wantBSL.Labels, tt.bsl.Labels)
 			}
-			if !reflect.DeepEqual(tt.bsl.OwnerReferences, wantBSl.OwnerReferences) {
-				t.Errorf("expected bsl owner references to be %#v, got %#v", wantBSl.OwnerReferences, tt.bsl.OwnerReferences)
+			if !reflect.DeepEqual(tt.bsl.OwnerReferences, tt.wantBSL.OwnerReferences) {
+				t.Errorf("expected bsl owner references to be %#v, got %#v", tt.wantBSL.OwnerReferences, tt.bsl.OwnerReferences)
+			}
+			if !reflect.DeepEqual(tt.bsl.Spec, tt.wantBSL.Spec) {
+				t.Errorf("expected bsl Spec to be %#v, got %#v", tt.wantBSL.Spec, tt.bsl.Spec)
 			}
 		})
 	}

--- a/controllers/registry.go
+++ b/controllers/registry.go
@@ -61,6 +61,7 @@ const (
 	Profile               = "profile"
 	S3URL                 = "s3Url"
 	S3ForcePathStyle      = "s3ForcePathStyle"
+	checksumAlgorithm     = "checksumAlgorithm"
 	InsecureSkipTLSVerify = "insecureSkipTLSVerify"
 	StorageAccount        = "storageAccount"
 	ResourceGroup         = "resourceGroup"


### PR DESCRIPTION
## Why the changes were made

<!-- Explain why this PR is important, what problems it fixes, link related issues -->
Fixes JIRA: https://issues.redhat.com/browse/OADP-4274 
Backups were failing for s3 compatible storage providers due to AWS SDK upgrade done for velero-plugin-for-aws.
Post upgrade the expected config from the user is changed, it needs some value for `checksumAlgorithm` param under BSL config.
This PR adds the `checksumAlgorithm` config value as an empty string if not specified by the user for s3 compatible storage providers (if string is empty then aws uses CRC32 as the algorithm for checksum computation to ensure data integrity)

## How to test the changes made
- Install OADP and configure a DPA for S3 compatible storage provider like noobaa, IBM, minio etc and do not specify the `checksumAlgorithm` config param under BSL config
- Verify that you can create a successful backup
<!-- Explain how the changes introduced by this PR can be tested and verified, with commands and pictures -->

