### PR TITLE
OADP-3562: Fix controller panic on secret key-value parsing

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -94,6 +94,7 @@ linters:
     # - gosimple
     # - govet
     # - ineffassign
+    - loggercheck
     # - misspell
     - nakedret
     # - nilerr

--- a/controllers/registry.go
+++ b/controllers/registry.go
@@ -472,8 +472,8 @@ func (r *DPAReconciler) getMatchedKeyValue(key string, s string) (string, error)
 		s = strings.TrimPrefix(s, prefix)
 	}
 	if len(s) == 0 {
-		r.Log.Info("Could not parse secret for %s", key)
-		return s, errors.New(key + " secret parsing error")
+		r.Log.Info(fmt.Sprintf("Could not parse secret for %s", key))
+		return s, errors.New("secret parsing error in key " + key)
 	}
 	return s, nil
 }


### PR DESCRIPTION
Fixes -> https://issues.redhat.com/browse/OADP-3562 

Tested successfully with empty value for key.

status:
  conditions:
  - lastTransitionTime: "2024-09-24T09:04:15Z"
    message: secret parsing error in key AZURE_STORAGE_ACCOUNT_ACCESS_KEY
    reason: Error
    status: "False"
    type: Reconciled
