### PR TITLE
fix: simplify E2E code

### DIFF
--- a/tests/e2e/backup_restore_suite_test.go
+++ b/tests/e2e/backup_restore_suite_test.go
@@ -299,7 +299,7 @@ func tearDownBackupAndRestore(brCase BackupRestoreCase, installTime time.Time, r
 	}
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-	err = dpaCR.Delete(runTimeClientForSuiteRun)
+	err = dpaCR.Delete()
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 	gomega.Eventually(lib.IsNamespaceDeleted(kubernetesClientForSuiteRun, brCase.Namespace), timeoutMultiplier*time.Minute*5, time.Second*5).Should(gomega.BeTrue())
 }

--- a/tests/e2e/dpa_deployment_suite_test.go
+++ b/tests/e2e/dpa_deployment_suite_test.go
@@ -104,7 +104,7 @@ var _ = ginkgov2.Describe("Configuration testing for DPA Custom Resource", func(
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			log.Printf("Waiting for velero pod to be running")
 			gomega.Eventually(lib.AreVeleroPodsRunning(kubernetesClientForSuiteRun, namespace), timeoutMultiplier*time.Minute*3, time.Second*5).Should(gomega.BeTrue())
-			dpa, err := dpaCR.Get(runTimeClientForSuiteRun)
+			dpa, err := dpaCR.Get()
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			if len(dpa.Spec.BackupLocations) > 0 {
 				log.Printf("Checking for bsl spec")
@@ -778,7 +778,7 @@ var _ = ginkgov2.Describe("Configuration testing for DPA Custom Resource", func(
 			log.Printf("Waiting for velero pod with restic to be running")
 			gomega.Eventually(lib.AreVeleroPodsRunning(kubernetesClientForSuiteRun, namespace), timeoutMultiplier*time.Minute*3, time.Second*5).Should(gomega.BeTrue())
 			log.Printf("Deleting dpa with restic")
-			err = dpaCR.Delete(runTimeClientForSuiteRun)
+			err = dpaCR.Delete()
 			if installCase.WantError {
 				gomega.Expect(err).To(gomega.HaveOccurred())
 			} else {
@@ -801,7 +801,7 @@ var _ = ginkgov2.Describe("Configuration testing for DPA Custom Resource", func(
 			log.Printf("Waiting for velero pod with kopia to be running")
 			gomega.Eventually(lib.AreVeleroPodsRunning(kubernetesClientForSuiteRun, namespace), timeoutMultiplier*time.Minute*3, time.Second*5).Should(gomega.BeTrue())
 			log.Printf("Deleting dpa with kopia")
-			err = dpaCR.Delete(runTimeClientForSuiteRun)
+			err = dpaCR.Delete()
 			if installCase.WantError {
 				gomega.Expect(err).To(gomega.HaveOccurred())
 			} else {

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -9,16 +9,26 @@ import (
 	"testing"
 	"time"
 
+	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
 	snapshotv1client "github.com/kubernetes-csi/external-snapshotter/client/v4/clientset/versioned"
 	ginkgov2 "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+	openshiftappsv1 "github.com/openshift/api/apps/v1"
+	openshiftbuildv1 "github.com/openshift/api/build/v1"
+	openshiftsecurityv1 "github.com/openshift/api/security/v1"
+	openshifttemplatev1 "github.com/openshift/api/template/v1"
+	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	veleroclientset "github.com/vmware-tanzu/velero/pkg/generated/clientset/versioned"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
+	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
 	"github.com/openshift/oadp-operator/tests/e2e/lib"
 )
 
@@ -130,6 +140,17 @@ var _ = ginkgov2.BeforeSuite(func() {
 	runTimeClientForSuiteRun, err = client.New(kubeConfig, client.Options{})
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
+	oadpv1alpha1.AddToScheme(runTimeClientForSuiteRun.Scheme())
+	velerov1.AddToScheme(runTimeClientForSuiteRun.Scheme())
+	openshiftappsv1.AddToScheme(runTimeClientForSuiteRun.Scheme())
+	openshiftbuildv1.AddToScheme(runTimeClientForSuiteRun.Scheme())
+	openshiftsecurityv1.AddToScheme(runTimeClientForSuiteRun.Scheme())
+	openshifttemplatev1.AddToScheme(runTimeClientForSuiteRun.Scheme())
+	corev1.AddToScheme(runTimeClientForSuiteRun.Scheme())
+	volumesnapshotv1.AddToScheme(runTimeClientForSuiteRun.Scheme())
+	operatorsv1alpha1.AddToScheme(runTimeClientForSuiteRun.Scheme())
+	operatorsv1.AddToScheme(runTimeClientForSuiteRun.Scheme())
+
 	veleroClientForSuiteRun, err = veleroclientset.NewForConfig(kubeConfig)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -173,7 +194,7 @@ var _ = ginkgov2.AfterSuite(func() {
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 	err = lib.DeleteSecret(kubernetesClientForSuiteRun, namespace, "bsl-cloud-credentials-"+provider+"-with-carriage-return")
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
-	err = dpaCR.Delete(runTimeClientForSuiteRun)
+	err = dpaCR.Delete()
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
-	gomega.Eventually(dpaCR.IsDeleted(runTimeClientForSuiteRun), timeoutMultiplier*time.Minute*2, time.Second*5).Should(gomega.BeTrue())
+	gomega.Eventually(dpaCR.IsDeleted(), timeoutMultiplier*time.Minute*2, time.Second*5).Should(gomega.BeTrue())
 })

--- a/tests/e2e/lib/plugins_helpers.go
+++ b/tests/e2e/lib/plugins_helpers.go
@@ -2,40 +2,14 @@ package lib
 
 import (
 	"context"
-	"log"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
 	"github.com/openshift/oadp-operator/pkg/credentials"
 )
-
-func (d *DpaCustomResource) RemoveVeleroPlugin(c client.Client, string, instanceName string, pluginValues []oadpv1alpha1.DefaultPlugin, removedPlugin string) error {
-	err := d.SetClient(c)
-	if err != nil {
-		return err
-	}
-	dpa := &oadpv1alpha1.DataProtectionApplication{}
-	err = d.Client.Get(context.Background(), client.ObjectKey{
-		Namespace: d.Namespace,
-		Name:      d.Name,
-	}, dpa)
-	if err != nil {
-		return err
-	}
-	// remove plugin from default_plugins
-	dpa.Spec.Configuration.Velero.DefaultPlugins = pluginValues
-
-	err = d.Client.Update(context.Background(), dpa)
-	if err != nil {
-		return err
-	}
-	log.Printf("%s plugin has been removed\n", removedPlugin)
-	return nil
-}
 
 func DoesPluginExist(c *kubernetes.Clientset, namespace string, plugin oadpv1alpha1.DefaultPlugin) wait.ConditionFunc {
 	return func() (bool, error) {
@@ -70,17 +44,5 @@ func DoesCustomPluginExist(c *kubernetes.Clientset, namespace string, plugin oad
 			}
 		}
 		return false, err
-	}
-}
-
-func DoesVeleroDeploymentExist(c *kubernetes.Clientset, namespace string, deploymentName string) wait.ConditionFunc {
-	log.Printf("Waiting for velero deployment to be created...")
-	return func() (bool, error) {
-		// Check for deployment
-		_, err := c.AppsV1().Deployments(namespace).Get(context.Background(), deploymentName, metav1.GetOptions{})
-		if err != nil {
-			return false, err
-		}
-		return true, nil
 	}
 }

--- a/tests/e2e/lib/subscription_helpers.go
+++ b/tests/e2e/lib/subscription_helpers.go
@@ -38,11 +38,6 @@ func getOperatorSubscription(c client.Client, namespace, label string) (*Subscri
 }
 
 func (d *DpaCustomResource) GetOperatorSubscription(c client.Client, stream StreamSource) (*Subscription, error) {
-	err := d.SetClient(c)
-	if err != nil {
-		return nil, err
-	}
-
 	label := ""
 	if stream == UPSTREAM {
 		label = "operators.coreos.com/oadp-operator." + d.Namespace

--- a/tests/e2e/subscription_suite_test.go
+++ b/tests/e2e/subscription_suite_test.go
@@ -24,9 +24,9 @@ var _ = ginkgov2.Describe("Subscription Config Suite Test", func() {
 	}
 
 	var _ = ginkgov2.AfterEach(func() {
-		err := dpaCR.Delete(runTimeClientForSuiteRun)
+		err := dpaCR.Delete()
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
-		gomega.Eventually(dpaCR.IsDeleted(runTimeClientForSuiteRun), timeoutMultiplier*time.Minute*2, time.Second*5).Should(gomega.BeTrue())
+		gomega.Eventually(dpaCR.IsDeleted(), timeoutMultiplier*time.Minute*2, time.Second*5).Should(gomega.BeTrue())
 	})
 
 	ginkgov2.DescribeTable("Proxy test table",
@@ -100,7 +100,7 @@ var _ = ginkgov2.Describe("Subscription Config Suite Test", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				log.Printf("Getting velero object")
-				velero, err := dpaCR.Get(runTimeClientForSuiteRun)
+				velero, err := dpaCR.Get()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				log.Printf("Waiting for velero pod to be running")
 				gomega.Eventually(lib.AreVeleroPodsRunning(kubernetesClientForSuiteRun, namespace), timeoutMultiplier*time.Minute*3, time.Second*5).Should(gomega.BeTrue())
@@ -134,7 +134,7 @@ var _ = ginkgov2.Describe("Subscription Config Suite Test", func() {
 					}
 				}
 				log.Printf("Deleting test Velero")
-				err = dpaCR.Delete(runTimeClientForSuiteRun)
+				err = dpaCR.Delete()
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			}
 


### PR DESCRIPTION
## Why the changes were made

Simplify E2E tests code to do not need call `AddToScheme` more than once. Also, remove unnecessary functions and functions calls.

## How to test the changes made

Run E2E tests or check CI logs and confirm the change did not break or change any behavior.
