### PR TITLE
fix OADP-5044 and other VSL validation errors

### DIFF
--- a/controllers/validator_test.go
+++ b/controllers/validator_test.go
@@ -1038,13 +1038,16 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 					SnapshotLocations: []oadpv1alpha1.SnapshotLocation{
 						{
 							Velero: &v1.VolumeSnapshotLocationSpec{
-								Provider: "velero.io/aws",
+								Provider: "aws",
 								Credential: &corev1.SecretKeySelector{
 									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "custom-vsl-credentials",
 									},
 									Key:      "cloud",
 									Optional: new(bool),
+								},
+								Config: map[string]string{
+									"region": "us-east-1",
 								},
 							},
 						},

--- a/controllers/vsl.go
+++ b/controllers/vsl.go
@@ -110,53 +110,37 @@ func (r *DPAReconciler) LabelVSLSecrets(log logr.Logger) (bool, error) {
 
 func (r *DPAReconciler) ValidateVolumeSnapshotLocations(dpa oadpv1alpha1.DataProtectionApplication) (bool, error) {
 	for i, vslSpec := range dpa.Spec.SnapshotLocations {
+		vslYAMLPath := fmt.Sprintf("spec.snapshotLocations[%v]", i)
+		veleroVSLYAMLPath := vslYAMLPath + ".velero"
+		veleroConfigYAMLPath := "spec.configuration.velero"
+
 		if vslSpec.Velero == nil {
 			return false, errors.New("snapshotLocation velero configuration cannot be nil")
-		}
-		vsl := velerov1.VolumeSnapshotLocation{
-			ObjectMeta: metav1.ObjectMeta{
-				// TODO: Use a hash instead of i
-				Name:      fmt.Sprintf("%s-%d", r.NamespacedName.Name, i+1),
-				Namespace: r.NamespacedName.Namespace,
-			},
-			Spec: *vslSpec.Velero,
 		}
 
 		// check for valid provider
 		if vslSpec.Velero.Provider != AWSProvider && vslSpec.Velero.Provider != GCPProvider &&
-			vslSpec.Velero.Provider != Azure {
-			r.Log.Info("Non-supported provider specified, might be a misconfiguration")
-
-			r.EventRecorder.Event(&vsl,
-				corev1.EventTypeWarning,
-				"VSL provider is invalid",
-				fmt.Sprintf("VSL provider %s is invalid, might be a misconfiguration", vslSpec.Velero.Provider),
-			)
+			vslSpec.Velero.Provider != AzureProvider {
+			return false, fmt.Errorf("DPA %s.provider %s is invalid: only %s, %s and %s are supported", veleroVSLYAMLPath, vslSpec.Velero.Provider, AWSProvider, GCPProvider, AzureProvider)
 		}
 
 		//AWS
 		if vslSpec.Velero.Provider == AWSProvider {
 			//in AWS, region is a required field
 			if len(vslSpec.Velero.Config[AWSRegion]) == 0 {
-				return false, errors.New("region for AWS VSL is not configured, please ensure a region is configured")
+				return false, fmt.Errorf("region for %s VSL in DPA %s.config is not configured, please ensure a region is configured", AWSProvider, veleroVSLYAMLPath)
 			}
 
 			// check for invalid config key
 			for key := range vslSpec.Velero.Config {
 				valid := validAWSKeys[key]
 				if !valid {
-					return false, fmt.Errorf("%s is not a valid AWS config value", key)
+					return false, fmt.Errorf("DPA %s.config key %s is not a valid %s config key", veleroVSLYAMLPath, key, AWSProvider)
 				}
 			}
 			//checking the aws plugin, if not present, throw warning message
 			if !containsPlugin(dpa.Spec.Configuration.Velero.DefaultPlugins, AWSProvider) {
-				r.Log.Info("VSL for AWS specified, but AWS plugin not present, might be a misconfiguration")
-
-				r.EventRecorder.Event(&vsl,
-					corev1.EventTypeWarning,
-					"VolumeSnapshotLocation is invalid",
-					fmt.Sprintf("could not validate vsl for AWS plugin on: %s/%s", vsl.Namespace, vsl.Name),
-				)
+				return false, fmt.Errorf("to use VSL for %s specified in DPA %s, %s plugin must be present in %s.defaultPlugins", AWSProvider, vslYAMLPath, AWSProvider, veleroConfigYAMLPath)
 			}
 		}
 
@@ -167,40 +151,30 @@ func (r *DPAReconciler) ValidateVolumeSnapshotLocations(dpa oadpv1alpha1.DataPro
 			for key := range vslSpec.Velero.Config {
 				valid := validGCPKeys[key]
 				if !valid {
-					return false, fmt.Errorf("%s is not a valid GCP config value", key)
+					return false, fmt.Errorf("DPA %s.config key %s is not a valid %s config key", veleroVSLYAMLPath, key, GCPProvider)
 				}
 			}
 			//checking the gcp plugin, if not present, throw warning message
 			if !containsPlugin(dpa.Spec.Configuration.Velero.DefaultPlugins, "gcp") {
-				r.Log.Info("VSL for GCP specified, but GCP plugin not present, might be a misconfiguration")
 
-				r.EventRecorder.Event(&vsl,
-					corev1.EventTypeWarning,
-					"VolumeSnapshotLocation is invalid",
-					fmt.Sprintf("could not validate vsl for GCP plugin on: %s/%s", vsl.Namespace, vsl.Name),
-				)
+				return false, fmt.Errorf("to use VSL for %s specified in DPA %s, %s plugin must be present in %s.defaultPlugins", GCPProvider, vslYAMLPath, GCPProvider, veleroConfigYAMLPath)
 			}
 		}
 
 		//Azure
-		if vslSpec.Velero.Provider == Azure {
+		if vslSpec.Velero.Provider == AzureProvider {
 
 			// check for invalid config key
 			for key := range vslSpec.Velero.Config {
 				valid := validAzureKeys[key]
 				if !valid {
-					return false, fmt.Errorf("%s is not a valid Azure config value", key)
+					return false, fmt.Errorf("DPA %s.config key %s is not a valid %s config key", veleroVSLYAMLPath, key, AzureProvider)
 				}
 			}
 			//checking the azure plugin, if not present, throw warning message
 			if !containsPlugin(dpa.Spec.Configuration.Velero.DefaultPlugins, "azure") {
-				r.Log.Info("VSL for Azure specified, but Azure plugin not present, might be a misconfiguration")
 
-				r.EventRecorder.Event(&vsl,
-					corev1.EventTypeWarning,
-					"VolumeSnapshotLocation is invalid",
-					fmt.Sprintf("could not validate vsl for Azure plugin on: %s/%s", vsl.Namespace, vsl.Name),
-				)
+				return false, fmt.Errorf("to use VSL for %s specified in DPA %s, %s plugin must be present in %s.defaultPlugins", AzureProvider, vslYAMLPath, AzureProvider, veleroConfigYAMLPath)
 			}
 		}
 

--- a/controllers/vsl_test.go
+++ b/controllers/vsl_test.go
@@ -48,7 +48,78 @@ func TestDPAReconciler_ValidateVolumeSnapshotLocation(t *testing.T) {
 			},
 		},
 
+		{
+			name: "test VSL with invalid provider specified",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-Velero-VSL-invalid-provider",
+					Namespace: "test-ns",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{
+							DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
+								oadpv1alpha1.DefaultPluginAWS,
+								oadpv1alpha1.DefaultPluginGCP,
+								oadpv1alpha1.DefaultPluginMicrosoftAzure,
+							},
+						},
+					},
+					SnapshotLocations: []oadpv1alpha1.SnapshotLocation{
+						{
+							Velero: &velerov1.VolumeSnapshotLocationSpec{
+								Provider: "invalid-provider",
+							},
+						},
+					},
+				},
+			},
+			want:    false,
+			wantErr: true,
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cloud-credentials",
+					Namespace: "test-ns",
+				},
+				Data: map[string][]byte{"cloud": []byte("dummy_data")},
+			},
+		},
+
 		// AWS tests
+		{
+			name: "test AWS VSL with AWS plugin missing",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-Velero-VSL-aws-plugin-missing",
+					Namespace: "test-ns",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{},
+					},
+					SnapshotLocations: []oadpv1alpha1.SnapshotLocation{
+						{
+							Velero: &velerov1.VolumeSnapshotLocationSpec{
+								Provider: AWSProvider,
+								Config: map[string]string{
+									Region: "us-east-1",
+								},
+							},
+						},
+					},
+				},
+			},
+			want:    false,
+			wantErr: true,
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cloud-credentials",
+					Namespace: "test-ns",
+				},
+				Data: map[string][]byte{"cloud": []byte("dummy_data")},
+			},
+		},
+
 		{
 			name: "test AWS VSL with only region specified",
 			dpa: &oadpv1alpha1.DataProtectionApplication{
@@ -58,7 +129,11 @@ func TestDPAReconciler_ValidateVolumeSnapshotLocation(t *testing.T) {
 				},
 				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
 					Configuration: &oadpv1alpha1.ApplicationConfig{
-						Velero: &oadpv1alpha1.VeleroConfig{},
+						Velero: &oadpv1alpha1.VeleroConfig{
+							DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
+								oadpv1alpha1.DefaultPluginAWS,
+							},
+						},
 					},
 					SnapshotLocations: []oadpv1alpha1.SnapshotLocation{
 						{
@@ -121,7 +196,11 @@ func TestDPAReconciler_ValidateVolumeSnapshotLocation(t *testing.T) {
 				},
 				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
 					Configuration: &oadpv1alpha1.ApplicationConfig{
-						Velero: &oadpv1alpha1.VeleroConfig{},
+						Velero: &oadpv1alpha1.VeleroConfig{
+							DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
+								oadpv1alpha1.DefaultPluginAWS,
+							},
+						},
 					},
 					SnapshotLocations: []oadpv1alpha1.SnapshotLocation{
 						{
@@ -191,7 +270,11 @@ func TestDPAReconciler_ValidateVolumeSnapshotLocation(t *testing.T) {
 				},
 				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
 					Configuration: &oadpv1alpha1.ApplicationConfig{
-						Velero: &oadpv1alpha1.VeleroConfig{},
+						Velero: &oadpv1alpha1.VeleroConfig{
+							DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
+								oadpv1alpha1.DefaultPluginGCP,
+							},
+						},
 					},
 					SnapshotLocations: []oadpv1alpha1.SnapshotLocation{
 						{
@@ -213,6 +296,36 @@ func TestDPAReconciler_ValidateVolumeSnapshotLocation(t *testing.T) {
 			},
 		},
 		{
+			name: "test GCP VSL with GCP plugin missing",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-Velero-VSL-GCP-plugin-missing",
+					Namespace: "test-ns",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{},
+					},
+					SnapshotLocations: []oadpv1alpha1.SnapshotLocation{
+						{
+							Velero: &velerov1.VolumeSnapshotLocationSpec{
+								Provider: GCPProvider,
+							},
+						},
+					},
+				},
+			},
+			want:    false,
+			wantErr: true,
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cloud-credentials-gcp",
+					Namespace: "test-ns",
+				},
+				Data: map[string][]byte{"cloud": []byte("dummy_data")},
+			},
+		},
+		{
 			name: "test GCP VSL with snapshotLocation specified",
 			dpa: &oadpv1alpha1.DataProtectionApplication{
 				ObjectMeta: metav1.ObjectMeta{
@@ -221,7 +334,11 @@ func TestDPAReconciler_ValidateVolumeSnapshotLocation(t *testing.T) {
 				},
 				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
 					Configuration: &oadpv1alpha1.ApplicationConfig{
-						Velero: &oadpv1alpha1.VeleroConfig{},
+						Velero: &oadpv1alpha1.VeleroConfig{
+							DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
+								oadpv1alpha1.DefaultPluginGCP,
+							},
+						},
 					},
 					SnapshotLocations: []oadpv1alpha1.SnapshotLocation{
 						{
@@ -254,7 +371,11 @@ func TestDPAReconciler_ValidateVolumeSnapshotLocation(t *testing.T) {
 				},
 				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
 					Configuration: &oadpv1alpha1.ApplicationConfig{
-						Velero: &oadpv1alpha1.VeleroConfig{},
+						Velero: &oadpv1alpha1.VeleroConfig{
+							DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
+								oadpv1alpha1.DefaultPluginGCP,
+							},
+						},
 					},
 					SnapshotLocations: []oadpv1alpha1.SnapshotLocation{
 						{
@@ -322,7 +443,11 @@ func TestDPAReconciler_ValidateVolumeSnapshotLocation(t *testing.T) {
 				},
 				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
 					Configuration: &oadpv1alpha1.ApplicationConfig{
-						Velero: &oadpv1alpha1.VeleroConfig{},
+						Velero: &oadpv1alpha1.VeleroConfig{
+							DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
+								oadpv1alpha1.DefaultPluginMicrosoftAzure,
+							},
+						},
 					},
 					SnapshotLocations: []oadpv1alpha1.SnapshotLocation{
 						{
@@ -344,6 +469,36 @@ func TestDPAReconciler_ValidateVolumeSnapshotLocation(t *testing.T) {
 			},
 		},
 		{
+			name: "test Azure VSL with Azure plugin missing",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-Velero-VSL-Azure-plugin-missing",
+					Namespace: "test-ns",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{},
+					},
+					SnapshotLocations: []oadpv1alpha1.SnapshotLocation{
+						{
+							Velero: &velerov1.VolumeSnapshotLocationSpec{
+								Provider: AzureProvider,
+							},
+						},
+					},
+				},
+			},
+			want:    false,
+			wantErr: true,
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cloud-credentials-azure",
+					Namespace: "test-ns",
+				},
+				Data: map[string][]byte{"cloud": []byte("dummy_data")},
+			},
+		},
+		{
 			name: "test Azure VSL with apiTimeout specified",
 			dpa: &oadpv1alpha1.DataProtectionApplication{
 				ObjectMeta: metav1.ObjectMeta{
@@ -352,7 +507,11 @@ func TestDPAReconciler_ValidateVolumeSnapshotLocation(t *testing.T) {
 				},
 				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
 					Configuration: &oadpv1alpha1.ApplicationConfig{
-						Velero: &oadpv1alpha1.VeleroConfig{},
+						Velero: &oadpv1alpha1.VeleroConfig{
+							DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
+								oadpv1alpha1.DefaultPluginMicrosoftAzure,
+							},
+						},
 					},
 					SnapshotLocations: []oadpv1alpha1.SnapshotLocation{
 						{
@@ -385,7 +544,11 @@ func TestDPAReconciler_ValidateVolumeSnapshotLocation(t *testing.T) {
 				},
 				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
 					Configuration: &oadpv1alpha1.ApplicationConfig{
-						Velero: &oadpv1alpha1.VeleroConfig{},
+						Velero: &oadpv1alpha1.VeleroConfig{
+							DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
+								oadpv1alpha1.DefaultPluginMicrosoftAzure,
+							},
+						},
 					},
 					SnapshotLocations: []oadpv1alpha1.SnapshotLocation{
 						{
@@ -418,7 +581,11 @@ func TestDPAReconciler_ValidateVolumeSnapshotLocation(t *testing.T) {
 				},
 				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
 					Configuration: &oadpv1alpha1.ApplicationConfig{
-						Velero: &oadpv1alpha1.VeleroConfig{},
+						Velero: &oadpv1alpha1.VeleroConfig{
+							DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
+								oadpv1alpha1.DefaultPluginMicrosoftAzure,
+							},
+						},
 					},
 					SnapshotLocations: []oadpv1alpha1.SnapshotLocation{
 						{
@@ -451,7 +618,11 @@ func TestDPAReconciler_ValidateVolumeSnapshotLocation(t *testing.T) {
 				},
 				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
 					Configuration: &oadpv1alpha1.ApplicationConfig{
-						Velero: &oadpv1alpha1.VeleroConfig{},
+						Velero: &oadpv1alpha1.VeleroConfig{
+							DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
+								oadpv1alpha1.DefaultPluginMicrosoftAzure,
+							},
+						},
 					},
 					SnapshotLocations: []oadpv1alpha1.SnapshotLocation{
 						{
@@ -489,7 +660,7 @@ func TestDPAReconciler_ValidateVolumeSnapshotLocation(t *testing.T) {
 					SnapshotLocations: []oadpv1alpha1.SnapshotLocation{
 						{
 							Velero: &velerov1.VolumeSnapshotLocationSpec{
-								Provider: GCPProvider,
+								Provider: AzureProvider,
 								Config: map[string]string{
 									"invalid-test": "foo",
 								},


### PR DESCRIPTION
## Why the changes were made

Fixed some VSL validation errors like:

-> throwing error on incorrect provider in VSL
-> throwing error on missing region in AWS VSL
-> throwing error if missing plugins for AWS, GCP, Azure VSLs

## How to test the changes made

Use "make deploy-olm" and configure VSL in DPA spec.

1. Provide incorrect provider in VSL
2. Configure AWS VSL, and dont provide region in VSL spec.
3. Add AWS/GCP/Azure VSL and dont add relevant velero plugin.
