### PR TITLE
cherry-pick: oadp-1.4: OADP-3050: Remove unwanted BSL/VSLs on create/edit DPA (#1525)

### DIFF
--- a/controllers/bsl.go
+++ b/controllers/bsl.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/go-logr/logr"
 	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
@@ -99,6 +100,8 @@ func (r *DPAReconciler) ReconcileBackupStorageLocations(log logr.Logger) (bool, 
 	if err := r.Get(r.Context, r.NamespacedName, &dpa); err != nil {
 		return false, err
 	}
+
+	dpaBSLNames := []string{}
 	// Loop through all configured BSLs
 	for i, bslSpec := range dpa.Spec.BackupLocations {
 		// Create BSL as is, we can safely assume they are valid from
@@ -109,6 +112,7 @@ func (r *DPAReconciler) ReconcileBackupStorageLocations(log logr.Logger) (bool, 
 		if bslSpec.Name != "" {
 			bslName = bslSpec.Name
 		}
+		dpaBSLNames = append(dpaBSLNames, bslName)
 
 		bsl := velerov1.BackupStorageLocation{
 			ObjectMeta: metav1.ObjectMeta{
@@ -195,6 +199,33 @@ func (r *DPAReconciler) ReconcileBackupStorageLocations(log logr.Logger) (bool, 
 			)
 		}
 	}
+
+	dpaBSLs := velerov1.BackupStorageLocationList{}
+	dpaBSLLabels := map[string]string{
+		"app.kubernetes.io/name":       common.OADPOperatorVelero,
+		"app.kubernetes.io/managed-by": common.OADPOperator,
+		"app.kubernetes.io/component":  "bsl",
+	}
+	err := r.List(r.Context, &dpaBSLs, client.InNamespace(r.NamespacedName.Namespace), client.MatchingLabels(dpaBSLLabels))
+	if err != nil {
+		return false, err
+	}
+	// If current BSLs do not match the spec, delete extra BSLs
+	if len(dpaBSLNames) != len(dpaBSLs.Items) {
+		for _, bsl := range dpaBSLs.Items {
+			if !slices.Contains(dpaBSLNames, bsl.Name) {
+				if err := r.Delete(r.Context, &bsl); err != nil {
+					return false, err
+				}
+				// Record event for BSL deletion
+				r.EventRecorder.Event(&bsl,
+					corev1.EventTypeNormal,
+					"BackupStorageLocationDeleted",
+					fmt.Sprintf("BackupStorageLocation %s created by OADP in namespace %s was deleted as it was not in DPA spec.", bsl.Name, bsl.Namespace))
+			}
+		}
+	}
+
 	return true, nil
 }
 

--- a/controllers/vsl.go
+++ b/controllers/vsl.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -12,6 +13,7 @@ import (
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
@@ -215,6 +217,7 @@ func (r *DPAReconciler) ReconcileVolumeSnapshotLocations(log logr.Logger) (bool,
 		return false, err
 	}
 
+	dpaVSLNames := []string{}
 	// Loop through all configured VSLs
 	for i, vslSpec := range dpa.Spec.SnapshotLocations {
 		// Create VSL as is, we can safely assume they are valid from
@@ -225,6 +228,7 @@ func (r *DPAReconciler) ReconcileVolumeSnapshotLocations(log logr.Logger) (bool,
 		if vslSpec.Name != "" {
 			vslName = vslSpec.Name
 		}
+		dpaVSLNames = append(dpaVSLNames, vslName)
 
 		vsl := velerov1.VolumeSnapshotLocation{
 			ObjectMeta: metav1.ObjectMeta{
@@ -271,6 +275,34 @@ func (r *DPAReconciler) ReconcileVolumeSnapshotLocations(log logr.Logger) (bool,
 		}
 
 	}
+
+	dpaVSLs := velerov1.VolumeSnapshotLocationList{}
+	dpaVslLabels := map[string]string{
+		"app.kubernetes.io/name":       common.OADPOperatorVelero,
+		"app.kubernetes.io/managed-by": common.OADPOperator,
+		"app.kubernetes.io/component":  "vsl",
+	}
+	err := r.List(r.Context, &dpaVSLs, client.InNamespace(r.NamespacedName.Namespace), client.MatchingLabels(dpaVslLabels))
+	if err != nil {
+		return false, err
+	}
+
+	// If current VSLs do not match the spec, delete extra VSLs
+	if len(dpaVSLNames) != len(dpaVSLs.Items) {
+		for _, vsl := range dpaVSLs.Items {
+			if !slices.Contains(dpaVSLNames, vsl.Name) {
+				if err := r.Delete(r.Context, &vsl); err != nil {
+					return false, err
+				}
+				// Record event for VSL deletion
+				r.EventRecorder.Event(&vsl,
+					corev1.EventTypeNormal,
+					"VolumeSnapshotLocationDeleted",
+					fmt.Sprintf("VolumeSnapshotLocation %s created by OADP in namespace %s was deleted as it was not in DPA spec.", vsl.Name, vsl.Namespace))
+			}
+		}
+	}
+
 	return true, nil
 }
 

--- a/tests/e2e/dpa_deployment_suite_test.go
+++ b/tests/e2e/dpa_deployment_suite_test.go
@@ -1,6 +1,7 @@
 package e2e_test
 
 import (
+	"fmt"
 	"log"
 	"strings"
 	"time"
@@ -190,14 +191,12 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 					log.Printf("Checking for BSL spec")
 					Expect(dpaCR.DoesBSLSpecMatchesDpa(namespace, *bsl.Velero)).To(BeTrue())
 				}
+			} else {
+				log.Println("Checking no BSLs are deployed")
+				_, err = dpaCR.ListBSLs()
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal(fmt.Sprintf("no BSL in %s namespace", namespace)))
 			}
-			// TODO bug
-			// else {
-			// 	log.Println("Checking no BSLs are deployed")
-			// 	_, err = dpaCR.ListBSLs()
-			// 	Expect(err).To(HaveOccurred())
-			// 	Expect(err.Error()).To(Equal(fmt.Sprintf("no BSL in %s namespace", namespace)))
-			// }
 
 			if len(installCase.DpaSpec.SnapshotLocations) > 0 {
 				// TODO Check if VSLs are available creating new backup/restore test with VSL
@@ -205,14 +204,12 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 					log.Printf("Checking for VSL spec")
 					Expect(dpaCR.DoesVSLSpecMatchesDpa(namespace, *vsl.Velero)).To(BeTrue())
 				}
+			} else {
+				log.Println("Checking no VSLs are deployed")
+				_, err = dpaCR.ListVSLs()
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal(fmt.Sprintf("no VSL in %s namespace", namespace)))
 			}
-			// TODO bug
-			// else {
-			// 	log.Println("Checking no VSLs are deployed")
-			// 	_, err = dpaCR.ListVSLs()
-			// 	Expect(err).To(HaveOccurred())
-			// 	Expect(err.Error()).To(Equal(fmt.Sprintf("no VSL in %s namespace", namespace)))
-			// }
 
 			if len(installCase.DpaSpec.Configuration.Velero.PodConfig.Tolerations) > 0 {
 				log.Printf("Checking for velero tolerances")


### PR DESCRIPTION
(cherry picked from commit fee74a5a7da9625bbe0dc444679a4e0e0718d919)

## Why the changes were made

This is a cherry-pick to oadp-1.4 for [OADP-3050](https://issues.redhat.com//browse/OADP-3050): Remove unwanted BSL/VSLs on create/edit DPA

## How to test the changes made

Use make deploy-olm
