### PR TITLE
cherry-pick: oadp-1.3: Add support for VSL name and labels (#1523)

### DIFF
--- a/api/v1alpha1/oadp_types.go
+++ b/api/v1alpha1/oadp_types.go
@@ -229,6 +229,8 @@ type BackupLocation struct {
 type SnapshotLocation struct {
 	// TODO: Add name/annotations/labels support
 
+	// +optional
+	Name   string                             `json:"name,omitempty"`
 	Velero *velero.VolumeSnapshotLocationSpec `json:"velero"`
 }
 

--- a/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
@@ -965,6 +965,8 @@ spec:
                   items:
                     description: SnapshotLocation defines the configuration for the DPA snapshot store
                     properties:
+                      name:
+                        type: string
                       velero:
                         description: VolumeSnapshotLocationSpec defines the specification for a Velero VolumeSnapshotLocation.
                         properties:

--- a/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
@@ -965,6 +965,8 @@ spec:
                   items:
                     description: SnapshotLocation defines the configuration for the DPA snapshot store
                     properties:
+                      name:
+                        type: string
                       velero:
                         description: VolumeSnapshotLocationSpec defines the specification for a Velero VolumeSnapshotLocation.
                         properties:


### PR DESCRIPTION
(cherry picked from commit b5291301ff444e689e1384602f3b73de663a170f)

## Why the changes were made

This is a cherry pick to 1.3 -> Add support for VSL name and labels

## How to test the changes made

By using make deploy-olm and using name and labels in VSL
