### PR TITLE
[oadp-1.0] fix: CI unit test (envtest version) (#1375)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -219,7 +219,7 @@ kustomize: ## Download kustomize locally if necessary.
 
 ENVTEST = $(shell pwd)/bin/setup-envtest
 envtest: ## Download envtest-setup locally if necessary.
-	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@latest)
+	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20240320141353-395cfc7486e6)
 
 # Codecov OS String for use in download url
 ifeq ($(OS),Windows_NT)


### PR DESCRIPTION
This is a cherry-pick of https://github.com/openshift/oadp-operator/pull/1375