### PR TITLE
CI: backport single test for powered-off CirrOS VM

### DIFF
--- a/tests/e2e/lib/virt_helpers.go
+++ b/tests/e2e/lib/virt_helpers.go
@@ -27,6 +27,7 @@ import (
 const (
 	emulationAnnotation = "kubevirt.kubevirt.io/jsonpatch"
 	useEmulation        = `[{"op": "add", "path": "/spec/configuration/developerConfiguration", "value": {"useEmulation": true}}]`
+	stopVmPath          = "/apis/subresources.kubevirt.io/v1/namespaces/%s/virtualmachines/%s/stop"
 )
 
 var packageManifestsGvr = schema.GroupVersionResource{
@@ -590,8 +591,8 @@ func (v *VirtOperator) ensureHcoRemoved(timeout time.Duration) error {
 	return err
 }
 
-func (v *VirtOperator) GetVmStatus(namespace, name string) (string, error) {
-	vm, err := v.Dynamic.Resource(virtualMachineGvr).Namespace(namespace).Get(context.Background(), name, metav1.GetOptions{})
+func GetVmStatus(dynamicClient dynamic.Interface, namespace, name string) (string, error) {
+	vm, err := dynamicClient.Resource(virtualMachineGvr).Namespace(namespace).Get(context.Background(), name, metav1.GetOptions{})
 	if err != nil {
 		return "", err
 	}
@@ -605,6 +606,20 @@ func (v *VirtOperator) GetVmStatus(namespace, name string) (string, error) {
 	}
 
 	return status, nil
+}
+
+func (v *VirtOperator) GetVmStatus(namespace, name string) (string, error) {
+	return GetVmStatus(v.Dynamic, namespace, name)
+}
+
+// StopVm stops a VM with a REST call to "stop". This is needed because a
+// poweroff from inside the VM results in KubeVirt restarting it.
+// From the KubeVirt API reference:
+//
+//	/apis/subresources.kubevirt.io/v1/namespaces/{namespace:[a-z0-9]}/virtualmachines/{name:[a-z0-9][a-z0-9\-]}/stop
+func (v *VirtOperator) StopVm(namespace, name string) error {
+	path := fmt.Sprintf(stopVmPath, namespace, name)
+	return v.Clientset.RESTClient().Put().AbsPath(path).Do(context.TODO()).Error()
 }
 
 func (v *VirtOperator) checkVmExists(namespace, name string) bool {

--- a/tests/e2e/sample-applications/virtual-machines/cirros-test/cirros-test.yaml
+++ b/tests/e2e/sample-applications/virtual-machines/cirros-test/cirros-test.yaml
@@ -33,6 +33,10 @@ items:
               - disk:
                   bus: virtio
                 name: rootdisk
+            firmware:
+              bootloader:
+                efi:
+                  secureBoot: false
             resources:
               requests:
                 cpu: 1

--- a/tests/e2e/virt_backup_restore_suite_test.go
+++ b/tests/e2e/virt_backup_restore_suite_test.go
@@ -1,7 +1,6 @@
 package e2e_test
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -59,7 +58,6 @@ type VmBackupRestoreCase struct {
 	Template   string
 	InitDelay  time.Duration
 	PowerState string
-	RestoreErr error
 }
 
 func runVmBackupAndRestore(brCase VmBackupRestoreCase, expectedErr error, updateLastBRcase func(brCase VmBackupRestoreCase), updateLastInstallTime func(), v *lib.VirtOperator) {
@@ -111,7 +109,7 @@ func runVmBackupAndRestore(brCase VmBackupRestoreCase, expectedErr error, update
 	Eventually(lib.IsNamespaceDeleted(kubernetesClientForSuiteRun, brCase.Namespace), timeoutMultiplier*time.Minute*5, time.Second*5).Should(BeTrue())
 
 	// Do restore
-	runVmRestore(brCase, backupName, restoreName, nsRequiresResticDCWorkaround)
+	runRestore(brCase.BackupRestoreCase, backupName, restoreName, nsRequiresResticDCWorkaround)
 
 	// Run optional custom verification
 	if brCase.PostRestoreVerify != nil {
@@ -212,7 +210,6 @@ var _ = Describe("VM backup and restore tests", Ordered, func() {
 				BackupTimeout:     20 * time.Minute,
 				PreBackupVerify:   vmPoweredOff("cirros-test", "cirros-test"),
 			},
-			RestoreErr: errors.New("fail to patch dynamic PV"),
 		}, nil),
 
 		Entry("todolist CSI backup and restore, in a Fedora VM", Label("virt"), VmBackupRestoreCase{
@@ -230,45 +227,3 @@ var _ = Describe("VM backup and restore tests", Ordered, func() {
 		}, nil),
 	)
 })
-
-// Temporary VM-specific copy of runRestore. This is here to avoid making big
-// changes to runRestore when they are likely to be taken out in the near future.
-func runVmRestore(brCase VmBackupRestoreCase, backupName, restoreName string, nsRequiresResticDCWorkaround bool) {
-	log.Printf("Creating restore %s for case %s", restoreName, brCase.Name)
-	restore, err := lib.CreateRestoreFromBackup(dpaCR.Client, namespace, backupName, restoreName)
-	Expect(err).ToNot(HaveOccurred())
-	Eventually(lib.IsRestoreDone(dpaCR.Client, namespace, restoreName), timeoutMultiplier*time.Minute*60, time.Second*10).Should(BeTrue())
-	// TODO only log on fail?
-	describeRestore := lib.DescribeRestore(veleroClientForSuiteRun, dpaCR.Client, restore)
-	GinkgoWriter.Println(describeRestore)
-
-	restoreLogs := lib.RestoreLogs(kubernetesClientForSuiteRun, dpaCR.Client, restore)
-	restoreErrorLogs := lib.RestoreErrorLogs(kubernetesClientForSuiteRun, dpaCR.Client, restore)
-	accumulatedTestLogs = append(accumulatedTestLogs, describeRestore, restoreLogs)
-
-	if !brCase.SkipVerifyLogs {
-		Expect(restoreErrorLogs).Should(Equal([]string{}))
-	}
-
-	// Check if restore succeeded
-	succeeded, err := lib.IsRestoreCompletedSuccessfully(kubernetesClientForSuiteRun, dpaCR.Client, namespace, restoreName)
-	if brCase.RestoreErr != nil {
-		Expect(succeeded).To(Equal(false))
-		Expect(err).NotTo(BeNil())
-		Expect(err.Error()).To(ContainSubstring(brCase.RestoreErr.Error()))
-	} else {
-		Expect(err).ToNot(HaveOccurred())
-		Expect(succeeded).To(Equal(true))
-	}
-
-	if nsRequiresResticDCWorkaround {
-		// We run the dc-post-restore.sh script for both restic and
-		// kopia backups and for any DCs with attached volumes,
-		// regardless of whether it was restic or kopia backup.
-		// The script is designed to work with labels set by the
-		// openshift-velero-plugin and can be run without pre-conditions.
-		log.Printf("Running dc-post-restore.sh script.")
-		err = lib.RunDcPostRestoreScript(restoreName)
-		Expect(err).ToNot(HaveOccurred())
-	}
-}

--- a/tests/e2e/virt_backup_restore_suite_test.go
+++ b/tests/e2e/virt_backup_restore_suite_test.go
@@ -1,6 +1,7 @@
 package e2e_test
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -11,6 +12,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openshift/oadp-operator/api/v1alpha1"
 	"github.com/openshift/oadp-operator/tests/e2e/lib"
@@ -37,10 +39,27 @@ func getLatestCirrosImageURL() (string, error) {
 	return imageURL, nil
 }
 
+func vmPoweredOff(vmnamespace, vmname string) VerificationFunction {
+	return VerificationFunction(func(ocClient client.Client, namespace string) error {
+		isOff := func() bool {
+			status, err := lib.GetVmStatus(dynamicClientForSuiteRun, vmnamespace, vmname)
+			if err != nil {
+				log.Printf("Error getting VM status: %v", err)
+			}
+			log.Printf("VM status is: %s\n", status)
+			return status == "Stopped"
+		}
+		Eventually(isOff, timeoutMultiplier*time.Minute*10, time.Second*10).Should(BeTrue())
+		return nil
+	})
+}
+
 type VmBackupRestoreCase struct {
 	BackupRestoreCase
-	Template  string
-	InitDelay time.Duration
+	Template   string
+	InitDelay  time.Duration
+	PowerState string
+	RestoreErr error
 }
 
 func runVmBackupAndRestore(brCase VmBackupRestoreCase, expectedErr error, updateLastBRcase func(brCase VmBackupRestoreCase), updateLastInstallTime func(), v *lib.VirtOperator) {
@@ -73,18 +92,26 @@ func runVmBackupAndRestore(brCase VmBackupRestoreCase, expectedErr error, update
 		time.Sleep(brCase.InitDelay)
 	}
 
+	// Check if this VM should be running or stopped for this test.
+	// Depend on pre-backup verification function to poll state.
+	if brCase.PowerState == "Stopped" {
+		log.Print("Stopping VM before backup as specified in test case.")
+		err = v.StopVm(brCase.Namespace, brCase.Name)
+		Expect(err).To(BeNil())
+	}
+
 	// Back up VM
 	nsRequiresResticDCWorkaround := runBackup(brCase.BackupRestoreCase, backupName)
 
 	// Delete everything in test namespace
-	err = v.RemoveVm(brCase.Namespace, brCase.Name, 2*time.Minute)
+	err = v.RemoveVm(brCase.Namespace, brCase.Name, 5*time.Minute)
 	Expect(err).To(BeNil())
 	err = lib.DeleteNamespace(v.Clientset, brCase.Namespace)
 	Expect(err).To(BeNil())
 	Eventually(lib.IsNamespaceDeleted(kubernetesClientForSuiteRun, brCase.Namespace), timeoutMultiplier*time.Minute*5, time.Second*5).Should(BeTrue())
 
 	// Do restore
-	runRestore(brCase.BackupRestoreCase, backupName, restoreName, nsRequiresResticDCWorkaround)
+	runVmRestore(brCase, backupName, restoreName, nsRequiresResticDCWorkaround)
 
 	// Run optional custom verification
 	if brCase.PostRestoreVerify != nil {
@@ -173,6 +200,21 @@ var _ = Describe("VM backup and restore tests", Ordered, func() {
 			},
 		}, nil),
 
+		Entry("no-application CSI backup and restore, powered-off CirrOS VM", Label("virt"), VmBackupRestoreCase{
+			Template:   "./sample-applications/virtual-machines/cirros-test/cirros-test.yaml",
+			InitDelay:  2 * time.Minute,
+			PowerState: "Stopped",
+			BackupRestoreCase: BackupRestoreCase{
+				Namespace:         "cirros-test",
+				Name:              "cirros-test",
+				SkipVerifyLogs:    true,
+				BackupRestoreType: lib.CSI,
+				BackupTimeout:     20 * time.Minute,
+				PreBackupVerify:   vmPoweredOff("cirros-test", "cirros-test"),
+			},
+			RestoreErr: errors.New("fail to patch dynamic PV"),
+		}, nil),
+
 		Entry("todolist CSI backup and restore, in a Fedora VM", Label("virt"), VmBackupRestoreCase{
 			Template:  "./sample-applications/virtual-machines/fedora-todolist/fedora-todolist.yaml",
 			InitDelay: 3 * time.Minute, // For cloud-init
@@ -188,3 +230,45 @@ var _ = Describe("VM backup and restore tests", Ordered, func() {
 		}, nil),
 	)
 })
+
+// Temporary VM-specific copy of runRestore. This is here to avoid making big
+// changes to runRestore when they are likely to be taken out in the near future.
+func runVmRestore(brCase VmBackupRestoreCase, backupName, restoreName string, nsRequiresResticDCWorkaround bool) {
+	log.Printf("Creating restore %s for case %s", restoreName, brCase.Name)
+	restore, err := lib.CreateRestoreFromBackup(dpaCR.Client, namespace, backupName, restoreName)
+	Expect(err).ToNot(HaveOccurred())
+	Eventually(lib.IsRestoreDone(dpaCR.Client, namespace, restoreName), timeoutMultiplier*time.Minute*60, time.Second*10).Should(BeTrue())
+	// TODO only log on fail?
+	describeRestore := lib.DescribeRestore(veleroClientForSuiteRun, dpaCR.Client, restore)
+	GinkgoWriter.Println(describeRestore)
+
+	restoreLogs := lib.RestoreLogs(kubernetesClientForSuiteRun, dpaCR.Client, restore)
+	restoreErrorLogs := lib.RestoreErrorLogs(kubernetesClientForSuiteRun, dpaCR.Client, restore)
+	accumulatedTestLogs = append(accumulatedTestLogs, describeRestore, restoreLogs)
+
+	if !brCase.SkipVerifyLogs {
+		Expect(restoreErrorLogs).Should(Equal([]string{}))
+	}
+
+	// Check if restore succeeded
+	succeeded, err := lib.IsRestoreCompletedSuccessfully(kubernetesClientForSuiteRun, dpaCR.Client, namespace, restoreName)
+	if brCase.RestoreErr != nil {
+		Expect(succeeded).To(Equal(false))
+		Expect(err).NotTo(BeNil())
+		Expect(err.Error()).To(ContainSubstring(brCase.RestoreErr.Error()))
+	} else {
+		Expect(err).ToNot(HaveOccurred())
+		Expect(succeeded).To(Equal(true))
+	}
+
+	if nsRequiresResticDCWorkaround {
+		// We run the dc-post-restore.sh script for both restic and
+		// kopia backups and for any DCs with attached volumes,
+		// regardless of whether it was restic or kopia backup.
+		// The script is designed to work with labels set by the
+		// openshift-velero-plugin and can be run without pre-conditions.
+		log.Printf("Running dc-post-restore.sh script.")
+		err = lib.RunDcPostRestoreScript(restoreName)
+		Expect(err).ToNot(HaveOccurred())
+	}
+}


### PR DESCRIPTION
## Why the changes were made

Backport of #1439 to oadp-1.4. Partially fixes [OADP-4291](https://issues.redhat.com//browse/OADP-4291) for 1.4.

## How to test the changes made

make TEST_VIRT=true test-e2e
