### PR TITLE
OADP-4935: Default permission for Secrets

### DIFF
--- a/controllers/common.go
+++ b/controllers/common.go
@@ -2,7 +2,7 @@ package controllers
 
 import (
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/openshift/oadp-operator/pkg/common"
 )
@@ -37,7 +37,7 @@ func setPodTemplateSpecDefaults(template *corev1.PodTemplateSpec) {
 		template.Spec.RestartPolicy = corev1.RestartPolicyAlways
 	}
 	if template.Spec.TerminationGracePeriodSeconds == nil {
-		template.Spec.TerminationGracePeriodSeconds = pointer.Int64(30)
+		template.Spec.TerminationGracePeriodSeconds = ptr.To(int64(30))
 	}
 	if template.Spec.DNSPolicy == "" {
 		template.Spec.DNSPolicy = corev1.DNSClusterFirst
@@ -51,18 +51,17 @@ func setPodTemplateSpecDefaults(template *corev1.PodTemplateSpec) {
 	if template.Spec.SchedulerName == "" {
 		template.Spec.SchedulerName = "default-scheduler"
 	}
-	// for each volumes, if volumeSource is Projected or SecretVolumeSource, set default mode
+	// for each volumes, if volumeSource is Projected or SecretVolumeSource, set default permission
 	for i := range template.Spec.Volumes {
 		if template.Spec.Volumes[i].Projected != nil {
 			if template.Spec.Volumes[i].Projected != nil {
-				template.Spec.Volumes[i].Projected.DefaultMode = common.DefaultModePtr()
+				template.Spec.Volumes[i].Projected.DefaultMode = ptr.To(common.DefaultPermission)
 			}
 		} else if template.Spec.Volumes[i].Secret != nil {
-			template.Spec.Volumes[i].Secret.DefaultMode = common.DefaultModePtr()
+			template.Spec.Volumes[i].Secret.DefaultMode = ptr.To(common.DefaultPermission)
 		} else if template.Spec.Volumes[i].HostPath != nil {
 			if template.Spec.Volumes[i].HostPath.Type == nil {
-				defaultHostPathType := corev1.HostPathType("")
-				template.Spec.Volumes[i].HostPath.Type = &defaultHostPathType
+				template.Spec.Volumes[i].HostPath.Type = ptr.To(corev1.HostPathType(""))
 			}
 		}
 	}

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -55,10 +55,10 @@ func setPodTemplateSpecDefaults(template *corev1.PodTemplateSpec) {
 	for i := range template.Spec.Volumes {
 		if template.Spec.Volumes[i].Projected != nil {
 			if template.Spec.Volumes[i].Projected != nil {
-				template.Spec.Volumes[i].Projected.DefaultMode = ptr.To(common.DefaultPermission)
+				template.Spec.Volumes[i].Projected.DefaultMode = ptr.To(common.DefaultProjectedPermission)
 			}
 		} else if template.Spec.Volumes[i].Secret != nil {
-			template.Spec.Volumes[i].Secret.DefaultMode = ptr.To(common.DefaultPermission)
+			template.Spec.Volumes[i].Secret.DefaultMode = ptr.To(common.DefaultSecretPermission)
 		} else if template.Spec.Volumes[i].HostPath != nil {
 			if template.Spec.Volumes[i].HostPath.Type == nil {
 				template.Spec.Volumes[i].HostPath.Type = ptr.To(corev1.HostPathType(""))

--- a/controllers/velero.go
+++ b/controllers/velero.go
@@ -21,7 +21,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -264,18 +264,16 @@ func (r *DPAReconciler) customizeVeleroDeployment(dpa *oadpv1alpha1.DataProtecti
 		})
 
 	if hasShortLivedCredentials {
-		expirationSeconds := int64(3600)
 		veleroDeployment.Spec.Template.Spec.Volumes = append(veleroDeployment.Spec.Template.Spec.Volumes,
 			corev1.Volume{
 				Name: "bound-sa-token",
 				VolumeSource: corev1.VolumeSource{
 					Projected: &corev1.ProjectedVolumeSource{
-						DefaultMode: common.DefaultModePtr(),
 						Sources: []corev1.VolumeProjection{
 							{
 								ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
 									Audience:          "openshift",
-									ExpirationSeconds: &expirationSeconds,
+									ExpirationSeconds: ptr.To(int64(3600)),
 									Path:              "token",
 								},
 							},
@@ -385,18 +383,30 @@ func (r *DPAReconciler) customizeVeleroDeployment(dpa *oadpv1alpha1.DataProtecti
 		}
 	}
 	if veleroDeployment.Spec.RevisionHistoryLimit == nil {
-		veleroDeployment.Spec.RevisionHistoryLimit = pointer.Int32(10)
+		veleroDeployment.Spec.RevisionHistoryLimit = ptr.To(int32(10))
 	}
 	if veleroDeployment.Spec.ProgressDeadlineSeconds == nil {
-		veleroDeployment.Spec.ProgressDeadlineSeconds = pointer.Int32(600)
+		veleroDeployment.Spec.ProgressDeadlineSeconds = ptr.To(int32(600))
 	}
+	r.appendPluginSpecificSpecs(dpa, veleroDeployment, veleroContainer, providerNeedsDefaultCreds, hasCloudStorage)
 	setPodTemplateSpecDefaults(&veleroDeployment.Spec.Template)
-	return r.appendPluginSpecificSpecs(dpa, veleroDeployment, veleroContainer, providerNeedsDefaultCreds, hasCloudStorage)
+	if configMapName, ok := dpa.Annotations[common.UnsupportedVeleroServerArgsAnnotation]; ok {
+		if configMapName != "" {
+			unsupportedServerArgsCM := corev1.ConfigMap{}
+			if err := r.Get(r.Context, types.NamespacedName{Namespace: dpa.Namespace, Name: configMapName}, &unsupportedServerArgsCM); err != nil {
+				return err
+			}
+			if err := common.ApplyUnsupportedServerArgsOverride(veleroContainer, unsupportedServerArgsCM, common.Velero); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
 }
 
 // add plugin specific specs to velero deployment
-func (r *DPAReconciler) appendPluginSpecificSpecs(dpa *oadpv1alpha1.DataProtectionApplication, veleroDeployment *appsv1.Deployment, veleroContainer *corev1.Container, providerNeedsDefaultCreds map[string]bool, hasCloudStorage bool) error {
-
+func (r *DPAReconciler) appendPluginSpecificSpecs(dpa *oadpv1alpha1.DataProtectionApplication, veleroDeployment *appsv1.Deployment, veleroContainer *corev1.Container, providerNeedsDefaultCreds map[string]bool, hasCloudStorage bool) {
 	init_container_resources := veleroContainer.Resources
 
 	for _, plugin := range dpa.Spec.Configuration.Velero.DefaultPlugins {
@@ -464,8 +474,7 @@ func (r *DPAReconciler) appendPluginSpecificSpecs(dpa *oadpv1alpha1.DataProtecti
 					Name: secretName,
 					VolumeSource: corev1.VolumeSource{
 						Secret: &corev1.SecretVolumeSource{
-							SecretName:  secretName,
-							DefaultMode: common.DefaultModePtr(),
+							SecretName: secretName,
 						},
 					},
 				})
@@ -496,20 +505,6 @@ func (r *DPAReconciler) appendPluginSpecificSpecs(dpa *oadpv1alpha1.DataProtecti
 				})
 		}
 	}
-
-	if configMapName, ok := dpa.Annotations[common.UnsupportedVeleroServerArgsAnnotation]; ok {
-		if configMapName != "" {
-			unsupportedServerArgsCM := corev1.ConfigMap{}
-			if err := r.Get(r.Context, types.NamespacedName{Namespace: dpa.Namespace, Name: configMapName}, &unsupportedServerArgsCM); err != nil {
-				return err
-			}
-			if err := common.ApplyUnsupportedServerArgsOverride(veleroContainer, unsupportedServerArgsCM, common.Velero); err != nil {
-				return err
-			}
-		}
-	}
-
-	return nil
 }
 
 func (r *DPAReconciler) customizeVeleroContainer(dpa *oadpv1alpha1.DataProtectionApplication, veleroDeployment *appsv1.Deployment, veleroContainer *corev1.Container, hasShortLivedCredentials bool, prometheusPort *int) error {

--- a/controllers/velero.go
+++ b/controllers/velero.go
@@ -450,22 +450,20 @@ func (r *DPAReconciler) appendPluginSpecificSpecs(dpa *oadpv1alpha1.DataProtecti
 			// set default secret name to use
 			secretName := pluginSpecificMap.SecretName
 			// append plugin specific volume mounts
-			if veleroContainer != nil {
-				veleroContainer.VolumeMounts = append(
-					veleroContainer.VolumeMounts,
-					corev1.VolumeMount{
-						Name:      secretName,
-						MountPath: pluginSpecificMap.MountPath,
-					})
+			veleroContainer.VolumeMounts = append(
+				veleroContainer.VolumeMounts,
+				corev1.VolumeMount{
+					Name:      secretName,
+					MountPath: pluginSpecificMap.MountPath,
+				})
 
-				// append plugin specific env vars
-				veleroContainer.Env = append(
-					veleroContainer.Env,
-					corev1.EnvVar{
-						Name:  pluginSpecificMap.EnvCredentialsFile,
-						Value: pluginSpecificMap.MountPath + "/" + credentials.CloudFieldPath,
-					})
-			}
+			// append plugin specific env vars
+			veleroContainer.Env = append(
+				veleroContainer.Env,
+				corev1.EnvVar{
+					Name:  pluginSpecificMap.EnvCredentialsFile,
+					Value: pluginSpecificMap.MountPath + "/" + credentials.CloudFieldPath,
+				})
 
 			// append plugin specific volumes
 			veleroDeployment.Spec.Template.Spec.Volumes = append(
@@ -756,12 +754,10 @@ func (r DPAReconciler) noDefaultCredentials(dpa oadpv1alpha1.DataProtectionAppli
 	hasCloudStorage := false
 	if dpa.Spec.Configuration.Velero.NoDefaultBackupLocation {
 		needDefaultCred := false
-
 		if dpa.Spec.UnsupportedOverrides[oadpv1alpha1.OperatorTypeKey] == oadpv1alpha1.OperatorTypeMTC {
 			// MTC requires default credentials
 			needDefaultCred = true
 		}
-		// go through cloudprovider plugins and mark providerNeedsDefaultCreds to false
 		for _, provider := range dpa.Spec.Configuration.Velero.DefaultPlugins {
 			if psf, ok := credentials.PluginSpecificFields[provider]; ok && psf.IsCloudProvider {
 				providerNeedsDefaultCreds[psf.PluginName] = needDefaultCred

--- a/controllers/velero_test.go
+++ b/controllers/velero_test.go
@@ -315,7 +315,7 @@ func deploymentVolumeSecret(name string) corev1.Volume {
 		VolumeSource: corev1.VolumeSource{
 			Secret: &corev1.SecretVolumeSource{
 				SecretName:  name,
-				DefaultMode: ptr.To(int32(420)),
+				DefaultMode: ptr.To(int32(0600)),
 			},
 		},
 	}
@@ -1451,7 +1451,7 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 						Name: "bound-sa-token",
 						VolumeSource: corev1.VolumeSource{
 							Projected: &corev1.ProjectedVolumeSource{
-								DefaultMode: ptr.To(int32(420)),
+								DefaultMode: ptr.To(int32(0600)),
 								Sources: []corev1.VolumeProjection{
 									{
 										ServiceAccountToken: &corev1.ServiceAccountTokenProjection{

--- a/controllers/velero_test.go
+++ b/controllers/velero_test.go
@@ -315,7 +315,7 @@ func deploymentVolumeSecret(name string) corev1.Volume {
 		VolumeSource: corev1.VolumeSource{
 			Secret: &corev1.SecretVolumeSource{
 				SecretName:  name,
-				DefaultMode: ptr.To(int32(0400)),
+				DefaultMode: ptr.To(int32(0440)),
 			},
 		},
 	}
@@ -1451,7 +1451,7 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 						Name: "bound-sa-token",
 						VolumeSource: corev1.VolumeSource{
 							Projected: &corev1.ProjectedVolumeSource{
-								DefaultMode: ptr.To(int32(0400)),
+								DefaultMode: ptr.To(int32(0440)),
 								Sources: []corev1.VolumeProjection{
 									{
 										ServiceAccountToken: &corev1.ServiceAccountTokenProjection{

--- a/controllers/velero_test.go
+++ b/controllers/velero_test.go
@@ -1451,7 +1451,7 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 						Name: "bound-sa-token",
 						VolumeSource: corev1.VolumeSource{
 							Projected: &corev1.ProjectedVolumeSource{
-								DefaultMode: ptr.To(int32(0440)),
+								DefaultMode: ptr.To(int32(0644)),
 								Sources: []corev1.VolumeProjection{
 									{
 										ServiceAccountToken: &corev1.ServiceAccountTokenProjection{

--- a/controllers/velero_test.go
+++ b/controllers/velero_test.go
@@ -315,7 +315,7 @@ func deploymentVolumeSecret(name string) corev1.Volume {
 		VolumeSource: corev1.VolumeSource{
 			Secret: &corev1.SecretVolumeSource{
 				SecretName:  name,
-				DefaultMode: ptr.To(int32(0600)),
+				DefaultMode: ptr.To(int32(0400)),
 			},
 		},
 	}
@@ -1451,7 +1451,7 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 						Name: "bound-sa-token",
 						VolumeSource: corev1.VolumeSource{
 							Projected: &corev1.ProjectedVolumeSource{
-								DefaultMode: ptr.To(int32(0600)),
+								DefaultMode: ptr.To(int32(0400)),
 								Sources: []corev1.VolumeProjection{
 									{
 										ServiceAccountToken: &corev1.ServiceAccountTokenProjection{

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -100,8 +100,8 @@ const (
 	UnsupportedNodeAgentServerArgsAnnotation = "oadp.openshift.io/unsupported-node-agent-server-args"
 )
 
-// Owner can read/write; Group and Public do not have any permissions
-const DefaultPermission = int32(0600)
+// Owner can read; Group and Public do not have any permissions
+const DefaultPermission = int32(0400)
 
 func AppendUniqueKeyTOfTMaps[T comparable](userLabels ...map[T]T) (map[T]T, error) {
 	var base map[T]T

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -100,12 +100,8 @@ const (
 	UnsupportedNodeAgentServerArgsAnnotation = "oadp.openshift.io/unsupported-node-agent-server-args"
 )
 
-const defaultMode = int32(420)
-
-func DefaultModePtr() *int32 {
-	var mode int32 = defaultMode
-	return &mode
-}
+// Owner can read/write; Group and Public do not have any permissions
+const DefaultPermission = int32(0600)
 
 func AppendUniqueKeyTOfTMaps[T comparable](userLabels ...map[T]T) (map[T]T, error) {
 	var base map[T]T

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -100,8 +100,8 @@ const (
 	UnsupportedNodeAgentServerArgsAnnotation = "oadp.openshift.io/unsupported-node-agent-server-args"
 )
 
-// Owner can read; Group and Public do not have any permissions
-const DefaultPermission = int32(0400)
+// Owner and Group can read; Public do not have any permissions
+const DefaultPermission = int32(0440)
 
 func AppendUniqueKeyTOfTMaps[T comparable](userLabels ...map[T]T) (map[T]T, error) {
 	var base map[T]T

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -100,8 +100,13 @@ const (
 	UnsupportedNodeAgentServerArgsAnnotation = "oadp.openshift.io/unsupported-node-agent-server-args"
 )
 
-// Owner and Group can read; Public do not have any permissions
-const DefaultPermission = int32(0440)
+// Volume permissions
+const (
+	// Owner and Group can read; Public do not have any permissions
+	DefaultSecretPermission = int32(0440)
+	// Owner can read and write; Group and Public can read
+	DefaultProjectedPermission = int32(0644)
+)
 
 func AppendUniqueKeyTOfTMaps[T comparable](userLabels ...map[T]T) (map[T]T, error) {
 	var base map[T]T


### PR DESCRIPTION
## Why the changes were made

have more restrictive permissions for Pods' `volume.secrets`.

## How to test the changes made

Run `make deploy-olm` and check if nothing was broken by the change.

To test `volume.secrets`, create a DPA WITHOUT specifying credentials in BSL/VSL. Reference https://redhat-internal.slack.com/archives/C039LRSDC8Z/p1728048939142289

In master, you should have this result
```console
sh-5.1$ ls -1la credentials/cloud
lrwxrwxrwx. 1 root 1000640000 12 Oct  4 17:27 credentials/cloud -> ..data/cloud
sh-5.1$ ls -1laL credentials/cloud
-rw-r--r--. 1 root 1000640000 132 Oct  4 17:27 credentials/cloud
```
In this PR branch, you should have this result
```console
sh-5.1$ ls -1la credentials/cloud 
lrwxrwxrwx. 1 root 1000660000 12 Oct  4 13:53 credentials/cloud -> ..data/cloud
sh-5.1$ ls -1laL credentials/cloud 
-r--r-----. 1 root 1000660000 132 Oct  4 13:53 credentials/cloud
```
You also need to test operations, like backup/restores, with these changes, since E2E tests do not create DPAs  WITHOUT specifying credentials in BSL/VSL.

### Test 1: No BSL credential and no VSL

DPA
```yaml
spec:
  backupLocations:
    - velero:
        config:
          profile: default
          region: us-east-1
        default: true
        objectStorage:
          bucket: my-bucket-name
          prefix: velero
        provider: aws
  configuration:
    velero:
      defaultPlugins:
        - openshift
        - aws
```

```console
sh-5.1$ ls -1a credentials/cloud
credentials/cloud
sh-5.1$ ls -1alL credentials/cloud
-r--r-----. 1 root 1000660000 132 Oct  7 18:22 credentials/cloud
sh-5.1$ ls -1a tmp/credentials/test-oadp-operator/
.
..
sh-5.1$ ls -1alL tmp/credentials/test-oadp-operator/
total 12
drwxr-xr-x. 2 1000660000 root 4096 Oct  7 18:22 .
drwxr-xr-x. 3 1000660000 root 4096 Oct  7 18:22 ..
```

### Test 2: BSL credential and no VSL

DPA
```yaml
spec:
  backupLocations:
    - velero:
        config:
          profile: default
          region: us-east-1
        credential:
          key: cloud
          name: cloud-credentials
        default: true
        objectStorage:
          bucket: my-bucket-name
          prefix: velero
        provider: aws
  configuration:
    velero:
      defaultPlugins:
        - openshift
        - aws
```

```console
sh-5.1$ ls -1a credentials/cloud
ls: cannot access 'credentials/cloud': No such file or directory
sh-5.1$ ls -1alL credentials/cloud
ls: cannot access 'credentials/cloud': No such file or directory
sh-5.1$ ls -1a tmp/credentials/test-oadp-operator/
.
..
cloud-credentials-cloud
sh-5.1$ ls -1alL tmp/credentials/test-oadp-operator/
total 16
drwxr-xr-x. 2 1000660000 root 4096 Oct  7 18:32 .
drwxr-xr-x. 3 1000660000 root 4096 Oct  7 18:32 ..
-rw-r--r--. 1 1000660000 root  132 Oct  7 18:33 cloud-credentials-cloud
```

### Test 3: BSL credential and no VSL credential

DPA
```yaml
spec:
  backupLocations:
    - velero:
        config:
          profile: default
          region: us-east-1
        credential:
          key: cloud
          name: cloud-credentials
        default: true
        objectStorage:
          bucket: my-bucket-name
          prefix: velero
        provider: aws
  configuration:
    velero:
      defaultPlugins:
        - openshift
        - aws
  snapshotLocations:
    - velero:
        config:
          profile: default
          region: us-west-2
        provider: aws
```

```console
sh-5.1$ ls -1a credentials/cloud
credentials/cloud
sh-5.1$ ls -1alL credentials/cloud
-r--r-----. 1 root 1000660000 132 Oct  7 18:35 credentials/cloud
sh-5.1$ ls -1a tmp/credentials/test-oadp-operator/
.
..
cloud-credentials-cloud
sh-5.1$ ls -1alL tmp/credentials/test-oadp-operator/
total 16
drwxr-xr-x. 2 1000660000 root 4096 Oct  7 18:35 .
drwxr-xr-x. 3 1000660000 root 4096 Oct  7 18:35 ..
-rw-r--r--. 1 1000660000 root  132 Oct  7 18:36 cloud-credentials-cloud
```