### PR TITLE
fix issue #1464: Added VSL Backup/Restore Tests

### DIFF
--- a/tests/e2e/dpa_deployment_suite_test.go
+++ b/tests/e2e/dpa_deployment_suite_test.go
@@ -198,7 +198,7 @@ var _ = ginkgo.Describe("Configuration testing for DPA Custom Resource", func() 
 			}
 
 			if len(installCase.DpaSpec.SnapshotLocations) > 0 {
-				// TODO Check if VSLs are available creating new backup/restore test with VSL
+				// Velero does not change status of VSL objects. Users can only confirm if VSLs are correct configured when running a native snapshot backup/restore
 				for _, vsl := range installCase.DpaSpec.SnapshotLocations {
 					log.Printf("Checking for VSL spec")
 					gomega.Expect(dpaCR.DoesVSLSpecMatchesDpa(namespace, *vsl.Velero)).To(gomega.BeTrue())

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -162,6 +162,7 @@ func TestOADPE2E(t *testing.T) {
 		Name:                 "ts-" + instanceName,
 		Namespace:            namespace,
 		Client:               runTimeClientForSuiteRun,
+		VSLSecretName:        vslSecretName,
 		BSLSecretName:        bslSecretName,
 		BSLConfig:            dpa.DeepCopy().Spec.BackupLocations[0].Velero.Config,
 		BSLProvider:          dpa.DeepCopy().Spec.BackupLocations[0].Velero.Provider,

--- a/tests/e2e/lib/dpa_helpers.go
+++ b/tests/e2e/lib/dpa_helpers.go
@@ -24,16 +24,18 @@ import (
 type BackupRestoreType string
 
 const (
-	CSI          BackupRestoreType = "csi"
-	CSIDataMover BackupRestoreType = "csi-datamover"
-	RESTIC       BackupRestoreType = "restic"
-	KOPIA        BackupRestoreType = "kopia"
+	CSI             BackupRestoreType = "csi"
+	CSIDataMover    BackupRestoreType = "csi-datamover"
+	RESTIC          BackupRestoreType = "restic"
+	KOPIA           BackupRestoreType = "kopia"
+	NativeSnapshots BackupRestoreType = "native-snapshots"
 )
 
 type DpaCustomResource struct {
 	Name                 string
 	Namespace            string
 	Client               client.Client
+	VSLSecretName        string
 	BSLSecretName        string
 	BSLConfig            map[string]string
 	BSLProvider          string
@@ -112,6 +114,13 @@ func (v *DpaCustomResource) Build(backupRestoreType BackupRestoreType) *oadpv1al
 		dpaSpec.Configuration.Velero.DefaultPlugins = append(dpaSpec.Configuration.Velero.DefaultPlugins, oadpv1alpha1.DefaultPluginCSI)
 		dpaSpec.Configuration.Velero.FeatureFlags = append(dpaSpec.Configuration.Velero.FeatureFlags, velero.CSIFeatureFlag)
 		dpaSpec.SnapshotLocations = nil
+	case NativeSnapshots:
+		dpaSpec.SnapshotLocations[0].Velero.Credential = &corev1.SecretKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{
+				Name: v.VSLSecretName,
+			},
+			Key: "cloud",
+		}
 	}
 
 	return &dpaSpec


### PR DESCRIPTION
## Why the changes were made

This PR adds VSL backup / restore tests to the e2e tests, for both mysql and mongo apps.

Fixes #1464 

## How to test the changes made

Use "make test-e2e" and run the new test cases with proper ginkgo variables.
