### PR TITLE
fix: make deploy-olm on ARM clusters

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 # Build the manager binary
-FROM quay.io/konveyor/builder:ubi9-latest AS builder
+FROM --platform=${BUILDPLATFORM} quay.io/konveyor/builder:ubi9-latest AS builder
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /go/src/github.com/openshift/oadp-operator
 # Copy the Go Modules manifests
@@ -16,7 +18,7 @@ COPY pkg/ pkg/
 COPY controllers/ controllers/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux go build -mod=mod -a -o /go/src/manager main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -mod=mod -a -o /go/src/manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=${BUILDPLATFORM} quay.io/konveyor/builder:ubi9-latest AS builder
+FROM quay.io/konveyor/builder:ubi9-latest AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,6 @@ vet: ## Run go vet against code.
 ENVTEST := $(shell pwd)/bin/setup-envtest
 ENVTESTPATH = $(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(shell pwd)/bin -p path)
 ifeq ($(shell $(ENVTEST) list | grep $(ENVTEST_K8S_VERSION)),)
-# TODO what --arch=amd64 does here?
 	ENVTESTPATH = $(shell $(ENVTEST) --arch=amd64 use $(ENVTEST_K8S_VERSION) -p path)
 endif
 $(ENVTEST): ## Download envtest-setup locally if necessary.

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,8 @@ endif
 # makes CLUSTER_TYPE quieter when unauthenticated
 CLUSTER_TYPE_SHELL := $(shell $(OC_CLI) get infrastructures cluster -o jsonpath='{.status.platform}' 2> /dev/null | tr A-Z a-z)
 CLUSTER_TYPE ?= $(CLUSTER_TYPE_SHELL)
+CLUSTER_OS = $(shell $(OC_CLI) get node -o jsonpath='{.items[0].status.nodeInfo.operatingSystem}' 2> /dev/null)
+CLUSTER_ARCH = $(shell $(OC_CLI) get node -o jsonpath='{.items[0].status.nodeInfo.architecture}' 2> /dev/null)
 
 ifeq ($(CLUSTER_TYPE), gcp)
 	CI_CRED_FILE = ${CLUSTER_PROFILE_DIR}/gce.json
@@ -161,6 +163,7 @@ vet: ## Run go vet against code.
 ENVTEST := $(shell pwd)/bin/setup-envtest
 ENVTESTPATH = $(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(shell pwd)/bin -p path)
 ifeq ($(shell $(ENVTEST) list | grep $(ENVTEST_K8S_VERSION)),)
+# TODO what --arch=amd64 does here?
 	ENVTESTPATH = $(shell $(ENVTEST) --arch=amd64 use $(ENVTEST_K8S_VERSION) -p path)
 endif
 $(ENVTEST): ## Download envtest-setup locally if necessary.
@@ -203,13 +206,14 @@ build: generate fmt vet ## Build manager binary.
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
-# Development clusters require linux/amd64 OCI image
-# Set platform to linux/amd64 regardless of host platform.
 # If using podman machine, and host platform is not linux/amd64 run
 # - podman machine ssh sudo rpm-ostree install qemu-user-static && sudo systemctl reboot
 # from: https://github.com/containers/podman/issues/12144#issuecomment-955760527
 # related enhancements that may remove the need to manually install qemu-user-static https://bugzilla.redhat.com/show_bug.cgi?id=2061584
 DOCKER_BUILD_ARGS ?= --platform=linux/amd64
+ifneq ($(CLUSTER_TYPE),)
+	DOCKER_BUILD_ARGS = --platform=$(CLUSTER_OS)/$(CLUSTER_ARCH)
+endif
 docker-build: ## Build docker image with the manager.
 	docker build -t $(IMG) . $(DOCKER_BUILD_ARGS)
 


### PR DESCRIPTION
## Why the changes were made

Allow `make deploy-olm` to also work in ARM clusters.

Related to https://github.com/openshift/release/pull/54877

## How to test the changes made

Run `make deploy-olm` on ARM and non ARM clusters and create DPA (to test quay images). Both should succeed.

> **Note**: you will need to use unsupported override, since quay images are still not available in ARM architecture. 
