### PR TITLE
Set unsupported images via shell in our e2e tests

### DIFF
--- a/docs/developer/testing/TESTING.md
+++ b/docs/developer/testing/TESTING.md
@@ -94,6 +94,22 @@ You can also execute make test-e2e with a $GINKGO_ARGS variable set. Example:
 make test-e2e GINKGO_ARGS="--ginkgo.focus='MySQL application DATAMOVER'"
 ```
 
+### Run tests with custom images
+
+You can run tests with custom images by setting the following environment variables:
+```bash
+export VELERO_IMAGE=<velero_image>
+export AWS_PLUGIN_IMAGE=<aws_plugin_image>
+export OPENSHIFT_PLUGIN_IMAGE=<openshift_plugin_image>
+export AZURE_PLUGIN_IMAGE=<azure_plugin_image>
+export GCP_PLUGIN_IMAGE=<gcp_plugin_image>
+export CSI_PLUGIN_IMAGE=<csi_plugin_image>
+export RESTORE_IMAGE=<restore_image>
+export KUBEVIRT_PLUGIN_IMAGE=<kubevirt_plugin_image>
+export NON_ADMIN_IMAGE=<non_admin_image>
+```
+For further details, see tests/e2e/scripts/
+
 ## Clean up
 
 To clean environment after running E2E tests, run

--- a/docs/developer/testing/TESTING.md
+++ b/docs/developer/testing/TESTING.md
@@ -108,7 +108,7 @@ export RESTORE_IMAGE=<restore_image>
 export KUBEVIRT_PLUGIN_IMAGE=<kubevirt_plugin_image>
 export NON_ADMIN_IMAGE=<non_admin_image>
 ```
-For further details, see tests/e2e/scripts/
+For further details, see [tests/e2e/scripts/](../../../tests/e2e/scripts/)
 
 ## Clean up
 

--- a/tests/e2e/dpa_deployment_suite_test.go
+++ b/tests/e2e/dpa_deployment_suite_test.go
@@ -32,7 +32,6 @@ type TestDPASpec struct {
 	NoS3ForcePathStyle      bool
 	NoRegion                bool
 	DoNotBackupImages       bool
-	UnsupportedOverrides    map[oadpv1alpha1.UnsupportedImageKey]string
 }
 
 func createTestDPASpec(testSpec TestDPASpec) *oadpv1alpha1.DataProtectionApplicationSpec {
@@ -66,7 +65,7 @@ func createTestDPASpec(testSpec TestDPASpec) *oadpv1alpha1.DataProtectionApplica
 			},
 		},
 		SnapshotLocations:    testSpec.SnapshotLocations,
-		UnsupportedOverrides: testSpec.UnsupportedOverrides,
+		UnsupportedOverrides: dpaCR.UnsupportedOverrides,
 	}
 	if testSpec.EnableNodeAgent {
 		dpaSpec.Configuration.NodeAgent = &oadpv1alpha1.NodeAgentConfig{
@@ -357,14 +356,6 @@ var _ = ginkgo.Describe("Configuration testing for DPA Custom Resource", func() 
 				NoRegion:           true,
 				NoS3ForcePathStyle: true,
 				DoNotBackupImages:  true,
-			}),
-		}),
-		ginkgo.Entry("DPA CR with unsupportedOverrides", ginkgo.Label("aws", "ibmcloud"), InstallCase{
-			DpaSpec: createTestDPASpec(TestDPASpec{
-				BSLSecretName: bslSecretName,
-				UnsupportedOverrides: map[oadpv1alpha1.UnsupportedImageKey]string{
-					"awsPluginImageFqin": "quay.io/konveyor/velero-plugin-for-aws:oadp-1.4",
-				},
 			}),
 		}),
 	)

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -49,8 +49,7 @@ var (
 	knownFlake          bool
 	accumulatedTestLogs []string
 
-	kvmEmulation         bool
-	unsupportedOverrides map[string]string
+	kvmEmulation bool
 )
 
 func init() {

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -49,7 +49,8 @@ var (
 	knownFlake          bool
 	accumulatedTestLogs []string
 
-	kvmEmulation bool
+	kvmEmulation         bool
+	unsupportedOverrides map[string]string
 )
 
 func init() {
@@ -169,6 +170,7 @@ func TestOADPE2E(t *testing.T) {
 		BSLBucketPrefix:      veleroPrefix,
 		VeleroDefaultPlugins: dpa.DeepCopy().Spec.Configuration.Velero.DefaultPlugins,
 		SnapshotLocations:    dpa.DeepCopy().Spec.SnapshotLocations,
+		UnsupportedOverrides: dpa.DeepCopy().Spec.UnsupportedOverrides,
 	}
 
 	ginkgo.RunSpecs(t, "OADP E2E using velero prefix: "+veleroPrefix)

--- a/tests/e2e/lib/dpa_helpers.go
+++ b/tests/e2e/lib/dpa_helpers.go
@@ -94,9 +94,7 @@ func (v *DpaCustomResource) Build(backupRestoreType BackupRestoreType) *oadpv1al
 				},
 			},
 		},
-		UnsupportedOverrides: map[oadpv1alpha1.UnsupportedImageKey]string{
-			oadpv1alpha1.VeleroImageKey: v.UnsupportedOverrides[oadpv1alpha1.VeleroImageKey],
-		},
+		UnsupportedOverrides: v.UnsupportedOverrides,
 	}
 	switch backupRestoreType {
 	case RESTIC, KOPIA:
@@ -120,7 +118,7 @@ func (v *DpaCustomResource) Build(backupRestoreType BackupRestoreType) *oadpv1al
 	// dpaSpec.UnsupportedOverrides = map[oadpv1alpha1.UnsupportedImageKey]string{
 	// 	oadpv1alpha1.VeleroImageKey: "quay.io/rhn_engineering_whayutin/velero:testlatest",
 	// }
-	// log.Printf("WES3 - DPA: %v", dpaSpec)
+	log.Printf("WES-Michal - DPA: %v", dpaSpec)
 	return &dpaSpec
 }
 
@@ -148,10 +146,6 @@ func (v *DpaCustomResource) Get() (*oadpv1alpha1.DataProtectionApplication, erro
 }
 
 func (v *DpaCustomResource) CreateOrUpdate(c client.Client, spec *oadpv1alpha1.DataProtectionApplicationSpec) error {
-	// for debugging
-	// prettyPrint, _ := json.MarshalIndent(spec, "", "  ")
-	// log.Printf("DPA with spec\n%s\n", prettyPrint)
-
 	dpa, err := v.Get()
 	log.Printf("WES2 - DPA: %v", dpa)
 	if err != nil {

--- a/tests/e2e/lib/dpa_helpers.go
+++ b/tests/e2e/lib/dpa_helpers.go
@@ -153,9 +153,8 @@ func (v *DpaCustomResource) CreateOrUpdate(c client.Client, spec *oadpv1alpha1.D
 				},
 				Spec: *spec.DeepCopy(),
 			}
-			dpaPatch := dpa.DeepCopy()
-			dpaPatch.Spec.UnsupportedOverrides = v.UnsupportedOverrides
-			return v.Create(dpaPatch)
+			dpa.Spec.UnsupportedOverrides = v.UnsupportedOverrides
+			return v.Create(dpa)
 		}
 		return err
 	}

--- a/tests/e2e/lib/dpa_helpers.go
+++ b/tests/e2e/lib/dpa_helpers.go
@@ -51,7 +51,6 @@ func LoadDpaSettingsFromJson(settings string) (*oadpv1alpha1.DataProtectionAppli
 	}
 	dpa := &oadpv1alpha1.DataProtectionApplication{}
 	err = json.Unmarshal(file, &dpa)
-	log.Printf("WES - DPA: %v", dpa)
 	if err != nil {
 		return nil, fmt.Errorf("Error decoding json file: %v", err)
 	}
@@ -114,16 +113,11 @@ func (v *DpaCustomResource) Build(backupRestoreType BackupRestoreType) *oadpv1al
 		dpaSpec.Configuration.Velero.FeatureFlags = append(dpaSpec.Configuration.Velero.FeatureFlags, velero.CSIFeatureFlag)
 		dpaSpec.SnapshotLocations = nil
 	}
-	// Uncomment to override plugin images to use
-	// dpaSpec.UnsupportedOverrides = map[oadpv1alpha1.UnsupportedImageKey]string{
-	// 	oadpv1alpha1.VeleroImageKey: "quay.io/rhn_engineering_whayutin/velero:testlatest",
-	// }
-	log.Printf("WES-Michal - DPA: %v", dpaSpec)
+
 	return &dpaSpec
 }
 
 func (v *DpaCustomResource) Create(dpa *oadpv1alpha1.DataProtectionApplication) error {
-	log.Printf("WES4 - DPA: %v", dpa)
 	err := v.Client.Create(context.Background(), dpa)
 	if apierrors.IsAlreadyExists(err) {
 		return errors.New("found unexpected existing Velero CR")

--- a/tests/e2e/lib/dpa_helpers.go
+++ b/tests/e2e/lib/dpa_helpers.go
@@ -140,6 +140,9 @@ func (v *DpaCustomResource) Get() (*oadpv1alpha1.DataProtectionApplication, erro
 }
 
 func (v *DpaCustomResource) CreateOrUpdate(c client.Client, spec *oadpv1alpha1.DataProtectionApplicationSpec) error {
+	// for debugging
+	// prettyPrint, _ := json.MarshalIndent(spec, "", "  ")
+	// log.Printf("DPA with spec\n%s\n", prettyPrint)
 	dpa, err := v.Get()
 	if err != nil {
 		if apierrors.IsNotFound(err) {

--- a/tests/e2e/scripts/aws_settings.sh
+++ b/tests/e2e/scripts/aws_settings.sh
@@ -13,6 +13,7 @@ cat > $TMP_DIR/oadpcreds <<EOF
         "resticRestoreImageFqin": "$RESTORE_IMAGE",
         "kubevirtPluginImageFqin": "$KUBEVIRT_PLUGIN_IMAGE",
         "nonAdminControllerImageFqin": "$NON_ADMIN_IMAGE"
+      },
       "configuration":{
         "velero":{
           "defaultPlugins": [

--- a/tests/e2e/scripts/aws_settings.sh
+++ b/tests/e2e/scripts/aws_settings.sh
@@ -9,7 +9,6 @@ cat > $TMP_DIR/oadpcreds <<EOF
         "openshiftPluginImageFqin": "$OPENSHIFT_PLUGIN_IMAGE",
         "azurePluginImageFqin": "$AZURE_PLUGIN_IMAGE",
         "gcpPluginImageFqin": "$GCP_PLUGIN_IMAGE",
-        "csiPluginImageFqin": "$CSI_PLUGIN_IMAGE",
         "resticRestoreImageFqin": "$RESTORE_IMAGE",
         "kubevirtPluginImageFqin": "$KUBEVIRT_PLUGIN_IMAGE",
         "nonAdminControllerImageFqin": "$NON_ADMIN_IMAGE"

--- a/tests/e2e/scripts/aws_settings.sh
+++ b/tests/e2e/scripts/aws_settings.sh
@@ -3,6 +3,16 @@
 cat > $TMP_DIR/oadpcreds <<EOF
 {
   "spec": {
+      "unsupportedOverrides": {
+        "veleroImageFqin": "$VELERO_IMAGE",
+        "awsPluginImageFqin": "$AWS_PLUGIN_IMAGE",
+        "openshiftPluginImageFqin": "$OPENSHIFT_PLUGIN_IMAGE",
+        "azurePluginImageFqin": "$AZURE_PLUGIN_IMAGE",
+        "gcpPluginImageFqin": "$GCP_PLUGIN_IMAGE",
+        "csiPluginImageFqin": "$CSI_PLUGIN_IMAGE",
+        "resticRestoreImageFqin": "$RESTORE_IMAGE",
+        "kubevirtPluginImageFqin": "$KUBEVIRT_PLUGIN_IMAGE",
+        "nonAdminControllerImageFqin": "$NON_ADMIN_IMAGE"
       "configuration":{
         "velero":{
           "defaultPlugins": [

--- a/tests/e2e/scripts/azure_settings.sh
+++ b/tests/e2e/scripts/azure_settings.sh
@@ -40,6 +40,17 @@ EOF
 cat > $TMP_DIR/oadpcreds <<EOF
 {
   "spec": {
+      "unsupportedOverrides": {
+        "veleroImageFqin": "$VELERO_IMAGE",
+        "awsPluginImageFqin": "$AWS_PLUGIN_IMAGE",
+        "openshiftPluginImageFqin": "$OPENSHIFT_PLUGIN_IMAGE",
+        "azurePluginImageFqin": "$AZURE_PLUGIN_IMAGE",
+        "gcpPluginImageFqin": "$GCP_PLUGIN_IMAGE",
+        "csiPluginImageFqin": "$CSI_PLUGIN_IMAGE",
+        "resticRestoreImageFqin": "$RESTORE_IMAGE",
+        "kubevirtPluginImageFqin": "$KUBEVIRT_PLUGIN_IMAGE",
+        "nonAdminControllerImageFqin": "$NON_ADMIN_IMAGE"
+      },
       "configuration":{
         "velero":{
           "defaultPlugins": [

--- a/tests/e2e/scripts/azure_settings.sh
+++ b/tests/e2e/scripts/azure_settings.sh
@@ -46,7 +46,6 @@ cat > $TMP_DIR/oadpcreds <<EOF
         "openshiftPluginImageFqin": "$OPENSHIFT_PLUGIN_IMAGE",
         "azurePluginImageFqin": "$AZURE_PLUGIN_IMAGE",
         "gcpPluginImageFqin": "$GCP_PLUGIN_IMAGE",
-        "csiPluginImageFqin": "$CSI_PLUGIN_IMAGE",
         "resticRestoreImageFqin": "$RESTORE_IMAGE",
         "kubevirtPluginImageFqin": "$KUBEVIRT_PLUGIN_IMAGE",
         "nonAdminControllerImageFqin": "$NON_ADMIN_IMAGE"

--- a/tests/e2e/scripts/gcp_settings.sh
+++ b/tests/e2e/scripts/gcp_settings.sh
@@ -9,7 +9,6 @@ cat > $TMP_DIR/oadpcreds <<EOF
         "openshiftPluginImageFqin": "$OPENSHIFT_PLUGIN_IMAGE",
         "azurePluginImageFqin": "$AZURE_PLUGIN_IMAGE",
         "gcpPluginImageFqin": "$GCP_PLUGIN_IMAGE",
-        "csiPluginImageFqin": "$CSI_PLUGIN_IMAGE",
         "resticRestoreImageFqin": "$RESTORE_IMAGE",
         "kubevirtPluginImageFqin": "$KUBEVIRT_PLUGIN_IMAGE",
         "nonAdminControllerImageFqin": "$NON_ADMIN_IMAGE"

--- a/tests/e2e/scripts/gcp_settings.sh
+++ b/tests/e2e/scripts/gcp_settings.sh
@@ -3,6 +3,17 @@
 cat > $TMP_DIR/oadpcreds <<EOF
 {
   "spec": {
+      "unsupportedOverrides": {
+        "veleroImageFqin": "$VELERO_IMAGE",
+        "awsPluginImageFqin": "$AWS_PLUGIN_IMAGE",
+        "openshiftPluginImageFqin": "$OPENSHIFT_PLUGIN_IMAGE",
+        "azurePluginImageFqin": "$AZURE_PLUGIN_IMAGE",
+        "gcpPluginImageFqin": "$GCP_PLUGIN_IMAGE",
+        "csiPluginImageFqin": "$CSI_PLUGIN_IMAGE",
+        "resticRestoreImageFqin": "$RESTORE_IMAGE",
+        "kubevirtPluginImageFqin": "$KUBEVIRT_PLUGIN_IMAGE",
+        "nonAdminControllerImageFqin": "$NON_ADMIN_IMAGE"
+      },
       "configuration":{
         "velero":{
           "defaultPlugins": [

--- a/tests/e2e/scripts/ibmcloud_settings.sh
+++ b/tests/e2e/scripts/ibmcloud_settings.sh
@@ -3,6 +3,17 @@
 cat > $TMP_DIR/oadpcreds <<EOF
 {
   "spec": {
+      "unsupportedOverrides": {
+        "veleroImageFqin": "$VELERO_IMAGE",
+        "awsPluginImageFqin": "$AWS_PLUGIN_IMAGE",
+        "openshiftPluginImageFqin": "$OPENSHIFT_PLUGIN_IMAGE",
+        "azurePluginImageFqin": "$AZURE_PLUGIN_IMAGE",
+        "gcpPluginImageFqin": "$GCP_PLUGIN_IMAGE",
+        "csiPluginImageFqin": "$CSI_PLUGIN_IMAGE",
+        "resticRestoreImageFqin": "$RESTORE_IMAGE",
+        "kubevirtPluginImageFqin": "$KUBEVIRT_PLUGIN_IMAGE",
+        "nonAdminControllerImageFqin": "$NON_ADMIN_IMAGE"  
+      },
       "configuration":{
         "velero":{
           "defaultPlugins": [

--- a/tests/e2e/scripts/ibmcloud_settings.sh
+++ b/tests/e2e/scripts/ibmcloud_settings.sh
@@ -9,7 +9,6 @@ cat > $TMP_DIR/oadpcreds <<EOF
         "openshiftPluginImageFqin": "$OPENSHIFT_PLUGIN_IMAGE",
         "azurePluginImageFqin": "$AZURE_PLUGIN_IMAGE",
         "gcpPluginImageFqin": "$GCP_PLUGIN_IMAGE",
-        "csiPluginImageFqin": "$CSI_PLUGIN_IMAGE",
         "resticRestoreImageFqin": "$RESTORE_IMAGE",
         "kubevirtPluginImageFqin": "$KUBEVIRT_PLUGIN_IMAGE",
         "nonAdminControllerImageFqin": "$NON_ADMIN_IMAGE"  

--- a/tests/e2e/scripts/openstack_settings.sh
+++ b/tests/e2e/scripts/openstack_settings.sh
@@ -9,7 +9,6 @@ cat > $TMP_DIR/oadpcreds <<EOF
         "openshiftPluginImageFqin": "$OPENSHIFT_PLUGIN_IMAGE",
         "azurePluginImageFqin": "$AZURE_PLUGIN_IMAGE",
         "gcpPluginImageFqin": "$GCP_PLUGIN_IMAGE",
-        "csiPluginImageFqin": "$CSI_PLUGIN_IMAGE",
         "resticRestoreImageFqin": "$RESTORE_IMAGE",
         "kubevirtPluginImageFqin": "$KUBEVIRT_PLUGIN_IMAGE",
         "nonAdminControllerImageFqin": "$NON_ADMIN_IMAGE"

--- a/tests/e2e/scripts/openstack_settings.sh
+++ b/tests/e2e/scripts/openstack_settings.sh
@@ -3,6 +3,17 @@
 cat > $TMP_DIR/oadpcreds <<EOF
 {
   "spec": {
+      "unsupportedOverrides": {
+        "veleroImageFqin": "$VELERO_IMAGE",
+        "awsPluginImageFqin": "$AWS_PLUGIN_IMAGE",
+        "openshiftPluginImageFqin": "$OPENSHIFT_PLUGIN_IMAGE",
+        "azurePluginImageFqin": "$AZURE_PLUGIN_IMAGE",
+        "gcpPluginImageFqin": "$GCP_PLUGIN_IMAGE",
+        "csiPluginImageFqin": "$CSI_PLUGIN_IMAGE",
+        "resticRestoreImageFqin": "$RESTORE_IMAGE",
+        "kubevirtPluginImageFqin": "$KUBEVIRT_PLUGIN_IMAGE",
+        "nonAdminControllerImageFqin": "$NON_ADMIN_IMAGE"
+      },
       "configuration":{
         "velero":{
           "defaultPlugins": [


### PR DESCRIPTION
## Why the changes were made

Generally speaking this will be handy for dev's to be able to easily use custom images in our e2e tests.
This especially is handy as we build out and use openshift/oadp-operator e2e tests across our various repos.

## How to test the changes made
Each cloud provider has a json template for the dpa under tests/e2e/scripts.  All the unsupported Image Overrides were added to each provider.   If the variable is empty oadp will use the default images [1].  The map of strings is patched to the created dpa.


[1]
```
      podConfig:
        resourceAllocations: {}
  podDnsConfig: {}
  unsupportedOverrides:
    openshiftPluginImageFqin: ''
    gcpPluginImageFqin: ''
    veleroImageFqin: 'quay.io/rhn_engineering_whayutin/velero:testlatest'
    azurePluginImageFqin: ''
    resticRestoreImageFqin: ''
    nonAdminControllerImageFqin: ''
    kubevirtPluginImageFqin: ''
    awsPluginImageFqin: ''
    csiPluginImageFqin: ''
```

