### PR TITLE
cherry-pick: oadp-1.3: OADP-3050: Remove unwanted BSL/VSLs on create/edit DPA

### DIFF
--- a/controllers/bsl.go
+++ b/controllers/bsl.go
@@ -99,6 +99,8 @@ func (r *DPAReconciler) ReconcileBackupStorageLocations(log logr.Logger) (bool, 
 	if err := r.Get(r.Context, r.NamespacedName, &dpa); err != nil {
 		return false, err
 	}
+
+	dpaBSLNames := []string{}
 	// Loop through all configured BSLs
 	for i, bslSpec := range dpa.Spec.BackupLocations {
 		// Create BSL as is, we can safely assume they are valid from
@@ -109,6 +111,7 @@ func (r *DPAReconciler) ReconcileBackupStorageLocations(log logr.Logger) (bool, 
 		if bslSpec.Name != "" {
 			bslName = bslSpec.Name
 		}
+		dpaBSLNames = append(dpaBSLNames, bslName)
 
 		bsl := velerov1.BackupStorageLocation{
 			ObjectMeta: metav1.ObjectMeta{
@@ -195,6 +198,33 @@ func (r *DPAReconciler) ReconcileBackupStorageLocations(log logr.Logger) (bool, 
 			)
 		}
 	}
+
+	dpaBSLs := velerov1.BackupStorageLocationList{}
+	dpaBSLLabels := map[string]string{
+		"app.kubernetes.io/name":       common.OADPOperatorVelero,
+		"app.kubernetes.io/managed-by": common.OADPOperator,
+		"app.kubernetes.io/component":  "bsl",
+	}
+	err := r.List(r.Context, &dpaBSLs, client.InNamespace(r.NamespacedName.Namespace), client.MatchingLabels(dpaBSLLabels))
+	if err != nil {
+		return false, err
+	}
+	// If current BSLs do not match the spec, delete extra BSLs
+	if len(dpaBSLNames) != len(dpaBSLs.Items) {
+		for _, bsl := range dpaBSLs.Items {
+			if !common.Contains(dpaBSLNames, bsl.Name) {
+				if err := r.Delete(r.Context, &bsl); err != nil {
+					return false, err
+				}
+				// Record event for BSL deletion
+				r.EventRecorder.Event(&bsl,
+					corev1.EventTypeNormal,
+					"BackupStorageLocationDeleted",
+					fmt.Sprintf("BackupStorageLocation %s created by OADP in namespace %s was deleted as it was not in DPA spec.", bsl.Name, bsl.Namespace))
+			}
+		}
+	}
+
 	return true, nil
 }
 

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -312,3 +312,12 @@ func ApplyUnsupportedServerArgsOverride(container *corev1.Container, unsupported
 	}
 	return nil
 }
+
+func Contains(slice []string, item string) bool {
+	for _, s := range slice {
+		if s == item {
+			return true
+		}
+	}
+	return false
+}

--- a/tests/e2e/dpa_deployment_suite_test.go
+++ b/tests/e2e/dpa_deployment_suite_test.go
@@ -112,12 +112,22 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 					// Check if bsl matches the spec
 					Expect(DoesBSLSpecMatchesDpa(namespace, *bsl.Velero, installCase.DpaSpec)).To(BeTrue())
 				}
+			} else {
+				log.Println("Checking no BSLs are deployed")
+				_, err = dpaCR.ListBSLs()
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal(fmt.Sprintf("no BSL in %s namespace", namespace)))
 			}
 			if len(dpa.Spec.SnapshotLocations) > 0 {
 				log.Printf("Checking for vsl spec")
 				for _, vsl := range dpa.Spec.SnapshotLocations {
 					Expect(DoesVSLSpecMatchesDpa(namespace, *vsl.Velero, installCase.DpaSpec)).To(BeTrue())
 				}
+			} else {
+				log.Println("Checking no VSLs are deployed")
+				_, err = dpaCR.ListVSLs()
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal(fmt.Sprintf("no VSL in %s namespace", namespace)))
 			}
 
 			// Check for velero tolerances

--- a/tests/e2e/lib/dpa_helpers.go
+++ b/tests/e2e/lib/dpa_helpers.go
@@ -328,6 +328,30 @@ func GetOpenShiftADPLogs(c *kubernetes.Clientset, namespace string) (string, err
 	return GetPodWithPrefixContainerLogs(c, namespace, "openshift-adp-controller-manager-", "manager")
 }
 
+func (v *DpaCustomResource) ListVSLs() (*velero.VolumeSnapshotLocationList, error) {
+	vsls := &velero.VolumeSnapshotLocationList{}
+	err := v.Client.List(context.Background(), vsls, client.InNamespace(v.Namespace))
+	if err != nil {
+		return nil, err
+	}
+	if len(vsls.Items) == 0 {
+		return nil, fmt.Errorf("no VSL in %s namespace", v.Namespace)
+	}
+	return vsls, nil
+}
+
+func (v *DpaCustomResource) ListBSLs() (*velero.BackupStorageLocationList, error) {
+	bsls := &velero.BackupStorageLocationList{}
+	err := v.Client.List(context.Background(), bsls, client.InNamespace(v.Namespace))
+	if err != nil {
+		return nil, err
+	}
+	if len(bsls.Items) == 0 {
+		return nil, fmt.Errorf("no BSL in %s namespace", v.Namespace)
+	}
+	return bsls, nil
+}
+
 // Returns logs from velero container on velero pod
 func GetVeleroContainerLogs(c *kubernetes.Clientset, namespace string) (string, error) {
 	return GetPodWithPrefixContainerLogs(c, namespace, "velero-", "velero")


### PR DESCRIPTION

## Why the changes were made

This is a cherry-pick to oadp-1.3 , for [OADP-3050](https://issues.redhat.com//browse/OADP-3050): Remove unwanted BSL/VSLs on create/edit DPA

## How to test the changes made

Use make deploy-olm
