### PR TITLE
OADP-4172: override imagePullPolicy

### DIFF
--- a/api/v1alpha1/oadp_types.go
+++ b/api/v1alpha1/oadp_types.go
@@ -375,11 +375,11 @@ type DataProtectionApplicationSpec struct {
 	// features defines the configuration for the DPA to enable the OADP tech preview features
 	// +optional
 	Features *Features `json:"features"`
-	// Which imagePullPolicy to use in all container images used by OADP.
+	// which imagePullPolicy to use in all container images used by OADP.
 	// By default, for images with sha256 or sha512 digest, OADP uses IfNotPresent and uses Always for all other images.
 	// +optional
 	// +kubebuilder:validation:Enum=Always;IfNotPresent;Never
-	ContainerImagePullPolicy *corev1.PullPolicy `json:"containerImagePullPolicy,omitempty"`
+	ImagePullPolicy *corev1.PullPolicy `json:"imagePullPolicy,omitempty"`
 	// nonAdmin defines the configuration for the DPA to enable backup and restore operations for non-admin users
 	// +optional
 	NonAdmin *NonAdmin `json:"nonAdmin,omitempty"`

--- a/api/v1alpha1/oadp_types.go
+++ b/api/v1alpha1/oadp_types.go
@@ -375,6 +375,11 @@ type DataProtectionApplicationSpec struct {
 	// features defines the configuration for the DPA to enable the OADP tech preview features
 	// +optional
 	Features *Features `json:"features"`
+	// Which imagePullPolicy to use in all container images used by OADP.
+	// By default, for images with sha256 or sha512 digest, OADP uses IfNotPresent and uses Always for all other images.
+	// +optional
+	// +kubebuilder:validation:Enum=Always;IfNotPresent;Never
+	ContainerImagePullPolicy *corev1.PullPolicy `json:"containerImagePullPolicy"`
 	// nonAdmin defines the configuration for the DPA to enable backup and restore operations for non-admin users
 	// +optional
 	NonAdmin *NonAdmin `json:"nonAdmin,omitempty"`

--- a/api/v1alpha1/oadp_types.go
+++ b/api/v1alpha1/oadp_types.go
@@ -379,7 +379,7 @@ type DataProtectionApplicationSpec struct {
 	// By default, for images with sha256 or sha512 digest, OADP uses IfNotPresent and uses Always for all other images.
 	// +optional
 	// +kubebuilder:validation:Enum=Always;IfNotPresent;Never
-	ContainerImagePullPolicy *corev1.PullPolicy `json:"containerImagePullPolicy"`
+	ContainerImagePullPolicy *corev1.PullPolicy `json:"containerImagePullPolicy,omitempty"`
 	// nonAdmin defines the configuration for the DPA to enable backup and restore operations for non-admin users
 	// +optional
 	NonAdmin *NonAdmin `json:"nonAdmin,omitempty"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -400,6 +400,11 @@ func (in *DataProtectionApplicationSpec) DeepCopyInto(out *DataProtectionApplica
 		*out = new(Features)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.ContainerImagePullPolicy != nil {
+		in, out := &in.ContainerImagePullPolicy, &out.ContainerImagePullPolicy
+		*out = new(v1.PullPolicy)
+		**out = **in
+	}
 	if in.NonAdmin != nil {
 		in, out := &in.NonAdmin, &out.NonAdmin
 		*out = new(NonAdmin)

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -400,8 +400,8 @@ func (in *DataProtectionApplicationSpec) DeepCopyInto(out *DataProtectionApplica
 		*out = new(Features)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.ContainerImagePullPolicy != nil {
-		in, out := &in.ContainerImagePullPolicy, &out.ContainerImagePullPolicy
+	if in.ImagePullPolicy != nil {
+		in, out := &in.ImagePullPolicy, &out.ImagePullPolicy
 		*out = new(v1.PullPolicy)
 		**out = **in
 	}

--- a/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
@@ -1086,6 +1086,15 @@ spec:
                           type: string
                       type: object
                   type: object
+                containerImagePullPolicy:
+                  description: |-
+                    Which imagePullPolicy to use in all container images used by OADP.
+                    By default, for images with sha256 or sha512 digest, OADP uses IfNotPresent and uses Always for all other images.
+                  enum:
+                    - Always
+                    - IfNotPresent
+                    - Never
+                  type: string
                 features:
                   description: features defines the configuration for the DPA to enable the OADP tech preview features
                   properties:

--- a/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
@@ -1086,15 +1086,6 @@ spec:
                           type: string
                       type: object
                   type: object
-                containerImagePullPolicy:
-                  description: |-
-                    Which imagePullPolicy to use in all container images used by OADP.
-                    By default, for images with sha256 or sha512 digest, OADP uses IfNotPresent and uses Always for all other images.
-                  enum:
-                    - Always
-                    - IfNotPresent
-                    - Never
-                  type: string
                 features:
                   description: features defines the configuration for the DPA to enable the OADP tech preview features
                   properties:
@@ -1210,6 +1201,15 @@ spec:
                           type: object
                       type: object
                   type: object
+                imagePullPolicy:
+                  description: |-
+                    which imagePullPolicy to use in all container images used by OADP.
+                    By default, for images with sha256 or sha512 digest, OADP uses IfNotPresent and uses Always for all other images.
+                  enum:
+                    - Always
+                    - IfNotPresent
+                    - Never
+                  type: string
                 nonAdmin:
                   description: nonAdmin defines the configuration for the DPA to enable backup and restore operations for non-admin users
                   properties:

--- a/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
@@ -1086,6 +1086,15 @@ spec:
                           type: string
                       type: object
                   type: object
+                containerImagePullPolicy:
+                  description: |-
+                    Which imagePullPolicy to use in all container images used by OADP.
+                    By default, for images with sha256 or sha512 digest, OADP uses IfNotPresent and uses Always for all other images.
+                  enum:
+                    - Always
+                    - IfNotPresent
+                    - Never
+                  type: string
                 features:
                   description: features defines the configuration for the DPA to enable the OADP tech preview features
                   properties:

--- a/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
@@ -1086,15 +1086,6 @@ spec:
                           type: string
                       type: object
                   type: object
-                containerImagePullPolicy:
-                  description: |-
-                    Which imagePullPolicy to use in all container images used by OADP.
-                    By default, for images with sha256 or sha512 digest, OADP uses IfNotPresent and uses Always for all other images.
-                  enum:
-                    - Always
-                    - IfNotPresent
-                    - Never
-                  type: string
                 features:
                   description: features defines the configuration for the DPA to enable the OADP tech preview features
                   properties:
@@ -1210,6 +1201,15 @@ spec:
                           type: object
                       type: object
                   type: object
+                imagePullPolicy:
+                  description: |-
+                    which imagePullPolicy to use in all container images used by OADP.
+                    By default, for images with sha256 or sha512 digest, OADP uses IfNotPresent and uses Always for all other images.
+                  enum:
+                    - Always
+                    - IfNotPresent
+                    - Never
+                  type: string
                 nonAdmin:
                   description: nonAdmin defines the configuration for the DPA to enable backup and restore operations for non-admin users
                   properties:

--- a/controllers/nodeagent.go
+++ b/controllers/nodeagent.go
@@ -326,7 +326,7 @@ func (r *DPAReconciler) customizeNodeAgentDaemonset(dpa *oadpv1alpha1.DataProtec
 				Privileged: pointer.Bool(true),
 			}
 
-			imagePullPolicy, err := common.GetImagePullPolicy(getVeleroImage(dpa))
+			imagePullPolicy, err := common.GetImagePullPolicy(dpa.Spec.ContainerImagePullPolicy, getVeleroImage(dpa))
 			if err != nil {
 				r.Log.Error(err, "imagePullPolicy regex failed")
 			}

--- a/controllers/nodeagent.go
+++ b/controllers/nodeagent.go
@@ -326,7 +326,7 @@ func (r *DPAReconciler) customizeNodeAgentDaemonset(dpa *oadpv1alpha1.DataProtec
 				Privileged: pointer.Bool(true),
 			}
 
-			imagePullPolicy, err := common.GetImagePullPolicy(dpa.Spec.ContainerImagePullPolicy, getVeleroImage(dpa))
+			imagePullPolicy, err := common.GetImagePullPolicy(dpa.Spec.ImagePullPolicy, getVeleroImage(dpa))
 			if err != nil {
 				r.Log.Error(err, "imagePullPolicy regex failed")
 			}

--- a/controllers/nonadmin_controller.go
+++ b/controllers/nonadmin_controller.go
@@ -120,7 +120,7 @@ func (r *DPAReconciler) ReconcileNonAdminController(log logr.Logger) (bool, erro
 func (r *DPAReconciler) buildNonAdminDeployment(deploymentObject *appsv1.Deployment, dpa *oadpv1alpha1.DataProtectionApplication) {
 	// TODO https://github.com/openshift/oadp-operator/pull/1316
 	nonAdminImage := r.getNonAdminImage(dpa)
-	imagePullPolicy, err := common.GetImagePullPolicy(dpa.Spec.ContainerImagePullPolicy, nonAdminImage)
+	imagePullPolicy, err := common.GetImagePullPolicy(dpa.Spec.ImagePullPolicy, nonAdminImage)
 	if err != nil {
 		r.Log.Error(err, "imagePullPolicy regex failed")
 	}

--- a/controllers/nonadmin_controller.go
+++ b/controllers/nonadmin_controller.go
@@ -120,7 +120,7 @@ func (r *DPAReconciler) ReconcileNonAdminController(log logr.Logger) (bool, erro
 func (r *DPAReconciler) buildNonAdminDeployment(deploymentObject *appsv1.Deployment, dpa *oadpv1alpha1.DataProtectionApplication) {
 	// TODO https://github.com/openshift/oadp-operator/pull/1316
 	nonAdminImage := r.getNonAdminImage(dpa)
-	imagePullPolicy, err := common.GetImagePullPolicy(nonAdminImage)
+	imagePullPolicy, err := common.GetImagePullPolicy(dpa.Spec.ContainerImagePullPolicy, nonAdminImage)
 	if err != nil {
 		r.Log.Error(err, "imagePullPolicy regex failed")
 	}

--- a/controllers/velero.go
+++ b/controllers/velero.go
@@ -395,7 +395,7 @@ func (r *DPAReconciler) appendPluginSpecificSpecs(dpa *oadpv1alpha1.DataProtecti
 
 	for _, plugin := range dpa.Spec.Configuration.Velero.DefaultPlugins {
 		if pluginSpecificMap, ok := credentials.PluginSpecificFields[plugin]; ok {
-			imagePullPolicy, err := common.GetImagePullPolicy(dpa.Spec.ContainerImagePullPolicy, credentials.GetPluginImage(pluginSpecificMap.PluginName, dpa))
+			imagePullPolicy, err := common.GetImagePullPolicy(dpa.Spec.ImagePullPolicy, credentials.GetPluginImage(pluginSpecificMap.PluginName, dpa))
 			if err != nil {
 				r.Log.Error(err, "imagePullPolicy regex failed")
 			}
@@ -468,7 +468,7 @@ func (r *DPAReconciler) appendPluginSpecificSpecs(dpa *oadpv1alpha1.DataProtecti
 	// append custom plugin init containers
 	if dpa.Spec.Configuration.Velero.CustomPlugins != nil {
 		for _, plugin := range dpa.Spec.Configuration.Velero.CustomPlugins {
-			imagePullPolicy, err := common.GetImagePullPolicy(dpa.Spec.ContainerImagePullPolicy, plugin.Image)
+			imagePullPolicy, err := common.GetImagePullPolicy(dpa.Spec.ImagePullPolicy, plugin.Image)
 			if err != nil {
 				r.Log.Error(err, "imagePullPolicy regex failed")
 			}
@@ -518,7 +518,7 @@ func (r *DPAReconciler) customizeVeleroContainer(dpa *oadpv1alpha1.DataProtectio
 			}
 		}
 	}
-	imagePullPolicy, err := common.GetImagePullPolicy(dpa.Spec.ContainerImagePullPolicy, getVeleroImage(dpa))
+	imagePullPolicy, err := common.GetImagePullPolicy(dpa.Spec.ImagePullPolicy, getVeleroImage(dpa))
 	if err != nil {
 		r.Log.Error(err, "imagePullPolicy regex failed")
 	}

--- a/controllers/velero.go
+++ b/controllers/velero.go
@@ -395,7 +395,7 @@ func (r *DPAReconciler) appendPluginSpecificSpecs(dpa *oadpv1alpha1.DataProtecti
 
 	for _, plugin := range dpa.Spec.Configuration.Velero.DefaultPlugins {
 		if pluginSpecificMap, ok := credentials.PluginSpecificFields[plugin]; ok {
-			imagePullPolicy, err := common.GetImagePullPolicy(credentials.GetPluginImage(pluginSpecificMap.PluginName, dpa))
+			imagePullPolicy, err := common.GetImagePullPolicy(dpa.Spec.ContainerImagePullPolicy, credentials.GetPluginImage(pluginSpecificMap.PluginName, dpa))
 			if err != nil {
 				r.Log.Error(err, "imagePullPolicy regex failed")
 			}
@@ -468,7 +468,7 @@ func (r *DPAReconciler) appendPluginSpecificSpecs(dpa *oadpv1alpha1.DataProtecti
 	// append custom plugin init containers
 	if dpa.Spec.Configuration.Velero.CustomPlugins != nil {
 		for _, plugin := range dpa.Spec.Configuration.Velero.CustomPlugins {
-			imagePullPolicy, err := common.GetImagePullPolicy(plugin.Image)
+			imagePullPolicy, err := common.GetImagePullPolicy(dpa.Spec.ContainerImagePullPolicy, plugin.Image)
 			if err != nil {
 				r.Log.Error(err, "imagePullPolicy regex failed")
 			}
@@ -518,7 +518,7 @@ func (r *DPAReconciler) customizeVeleroContainer(dpa *oadpv1alpha1.DataProtectio
 			}
 		}
 	}
-	imagePullPolicy, err := common.GetImagePullPolicy(getVeleroImage(dpa))
+	imagePullPolicy, err := common.GetImagePullPolicy(dpa.Spec.ContainerImagePullPolicy, getVeleroImage(dpa))
 	if err != nil {
 		r.Log.Error(err, "imagePullPolicy regex failed")
 	}

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -224,11 +224,15 @@ func StripDefaultPorts(fromUrl string) (string, error) {
 	return r.URL.String(), nil
 }
 
-// GetImagePullPolicy get imagePullPolicy for a container, based on its image.
+// GetImagePullPolicy get imagePullPolicy for a container, based on its image, if an override is not provided.
+// If override is provided, use the override imagePullPolicy.
 // If image contains a sha256 or sha512 digest, use IfNotPresent; otherwise, Always.
 // If an error occurs, Always is used.
 // Reference: https://github.com/distribution/distribution/blob/v2.7.1/reference/reference.go
-func GetImagePullPolicy(image string) (corev1.PullPolicy, error) {
+func GetImagePullPolicy(override *corev1.PullPolicy, image string) (corev1.PullPolicy, error) {
+	if override != nil {
+		return *override, nil
+	}
 	sha256regex, err := regexp.Compile("@sha256:[a-f0-9]{64}")
 	if err != nil {
 		return corev1.PullAlways, err

--- a/pkg/common/common_test.go
+++ b/pkg/common/common_test.go
@@ -152,10 +152,13 @@ func TestStripDefaultPorts(t *testing.T) {
 }
 
 func TestGetImagePullPolicy(t *testing.T) {
+	pointerPullNever := corev1.PullNever
+
 	tests := []struct {
-		name   string
-		image  string
-		result corev1.PullPolicy
+		name     string
+		image    string
+		override *corev1.PullPolicy
+		result   corev1.PullPolicy
 	}{
 		{
 			name:   "Image without digest",
@@ -187,10 +190,22 @@ func TestGetImagePullPolicy(t *testing.T) {
 			image:  "test.com/foo@sha256+b64u:LCa0a2j_xo_5m0U8HTBBNBNCLXBkg7-g-YpeiGJm564",
 			result: corev1.PullAlways,
 		},
+		{
+			name:     "Image without digest, but with override",
+			image:    "quay.io/konveyor/velero:oadp-1.4",
+			override: &pointerPullNever,
+			result:   corev1.PullNever,
+		},
+		{
+			name:     "Image with sha256 digest, but with override",
+			image:    "test.com/foo@sha256:1234567890098765432112345667890098765432112345667890098765432112",
+			override: &pointerPullNever,
+			result:   corev1.PullNever,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			result, err := GetImagePullPolicy(test.image)
+			result, err := GetImagePullPolicy(test.override, test.image)
 			if err != nil {
 				t.Errorf("Error occurred in test: %s", err)
 			}

--- a/pkg/common/common_test.go
+++ b/pkg/common/common_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
 )
 
 func TestAppendUniqueKeyTOfTMaps(t *testing.T) {
@@ -152,8 +153,6 @@ func TestStripDefaultPorts(t *testing.T) {
 }
 
 func TestGetImagePullPolicy(t *testing.T) {
-	pointerPullNever := corev1.PullNever
-
 	tests := []struct {
 		name     string
 		image    string
@@ -191,15 +190,15 @@ func TestGetImagePullPolicy(t *testing.T) {
 			result: corev1.PullAlways,
 		},
 		{
-			name:     "Image without digest, but with override",
+			name:     "Image without digest, but with override to Never",
 			image:    "quay.io/konveyor/velero:oadp-1.4",
-			override: &pointerPullNever,
+			override: ptr.To(corev1.PullNever),
 			result:   corev1.PullNever,
 		},
 		{
-			name:     "Image with sha256 digest, but with override",
+			name:     "Image with sha256 digest, but with override to Never",
 			image:    "test.com/foo@sha256:1234567890098765432112345667890098765432112345667890098765432112",
-			override: &pointerPullNever,
+			override: ptr.To(corev1.PullNever),
 			result:   corev1.PullNever,
 		},
 	}


### PR DESCRIPTION
## Why the changes were made

Follow up of https://github.com/openshift/oadp-operator/pull/1397 to allow users to override imagePullPolicy.

## How to test the changes made

Run `make deploy-olm` from this PR branch and use the new DPA field `spec.containerImagePullPolicy`.
