### PR TITLE
fix: NonAdmin container code

### DIFF
--- a/controllers/nonadmin_controller.go
+++ b/controllers/nonadmin_controller.go
@@ -11,7 +11,7 @@ import (
 	k8serror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -68,11 +68,10 @@ func (r *DPAReconciler) ReconcileNonAdminController(log logr.Logger) (bool, erro
 			return false, err
 		}
 
-		deleteOptionPropagationForeground := metav1.DeletePropagationForeground
 		if err := r.Delete(
 			r.Context,
 			nonAdminDeployment,
-			&client.DeleteOptions{PropagationPolicy: &deleteOptionPropagationForeground},
+			&client.DeleteOptions{PropagationPolicy: ptr.To(metav1.DeletePropagationForeground)},
 		); err != nil {
 			r.EventRecorder.Event(
 				nonAdminDeployment,
@@ -96,7 +95,10 @@ func (r *DPAReconciler) ReconcileNonAdminController(log logr.Logger) (bool, erro
 		r.Client,
 		nonAdminDeployment,
 		func() error {
-			r.buildNonAdminDeployment(nonAdminDeployment, &dpa)
+			err := r.buildNonAdminDeployment(nonAdminDeployment, &dpa)
+			if err != nil {
+				return err
+			}
 
 			// Setting controller owner reference on the non admin controller deployment
 			return controllerutil.SetControllerReference(&dpa, nonAdminDeployment, r.Scheme)
@@ -117,7 +119,7 @@ func (r *DPAReconciler) ReconcileNonAdminController(log logr.Logger) (bool, erro
 	return true, nil
 }
 
-func (r *DPAReconciler) buildNonAdminDeployment(deploymentObject *appsv1.Deployment, dpa *oadpv1alpha1.DataProtectionApplication) {
+func (r *DPAReconciler) buildNonAdminDeployment(deploymentObject *appsv1.Deployment, dpa *oadpv1alpha1.DataProtectionApplication) error {
 	// TODO https://github.com/openshift/oadp-operator/pull/1316
 	nonAdminImage := r.getNonAdminImage(dpa)
 	imagePullPolicy, err := common.GetImagePullPolicy(dpa.Spec.ImagePullPolicy, nonAdminImage)
@@ -125,7 +127,11 @@ func (r *DPAReconciler) buildNonAdminDeployment(deploymentObject *appsv1.Deploym
 		r.Log.Error(err, "imagePullPolicy regex failed")
 	}
 	ensureRequiredLabels(deploymentObject)
-	ensureRequiredSpecs(deploymentObject, nonAdminImage, imagePullPolicy)
+	err = ensureRequiredSpecs(deploymentObject, nonAdminImage, imagePullPolicy)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func ensureRequiredLabels(deploymentObject *appsv1.Deployment) {
@@ -141,13 +147,13 @@ func ensureRequiredLabels(deploymentObject *appsv1.Deployment) {
 	}
 }
 
-func ensureRequiredSpecs(deploymentObject *appsv1.Deployment, image string, imagePullPolicy corev1.PullPolicy) {
+func ensureRequiredSpecs(deploymentObject *appsv1.Deployment, image string, imagePullPolicy corev1.PullPolicy) error {
 	namespaceEnvVar := corev1.EnvVar{
 		Name:  "WATCH_NAMESPACE",
 		Value: deploymentObject.Namespace,
 	}
 
-	deploymentObject.Spec.Replicas = pointer.Int32(1)
+	deploymentObject.Spec.Replicas = ptr.To(int32(1))
 	deploymentObject.Spec.Selector = &metav1.LabelSelector{
 		MatchLabels: controlPlaneLabel,
 	}
@@ -158,6 +164,7 @@ func ensureRequiredSpecs(deploymentObject *appsv1.Deployment, image string, imag
 		templateObjectLabels[controlPlaneKey] = controlPlaneLabel[controlPlaneKey]
 		deploymentObject.Spec.Template.SetLabels(templateObjectLabels)
 	}
+	nonAdminContainerFound := false
 	if len(deploymentObject.Spec.Template.Spec.Containers) == 0 {
 		deploymentObject.Spec.Template.Spec.Containers = []corev1.Container{{
 			Name:            nonAdminObjectName,
@@ -165,6 +172,7 @@ func ensureRequiredSpecs(deploymentObject *appsv1.Deployment, image string, imag
 			ImagePullPolicy: imagePullPolicy,
 			Env:             []corev1.EnvVar{namespaceEnvVar},
 		}}
+		nonAdminContainerFound = true
 	} else {
 		for index, container := range deploymentObject.Spec.Template.Spec.Containers {
 			if container.Name == nonAdminObjectName {
@@ -172,12 +180,17 @@ func ensureRequiredSpecs(deploymentObject *appsv1.Deployment, image string, imag
 				nonAdminContainer.Image = image
 				nonAdminContainer.ImagePullPolicy = imagePullPolicy
 				nonAdminContainer.Env = []corev1.EnvVar{namespaceEnvVar}
+				nonAdminContainerFound = true
 				break
 			}
 		}
 	}
+	if !nonAdminContainerFound {
+		return fmt.Errorf("could not find Non admin container in Deployment")
+	}
 	deploymentObject.Spec.Template.Spec.RestartPolicy = corev1.RestartPolicyAlways
 	deploymentObject.Spec.Template.Spec.ServiceAccountName = nonAdminObjectName
+	return nil
 }
 
 func (r *DPAReconciler) checkNonAdminEnabled(dpa *oadpv1alpha1.DataProtectionApplication) bool {

--- a/controllers/nonadmin_controller.go
+++ b/controllers/nonadmin_controller.go
@@ -166,11 +166,12 @@ func ensureRequiredSpecs(deploymentObject *appsv1.Deployment, image string, imag
 			Env:             []corev1.EnvVar{namespaceEnvVar},
 		}}
 	} else {
-		for _, container := range deploymentObject.Spec.Template.Spec.Containers {
+		for index, container := range deploymentObject.Spec.Template.Spec.Containers {
 			if container.Name == nonAdminObjectName {
-				container.Image = image
-				container.ImagePullPolicy = imagePullPolicy
-				container.Env = []corev1.EnvVar{namespaceEnvVar}
+				nonAdminContainer := &deploymentObject.Spec.Template.Spec.Containers[index]
+				nonAdminContainer.Image = image
+				nonAdminContainer.ImagePullPolicy = imagePullPolicy
+				nonAdminContainer.Env = []corev1.EnvVar{namespaceEnvVar}
 				break
 			}
 		}

--- a/controllers/nonadmin_controller_test.go
+++ b/controllers/nonadmin_controller_test.go
@@ -13,7 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
 )
@@ -41,7 +41,7 @@ func createTestDeployment(namespace string) *appsv1.Deployment {
 			},
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: pointer.Int32(2),
+			Replicas: ptr.To(int32(2)),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: controlPlaneLabel,
 			},
@@ -53,7 +53,7 @@ func createTestDeployment(namespace string) *appsv1.Deployment {
 					Containers: []corev1.Container{
 						{
 							Name:  nonAdminObjectName,
-							Image: defaultNonAdminImage,
+							Image: "wrong",
 						},
 					},
 					ServiceAccountName: "wrong-one",
@@ -86,7 +86,7 @@ func runReconcileNonAdminControllerTest(
 		Spec: oadpv1alpha1.DataProtectionApplicationSpec{
 			Configuration: &oadpv1alpha1.ApplicationConfig{},
 			NonAdmin: &oadpv1alpha1.NonAdmin{
-				Enable: pointer.Bool(scenario.nonAdminEnabled),
+				Enable: ptr.To(scenario.nonAdminEnabled),
 			},
 			UnsupportedOverrides: map[oadpv1alpha1.UnsupportedImageKey]string{
 				oadpv1alpha1.TechPreviewAck: "true",
@@ -252,6 +252,9 @@ func TestEnsureRequiredSpecs(t *testing.T) {
 	if deployment.Spec.Template.Spec.ServiceAccountName != nonAdminObjectName {
 		t.Errorf("Deployment has wrong ServiceAccount: %v", deployment.Spec.Template.Spec.ServiceAccountName)
 	}
+	if deployment.Spec.Template.Spec.Containers[0].Image != defaultNonAdminImage {
+		t.Errorf("Deployment has wrong Image: %v", deployment.Spec.Template.Spec.Containers[0].Image)
+	}
 }
 
 func TestDPAReconcilerCheckNonAdminEnabled(t *testing.T) {
@@ -267,7 +270,7 @@ func TestDPAReconcilerCheckNonAdminEnabled(t *testing.T) {
 			dpa: &oadpv1alpha1.DataProtectionApplication{
 				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
 					NonAdmin: &oadpv1alpha1.NonAdmin{
-						Enable: pointer.Bool(true),
+						Enable: ptr.To(true),
 					},
 				},
 			},
@@ -278,7 +281,7 @@ func TestDPAReconcilerCheckNonAdminEnabled(t *testing.T) {
 			dpa: &oadpv1alpha1.DataProtectionApplication{
 				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
 					NonAdmin: &oadpv1alpha1.NonAdmin{
-						Enable: pointer.Bool(false),
+						Enable: ptr.To(false),
 					},
 				},
 			},


### PR DESCRIPTION
## Why the changes were made

Fix code implementation in NonAdmin container code that would not work because when a struct object or an array is copied, its elements are copied implicitly by the compiler, and any element write to this copy does nothing with the original object. Refence https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/unusedwrite

Also, remove usage of `k8s.io/utils/pointer` in NonAdmin code, which is deprecated.

## How to test the changes made

Check new unit test case or run `make deploy-olm` and try updating NonAdmin deployment `spec.template.spec.containers[0].image`; any changes should be undone in next reconcile.
