### PR TITLE
[oadp-1.3] bump kubevirt to 0.6.2

### DIFF
--- a/bundle/manifests/oadp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/oadp-operator.clusterserviceversion.yaml
@@ -858,7 +858,7 @@ spec:
                 - name: RELATED_IMAGE_VELERO_PLUGIN_FOR_CSI
                   value: quay.io/konveyor/velero-plugin-for-csi:oadp-1.3
                 - name: RELATED_IMAGE_KUBEVIRT_VELERO_PLUGIN
-                  value: quay.io/konveyor/kubevirt-velero-plugin:v0.2.0
+                  value: quay.io/konveyor/kubevirt-velero-plugin:v0.6.2
                 - name: RELATED_IMAGE_MUSTGATHER
                   value: registry.redhat.io/oadp/oadp-mustgather-rhel8:v1.2
                 image: quay.io/konveyor/oadp-operator:oadp-1.3
@@ -1008,7 +1008,7 @@ spec:
     name: velero-plugin-for-gcp
   - image: quay.io/konveyor/velero-plugin-for-csi:oadp-1.3
     name: velero-plugin-for-csi
-  - image: quay.io/konveyor/kubevirt-velero-plugin:v0.2.0
+  - image: quay.io/konveyor/kubevirt-velero-plugin:v0.6.2
     name: kubevirt-velero-plugin
   - image: registry.redhat.io/oadp/oadp-mustgather-rhel8:v1.2
     name: mustgather

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -51,7 +51,7 @@ spec:
           - name: RELATED_IMAGE_VELERO_PLUGIN_FOR_CSI
             value: quay.io/konveyor/velero-plugin-for-csi:oadp-1.3
           - name: RELATED_IMAGE_KUBEVIRT_VELERO_PLUGIN
-            value: quay.io/konveyor/kubevirt-velero-plugin:v0.2.0
+            value: quay.io/konveyor/kubevirt-velero-plugin:v0.6.2
           - name: RELATED_IMAGE_MUSTGATHER
             value: registry.redhat.io/oadp/oadp-mustgather-rhel8:v1.2
         args:

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -66,7 +66,7 @@ const (
 	GCPPluginImage       = "quay.io/konveyor/velero-plugin-for-gcp:latest"
 	CSIPluginImage       = "quay.io/konveyor/velero-plugin-for-csi:latest"
 	RegistryImage        = "quay.io/konveyor/registry:latest"
-	KubeVirtPluginImage  = "quay.io/konveyor/kubevirt-velero-plugin:v0.2.0"
+	KubeVirtPluginImage  = "quay.io/konveyor/kubevirt-velero-plugin:v0.6.2"
 )
 
 // Plugin names

--- a/pkg/credentials/credentials_test.go
+++ b/pkg/credentials/credentials_test.go
@@ -404,7 +404,7 @@ func TestCredentials_getPluginImage(t *testing.T) {
 				},
 			},
 			pluginName: common.KubeVirtPlugin,
-			wantImage:  "quay.io/konveyor/kubevirt-velero-plugin:v0.2.0",
+			wantImage:  "quay.io/konveyor/kubevirt-velero-plugin:v0.6.2",
 		},
 		{
 			name: "given default Velero CR with env var set, image should be built via env vars",


### PR DESCRIPTION
Signed-off-by: Tiger Kaovilai <tkaovila@redhat.com>

Why the changes were made
We're using a VERY old kubevirt plugin in prow tests and dev setup

How to test the changes made
make deploy-olm and check the deployment