### PR TITLE
OADP-4803: Block OCP upgrade to v4.16

### DIFF
--- a/bundle/manifests/oadp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/oadp-operator.clusterserviceversion.yaml
@@ -166,6 +166,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "true"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
+    olm.properties: '[{"type": "olm.maxOpenShiftVersion", "value": "4.15"}]'
     olm.skipRange: '>=0.0.0 <1.3.0'
     operatorframework.io/suggested-namespace: openshift-adp
     operators.openshift.io/infrastructure-features: '["Disconnected"]'

--- a/config/manifests/bases/oadp-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/oadp-operator.clusterserviceversion.yaml
@@ -20,6 +20,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "true"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
+    olm.properties: '[{"type": "olm.maxOpenShiftVersion", "value": "4.15"}]'
     olm.skipRange: '>=0.0.0 <1.3.0'
     operatorframework.io/suggested-namespace: openshift-adp
     operators.openshift.io/infrastructure-features: '["Disconnected"]'


### PR DESCRIPTION
https://issues.redhat.com/browse/OADP-4803

Use `olm.maxOpenShiftVersion` to prevent upgrading to OCP v4.16 when OADP 1.3 is installed.  OADP 1.3 on OCP v4.15 should upgrade to OADP 1.4 prior to upgrading to OCP v4.16.

