### PR TITLE
Fix OADP-4110:Unsupported Node-Agent Server args

### DIFF
--- a/controllers/nodeagent.go
+++ b/controllers/nodeagent.go
@@ -335,8 +335,8 @@ func (r *DPAReconciler) customizeNodeAgentDaemonset(dpa *oadpv1alpha1.DataProtec
 			setContainerDefaults(nodeAgentContainer)
 
 			if configMapName, ok := dpa.Annotations[common.UnsupportedNodeAgentServerArgsAnnotation]; ok {
-				unsupportedServerArgsCM := corev1.ConfigMap{}
 				if configMapName != "" {
+					unsupportedServerArgsCM := corev1.ConfigMap{}
 					if err := r.Get(r.Context, types.NamespacedName{Namespace: dpa.Namespace, Name: configMapName}, &unsupportedServerArgsCM); err != nil {
 						return nil, err
 					}

--- a/controllers/nodeagent.go
+++ b/controllers/nodeagent.go
@@ -29,8 +29,6 @@ const (
 	FsRestoreHelperCM     = "fs-restore-action-config"
 	HostPods              = "host-pods"
 	HostPlugins           = "host-plugins"
-
-	UnsupportedNodeAgentServerArgsAnnotation = "oadp.openshift.io/unsupported-node-agent-server-args"
 )
 
 var (
@@ -306,39 +304,50 @@ func (r *DPAReconciler) customizeNodeAgentDaemonset(dpa *oadpv1alpha1.DataProtec
 	for i, container := range ds.Spec.Template.Spec.Containers {
 		if container.Name == common.NodeAgent {
 			nodeAgentContainer = &ds.Spec.Template.Spec.Containers[i]
+
+			// append certs volume mount
+			nodeAgentContainer.VolumeMounts = append(nodeAgentContainer.VolumeMounts, corev1.VolumeMount{
+				Name:      "certs",
+				MountPath: "/etc/ssl/certs",
+			})
+			// append PodConfig envs to nodeAgent container
+			if useResticConf {
+				if dpa.Spec.Configuration.Restic.PodConfig != nil && dpa.Spec.Configuration.Restic.PodConfig.Env != nil {
+					nodeAgentContainer.Env = common.AppendUniqueEnvVars(nodeAgentContainer.Env, dpa.Spec.Configuration.Restic.PodConfig.Env)
+				}
+			} else if dpa.Spec.Configuration.NodeAgent.PodConfig != nil && dpa.Spec.Configuration.NodeAgent.PodConfig.Env != nil {
+				nodeAgentContainer.Env = common.AppendUniqueEnvVars(nodeAgentContainer.Env, dpa.Spec.Configuration.NodeAgent.PodConfig.Env)
+			}
+
+			// append env vars to the nodeAgent container
+			nodeAgentContainer.Env = common.AppendUniqueEnvVars(nodeAgentContainer.Env, proxy.ReadProxyVarsFromEnv())
+
+			nodeAgentContainer.SecurityContext = &corev1.SecurityContext{
+				Privileged: pointer.Bool(true),
+			}
+
+			imagePullPolicy, err := common.GetImagePullPolicy(getVeleroImage(dpa))
+			if err != nil {
+				r.Log.Error(err, "imagePullPolicy regex failed")
+			}
+
+			nodeAgentContainer.ImagePullPolicy = imagePullPolicy
+			setContainerDefaults(nodeAgentContainer)
+
+			if configMapName, ok := dpa.Annotations[common.UnsupportedNodeAgentServerArgsAnnotation]; ok {
+				unsupportedServerArgsCM := corev1.ConfigMap{}
+				if configMapName != "" {
+					if err := r.Get(r.Context, types.NamespacedName{Namespace: dpa.Namespace, Name: configMapName}, &unsupportedServerArgsCM); err != nil {
+						return nil, err
+					}
+					if err := common.ApplyUnsupportedServerArgsOverride(nodeAgentContainer, unsupportedServerArgsCM, common.NodeAgent); err != nil {
+						return nil, err
+					}
+				}
+			}
+
 			break
 		}
-	}
-
-	if nodeAgentContainer != nil {
-		// append certs volume mount
-		nodeAgentContainer.VolumeMounts = append(nodeAgentContainer.VolumeMounts, corev1.VolumeMount{
-			Name:      "certs",
-			MountPath: "/etc/ssl/certs",
-		})
-		// append PodConfig envs to nodeAgent container
-		if useResticConf {
-			if dpa.Spec.Configuration.Restic.PodConfig != nil && dpa.Spec.Configuration.Restic.PodConfig.Env != nil {
-				nodeAgentContainer.Env = common.AppendUniqueEnvVars(nodeAgentContainer.Env, dpa.Spec.Configuration.Restic.PodConfig.Env)
-			}
-		} else if dpa.Spec.Configuration.NodeAgent.PodConfig != nil && dpa.Spec.Configuration.NodeAgent.PodConfig.Env != nil {
-			nodeAgentContainer.Env = common.AppendUniqueEnvVars(nodeAgentContainer.Env, dpa.Spec.Configuration.NodeAgent.PodConfig.Env)
-		}
-
-		// append env vars to the nodeAgent container
-		nodeAgentContainer.Env = common.AppendUniqueEnvVars(nodeAgentContainer.Env, proxy.ReadProxyVarsFromEnv())
-
-		nodeAgentContainer.SecurityContext = &corev1.SecurityContext{
-			Privileged: pointer.Bool(true),
-		}
-
-		imagePullPolicy, err := common.GetImagePullPolicy(getVeleroImage(dpa))
-		if err != nil {
-			r.Log.Error(err, "imagePullPolicy regex failed")
-		}
-
-		nodeAgentContainer.ImagePullPolicy = imagePullPolicy
-		setContainerDefaults(nodeAgentContainer)
 	}
 
 	// attach DNS policy and config if enabled
@@ -372,32 +381,7 @@ func (r *DPAReconciler) customizeNodeAgentDaemonset(dpa *oadpv1alpha1.DataProtec
 		ds.Spec.RevisionHistoryLimit = pointer.Int32(10)
 	}
 
-	if err := r.applyUnsupportedNodeAgentServerArgsOverride(dpa, nodeAgentContainer); err != nil {
-		return nil, err
-	}
-
 	return ds, nil
-}
-
-// Apply Override unsupported Node agent Server Args
-func (r *DPAReconciler) applyUnsupportedNodeAgentServerArgsOverride(dpa *oadpv1alpha1.DataProtectionApplication, nodeAgentContainer *corev1.Container) error {
-	if configMapName, ok := dpa.Annotations[UnsupportedNodeAgentServerArgsAnnotation]; ok {
-		// Got an DPA annotation for Unsupported Node Agent Server Args
-		if configMapName == "" {
-			// Can't be empty string, do not report error
-			return nil
-		}
-
-		unsupportedNodeAgentServerArgsCM := corev1.ConfigMap{}
-		if err := r.Get(r.Context, types.NamespacedName{Namespace: dpa.Namespace, Name: configMapName}, &unsupportedNodeAgentServerArgsCM); err != nil {
-			return err
-		}
-
-		r.Log.Info("Applying Unsupported Node Agent Server Args.")
-		// if server args is set, override the default server args
-		nodeAgentContainer.Args = common.GenerateCliArgsFromConfigMap(&unsupportedNodeAgentServerArgsCM, "node-agent", "server")
-	}
-	return nil
 }
 
 func (r *DPAReconciler) ReconcileFsRestoreHelperConfig(log logr.Logger) (bool, error) {

--- a/controllers/nodeagent.go
+++ b/controllers/nodeagent.go
@@ -29,6 +29,8 @@ const (
 	FsRestoreHelperCM     = "fs-restore-action-config"
 	HostPods              = "host-pods"
 	HostPlugins           = "host-plugins"
+
+	UnsupportedNodeAgentServerArgsAnnotation = "oadp.openshift.io/unsupported-node-agent-server-args"
 )
 
 var (
@@ -369,7 +371,33 @@ func (r *DPAReconciler) customizeNodeAgentDaemonset(dpa *oadpv1alpha1.DataProtec
 	if ds.Spec.RevisionHistoryLimit == nil {
 		ds.Spec.RevisionHistoryLimit = pointer.Int32(10)
 	}
+
+	if err := r.applyUnsupportedNodeAgentServerArgsOverride(dpa, nodeAgentContainer); err != nil {
+		return nil, err
+	}
+
 	return ds, nil
+}
+
+// Apply Override unsupported Node agent Server Args
+func (r *DPAReconciler) applyUnsupportedNodeAgentServerArgsOverride(dpa *oadpv1alpha1.DataProtectionApplication, nodeAgentContainer *corev1.Container) error {
+	if configMapName, ok := dpa.Annotations[UnsupportedNodeAgentServerArgsAnnotation]; ok {
+		// Got an DPA annotation for Unsupported Node Agent Server Args
+		if configMapName == "" {
+			// Can't be empty string, do not report error
+			return nil
+		}
+
+		unsupportedNodeAgentServerArgsCM := corev1.ConfigMap{}
+		if err := r.Get(r.Context, types.NamespacedName{Namespace: dpa.Namespace, Name: configMapName}, &unsupportedNodeAgentServerArgsCM); err != nil {
+			return err
+		}
+
+		r.Log.Info("Applying Unsupported Node Agent Server Args.")
+		// if server args is set, override the default server args
+		nodeAgentContainer.Args = common.GenerateCliArgsFromConfigMap(&unsupportedNodeAgentServerArgsCM, "node-agent", "server")
+	}
+	return nil
 }
 
 func (r *DPAReconciler) ReconcileFsRestoreHelperConfig(log logr.Logger) (bool, error) {

--- a/controllers/nodeagent_test.go
+++ b/controllers/nodeagent_test.go
@@ -69,14 +69,6 @@ func TestDPAReconciler_ReconcileNodeAgentDaemonset(t *testing.T) {
 }
 
 func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
-	type fields struct {
-		Client         client.Client
-		Scheme         *runtime.Scheme
-		Log            logr.Logger
-		Context        context.Context
-		NamespacedName types.NamespacedName
-		EventRecorder  record.EventRecorder
-	}
 	type args struct {
 		dpa *oadpv1alpha1.DataProtectionApplication
 		ds  *appsv1.DaemonSet
@@ -96,15 +88,13 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 	}
 	tests := []struct {
 		name          string
-		fields        fields
 		args          args
 		want          *appsv1.DaemonSet
 		wantErr       bool
 		clientObjects []client.Object
 	}{
 		{
-			name:   "dpa is nil",
-			fields: fields{NamespacedName: types.NamespacedName{Namespace: "velero"}},
+			name: "dpa is nil",
 			args: args{
 				nil, &appsv1.DaemonSet{},
 			},
@@ -1961,7 +1951,7 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 						Name:      "sample-dpa",
 						Namespace: "sample-ns",
 						Annotations: map[string]string{
-							UnsupportedNodeAgentServerArgsAnnotation: "unsupported-node-agent-server-args-cm",
+							common.UnsupportedNodeAgentServerArgsAnnotation: "unsupported-node-agent-server-args-cm",
 						},
 					},
 					Spec: oadpv1alpha1.DataProtectionApplicationSpec{
@@ -2157,7 +2147,7 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 						Name:      "sample-dpa",
 						Namespace: "sample-ns",
 						Annotations: map[string]string{
-							UnsupportedNodeAgentServerArgsAnnotation: "",
+							common.UnsupportedNodeAgentServerArgsAnnotation: "",
 						},
 					},
 					Spec: oadpv1alpha1.DataProtectionApplicationSpec{
@@ -2351,7 +2341,7 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 						Name:      "sample-dpa",
 						Namespace: "sample-ns",
 						Annotations: map[string]string{
-							UnsupportedNodeAgentServerArgsAnnotation: "unsupported-node-agent-server-args-cm",
+							common.UnsupportedNodeAgentServerArgsAnnotation: "unsupported-node-agent-server-args-cm",
 						},
 					},
 					Spec: oadpv1alpha1.DataProtectionApplicationSpec{
@@ -2965,12 +2955,7 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 				t.Errorf("error in creating fake client, likely programmer error")
 			}
 			r := &DPAReconciler{
-				Client:         fakeClient,
-				Scheme:         tt.fields.Scheme,
-				Log:            tt.fields.Log,
-				Context:        tt.fields.Context,
-				NamespacedName: tt.fields.NamespacedName,
-				EventRecorder:  tt.fields.EventRecorder,
+				Client: fakeClient,
 			}
 			got, err := r.buildNodeAgentDaemonset(tt.args.dpa, tt.args.ds)
 			if (err != nil) != tt.wantErr {

--- a/controllers/nodeagent_test.go
+++ b/controllers/nodeagent_test.go
@@ -95,11 +95,12 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 		},
 	}
 	tests := []struct {
-		name    string
-		fields  fields
-		args    args
-		want    *appsv1.DaemonSet
-		wantErr bool
+		name          string
+		fields        fields
+		args          args
+		want          *appsv1.DaemonSet
+		wantErr       bool
+		clientObjects []client.Object
 	}{
 		{
 			name:   "dpa is nil",
@@ -1953,7 +1954,431 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 			},
 		},
 		{
-			name: "Valid velero and daemonset for aws as bsl",
+			name: "Valid DPA CR with Unsupported NodeAgent Args, appropriate NodeAgent DaemonSet is built",
+			args: args{
+				&oadpv1alpha1.DataProtectionApplication{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "sample-dpa",
+						Namespace: "sample-ns",
+						Annotations: map[string]string{
+							UnsupportedNodeAgentServerArgsAnnotation: "unsupported-node-agent-server-args-cm",
+						},
+					},
+					Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+						Configuration: &oadpv1alpha1.ApplicationConfig{
+							NodeAgent: &oadpv1alpha1.NodeAgentConfig{
+								NodeAgentCommonFields: oadpv1alpha1.NodeAgentCommonFields{
+									PodConfig: &oadpv1alpha1.PodConfig{},
+								},
+								UploaderType: "",
+							},
+							Velero: &oadpv1alpha1.VeleroConfig{
+								PodConfig: &oadpv1alpha1.PodConfig{},
+								DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
+									oadpv1alpha1.DefaultPluginAWS,
+								},
+							},
+						},
+					},
+				}, &appsv1.DaemonSet{
+					ObjectMeta: getNodeAgentObjectMeta(r),
+				},
+			},
+			clientObjects: []client.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "unsupported-node-agent-server-args-cm",
+						Namespace: "sample-ns",
+					},
+					Data: map[string]string{
+						"unsupported-arg":      "value1",
+						"unsupported-bool-arg": "True",
+					},
+				},
+			},
+			wantErr: false,
+			want: &appsv1.DaemonSet{
+				ObjectMeta: getNodeAgentObjectMeta(r),
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "DaemonSet",
+					APIVersion: appsv1.SchemeGroupVersion.String(),
+				},
+				Spec: appsv1.DaemonSetSpec{
+					UpdateStrategy: appsv1.DaemonSetUpdateStrategy{
+						Type: appsv1.RollingUpdateDaemonSetStrategyType,
+					},
+					Selector: nodeAgentLabelSelector,
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								"component": common.Velero,
+								"name":      common.NodeAgent,
+							},
+						},
+						Spec: corev1.PodSpec{
+							NodeSelector:       dpa.Spec.Configuration.NodeAgent.PodConfig.NodeSelector,
+							ServiceAccountName: common.Velero,
+							SecurityContext: &corev1.PodSecurityContext{
+								RunAsUser:          pointer.Int64(0),
+								SupplementalGroups: dpa.Spec.Configuration.NodeAgent.SupplementalGroups,
+							},
+							Volumes: []corev1.Volume{
+								// Cloud Provider volumes are dynamically added in the for loop below
+								{
+									Name: HostPods,
+									VolumeSource: corev1.VolumeSource{
+										HostPath: &corev1.HostPathVolumeSource{
+											Path: fsPvHostPath,
+										},
+									},
+								},
+								{
+									Name: HostPlugins,
+									VolumeSource: corev1.VolumeSource{
+										HostPath: &corev1.HostPathVolumeSource{
+											Path: "/var/lib/kubelet/plugins",
+										},
+									},
+								},
+								{
+									Name: "scratch",
+									VolumeSource: corev1.VolumeSource{
+										EmptyDir: &corev1.EmptyDirVolumeSource{},
+									},
+								},
+								{
+									Name: "certs",
+									VolumeSource: corev1.VolumeSource{
+										EmptyDir: &corev1.EmptyDirVolumeSource{},
+									},
+								},
+								{
+									Name: "cloud-credentials",
+									VolumeSource: corev1.VolumeSource{
+										Secret: &corev1.SecretVolumeSource{
+											SecretName: "cloud-credentials",
+										},
+									},
+								},
+							},
+							Tolerations: dpa.Spec.Configuration.NodeAgent.PodConfig.Tolerations,
+							Containers: []corev1.Container{
+								{
+									Name: common.NodeAgent,
+									SecurityContext: &corev1.SecurityContext{
+										Privileged: pointer.Bool(true),
+									},
+									Image:           getVeleroImage(&dpa),
+									ImagePullPolicy: corev1.PullAlways,
+									Command: []string{
+										"/velero",
+									},
+									Args: []string{
+										common.NodeAgent,
+										"server",
+										"--unsupported-arg=value1",
+										"--unsupported-bool-arg=true",
+									},
+									Ports: []corev1.ContainerPort{
+										{
+											Name:          "metrics",
+											ContainerPort: 8085,
+											Protocol:      "TCP",
+										},
+									},
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:             HostPods,
+											MountPath:        "/host_pods",
+											MountPropagation: &mountPropagationToHostContainer,
+										},
+										{
+											Name:             HostPlugins,
+											MountPath:        "/var/lib/kubelet/plugins",
+											MountPropagation: &mountPropagationToHostContainer,
+										},
+										{
+											Name:      "scratch",
+											MountPath: "/scratch",
+										},
+										{
+											Name:      "certs",
+											MountPath: "/etc/ssl/certs",
+										},
+										{
+											Name:      "cloud-credentials",
+											MountPath: "/credentials",
+										},
+									},
+									Resources: corev1.ResourceRequirements{
+										Requests: corev1.ResourceList{
+											corev1.ResourceCPU:    resource.MustParse("500m"),
+											corev1.ResourceMemory: resource.MustParse("128Mi"),
+										},
+									},
+									Env: []corev1.EnvVar{
+										{
+											Name: "NODE_NAME",
+											ValueFrom: &corev1.EnvVarSource{
+												FieldRef: &corev1.ObjectFieldSelector{
+													FieldPath: "spec.nodeName",
+												},
+											},
+										},
+										{
+											Name: "VELERO_NAMESPACE",
+											ValueFrom: &corev1.EnvVarSource{
+												FieldRef: &corev1.ObjectFieldSelector{
+													FieldPath: "metadata.namespace",
+												},
+											},
+										},
+										{
+											Name:  "VELERO_SCRATCH_DIR",
+											Value: "/scratch",
+										},
+										{
+											Name:  common.AWSSharedCredentialsFileEnvKey,
+											Value: "/credentials/cloud",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Valid DPA CR with empty value for Unsupported NodeAgent Args cm annotation, appropriate NodeAgent DaemonSet is built",
+			args: args{
+				&oadpv1alpha1.DataProtectionApplication{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "sample-dpa",
+						Namespace: "sample-ns",
+						Annotations: map[string]string{
+							UnsupportedNodeAgentServerArgsAnnotation: "",
+						},
+					},
+					Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+						Configuration: &oadpv1alpha1.ApplicationConfig{
+							NodeAgent: &oadpv1alpha1.NodeAgentConfig{
+								NodeAgentCommonFields: oadpv1alpha1.NodeAgentCommonFields{
+									PodConfig: &oadpv1alpha1.PodConfig{},
+								},
+								UploaderType: "",
+							},
+							Velero: &oadpv1alpha1.VeleroConfig{
+								PodConfig: &oadpv1alpha1.PodConfig{},
+								DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
+									oadpv1alpha1.DefaultPluginAWS,
+								},
+							},
+						},
+					},
+				}, &appsv1.DaemonSet{
+					ObjectMeta: getNodeAgentObjectMeta(r),
+				},
+			},
+			clientObjects: []client.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "unsupported-node-agent-server-args-cm",
+						Namespace: "sample-ns",
+					},
+					Data: map[string]string{
+						"unsupported-arg":      "value1",
+						"unsupported-bool-arg": "True",
+					},
+				},
+			},
+			wantErr: false,
+			want: &appsv1.DaemonSet{
+				ObjectMeta: getNodeAgentObjectMeta(r),
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "DaemonSet",
+					APIVersion: appsv1.SchemeGroupVersion.String(),
+				},
+				Spec: appsv1.DaemonSetSpec{
+					UpdateStrategy: appsv1.DaemonSetUpdateStrategy{
+						Type: appsv1.RollingUpdateDaemonSetStrategyType,
+					},
+					Selector: nodeAgentLabelSelector,
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								"component": common.Velero,
+								"name":      common.NodeAgent,
+							},
+						},
+						Spec: corev1.PodSpec{
+							NodeSelector:       dpa.Spec.Configuration.NodeAgent.PodConfig.NodeSelector,
+							ServiceAccountName: common.Velero,
+							SecurityContext: &corev1.PodSecurityContext{
+								RunAsUser:          pointer.Int64(0),
+								SupplementalGroups: dpa.Spec.Configuration.NodeAgent.SupplementalGroups,
+							},
+							Volumes: []corev1.Volume{
+								// Cloud Provider volumes are dynamically added in the for loop below
+								{
+									Name: HostPods,
+									VolumeSource: corev1.VolumeSource{
+										HostPath: &corev1.HostPathVolumeSource{
+											Path: fsPvHostPath,
+										},
+									},
+								},
+								{
+									Name: HostPlugins,
+									VolumeSource: corev1.VolumeSource{
+										HostPath: &corev1.HostPathVolumeSource{
+											Path: "/var/lib/kubelet/plugins",
+										},
+									},
+								},
+								{
+									Name: "scratch",
+									VolumeSource: corev1.VolumeSource{
+										EmptyDir: &corev1.EmptyDirVolumeSource{},
+									},
+								},
+								{
+									Name: "certs",
+									VolumeSource: corev1.VolumeSource{
+										EmptyDir: &corev1.EmptyDirVolumeSource{},
+									},
+								},
+								{
+									Name: "cloud-credentials",
+									VolumeSource: corev1.VolumeSource{
+										Secret: &corev1.SecretVolumeSource{
+											SecretName: "cloud-credentials",
+										},
+									},
+								},
+							},
+							Tolerations: dpa.Spec.Configuration.NodeAgent.PodConfig.Tolerations,
+							Containers: []corev1.Container{
+								{
+									Name: common.NodeAgent,
+									SecurityContext: &corev1.SecurityContext{
+										Privileged: pointer.Bool(true),
+									},
+									Image:           getVeleroImage(&dpa),
+									ImagePullPolicy: corev1.PullAlways,
+									Command: []string{
+										"/velero",
+									},
+									Args: []string{
+										common.NodeAgent,
+										"server",
+									},
+									Ports: []corev1.ContainerPort{
+										{
+											Name:          "metrics",
+											ContainerPort: 8085,
+											Protocol:      "TCP",
+										},
+									},
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:             HostPods,
+											MountPath:        "/host_pods",
+											MountPropagation: &mountPropagationToHostContainer,
+										},
+										{
+											Name:             HostPlugins,
+											MountPath:        "/var/lib/kubelet/plugins",
+											MountPropagation: &mountPropagationToHostContainer,
+										},
+										{
+											Name:      "scratch",
+											MountPath: "/scratch",
+										},
+										{
+											Name:      "certs",
+											MountPath: "/etc/ssl/certs",
+										},
+										{
+											Name:      "cloud-credentials",
+											MountPath: "/credentials",
+										},
+									},
+									Resources: corev1.ResourceRequirements{
+										Requests: corev1.ResourceList{
+											corev1.ResourceCPU:    resource.MustParse("500m"),
+											corev1.ResourceMemory: resource.MustParse("128Mi"),
+										},
+									},
+									Env: []corev1.EnvVar{
+										{
+											Name: "NODE_NAME",
+											ValueFrom: &corev1.EnvVarSource{
+												FieldRef: &corev1.ObjectFieldSelector{
+													FieldPath: "spec.nodeName",
+												},
+											},
+										},
+										{
+											Name: "VELERO_NAMESPACE",
+											ValueFrom: &corev1.EnvVarSource{
+												FieldRef: &corev1.ObjectFieldSelector{
+													FieldPath: "metadata.namespace",
+												},
+											},
+										},
+										{
+											Name:  "VELERO_SCRATCH_DIR",
+											Value: "/scratch",
+										},
+										{
+											Name:  common.AWSSharedCredentialsFileEnvKey,
+											Value: "/credentials/cloud",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Valid DPA CR with Unsupported NodeAgent Args cm missing, DPA error case",
+			args: args{
+				&oadpv1alpha1.DataProtectionApplication{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "sample-dpa",
+						Namespace: "sample-ns",
+						Annotations: map[string]string{
+							UnsupportedNodeAgentServerArgsAnnotation: "unsupported-node-agent-server-args-cm",
+						},
+					},
+					Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+						Configuration: &oadpv1alpha1.ApplicationConfig{
+							NodeAgent: &oadpv1alpha1.NodeAgentConfig{
+								NodeAgentCommonFields: oadpv1alpha1.NodeAgentCommonFields{
+									PodConfig: &oadpv1alpha1.PodConfig{},
+								},
+								UploaderType: "",
+							},
+							Velero: &oadpv1alpha1.VeleroConfig{
+								PodConfig: &oadpv1alpha1.PodConfig{},
+								DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
+									oadpv1alpha1.DefaultPluginAWS,
+								},
+							},
+						},
+					},
+				}, &appsv1.DaemonSet{
+					ObjectMeta: getNodeAgentObjectMeta(r),
+				},
+			},
+			wantErr: true,
+			want:    nil,
+		},
+		{
+			name: "Valid velero and daemon set for aws as bsl",
 			args: args{
 				&oadpv1alpha1.DataProtectionApplication{
 					Spec: oadpv1alpha1.DataProtectionApplicationSpec{
@@ -2535,8 +2960,12 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			fakeClient, err := getFakeClientFromObjects(tt.clientObjects...)
+			if err != nil {
+				t.Errorf("error in creating fake client, likely programmer error")
+			}
 			r := &DPAReconciler{
-				Client:         tt.fields.Client,
+				Client:         fakeClient,
 				Scheme:         tt.fields.Scheme,
 				Log:            tt.fields.Log,
 				Context:        tt.fields.Context,

--- a/controllers/velero.go
+++ b/controllers/velero.go
@@ -45,8 +45,6 @@ const (
 
 	TrueVal  = "true"
 	FalseVal = "false"
-
-	UnsupportedVeleroServerArgsAnnotation = "oadp.openshift.io/unsupported-velero-server-args"
 )
 
 var (
@@ -144,27 +142,6 @@ func (r *DPAReconciler) veleroClusterRoleBinding(dpa *oadpv1alpha1.DataProtectio
 	crb := install.ClusterRoleBinding(dpa.Namespace)
 	crb.Labels = getDpaAppLabels(dpa)
 	return crb, nil
-}
-
-// Apply Override unsupported Args
-func (r *DPAReconciler) applyUnsupportedArgsOverride(dpa *oadpv1alpha1.DataProtectionApplication, veleroDeployment *appsv1.Deployment, veleroContainer *corev1.Container) error {
-	if configMapName, ok := dpa.Annotations[UnsupportedVeleroServerArgsAnnotation]; ok {
-		// Got an DPA annotation for Unsupported Server Args
-		if configMapName == "" {
-			// Can't be empty string, do not report error
-			return nil
-		}
-
-		unsupportedServerArgsCM := corev1.ConfigMap{}
-		if err := r.Get(r.Context, types.NamespacedName{Namespace: dpa.Namespace, Name: configMapName}, &unsupportedServerArgsCM); err != nil {
-			return err
-		}
-
-		r.Log.Info("Applying Unsupported Server Args.")
-		// if server args is set, override the default server args
-		veleroContainer.Args = common.GenerateCliArgsFromConfigMap(&unsupportedServerArgsCM, "server")
-	}
-	return nil
 }
 
 // Build VELERO Deployment
@@ -513,7 +490,20 @@ func (r *DPAReconciler) appendPluginSpecificSpecs(dpa *oadpv1alpha1.DataProtecti
 				})
 		}
 	}
-	return r.applyUnsupportedArgsOverride(dpa, veleroDeployment, veleroContainer)
+
+	if configMapName, ok := dpa.Annotations[common.UnsupportedVeleroServerArgsAnnotation]; ok {
+		unsupportedServerArgsCM := corev1.ConfigMap{}
+		if configMapName != "" {
+			if err := r.Get(r.Context, types.NamespacedName{Namespace: dpa.Namespace, Name: configMapName}, &unsupportedServerArgsCM); err != nil {
+				return err
+			}
+			if err := common.ApplyUnsupportedServerArgsOverride(veleroContainer, unsupportedServerArgsCM, common.Velero); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
 }
 
 func (r *DPAReconciler) customizeVeleroContainer(dpa *oadpv1alpha1.DataProtectionApplication, veleroDeployment *appsv1.Deployment, veleroContainer *corev1.Container, hasShortLivedCredentials bool, prometheusPort *int) error {

--- a/controllers/velero.go
+++ b/controllers/velero.go
@@ -492,8 +492,8 @@ func (r *DPAReconciler) appendPluginSpecificSpecs(dpa *oadpv1alpha1.DataProtecti
 	}
 
 	if configMapName, ok := dpa.Annotations[common.UnsupportedVeleroServerArgsAnnotation]; ok {
-		unsupportedServerArgsCM := corev1.ConfigMap{}
 		if configMapName != "" {
+			unsupportedServerArgsCM := corev1.ConfigMap{}
 			if err := r.Get(r.Context, types.NamespacedName{Namespace: dpa.Namespace, Name: configMapName}, &unsupportedServerArgsCM); err != nil {
 				return err
 			}

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -94,6 +94,12 @@ const (
 	NoProxyEnvVar                  = "NO_PROXY"
 )
 
+// Unsupported Server Args annotation keys
+const (
+	UnsupportedVeleroServerArgsAnnotation    = "oadp.openshift.io/unsupported-velero-server-args"
+	UnsupportedNodeAgentServerArgsAnnotation = "oadp.openshift.io/unsupported-node-agent-server-args"
+)
+
 const defaultMode = int32(420)
 
 func DefaultModePtr() *int32 {
@@ -290,4 +296,19 @@ func GenerateCliArgsFromConfigMap(configMap *corev1.ConfigMap, cliSubCommand ...
 	cliSubCommand = append(cliSubCommand, keyValueArgs...)
 
 	return cliSubCommand
+}
+
+// Apply Override unsupported Node agent Server Args
+func ApplyUnsupportedServerArgsOverride(container *corev1.Container, unsupportedServerArgsCM corev1.ConfigMap, serverType string) error {
+
+	switch serverType {
+	case NodeAgent:
+		// if server args is set, override the default server args
+		container.Args = GenerateCliArgsFromConfigMap(&unsupportedServerArgsCM, "node-agent", "server")
+
+	case Velero:
+		// if server args is set, override the default server args
+		container.Args = GenerateCliArgsFromConfigMap(&unsupportedServerArgsCM, "server")
+	}
+	return nil
 }


### PR DESCRIPTION
## Why the changes were made

<!-- Explain why this PR is important, what problems it fixes, link related issues -->
Add unsupported server args for the node-agent daemon set via ConfigMap within the DPA namespace.

Fixes https://issues.redhat.com/browse/OADP-4110

## How to test the changes made

<!-- Explain how the changes introduced by this PR can be tested and verified, with commands and pictures -->

- Deploy OADP Operator using the PR
- Create ConfigMap with key/value pairs, where key will correspond to the node-agent server argument name and value is it's value
- Create DPA with annotation (replace <ConfigMap-Name> to adopt to your ConfigMap:
  `oadp.openshift.io/unsupported-node-agent-server-args=<ConfigMap-Name>`
- Verify the node-agent server pod runs with the expected server args

Notes:
 - NonExisting ConfigMap referenced by the annotation will report error
 - Empty ConfigMap name will not cause override 