### PR TITLE
Delete the backuprepository object for namespace cirros-test in beforeAll

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ VELERO_INSTANCE_NAME ?= velero-test
 ARTIFACT_DIR ?= /tmp
 OC_CLI = $(shell which oc)
 TEST_VIRT ?= false
+KVM_EMULATION ?= true
 TEST_UPGRADE ?= false
 
 ifdef CLI_DIR
@@ -61,6 +62,10 @@ VELERO_PLUGIN ?= ${CLUSTER_TYPE}
 
 ifeq ($(CLUSTER_TYPE), ibmcloud)
 	VELERO_PLUGIN = aws
+endif
+
+ifeq ($(CLUSTER_TYPE), openstack)
+	KVM_EMULATION = false
 endif
 
 # Kubernetes version from OpenShift 4.16.x https://openshift-release.apps.ci.l2s4.p1.openshiftapps.com/#4-stable
@@ -517,6 +522,7 @@ test-e2e: test-e2e-setup install-ginkgo
 	-velero_instance_name=$(VELERO_INSTANCE_NAME) \
 	-artifact_dir=$(ARTIFACT_DIR) \
 	-oc_cli=$(OC_CLI) \
+	-kvm_emulation=$(KVM_EMULATION) \
 	--ginkgo.vv \
 	--ginkgo.no-color=$(OPENSHIFT_CI) \
 	--ginkgo.label-filter="$(TEST_FILTER)" \

--- a/tests/e2e/backup_restore_suite_test.go
+++ b/tests/e2e/backup_restore_suite_test.go
@@ -72,7 +72,7 @@ func prepareBackupAndRestore(brCase BackupRestoreCase, updateLastInstallTime fun
 	gomega.Eventually(dpaCR.BSLsAreAvailable(), time.Minute*3, time.Second*5).Should(gomega.BeTrue())
 
 	if brCase.BackupRestoreType == lib.CSI || brCase.BackupRestoreType == lib.CSIDataMover {
-		if provider == "aws" || provider == "ibmcloud" || provider == "gcp" || provider == "azure" {
+		if provider == "aws" || provider == "ibmcloud" || provider == "gcp" || provider == "azure" || provider == "openstack" {
 			log.Printf("Creating VolumeSnapshotClass for CSI backuprestore of %s", brCase.Name)
 			snapshotClassPath := fmt.Sprintf("./sample-applications/snapclass-csi/%s.yaml", provider)
 			err = lib.InstallApplication(dpaCR.Client, snapshotClassPath)

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -48,6 +48,8 @@ var (
 	kubeConfig          *rest.Config
 	knownFlake          bool
 	accumulatedTestLogs []string
+
+	kvmEmulation bool
 )
 
 func init() {
@@ -62,6 +64,7 @@ func init() {
 	flag.StringVar(&artifact_dir, "artifact_dir", "/tmp", "Directory for storing must gather")
 	flag.StringVar(&oc_cli, "oc_cli", "oc", "OC CLI Client")
 	flag.Int64Var(&flakeAttempts, "flakeAttempts", 3, "Customize the number of flake retries (3)")
+	flag.BoolVar(&kvmEmulation, "kvm_emulation", true, "Enable or disable KVM emulation for virtualization testing")
 
 	// helps with launching debug sessions from IDE
 	if os.Getenv("E2E_USE_ENV_FLAGS") == "true" {
@@ -100,7 +103,15 @@ func init() {
 				flakeAttempts = parsedValue
 			}
 		}
+		if envValue := os.Getenv("KVM_EMULATION"); envValue != "" {
+			if parsedValue, err := strconv.ParseBool(envValue); err == nil {
+				kvmEmulation = parsedValue
+			} else {
+				log.Println("Error parsing KVM_EMULATION, it will be enabled by default: ", err)
+			}
+		}
 	}
+
 }
 
 func TestOADPE2E(t *testing.T) {

--- a/tests/e2e/lib/k8s_common_helpers.go
+++ b/tests/e2e/lib/k8s_common_helpers.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"log"
 	"os"
-	"regexp"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -91,34 +90,6 @@ func DeleteSecret(clientset *kubernetes.Clientset, namespace string, credSecretR
 		return nil
 	}
 	return err
-}
-
-// DeleteBackupRepositoryByRegex deletes a BackupRepository instance that matches the given regex pattern.
-func DeleteBackupRepositoryByRegex(c *kubernetes.Clientset, namespace string, regexPattern string) error {
-	// Compile the regex pattern
-	regex, err := regexp.Compile(regexPattern)
-	if err != nil {
-		return fmt.Errorf("failed to compile regex pattern: %v", err)
-	}
-	// List all BackupRepository instances in the namespace
-	backupRepos, err := clientset.CoreV1().BackupRepositories(namespace).Get(context.Background(), namespace, metav1.GetOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to list BackupRepositories: %v", err)
-	}
-
-	// Iterate through the BackupRepositories and delete the one that matches the regex
-	for _, repo := range backupRepos.Items {
-		if regex.MatchString(repo.Name) {
-			err := clientset.CoreV1().BackupRepositories(namespace).Delete(context.TODO(), repo.Name, metav1.DeleteOptions{})
-			if err != nil {
-				return fmt.Errorf("failed to delete BackupRepository %s: %v", repo.Name, err)
-			}
-			log.Printf("Successfully deleted BackupRepository: %s", repo.Name)
-			return nil
-		}
-	}
-
-	return fmt.Errorf("no BackupRepository matching the regex pattern %s was found", regexPattern)
 }
 
 // ExecuteCommandInPodsSh executes a command in a Kubernetes pod using the provided parameters.

--- a/tests/e2e/sample-applications/mongo-persistent/pvc/openstack.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/pvc/openstack.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: mongo
+      namespace: mongo-persistent
+      labels:
+        app: mongo
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      storageClassName: ocs-storagecluster-ceph-rbd
+      resources:
+        requests:
+          storage: 1Gi

--- a/tests/e2e/sample-applications/mysql-persistent/pvc-twoVol/openstack.yaml
+++ b/tests/e2e/sample-applications/mysql-persistent/pvc-twoVol/openstack.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: mysql
+      namespace: mysql-persistent
+      labels:
+        app: mysql
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      storageClassName: ocs-storagecluster-ceph-rbd
+      resources:
+        requests:
+          storage: 1Gi
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: applog
+      namespace: mysql-persistent
+      labels:
+        app: todolist
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      storageClassName: ocs-storagecluster-ceph-rbd
+      resources:
+        requests:
+          storage: 1Gi

--- a/tests/e2e/sample-applications/mysql-persistent/pvc/openstack.yaml
+++ b/tests/e2e/sample-applications/mysql-persistent/pvc/openstack.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: mysql
+      namespace: mysql-persistent
+      labels:
+        app: mysql
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      storageClassName: ocs-storagecluster-ceph-rbd
+      resources:
+        requests:
+          storage: 1Gi

--- a/tests/e2e/sample-applications/snapclass-csi/openstack.yaml
+++ b/tests/e2e/sample-applications/snapclass-csi/openstack.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: snapshot.storage.k8s.io/v1
+    kind: VolumeSnapshotClass
+    metadata:
+      name: oadp-example-snapclass
+      labels:
+        velero.io/csi-volumesnapshot-class: 'true'
+    driver: openshift-storage.rbd.csi.ceph.com
+    deletionPolicy: Retain
+    parameters:
+      clusterID: openshift-storage
+      csi.storage.k8s.io/snapshotter-secret-name: rook-csi-rbd-provisioner
+      csi.storage.k8s.io/snapshotter-secret-namespace: openshift-storage

--- a/tests/e2e/sample-applications/virtual-machines/cirros-test/cirros-test.yaml
+++ b/tests/e2e/sample-applications/virtual-machines/cirros-test/cirros-test.yaml
@@ -21,6 +21,7 @@ items:
               resources:
                 requests:
                   storage: 150Mi
+              storageClassName: test-sc-wffc
       running: true
       template:
         metadata:

--- a/tests/e2e/scripts/openstack_settings.sh
+++ b/tests/e2e/scripts/openstack_settings.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+cat > $TMP_DIR/oadpcreds <<EOF
+{
+  "spec": {
+      "configuration":{
+        "velero":{
+          "defaultPlugins": [
+            "openshift", "aws"
+          ]
+        }
+      },
+      "backupLocations": [
+        {
+          "velero": {
+            "provider": "aws",
+            "config": {
+             "profile": "$BSL_AWS_PROFILE",
+              "region": "$BSL_REGION"
+            },
+            "objectStorage":{
+              "bucket": "$BUCKET"
+            }
+          }
+        }
+      ],
+    "credential":{
+      "name": "$SECRET",
+      "key": "cloud"
+    },
+     "snapshotLocations": [
+       {
+         "velero": {
+           "provider": "aws",
+           "config": { 
+             "profile": "default",
+             "region": "$VSL_REGION"
+           }
+         }
+       }
+     ]
+  }
+}
+EOF
+
+x=$(cat $TMP_DIR/oadpcreds); echo "$x" | grep -o '^[^#]*'  > $TMP_DIR/oadpcreds

--- a/tests/e2e/virt_backup_restore_suite_test.go
+++ b/tests/e2e/virt_backup_restore_suite_test.go
@@ -187,8 +187,7 @@ var _ = ginkgo.Describe("VM backup and restore tests", ginkgo.Ordered, func() {
 
 		err = v.CreateImmediateModeStorageClass("test-sc-immediate")
 		gomega.Expect(err).To(gomega.BeNil())
-		err = lib.DeleteBackupRepositoryByRegex(kubernetesClientForSuiteRun, "openshift-oadp", "cirros-test.*")
-		gomega.Expect(err).To(gomega.BeNil())
+		lib.DeleteBackupRepositoryByRegex(runTimeClientForSuiteRun, "openshift-oadp", "cirros-test.*")
 	})
 
 	var _ = ginkgo.AfterAll(func() {

--- a/tests/e2e/virt_backup_restore_suite_test.go
+++ b/tests/e2e/virt_backup_restore_suite_test.go
@@ -187,6 +187,8 @@ var _ = ginkgo.Describe("VM backup and restore tests", ginkgo.Ordered, func() {
 
 		err = v.CreateImmediateModeStorageClass("test-sc-immediate")
 		gomega.Expect(err).To(gomega.BeNil())
+		err = lib.DeleteBackupRepositoryByRegex(kubernetesClientForSuiteRun, "openshift-oadp", "cirros-test.*")
+		gomega.Expect(err).To(gomega.BeNil())
 	})
 
 	var _ = ginkgo.AfterAll(func() {


### PR DESCRIPTION
## Why the changes were made

There is only one namespace used for all cirros tests and the backuprepository can fail backups in runs.
The bsl is recreated for each test, but the br is reused if on the cluster.  If we have a new bsl, we need a new br.

## How to test the changes made

make test-e2e w/ virt settings.