### PR TITLE
Allow developer to specify e2e test name on cli

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -527,7 +527,7 @@ test-e2e: test-e2e-setup install-ginkgo
 	--ginkgo.no-color=$(OPENSHIFT_CI) \
 	--ginkgo.label-filter="$(TEST_FILTER)" \
 	--ginkgo.timeout=2h \
-	$(TEST_ARGS)
+	$(GINKGO_ARGS)
 
 .PHONY: test-e2e-cleanup
 test-e2e-cleanup: login-required

--- a/Makefile
+++ b/Makefile
@@ -526,7 +526,8 @@ test-e2e: test-e2e-setup install-ginkgo
 	--ginkgo.vv \
 	--ginkgo.no-color=$(OPENSHIFT_CI) \
 	--ginkgo.label-filter="$(TEST_FILTER)" \
-	--ginkgo.timeout=2h
+	--ginkgo.timeout=2h \
+	$(TEST_ARGS)
 
 .PHONY: test-e2e-cleanup
 test-e2e-cleanup: login-required

--- a/docs/developer/testing/TESTING.md
+++ b/docs/developer/testing/TESTING.md
@@ -90,7 +90,7 @@ FIt("the assertion", func() { ... })
 You can also execute make test-e2e with a $TEST_ARGS variable set. Example:
 
 ```bash
-make test-e2e TEST_ARGS="--ginkgo.focus='MySQL application DATAMOVER'"
+make test-e2e GINKGO_ARGS="--ginkgo.focus='MySQL application DATAMOVER'"
 ```
 
 These need to be removed to run all specs. Checks [Ginkgo docs](https://onsi.github.io/ginkgo/) for more info.

--- a/docs/developer/testing/TESTING.md
+++ b/docs/developer/testing/TESTING.md
@@ -86,14 +86,13 @@ FContext("test scenario", func() { ... })
 FIt("the assertion", func() { ... })
 ...
 ```
+These need to be removed to run all specs. Checks [Ginkgo docs](https://onsi.github.io/ginkgo/) for more info.
 
-You can also execute make test-e2e with a $TEST_ARGS variable set. Example:
+You can also execute make test-e2e with a $GINKGO_ARGS variable set. Example:
 
 ```bash
 make test-e2e GINKGO_ARGS="--ginkgo.focus='MySQL application DATAMOVER'"
 ```
-
-These need to be removed to run all specs. Checks [Ginkgo docs](https://onsi.github.io/ginkgo/) for more info.
 
 ## Clean up
 

--- a/docs/developer/testing/TESTING.md
+++ b/docs/developer/testing/TESTING.md
@@ -87,6 +87,12 @@ FIt("the assertion", func() { ... })
 ...
 ```
 
+You can also execute make test-e2e with a $TEST_ARGS variable set. Example:
+
+```bash
+make test-e2e TEST_ARGS="--ginkgo.focus='MySQL application DATAMOVER'"
+```
+
 These need to be removed to run all specs. Checks [Ginkgo docs](https://onsi.github.io/ginkgo/) for more info.
 
 ## Clean up


### PR DESCRIPTION
## Why the changes were made

BECAUSE, you shouldn't have to change src code to specify the dam test you want to execute.
GOLANG / Ginkgo pffft.

## How to test the changes made

make test-e2e TEST_ARGS="--ginkgo.focus='MySQL application DATAMOVER'"
should only run 1 test :)