### PR TITLE
Virtualization E2E tests on OpenStack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ VELERO_INSTANCE_NAME ?= velero-test
 ARTIFACT_DIR ?= /tmp
 OC_CLI = $(shell which oc)
 TEST_VIRT ?= false
+KVM_EMULATION ?= true
 TEST_UPGRADE ?= false
 
 ifdef CLI_DIR
@@ -61,6 +62,12 @@ VELERO_PLUGIN ?= ${CLUSTER_TYPE}
 
 ifeq ($(CLUSTER_TYPE), ibmcloud)
 	VELERO_PLUGIN = aws
+endif
+
+ifeq ($(CLUSTER_TYPE), openstack)
+	CLUSTER_TYPE = aws
+	VELERO_PLUGIN = aws
+	KVM_EMULATION = false
 endif
 
 # Kubernetes version from OpenShift 4.16.x https://openshift-release.apps.ci.l2s4.p1.openshiftapps.com/#4-stable
@@ -517,6 +524,7 @@ test-e2e: test-e2e-setup install-ginkgo
 	-velero_instance_name=$(VELERO_INSTANCE_NAME) \
 	-artifact_dir=$(ARTIFACT_DIR) \
 	-oc_cli=$(OC_CLI) \
+	-kvm_emulation=$(KVM_EMULATION) \
 	--ginkgo.vv \
 	--ginkgo.no-color=$(OPENSHIFT_CI) \
 	--ginkgo.label-filter="$(TEST_FILTER)" \

--- a/Makefile
+++ b/Makefile
@@ -65,8 +65,6 @@ ifeq ($(CLUSTER_TYPE), ibmcloud)
 endif
 
 ifeq ($(CLUSTER_TYPE), openstack)
-	CLUSTER_TYPE = aws
-	VELERO_PLUGIN = aws
 	KVM_EMULATION = false
 endif
 

--- a/tests/e2e/backup_restore_suite_test.go
+++ b/tests/e2e/backup_restore_suite_test.go
@@ -72,7 +72,7 @@ func prepareBackupAndRestore(brCase BackupRestoreCase, updateLastInstallTime fun
 	gomega.Eventually(dpaCR.BSLsAreAvailable(), time.Minute*3, time.Second*5).Should(gomega.BeTrue())
 
 	if brCase.BackupRestoreType == lib.CSI || brCase.BackupRestoreType == lib.CSIDataMover {
-		if provider == "aws" || provider == "ibmcloud" || provider == "gcp" || provider == "azure" {
+		if provider == "aws" || provider == "ibmcloud" || provider == "gcp" || provider == "azure" || provider == "openstack" {
 			log.Printf("Creating VolumeSnapshotClass for CSI backuprestore of %s", brCase.Name)
 			snapshotClassPath := fmt.Sprintf("./sample-applications/snapclass-csi/%s.yaml", provider)
 			err = lib.InstallApplication(dpaCR.Client, snapshotClassPath)

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -48,6 +48,8 @@ var (
 	kubeConfig          *rest.Config
 	knownFlake          bool
 	accumulatedTestLogs []string
+
+	kvmEmulation bool
 )
 
 func init() {
@@ -62,6 +64,7 @@ func init() {
 	flag.StringVar(&artifact_dir, "artifact_dir", "/tmp", "Directory for storing must gather")
 	flag.StringVar(&oc_cli, "oc_cli", "oc", "OC CLI Client")
 	flag.Int64Var(&flakeAttempts, "flakeAttempts", 3, "Customize the number of flake retries (3)")
+	flag.BoolVar(&kvmEmulation, "kvm_emulation", true, "Enable or disable KVM emulation for virtualization testing")
 
 	// helps with launching debug sessions from IDE
 	if os.Getenv("E2E_USE_ENV_FLAGS") == "true" {
@@ -100,7 +103,15 @@ func init() {
 				flakeAttempts = parsedValue
 			}
 		}
+		if envValue := os.Getenv("KVM_EMULATION"); envValue != "" {
+			if parsedValue, err := strconv.ParseBool(envValue); err == nil {
+				kvmEmulation = parsedValue
+			} else {
+				log.Println("Error parsing KVM_EMULATION, it will be enabled by default: ", err)
+			}
+		}
 	}
+
 }
 
 func TestOADPE2E(t *testing.T) {

--- a/tests/e2e/lib/virt_storage_helpers.go
+++ b/tests/e2e/lib/virt_storage_helpers.go
@@ -38,7 +38,7 @@ func (v *VirtOperator) deleteDataVolume(namespace, name string) error {
 	return v.Dynamic.Resource(dataVolumeGVR).Namespace(namespace).Delete(context.Background(), name, metav1.DeleteOptions{})
 }
 
-func (v *VirtOperator) checkDataVolumeExists(namespace, name string) bool {
+func (v *VirtOperator) CheckDataVolumeExists(namespace, name string) bool {
 	unstructuredDataVolume, err := v.getDataVolume(namespace, name)
 	if err != nil {
 		return false
@@ -122,7 +122,7 @@ func (v *VirtOperator) createDataVolumeFromUrl(namespace, name, url, size string
 
 // Create a DataVolume and wait for it to be ready.
 func (v *VirtOperator) EnsureDataVolumeFromUrl(namespace, name, url, size string, timeout time.Duration) error {
-	if !v.checkDataVolumeExists(namespace, name) {
+	if !v.CheckDataVolumeExists(namespace, name) {
 		if err := v.createDataVolumeFromUrl(namespace, name, url, size); err != nil {
 			return err
 		}
@@ -155,7 +155,7 @@ func (v *VirtOperator) RemoveDataVolume(namespace, name string, timeout time.Dur
 	}
 
 	err = wait.PollImmediate(5*time.Second, timeout, func() (bool, error) {
-		return !v.checkDataVolumeExists(namespace, name), nil
+		return !v.CheckDataVolumeExists(namespace, name), nil
 	})
 	if err != nil {
 		return fmt.Errorf("timed out waiting for DataVolume %s/%s to be deleted: %w", namespace, name, err)

--- a/tests/e2e/lib/virt_storage_helpers.go
+++ b/tests/e2e/lib/virt_storage_helpers.go
@@ -242,5 +242,12 @@ func (v *VirtOperator) CreateImmediateModeStorageClass(name string) error {
 }
 
 func (v *VirtOperator) RemoveStorageClass(name string) error {
-	return v.Clientset.StorageV1().StorageClasses().Delete(context.Background(), name, metav1.DeleteOptions{})
+	err := v.Clientset.StorageV1().StorageClasses().Delete(context.Background(), name, metav1.DeleteOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	return nil
 }

--- a/tests/e2e/sample-applications/mongo-persistent/pvc/openstack.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/pvc/openstack.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: mongo
+      namespace: mongo-persistent
+      labels:
+        app: mongo
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      storageClassName: ocs-storagecluster-ceph-rbd
+      resources:
+        requests:
+          storage: 1Gi

--- a/tests/e2e/sample-applications/mysql-persistent/pvc-twoVol/openstack.yaml
+++ b/tests/e2e/sample-applications/mysql-persistent/pvc-twoVol/openstack.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: mysql
+      namespace: mysql-persistent
+      labels:
+        app: mysql
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      storageClassName: ocs-storagecluster-ceph-rbd
+      resources:
+        requests:
+          storage: 1Gi
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: applog
+      namespace: mysql-persistent
+      labels:
+        app: todolist
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      storageClassName: ocs-storagecluster-ceph-rbd
+      resources:
+        requests:
+          storage: 1Gi

--- a/tests/e2e/sample-applications/mysql-persistent/pvc/openstack.yaml
+++ b/tests/e2e/sample-applications/mysql-persistent/pvc/openstack.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: mysql
+      namespace: mysql-persistent
+      labels:
+        app: mysql
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      storageClassName: ocs-storagecluster-ceph-rbd
+      resources:
+        requests:
+          storage: 1Gi

--- a/tests/e2e/sample-applications/snapclass-csi/openstack.yaml
+++ b/tests/e2e/sample-applications/snapclass-csi/openstack.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: snapshot.storage.k8s.io/v1
+    kind: VolumeSnapshotClass
+    metadata:
+      name: oadp-example-snapclass
+      labels:
+        velero.io/csi-volumesnapshot-class: 'true'
+    driver: openshift-storage.rbd.csi.ceph.com
+    deletionPolicy: Retain
+    parameters:
+      clusterID: openshift-storage
+      csi.storage.k8s.io/snapshotter-secret-name: rook-csi-rbd-provisioner
+      csi.storage.k8s.io/snapshotter-secret-namespace: openshift-storage

--- a/tests/e2e/sample-applications/virtual-machines/cirros-test/cirros-test.yaml
+++ b/tests/e2e/sample-applications/virtual-machines/cirros-test/cirros-test.yaml
@@ -21,6 +21,7 @@ items:
               resources:
                 requests:
                   storage: 150Mi
+              storageClassName: test-sc-wffc
       running: true
       template:
         metadata:

--- a/tests/e2e/scripts/openstack_settings.sh
+++ b/tests/e2e/scripts/openstack_settings.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+cat > $TMP_DIR/oadpcreds <<EOF
+{
+  "spec": {
+      "configuration":{
+        "velero":{
+          "defaultPlugins": [
+            "openshift", "aws"
+          ]
+        }
+      },
+      "backupLocations": [
+        {
+          "velero": {
+            "provider": "aws",
+            "config": {
+             "profile": "$BSL_AWS_PROFILE",
+              "region": "$BSL_REGION"
+            },
+            "objectStorage":{
+              "bucket": "$BUCKET"
+            }
+          }
+        }
+      ],
+    "credential":{
+      "name": "$SECRET",
+      "key": "cloud"
+    },
+     "snapshotLocations": [
+       {
+         "velero": {
+           "provider": "aws",
+           "config": { 
+             "profile": "default",
+             "region": "$VSL_REGION"
+           }
+         }
+       }
+     ]
+  }
+}
+EOF
+
+x=$(cat $TMP_DIR/oadpcreds); echo "$x" | grep -o '^[^#]*'  > $TMP_DIR/oadpcreds

--- a/tests/e2e/virt_backup_restore_suite_test.go
+++ b/tests/e2e/virt_backup_restore_suite_test.go
@@ -198,6 +198,8 @@ var _ = ginkgo.Describe("VM backup and restore tests", ginkgo.Ordered, func() {
 
 		err = v.CreateImmediateModeStorageClass("test-sc-immediate")
 		gomega.Expect(err).To(gomega.BeNil())
+		err = v.CreateWaitForFirstConsumerStorageClass("test-sc-wffc")
+		gomega.Expect(err).To(gomega.BeNil())
 	})
 
 	var _ = ginkgo.AfterAll(func() {
@@ -211,6 +213,8 @@ var _ = ginkgo.Describe("VM backup and restore tests", ginkgo.Ordered, func() {
 		}
 
 		err := v.RemoveStorageClass("test-sc-immediate")
+		gomega.Expect(err).To(gomega.BeNil())
+		err = v.RemoveStorageClass("test-sc-wffc")
 		gomega.Expect(err).To(gomega.BeNil())
 	})
 

--- a/tests/e2e/virt_backup_restore_suite_test.go
+++ b/tests/e2e/virt_backup_restore_suite_test.go
@@ -177,8 +177,12 @@ var _ = ginkgo.Describe("VM backup and restore tests", ginkgo.Ordered, func() {
 			wasInstalledFromTest = true
 		}
 
-		err = v.EnsureEmulation(20 * time.Second)
-		gomega.Expect(err).To(gomega.BeNil())
+		if kvmEmulation {
+			err = v.EnsureEmulation(20 * time.Second)
+			gomega.Expect(err).To(gomega.BeNil())
+		} else {
+			log.Println("Avoiding setting KVM emulation, by command line request")
+		}
 
 		url, err := getLatestCirrosImageURL()
 		gomega.Expect(err).To(gomega.BeNil())


### PR DESCRIPTION
## Why the changes were made

This adds an E2E OpenStack provider that gets VM tests working on PSI, using an AWS bucket as the backup location. Includes a handful of tweaks like making KVM emulation configurable, creating a WFFC storage class when the default is Immediate, and creating a VolumeSnapshotClass for Ceph RBD.

## How to test the changes made

Log in to shared PSI cluster, set up AWS bucket as per usual instructions, then make TEST_VIRT=true test-e2e.
