### PR TITLE
OADP-4290: Add flake for snapshot creation to ignore error list 

### DIFF
--- a/tests/e2e/lib/flakes.go
+++ b/tests/e2e/lib/flakes.go
@@ -19,6 +19,7 @@ var errorIgnorePatterns = []string{
 	// Ignore managed fields errors per https://github.com/vmware-tanzu/velero/pull/6110 and avoid e2e failure.
 	// https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_oadp-operator/1126/pull-ci-openshift-oadp-operator-master-4.10-operator-e2e-aws/1690109468546699264#1:build-log.txt%3A686
 	"level=error msg=\"error patch for managed fields ",
+        "VolumeSnapshot has a temporary error Failed to create snapshot: error updating status for volume snapshot content snapcontent-",
 }
 
 type FlakePattern struct {

--- a/tests/e2e/lib/flakes.go
+++ b/tests/e2e/lib/flakes.go
@@ -19,7 +19,7 @@ var errorIgnorePatterns = []string{
 	// Ignore managed fields errors per https://github.com/vmware-tanzu/velero/pull/6110 and avoid e2e failure.
 	// https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_oadp-operator/1126/pull-ci-openshift-oadp-operator-master-4.10-operator-e2e-aws/1690109468546699264#1:build-log.txt%3A686
 	"level=error msg=\"error patch for managed fields ",
-        "VolumeSnapshot has a temporary error Failed to create snapshot: error updating status for volume snapshot content snapcontent-",
+	"VolumeSnapshot has a temporary error Failed to create snapshot: error updating status for volume snapshot content snapcontent-",
 }
 
 type FlakePattern struct {


### PR DESCRIPTION
## Why the changes were made

This will add ci tests that hit:
"VolumeSnapshot has a temporary error Failed to create snapshot: error updating status for volume snapshot content snapcontent-"  
Which has been determined to be temporary and a flake and the error can be safely ignored

## How to test the changes made

Added error description to json list.