### PR TITLE
delete the existing backuprepositories prior to a new test 

### DIFF
--- a/tests/e2e/backup_restore_suite_test.go
+++ b/tests/e2e/backup_restore_suite_test.go
@@ -98,7 +98,7 @@ func runApplicationBackupAndRestore(brCase ApplicationBackupRestoreCase, expecte
 	backupName, restoreName := prepareBackupAndRestore(brCase.BackupRestoreCase, updateLastInstallTime)
 
 	// Ensure that an existing backup repository is deleted
-	brerr := lib.DeleteBackupRepositoryByRegex(runTimeClientForSuiteRun, namespace)
+	brerr := lib.DeleteBackupRepositories(runTimeClientForSuiteRun, namespace)
 	gomega.Expect(brerr).ToNot(gomega.HaveOccurred())
 
 	// install app

--- a/tests/e2e/backup_restore_suite_test.go
+++ b/tests/e2e/backup_restore_suite_test.go
@@ -97,6 +97,10 @@ func runApplicationBackupAndRestore(brCase ApplicationBackupRestoreCase, expecte
 	// create DPA
 	backupName, restoreName := prepareBackupAndRestore(brCase.BackupRestoreCase, updateLastInstallTime)
 
+	// Ensure that an existing backup repository is deleted
+	brerr := lib.DeleteBackupRepositoryByRegex(runTimeClientForSuiteRun, namespace)
+	gomega.Expect(brerr).ToNot(gomega.HaveOccurred())
+
 	// install app
 	updateLastInstallTime()
 	log.Printf("Installing application for case %s", brCase.Name)

--- a/tests/e2e/lib/backup.go
+++ b/tests/e2e/lib/backup.go
@@ -183,7 +183,7 @@ func DeleteBackupRepositoryByRegex(c client.Client, namespace string, regexPatte
 		return fmt.Errorf("failed to get BackupRepository list: %v", err)
 	}
 
-	// Iterate through the BackupRepositories and delete the one that matches the regex
+	// Get a list of the BackupRepositories and delete the one that matches the regex
 	for _, repo := range backupRepos.Items {
 		if regex.MatchString(repo.Name) {
 			err := DeleteBackupRepository(c, namespace, repo.Name)

--- a/tests/e2e/lib/backup.go
+++ b/tests/e2e/lib/backup.go
@@ -147,11 +147,12 @@ func BackupErrorLogs(c *kubernetes.Clientset, ocClient client.Client, namespace 
 }
 
 func GetBackupRepositoryList(c client.Client, namespace string) (*velero.BackupRepositoryList, error) {
+	// initialize an empty list of BackupRepositories
 	backupRepositoryList := &velero.BackupRepositoryList{
 		Items: []velero.BackupRepository{},
 	}
+	// get the list of BackupRepositories in the given namespace
 	err := c.List(context.Background(), backupRepositoryList, client.InNamespace(namespace))
-	// if there is an error, just print, don't return the error
 	if err != nil {
 		log.Printf("error getting BackupRepository list: %v", err)
 		return nil, err
@@ -173,7 +174,7 @@ func DeleteBackupRepository(c client.Client, namespace string, name string) erro
 	return nil
 }
 
-// DeleteBackupRepositories deletes all BackupRepositories n.
+// DeleteBackupRepositories deletes all BackupRepositories in the given namespace.
 func DeleteBackupRepositories(c client.Client, namespace string) error {
 	log.Printf("Checking if backuprepository's exist in %s", namespace)
 

--- a/tests/e2e/lib/backup.go
+++ b/tests/e2e/lib/backup.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"regexp"
 	"time"
 
 	velero "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
@@ -144,4 +145,58 @@ func BackupLogs(c *kubernetes.Clientset, ocClient client.Client, namespace strin
 func BackupErrorLogs(c *kubernetes.Clientset, ocClient client.Client, namespace string, name string) []string {
 	bl := BackupLogs(c, ocClient, namespace, name)
 	return errorLogsExcludingIgnored(bl)
+}
+
+func GetBackupRepositoryList(c client.Client) (*velero.BackupRepositoryList, error) {
+	backupRepositoryList := &velero.BackupRepositoryList{}
+	err := c.List(context.Background(), backupRepositoryList)
+	if err != nil {
+		return nil, err
+	}
+	return backupRepositoryList, nil
+}
+
+func DeleteBackupRepository(c client.Client, namespace string, name string) error {
+	backupRepository := &velero.BackupRepository{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "openshift-adp",
+			Name:      name,
+		},
+	}
+	err := c.Delete(context.Background(), backupRepository)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// DeleteBackupRepositoryByRegex deletes a BackupRepository instance that matches the given regex pattern.
+func DeleteBackupRepositoryByRegex(c client.Client, namespace string, regexPattern string) error {
+	log.Printf("Checking if backuprepository for cirros-test exists")
+	regex, err := regexp.Compile(regexPattern)
+	if err != nil {
+		return fmt.Errorf("failed to compile regex pattern: %v", err)
+	}
+	// List all BackupRepository instances in the namespace
+	backupRepos, err := GetBackupRepositoryList(c)
+	if err != nil {
+		return fmt.Errorf("failed to get BackupRepository list: %v", err)
+	}
+
+	// Iterate through the BackupRepositories and delete the one that matches the regex
+	for _, repo := range backupRepos.Items {
+		if regex.MatchString(repo.Name) {
+			err := DeleteBackupRepository(c, namespace, repo.Name)
+			if err != nil {
+				return fmt.Errorf("failed to delete BackupRepository %s: %v", repo.Name, err)
+			}
+			log.Printf("Successfully deleted BackupRepository: %s", repo.Name)
+			return nil
+		} else {
+			log.Printf("backuprepository starting with %s not found", regexPattern)
+			return nil
+		}
+	}
+
+	return fmt.Errorf("no BackupRepository matching the regex pattern %s was found", regexPattern)
 }

--- a/tests/e2e/virt_backup_restore_suite_test.go
+++ b/tests/e2e/virt_backup_restore_suite_test.go
@@ -200,7 +200,7 @@ var _ = ginkgo.Describe("VM backup and restore tests", ginkgo.Ordered, func() {
 		gomega.Expect(err).To(gomega.BeNil())
 		err = v.CreateWaitForFirstConsumerStorageClass("test-sc-wffc")
 		gomega.Expect(err).To(gomega.BeNil())
-		lib.DeleteBackupRepositoryByRegex(runTimeClientForSuiteRun, namespace, "cirros-test.*")
+		lib.DeleteBackupRepositoryByRegex(runTimeClientForSuiteRun, namespace)
 		gomega.Expect(err).To(gomega.BeNil())
 	})
 

--- a/tests/e2e/virt_backup_restore_suite_test.go
+++ b/tests/e2e/virt_backup_restore_suite_test.go
@@ -200,6 +200,8 @@ var _ = ginkgo.Describe("VM backup and restore tests", ginkgo.Ordered, func() {
 		gomega.Expect(err).To(gomega.BeNil())
 		err = v.CreateWaitForFirstConsumerStorageClass("test-sc-wffc")
 		gomega.Expect(err).To(gomega.BeNil())
+		lib.DeleteBackupRepositoryByRegex(runTimeClientForSuiteRun, "openshift-oadp", "cirros-test.*")
+		gomega.Expect(err).To(gomega.BeNil())
 	})
 
 	var _ = ginkgo.AfterAll(func() {

--- a/tests/e2e/virt_backup_restore_suite_test.go
+++ b/tests/e2e/virt_backup_restore_suite_test.go
@@ -200,7 +200,7 @@ var _ = ginkgo.Describe("VM backup and restore tests", ginkgo.Ordered, func() {
 		gomega.Expect(err).To(gomega.BeNil())
 		err = v.CreateWaitForFirstConsumerStorageClass("test-sc-wffc")
 		gomega.Expect(err).To(gomega.BeNil())
-		lib.DeleteBackupRepositoryByRegex(runTimeClientForSuiteRun, "openshift-oadp", "cirros-test.*")
+		lib.DeleteBackupRepositoryByRegex(runTimeClientForSuiteRun, namespace, "cirros-test.*")
 		gomega.Expect(err).To(gomega.BeNil())
 	})
 

--- a/tests/e2e/virt_backup_restore_suite_test.go
+++ b/tests/e2e/virt_backup_restore_suite_test.go
@@ -200,7 +200,7 @@ var _ = ginkgo.Describe("VM backup and restore tests", ginkgo.Ordered, func() {
 		gomega.Expect(err).To(gomega.BeNil())
 		err = v.CreateWaitForFirstConsumerStorageClass("test-sc-wffc")
 		gomega.Expect(err).To(gomega.BeNil())
-		lib.DeleteBackupRepositoryByRegex(runTimeClientForSuiteRun, namespace)
+		err = lib.DeleteBackupRepositories(runTimeClientForSuiteRun, namespace)
 		gomega.Expect(err).To(gomega.BeNil())
 	})
 


### PR DESCRIPTION

## Why the changes were made

delete the backuprepository for cirros-test namespace if found.
The e2e tests use a new bsl for every test run but the backuprepository can be stale and prevent backups from passing.
We need to delete backuprepository as well.

## How to test the changes made

make test-e2e with virt settings