### PR TITLE
fix: remove must-gather E2E test

### DIFF
--- a/tests/e2e/backup_restore_suite_test.go
+++ b/tests/e2e/backup_restore_suite_test.go
@@ -29,10 +29,8 @@ type BackupRestoreCase struct {
 
 type ApplicationBackupRestoreCase struct {
 	BackupRestoreCase
-	ApplicationTemplate          string
-	PvcSuffixName                string
-	MustGatherFiles              []string            // list of files expected in must-gather under quay.io.../clusters/clustername/... ie. "namespaces/openshift-adp/oadp.openshift.io/dpa-ts-example-velero/ts-example-velero.yml"
-	MustGatherValidationFunction *func(string) error // validation function for must-gather where string parameter is the path to "quay.io.../clusters/clustername/"
+	ApplicationTemplate string
+	PvcSuffixName       string
 }
 
 func todoListReady(preBackupState bool, twoVol bool, database string) VerificationFunction {

--- a/tests/e2e/lib/apps.go
+++ b/tests/e2e/lib/apps.go
@@ -352,7 +352,7 @@ func RunMustGather(oc_cli string, artifact_dir string) error {
 	ocClient := oc_cli
 	ocAdmin := "adm"
 	mustGatherCmd := "must-gather"
-	mustGatherImg := "--image=quay.io/konveyor/oadp-must-gather:latest"
+	mustGatherImg := "--image=ttl.sh/oadp/must-gather:mateus-test"
 	destDir := "--dest-dir=" + artifact_dir
 
 	cmd := exec.Command(ocClient, ocAdmin, mustGatherCmd, mustGatherImg, destDir)

--- a/tests/e2e/lib/dpa_helpers.go
+++ b/tests/e2e/lib/dpa_helpers.go
@@ -113,7 +113,7 @@ func (v *DpaCustomResource) Build(backupRestoreType BackupRestoreType) *oadpv1al
 	}
 	// Uncomment to override plugin images to use
 	dpaSpec.UnsupportedOverrides = map[oadpv1alpha1.UnsupportedImageKey]string{
-		// oadpv1alpha1.VeleroImageKey: "quay.io/konveyor/velero:oadp-1.1",
+		oadpv1alpha1.VeleroImageKey: "quay.io/konveyor/velero:oadp-1.4",
 	}
 	return &dpaSpec
 }

--- a/tests/e2e/upgrade_suite_test.go
+++ b/tests/e2e/upgrade_suite_test.go
@@ -55,10 +55,10 @@ var _ = ginkgo.Describe("OADP upgrade scenarios", ginkgo.Ordered, func() {
 				subscriptionSource = "redhat-operators"
 			}
 
-			log.Print("Creating Subscription oadp-operator")
+			log.Printf("Creating Subscription %v", subscriptionPackage)
 			subscription := v1alpha1.Subscription{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "oadp-operator",
+					Name:      subscriptionPackage,
 					Namespace: namespace,
 				},
 				Spec: &v1alpha1.SubscriptionSpec{


### PR DESCRIPTION
## Why the changes were made

With the updates from https://github.com/openshift/oadp-operator/issues/1487, must-gather E2E test will break. It will be updated to work on master and oadp-1.4 branch, but removed from other branches, as no new development tags will be created for those branches.

## How to test the changes made

TODO
