### PR TITLE
OADP-3562: Fix controller panic on secret key-value parsing (#1529)

### DIFF
--- a/controllers/registry.go
+++ b/controllers/registry.go
@@ -474,8 +474,8 @@ func (r *DPAReconciler) getMatchedKeyValue(key string, s string) (string, error)
 		s = strings.TrimPrefix(s, prefix)
 	}
 	if len(s) == 0 {
-		r.Log.Info("Could not parse secret for %s", key)
-		return s, errors.New(key + " secret parsing error")
+		r.Log.Info(fmt.Sprintf("Could not parse secret for %s", key))
+		return s, errors.New("secret parsing error in key " + key)
 	}
 	return s, nil
 }


### PR DESCRIPTION
(cherry picked from commit 5b0b9fcbc0d86c09158f9a6bcf9ec47fd61ae50e)

## Why the changes were made

This is a cherry-pick to oadp-1.4 for [OADP-3562](https://issues.redhat.com//browse/OADP-3562): Fix controller panic on secret key-value parsing (#1529)

## How to test the changes made

Use make deploy-olm
