### PR TITLE
CI: convert Fedora DeploymentConfig to Deployment.

### DIFF
--- a/tests/e2e/sample-applications/virtual-machines/fedora-todolist/fedora-todolist.yaml
+++ b/tests/e2e/sample-applications/virtual-machines/fedora-todolist/fedora-todolist.yaml
@@ -164,8 +164,8 @@ items:
       selector:
         app: todolist
         service: todolist
-  - apiVersion: apps.openshift.io/v1
-    kind: DeploymentConfig
+  - apiVersion: apps/v1
+    kind: Deployment
     metadata:
       name: todolist
       namespace: mysql-persistent
@@ -176,8 +176,9 @@ items:
     spec:
       replicas: 1
       selector:
-        app: todolist
-        service: todolist
+        matchLabels:
+          app: todolist
+          service: todolist
       strategy:
         type: Recreate
       template:


### PR DESCRIPTION
## Why the changes were made

Try to fix failing Fedora test by converting its DeploymentConfig to a Deployment. I am not sure if this is the cause of the failure, but the logs have warnings about DeploymentConfig getting removed. It's worth running through CI tests anyway.

## How to test the changes made

Run virtualization E2E tests: make TEST_VIRT=true test-e2e
