### PR TITLE
use the multiarch build of mariadb-todolist

### DIFF
--- a/tests/e2e/sample-applications/mysql-persistent/mysql-persistent-csi.yaml
+++ b/tests/e2e/sample-applications/mysql-persistent/mysql-persistent-csi.yaml
@@ -176,7 +176,7 @@ items:
         spec:
           containers:
           - name: todolist
-            image: quay.io/migtools/oadp-ci-todolist-mariadb-go:latest
+            image: quay.io/migtools/oadp-ci-todolist-mariadb-go:multiarch
             env:
               - name: foo
                 value: bar

--- a/tests/e2e/sample-applications/mysql-persistent/mysql-persistent-twovol-csi.yaml
+++ b/tests/e2e/sample-applications/mysql-persistent/mysql-persistent-twovol-csi.yaml
@@ -167,7 +167,7 @@ items:
         spec:
           containers:
           - name: todolist
-            image: quay.io/migtools/oadp-ci-todolist-mariadb-go:latest
+            image: quay.io/migtools/oadp-ci-todolist-mariadb-go:multiarch
             env:
               - name: foo
                 value: bar

--- a/tests/e2e/sample-applications/mysql-persistent/mysql-persistent.yaml
+++ b/tests/e2e/sample-applications/mysql-persistent/mysql-persistent.yaml
@@ -189,7 +189,7 @@ items:
         spec:
           containers:
           - name: todolist
-            image: quay.io/migtools/oadp-ci-todolist-mariadb-go:latest
+            image: quay.io/migtools/oadp-ci-todolist-mariadb-go:multiarch
             env:
               - name: foo
                 value: bar


### PR DESCRIPTION
Current source for this image is:
https://github.com/weshayutin/todolist-mariadb-go.git
quay.io/migtools/oadp-ci-todolist-mariadb-go:multiarch

This is an updated version that is cleaned up a bit and also works with VM's or with containers.  Will push to migtools when this is passing.

## Why the changes were made

<!-- Explain why this PR is important, what problems it fixes, link related issues -->

## How to test the changes made

<!-- Explain how the changes introduced by this PR can be tested and verified, with commands and pictures -->
