### PR TITLE
Add support for VSL name and labels

### DIFF
--- a/api/v1alpha1/oadp_types.go
+++ b/api/v1alpha1/oadp_types.go
@@ -237,6 +237,8 @@ type BackupLocation struct {
 type SnapshotLocation struct {
 	// TODO: Add name/annotations/labels support
 
+	// +optional
+	Name   string                             `json:"name,omitempty"`
 	Velero *velero.VolumeSnapshotLocationSpec `json:"velero"`
 }
 

--- a/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
@@ -1277,6 +1277,8 @@ spec:
                   items:
                     description: SnapshotLocation defines the configuration for the DPA snapshot store
                     properties:
+                      name:
+                        type: string
                       velero:
                         description: VolumeSnapshotLocationSpec defines the specification for a Velero VolumeSnapshotLocation.
                         properties:

--- a/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
@@ -1277,6 +1277,8 @@ spec:
                   items:
                     description: SnapshotLocation defines the configuration for the DPA snapshot store
                     properties:
+                      name:
+                        type: string
                       velero:
                         description: VolumeSnapshotLocationSpec defines the specification for a Velero VolumeSnapshotLocation.
                         properties:

--- a/controllers/vsl.go
+++ b/controllers/vsl.go
@@ -12,6 +12,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
+	"github.com/openshift/oadp-operator/pkg/common"
 	"github.com/openshift/oadp-operator/pkg/credentials"
 )
 
@@ -219,10 +220,17 @@ func (r *DPAReconciler) ReconcileVolumeSnapshotLocations(log logr.Logger) (bool,
 	for i, vslSpec := range dpa.Spec.SnapshotLocations {
 		// Create VSL as is, we can safely assume they are valid from
 		// ValidateVolumeSnapshotLocations
+
+		// check if VSL name is specified in DPA spec
+		vslName := fmt.Sprintf("%s-%d", r.NamespacedName.Name, i+1)
+		if vslSpec.Name != "" {
+			vslName = vslSpec.Name
+		}
+
 		vsl := velerov1.VolumeSnapshotLocation{
 			ObjectMeta: metav1.ObjectMeta{
 				// TODO: Use a hash instead of i
-				Name:      fmt.Sprintf("%s-%d", r.NamespacedName.Name, i+1),
+				Name:      vslName,
 				Namespace: r.NamespacedName.Namespace,
 			},
 			Spec: *vslSpec.Velero,
@@ -239,6 +247,14 @@ func (r *DPAReconciler) ReconcileVolumeSnapshotLocations(log logr.Logger) (bool,
 				return err
 			}
 			// TODO: check for VSL status condition errors and respond here
+
+			vsl.Labels = map[string]string{
+				"app.kubernetes.io/name":       common.OADPOperatorVelero,
+				"app.kubernetes.io/instance":   vslName,
+				"app.kubernetes.io/managed-by": common.OADPOperator,
+				"app.kubernetes.io/component":  "vsl",
+				oadpv1alpha1.OadpOperatorLabel: "True",
+			}
 
 			vsl.Spec = *vslSpec.Velero
 			return nil

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 )
 
 require (
+	github.com/aws/aws-sdk-go-v2 v1.30.3
 	github.com/aws/aws-sdk-go-v2/config v1.26.3
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.15.11
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.48.0
@@ -45,7 +46,6 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.5.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.3.2 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 // indirect
-	github.com/aws/aws-sdk-go-v2 v1.30.3 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.5.4 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.26 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.11 // indirect


### PR DESCRIPTION
## Why the changes were made

Added VSL name and labels, similar to BSL, so it is easier to remove the unwanted VSLs when DPA is edited.

Context: Issue #1469
