### PR TITLE
[OADP-1.4] Bump up CirrOS image size for PSI

### DIFF
--- a/tests/e2e/sample-applications/virtual-machines/cirros-test/cirros-test-immediate.yaml
+++ b/tests/e2e/sample-applications/virtual-machines/cirros-test/cirros-test-immediate.yaml
@@ -20,7 +20,7 @@ items:
             storage:
               resources:
                 requests:
-                  storage: 128Mi
+                  storage: 150Mi
               storageClassName: test-sc-immediate
       running: true
       template:

--- a/tests/e2e/sample-applications/virtual-machines/cirros-test/cirros-test.yaml
+++ b/tests/e2e/sample-applications/virtual-machines/cirros-test/cirros-test.yaml
@@ -20,7 +20,7 @@ items:
             storage:
               resources:
                 requests:
-                  storage: 128Mi
+                  storage: 150Mi
       running: true
       template:
         metadata:

--- a/tests/e2e/virt_backup_restore_suite_test.go
+++ b/tests/e2e/virt_backup_restore_suite_test.go
@@ -159,7 +159,7 @@ var _ = Describe("VM backup and restore tests", Ordered, func() {
 
 		url, err := getLatestCirrosImageURL()
 		Expect(err).To(BeNil())
-		err = v.EnsureDataVolumeFromUrl("openshift-virtualization-os-images", "cirros", url, "128Mi", 5*time.Minute)
+		err = v.EnsureDataVolumeFromUrl("openshift-virtualization-os-images", "cirros", url, "150Mi", 5*time.Minute)
 		Expect(err).To(BeNil())
 		err = v.CreateDataSourceFromPvc("openshift-virtualization-os-images", "cirros")
 		Expect(err).To(BeNil())


### PR DESCRIPTION
Why the changes were made
Importing the CirrOS image into a cluster on OpenStack (storage class ocs-storagecluster-ceph-rbd-virtualization) fails with Virtual image size 117440512 is larger than the reported available storage 117317632. A larger PVC is required.

I'm not sure why this is the case, but bumping it up from 128M to 150 works.

How to test the changes made
E2E tests are not set up to run against OpenStack just yet, but hacking it up to do nothing but download the CirrOS image reproduces the bug and the fix. You can also create the Data Volume manually:

bah: replaces https://github.com/openshift/oadp-operator/pull/1500