### PR TITLE
CI: Enable upstream virtualization operator E2E tests.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ OC_CLI = $(shell which oc)
 TEST_VIRT ?= false
 KVM_EMULATION ?= true
 TEST_UPGRADE ?= false
-HCO_UPSTREAM ?= true
+HCO_UPSTREAM ?= false
 
 ifdef CLI_DIR
 	OC_CLI = ${CLI_DIR}/oc

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ OC_CLI = $(shell which oc)
 TEST_VIRT ?= false
 KVM_EMULATION ?= true
 TEST_UPGRADE ?= false
+HCO_UPSTREAM ?= false
 
 ifdef CLI_DIR
 	OC_CLI = ${CLI_DIR}/oc
@@ -524,6 +525,7 @@ test-e2e: test-e2e-setup install-ginkgo
 	-artifact_dir=$(ARTIFACT_DIR) \
 	-oc_cli=$(OC_CLI) \
 	-kvm_emulation=$(KVM_EMULATION) \
+	-hco_upstream=$(HCO_UPSTREAM) \
 	--ginkgo.vv \
 	--ginkgo.no-color=$(OPENSHIFT_CI) \
 	--ginkgo.label-filter="$(TEST_FILTER)" \

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ OC_CLI = $(shell which oc)
 TEST_VIRT ?= false
 KVM_EMULATION ?= true
 TEST_UPGRADE ?= false
-HCO_UPSTREAM ?= false
+HCO_UPSTREAM ?= true
 
 ifdef CLI_DIR
 	OC_CLI = ${CLI_DIR}/oc

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -49,7 +49,8 @@ var (
 	knownFlake          bool
 	accumulatedTestLogs []string
 
-	kvmEmulation bool
+	kvmEmulation   bool
+	useUpstreamHco bool
 )
 
 func init() {
@@ -65,6 +66,7 @@ func init() {
 	flag.StringVar(&oc_cli, "oc_cli", "oc", "OC CLI Client")
 	flag.Int64Var(&flakeAttempts, "flakeAttempts", 3, "Customize the number of flake retries (3)")
 	flag.BoolVar(&kvmEmulation, "kvm_emulation", true, "Enable or disable KVM emulation for virtualization testing")
+	flag.BoolVar(&useUpstreamHco, "hco_upstream", false, "Force use of upstream virtualization operator")
 
 	// helps with launching debug sessions from IDE
 	if os.Getenv("E2E_USE_ENV_FLAGS") == "true" {
@@ -108,6 +110,13 @@ func init() {
 				kvmEmulation = parsedValue
 			} else {
 				log.Println("Error parsing KVM_EMULATION, it will be enabled by default: ", err)
+			}
+		}
+		if envValue := os.Getenv("HCO_UPSTREAM"); envValue != "" {
+			if parsedValue, err := strconv.ParseBool(envValue); err == nil {
+				useUpstreamHco = parsedValue
+			} else {
+				log.Println("Error parsing HCO_UPSTREAM, it will be disabled by default: ", err)
 			}
 		}
 	}

--- a/tests/e2e/lib/subscription_helpers.go
+++ b/tests/e2e/lib/subscription_helpers.go
@@ -35,6 +35,9 @@ func getOperatorSubscription(c client.Client, namespace, label string) (*Subscri
 
 func (v *VirtOperator) getOperatorSubscription() (*Subscription, error) {
 	label := "operators.coreos.com/kubevirt-hyperconverged.openshift-cnv"
+	if v.Upstream {
+		label = "operators.coreos.com/community-kubevirt-hyperconverged.kubevirt-hyperconverged"
+	}
 	return getOperatorSubscription(v.Client, v.Namespace, label)
 }
 

--- a/tests/e2e/lib/virt_helpers.go
+++ b/tests/e2e/lib/virt_helpers.go
@@ -93,16 +93,23 @@ func GetVirtOperator(c client.Client, clientset *kubernetes.Clientset, dynamicCl
 // Helper to create an operator group object, common to installOperatorGroup
 // and removeOperatorGroup.
 func (v *VirtOperator) makeOperatorGroup() *operatorsv1.OperatorGroup {
+	// Community operator fails with "cannot configure to watch own namespace",
+	// need to remove target namespaces.
+	spec := operatorsv1.OperatorGroupSpec{}
+	if !v.Upstream {
+		spec = operatorsv1.OperatorGroupSpec{
+			TargetNamespaces: []string{
+				v.Namespace,
+			},
+		}
+	}
+
 	return &operatorsv1.OperatorGroup{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kubevirt-hyperconverged-group",
 			Namespace: v.Namespace,
 		},
-		Spec: operatorsv1.OperatorGroupSpec{
-			TargetNamespaces: []string{
-				v.Namespace,
-			},
-		},
+		Spec: spec,
 	}
 }
 

--- a/tests/e2e/lib/virt_storage_helpers.go
+++ b/tests/e2e/lib/virt_storage_helpers.go
@@ -173,26 +173,30 @@ func (v *VirtOperator) RemoveDataSource(namespace, name string) error {
 // Create a DataSource from an existing PVC, with the same name and namespace.
 // This way, the PVC can be specified as a sourceRef in the VM spec.
 func (v *VirtOperator) CreateDataSourceFromPvc(namespace, name string) error {
+	return v.CreateTargetDataSourceFromPvc(namespace, namespace, name, name)
+}
+
+func (v *VirtOperator) CreateTargetDataSourceFromPvc(sourceNamespace, destinationNamespace, sourcePvcName, destinationDataSourceName string) error {
 	unstructuredDataSource := unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": "cdi.kubevirt.io/v1beta1",
 			"kind":       "DataSource",
 			"metadata": map[string]interface{}{
-				"name":      name,
-				"namespace": namespace,
+				"name":      destinationDataSourceName,
+				"namespace": destinationNamespace,
 			},
 			"spec": map[string]interface{}{
 				"source": map[string]interface{}{
 					"pvc": map[string]interface{}{
-						"name":      name,
-						"namespace": namespace,
+						"name":      sourcePvcName,
+						"namespace": sourceNamespace,
 					},
 				},
 			},
 		},
 	}
 
-	_, err := v.Dynamic.Resource(dataSourceGVR).Namespace(namespace).Create(context.Background(), &unstructuredDataSource, metav1.CreateOptions{})
+	_, err := v.Dynamic.Resource(dataSourceGVR).Namespace(destinationNamespace).Create(context.Background(), &unstructuredDataSource, metav1.CreateOptions{})
 	if err != nil {
 		if apierrors.IsAlreadyExists(err) {
 			return nil
@@ -205,6 +209,36 @@ func (v *VirtOperator) CreateDataSourceFromPvc(namespace, name string) error {
 	}
 
 	return nil
+}
+
+// Find the given DataSource, and return the PVC it points to
+func (v *VirtOperator) GetDataSourcePvc(ns, name string) (string, string, error) {
+	unstructuredDataSource, err := v.Dynamic.Resource(dataSourceGVR).Namespace(ns).Get(context.Background(), name, metav1.GetOptions{})
+	if err != nil {
+		log.Printf("Error getting DataSource %s: %v", name, err)
+		return "", "", err
+	}
+
+	pvcName, ok, err := unstructured.NestedString(unstructuredDataSource.UnstructuredContent(), "status", "source", "pvc", "name")
+	if err != nil {
+		log.Printf("Error getting PVC from DataSource: %v", err)
+		return "", "", err
+	}
+	if !ok {
+		return "", "", errors.New("failed to get PVC from " + name + " DataSource")
+	}
+
+	pvcNamespace, ok, err := unstructured.NestedString(unstructuredDataSource.UnstructuredContent(), "status", "source", "pvc", "namespace")
+	if err != nil {
+		log.Printf("Error getting PVC namespace from DataSource: %v", err)
+		return "", "", err
+	}
+	if !ok {
+		return "", "", errors.New("failed to get PVC namespace from " + name + " DataSource")
+	}
+
+	return pvcNamespace, pvcName, nil
+
 }
 
 // Find the default storage class

--- a/tests/e2e/lib/virt_storage_helpers.go
+++ b/tests/e2e/lib/virt_storage_helpers.go
@@ -275,6 +275,9 @@ func (v *VirtOperator) CreateImmediateModeStorageClass(name string) error {
 	immediateStorageClass.Annotations["storageclass.kubernetes.io/is-default-class"] = "false"
 
 	_, err = v.Clientset.StorageV1().StorageClasses().Create(context.Background(), immediateStorageClass, metav1.CreateOptions{})
+	if apierrors.IsAlreadyExists(err) {
+		return nil
+	}
 	return err
 }
 

--- a/tests/e2e/sample-applications/virtual-machines/cirros-test/cirros-rbac.yaml
+++ b/tests/e2e/sample-applications/virtual-machines/cirros-test/cirros-rbac.yaml
@@ -22,17 +22,3 @@ items:
       kind: ClusterRole
       name: dv-cloner-role
       apiGroup: rbac.authorization.k8s.io
-  - apiVersion: rbac.authorization.k8s.io/v1
-    kind: RoleBinding
-    metadata:
-      name: cirros-test-cloner
-      namespace: kubevirt-os-images
-    subjects:
-    - kind: ServiceAccount
-      name: default
-      namespace: cirros-test
-    roleRef:
-      kind: ClusterRole
-      name: dv-cloner-role
-      apiGroup: rbac.authorization.k8s.io
-

--- a/tests/e2e/sample-applications/virtual-machines/cirros-test/cirros-rbac.yaml
+++ b/tests/e2e/sample-applications/virtual-machines/cirros-test/cirros-rbac.yaml
@@ -18,6 +18,9 @@ items:
     - kind: ServiceAccount
       name: default
       namespace: cirros-test
+    - kind: ServiceAccount
+      name: default
+      namespace: mysql-persistent
     roleRef:
       kind: ClusterRole
       name: dv-cloner-role

--- a/tests/e2e/sample-applications/virtual-machines/cirros-test/cirros-rbac.yaml
+++ b/tests/e2e/sample-applications/virtual-machines/cirros-test/cirros-rbac.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: dv-cloner-role
+    rules:
+    - apiGroups: ["cdi.kubevirt.io"]
+      resources: ["datavolumes/source"]
+      verbs: ["*"]
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      name: cirros-test-cloner
+      namespace: openshift-virtualization-os-images
+    subjects:
+    - kind: ServiceAccount
+      name: default
+      namespace: cirros-test
+    roleRef:
+      kind: ClusterRole
+      name: dv-cloner-role
+      apiGroup: rbac.authorization.k8s.io
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      name: cirros-test-cloner
+      namespace: kubevirt-os-images
+    subjects:
+    - kind: ServiceAccount
+      name: default
+      namespace: cirros-test
+    roleRef:
+      kind: ClusterRole
+      name: dv-cloner-role
+      apiGroup: rbac.authorization.k8s.io
+

--- a/tests/e2e/sample-applications/virtual-machines/fedora-todolist/fedora-todolist.yaml
+++ b/tests/e2e/sample-applications/virtual-machines/fedora-todolist/fedora-todolist.yaml
@@ -228,7 +228,6 @@ items:
               name: fedora
               namespace: openshift-virtualization-os-images
             storage:
-              volumeMode: Filesystem
               resources:
                 requests:
                   storage: 30Gi

--- a/tests/e2e/sample-applications/virtual-machines/fedora-todolist/fedora-todolist.yaml
+++ b/tests/e2e/sample-applications/virtual-machines/fedora-todolist/fedora-todolist.yaml
@@ -228,6 +228,7 @@ items:
               name: fedora
               namespace: openshift-virtualization-os-images
             storage:
+              volumeMode: Filesystem
               resources:
                 requests:
                   storage: 30Gi

--- a/tests/e2e/virt_backup_restore_suite_test.go
+++ b/tests/e2e/virt_backup_restore_suite_test.go
@@ -155,7 +155,7 @@ var _ = ginkgo.Describe("VM backup and restore tests", ginkgo.Ordered, func() {
 	wasInstalledFromTest := false
 
 	cirrosDownloadedFromTest := false
-	cirrosNamespace := "openshift-virtualization-os-images"
+	bootImageNamespace := "openshift-virtualization-os-images"
 
 	var lastBRCase VmBackupRestoreCase
 	var lastInstallTime time.Time
@@ -186,16 +186,15 @@ var _ = ginkgo.Describe("VM backup and restore tests", ginkgo.Ordered, func() {
 
 		url, err := getLatestCirrosImageURL()
 		gomega.Expect(err).To(gomega.BeNil())
-		err = v.EnsureNamespace(cirrosNamespace, 1*time.Minute)
+		err = v.EnsureNamespace(bootImageNamespace, 1*time.Minute)
 		gomega.Expect(err).To(gomega.BeNil())
-		if !v.CheckDataVolumeExists(cirrosNamespace, "cirros") {
-			err = v.EnsureDataVolumeFromUrl(cirrosNamespace, "cirros", url, "150Mi", 5*time.Minute)
+		if !v.CheckDataVolumeExists(bootImageNamespace, "cirros") {
+			err = v.EnsureDataVolumeFromUrl(bootImageNamespace, "cirros", url, "150Mi", 5*time.Minute)
 			gomega.Expect(err).To(gomega.BeNil())
-			err = v.CreateDataSourceFromPvc(cirrosNamespace, "cirros")
+			err = v.CreateDataSourceFromPvc(bootImageNamespace, "cirros")
 			gomega.Expect(err).To(gomega.BeNil())
 			cirrosDownloadedFromTest = true
 		}
-
 		dpaCR.VeleroDefaultPlugins = append(dpaCR.VeleroDefaultPlugins, v1alpha1.DefaultPluginKubeVirt)
 
 		err = v.CreateImmediateModeStorageClass("test-sc-immediate")
@@ -206,12 +205,21 @@ var _ = ginkgo.Describe("VM backup and restore tests", ginkgo.Ordered, func() {
 		gomega.Expect(err).To(gomega.BeNil())
 		err = lib.InstallApplication(v.Client, "./sample-applications/virtual-machines/cirros-test/cirros-rbac.yaml")
 		gomega.Expect(err).To(gomega.BeNil())
+
+		if v.Upstream {
+			log.Printf("Creating fedora DataSource in openshift-virtualization-os-images namespace")
+			pvcNamespace, pvcName, err := v.GetDataSourcePvc("kubevirt-os-images", "fedora")
+			gomega.Expect(err).To(gomega.BeNil())
+			err = v.CreateTargetDataSourceFromPvc(pvcNamespace, "openshift-virtualization-os-images", pvcName, "fedora")
+			gomega.Expect(err).To(gomega.BeNil())
+		}
+
 	})
 
 	var _ = ginkgo.AfterAll(func() {
 		if v != nil && cirrosDownloadedFromTest {
-			v.RemoveDataSource(cirrosNamespace, "cirros")
-			v.RemoveDataVolume(cirrosNamespace, "cirros", 2*time.Minute)
+			v.RemoveDataSource(bootImageNamespace, "cirros")
+			v.RemoveDataVolume(bootImageNamespace, "cirros", 2*time.Minute)
 		}
 
 		if v != nil && wasInstalledFromTest {

--- a/tests/e2e/virt_backup_restore_suite_test.go
+++ b/tests/e2e/virt_backup_restore_suite_test.go
@@ -204,6 +204,8 @@ var _ = ginkgo.Describe("VM backup and restore tests", ginkgo.Ordered, func() {
 		gomega.Expect(err).To(gomega.BeNil())
 		err = lib.DeleteBackupRepositories(runTimeClientForSuiteRun, namespace)
 		gomega.Expect(err).To(gomega.BeNil())
+		err = lib.InstallApplication(v.Client, "./sample-applications/virtual-machines/cirros-test/cirros-rbac.yaml")
+		gomega.Expect(err).To(gomega.BeNil())
 	})
 
 	var _ = ginkgo.AfterAll(func() {

--- a/tests/e2e/virt_backup_restore_suite_test.go
+++ b/tests/e2e/virt_backup_restore_suite_test.go
@@ -186,6 +186,8 @@ var _ = ginkgo.Describe("VM backup and restore tests", ginkgo.Ordered, func() {
 
 		url, err := getLatestCirrosImageURL()
 		gomega.Expect(err).To(gomega.BeNil())
+		err = v.EnsureNamespace(cirrosNamespace, 1*time.Minute)
+		gomega.Expect(err).To(gomega.BeNil())
 		if !v.CheckDataVolumeExists(cirrosNamespace, "cirros") {
 			err = v.EnsureDataVolumeFromUrl(cirrosNamespace, "cirros", url, "150Mi", 5*time.Minute)
 			gomega.Expect(err).To(gomega.BeNil())

--- a/tests/e2e/virt_backup_restore_suite_test.go
+++ b/tests/e2e/virt_backup_restore_suite_test.go
@@ -167,7 +167,7 @@ var _ = ginkgo.Describe("VM backup and restore tests", ginkgo.Ordered, func() {
 	}
 
 	var _ = ginkgo.BeforeAll(func() {
-		v, err = lib.GetVirtOperator(runTimeClientForSuiteRun, kubernetesClientForSuiteRun, dynamicClientForSuiteRun)
+		v, err = lib.GetVirtOperator(runTimeClientForSuiteRun, kubernetesClientForSuiteRun, dynamicClientForSuiteRun, useUpstreamHco)
 		gomega.Expect(err).To(gomega.BeNil())
 		gomega.Expect(v).ToNot(gomega.BeNil())
 


### PR DESCRIPTION
## Why the changes were made

An early test of OpenShift 4.18 did not have the virtualization operator available in the usual place yet. This pull request enables testing with the upstream community KubeVirt operator with a new HCO_UPSTREAM test option.


## How to test the changes made

make TEST_VIRT=true HCO_UPSTREAM=true test-e2e

