### PR TITLE
Bump up CirrOS image size for PSI.

### DIFF
--- a/tests/e2e/sample-applications/virtual-machines/cirros-test/cirros-test.yaml
+++ b/tests/e2e/sample-applications/virtual-machines/cirros-test/cirros-test.yaml
@@ -20,7 +20,7 @@ items:
             storage:
               resources:
                 requests:
-                  storage: 128Mi
+                  storage: 150Mi
       running: true
       template:
         metadata:

--- a/tests/e2e/virt_backup_restore_suite_test.go
+++ b/tests/e2e/virt_backup_restore_suite_test.go
@@ -180,7 +180,7 @@ var _ = ginkgo.Describe("VM backup and restore tests", ginkgo.Ordered, func() {
 
 		url, err := getLatestCirrosImageURL()
 		gomega.Expect(err).To(gomega.BeNil())
-		err = v.EnsureDataVolumeFromUrl("openshift-virtualization-os-images", "cirros", url, "128Mi", 5*time.Minute)
+		err = v.EnsureDataVolumeFromUrl("openshift-virtualization-os-images", "cirros", url, "150Mi", 5*time.Minute)
 		gomega.Expect(err).To(gomega.BeNil())
 		err = v.CreateDataSourceFromPvc("openshift-virtualization-os-images", "cirros")
 		gomega.Expect(err).To(gomega.BeNil())


### PR DESCRIPTION
## Why the changes were made

Importing the CirrOS image into a cluster on OpenStack (storage class ocs-storagecluster-ceph-rbd-virtualization) fails with `Virtual image size 117440512 is larger than the reported available storage 117317632. A larger PVC is required.`

I'm not sure why this is the case, but bumping it up from 128M to 150 works.

## How to test the changes made

E2E tests are not set up to run against OpenStack just yet, but hacking it up to do nothing but download the CirrOS image reproduces the bug and the fix. You can also create the Data Volume manually: 

```
---
apiVersion: cdi.kubevirt.io/v1beta1
kind: DataVolume
metadata:
  name: cirros
  namespace: openshift-virtualization-os-images
spec:
  pvc:
    accessModes:
    - ReadWriteOnce
    resources:
      requests:
        storage: 150Mi
  source:
    http:
      url: https://download.cirros-cloud.net/0.6.2/cirros-0.6.2-x86_64-disk.img
```