### PR TITLE
OADP-3050: Remove unwanted BSL/VSLs on create/edit DPA

### DIFF
--- a/controllers/vsl.go
+++ b/controllers/vsl.go
@@ -3,12 +3,14 @@ package controllers
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/go-logr/logr"
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
@@ -216,6 +218,7 @@ func (r *DPAReconciler) ReconcileVolumeSnapshotLocations(log logr.Logger) (bool,
 		return false, err
 	}
 
+	dpaVSLNames := []string{}
 	// Loop through all configured VSLs
 	for i, vslSpec := range dpa.Spec.SnapshotLocations {
 		// Create VSL as is, we can safely assume they are valid from
@@ -226,6 +229,7 @@ func (r *DPAReconciler) ReconcileVolumeSnapshotLocations(log logr.Logger) (bool,
 		if vslSpec.Name != "" {
 			vslName = vslSpec.Name
 		}
+		dpaVSLNames = append(dpaVSLNames, vslName)
 
 		vsl := velerov1.VolumeSnapshotLocation{
 			ObjectMeta: metav1.ObjectMeta{
@@ -272,6 +276,34 @@ func (r *DPAReconciler) ReconcileVolumeSnapshotLocations(log logr.Logger) (bool,
 		}
 
 	}
+
+	dpaVSLs := velerov1.VolumeSnapshotLocationList{}
+	dpaVslLabels := map[string]string{
+		"app.kubernetes.io/name":       common.OADPOperatorVelero,
+		"app.kubernetes.io/managed-by": common.OADPOperator,
+		"app.kubernetes.io/component":  "vsl",
+	}
+	err := r.List(r.Context, &dpaVSLs, client.InNamespace(r.NamespacedName.Namespace), client.MatchingLabels(dpaVslLabels))
+	if err != nil {
+		return false, err
+	}
+
+	// If current VSLs do not match the spec, delete extra VSLs
+	if len(dpaVSLNames) != len(dpaVSLs.Items) {
+		for _, vsl := range dpaVSLs.Items {
+			if !slices.Contains(dpaVSLNames, vsl.Name) {
+				if err := r.Delete(r.Context, &vsl); err != nil {
+					return false, err
+				}
+				// Record event for VSL deletion
+				r.EventRecorder.Event(&vsl,
+					corev1.EventTypeNormal,
+					"VolumeSnapshotLocationDeleted",
+					fmt.Sprintf("VolumeSnapshotLocation %s created by OADP in namespace %s was deleted as it was not in DPA spec.", vsl.Name, vsl.Namespace))
+			}
+		}
+	}
+
 	return true, nil
 }
 

--- a/tests/e2e/dpa_deployment_suite_test.go
+++ b/tests/e2e/dpa_deployment_suite_test.go
@@ -1,6 +1,7 @@
 package e2e_test
 
 import (
+	"fmt"
 	"log"
 	"strings"
 	"time"
@@ -190,14 +191,12 @@ var _ = ginkgo.Describe("Configuration testing for DPA Custom Resource", func() 
 					log.Printf("Checking for BSL spec")
 					gomega.Expect(dpaCR.DoesBSLSpecMatchesDpa(namespace, *bsl.Velero)).To(gomega.BeTrue())
 				}
+			} else {
+				log.Println("Checking no BSLs are deployed")
+				_, err = dpaCR.ListBSLs()
+				gomega.Expect(err).To(gomega.HaveOccurred())
+				gomega.Expect(err.Error()).To(gomega.Equal(fmt.Sprintf("no BSL in %s namespace", namespace)))
 			}
-			// TODO bug
-			// else {
-			// 	log.Println("Checking no BSLs are deployed")
-			// 	_, err = dpaCR.ListBSLs()
-			// 	Expect(err).To(HaveOccurred())
-			// 	Expect(err.Error()).To(Equal(fmt.Sprintf("no BSL in %s namespace", namespace)))
-			// }
 
 			if len(installCase.DpaSpec.SnapshotLocations) > 0 {
 				// TODO Check if VSLs are available creating new backup/restore test with VSL
@@ -205,14 +204,12 @@ var _ = ginkgo.Describe("Configuration testing for DPA Custom Resource", func() 
 					log.Printf("Checking for VSL spec")
 					gomega.Expect(dpaCR.DoesVSLSpecMatchesDpa(namespace, *vsl.Velero)).To(gomega.BeTrue())
 				}
+			} else {
+				log.Println("Checking no VSLs are deployed")
+				_, err = dpaCR.ListVSLs()
+				gomega.Expect(err).To(gomega.HaveOccurred())
+				gomega.Expect(err.Error()).To(gomega.Equal(fmt.Sprintf("no VSL in %s namespace", namespace)))
 			}
-			// TODO bug
-			// else {
-			// 	log.Println("Checking no VSLs are deployed")
-			// 	_, err = dpaCR.ListVSLs()
-			// 	Expect(err).To(HaveOccurred())
-			// 	Expect(err.Error()).To(Equal(fmt.Sprintf("no VSL in %s namespace", namespace)))
-			// }
 
 			if len(installCase.DpaSpec.Configuration.Velero.PodConfig.Tolerations) > 0 {
 				log.Printf("Checking for velero tolerances")


### PR DESCRIPTION
Fixes #1469 of unwanted BSL or VSLs in the cases:

1. BSLs/VSLs removed from DPA spec.
2. BSL/VSLs names modified in-place from DPA spec.
3. Default-named BSL/VSLs removed from DPA spec.

hope that covers all cases.