### PR TITLE
fix: Remove duplication around plugins' names

### DIFF
--- a/controllers/bsl_test.go
+++ b/controllers/bsl_test.go
@@ -123,7 +123,7 @@ func TestDPAReconciler_ValidateBackupStorageLocations(t *testing.T) {
 					BackupLocations: []oadpv1alpha1.BackupLocation{
 						{
 							Velero: &velerov1.BackupStorageLocationSpec{
-								Provider: "aws",
+								Provider: string(oadpv1alpha1.DefaultPluginAWS),
 								Config: map[string]string{
 									Region: "us-east-1",
 								},
@@ -219,7 +219,7 @@ func TestDPAReconciler_ValidateBackupStorageLocations(t *testing.T) {
 					BackupLocations: []oadpv1alpha1.BackupLocation{
 						{
 							Velero: &velerov1.BackupStorageLocationSpec{
-								Provider: "aws",
+								Provider: string(oadpv1alpha1.DefaultPluginAWS),
 								Config: map[string]string{
 									Region: "us-east-1",
 								},
@@ -256,7 +256,7 @@ func TestDPAReconciler_ValidateBackupStorageLocations(t *testing.T) {
 					BackupLocations: []oadpv1alpha1.BackupLocation{
 						{
 							Velero: &velerov1.BackupStorageLocationSpec{
-								Provider: "aws",
+								Provider: string(oadpv1alpha1.DefaultPluginAWS),
 								Config: map[string]string{
 									Region: "us-east-1",
 								},
@@ -293,7 +293,7 @@ func TestDPAReconciler_ValidateBackupStorageLocations(t *testing.T) {
 					BackupLocations: []oadpv1alpha1.BackupLocation{
 						{
 							Velero: &velerov1.BackupStorageLocationSpec{
-								Provider: "aws",
+								Provider: string(oadpv1alpha1.DefaultPluginAWS),
 								StorageType: velerov1.StorageType{
 									ObjectStorage: &velerov1.ObjectStorageLocation{
 										Bucket: "",
@@ -335,7 +335,7 @@ func TestDPAReconciler_ValidateBackupStorageLocations(t *testing.T) {
 					BackupLocations: []oadpv1alpha1.BackupLocation{
 						{
 							Velero: &velerov1.BackupStorageLocationSpec{
-								Provider: "aws",
+								Provider: string(oadpv1alpha1.DefaultPluginAWS),
 								StorageType: velerov1.StorageType{
 									ObjectStorage: &velerov1.ObjectStorageLocation{
 										Bucket: "test-aws-bucket",
@@ -377,7 +377,7 @@ func TestDPAReconciler_ValidateBackupStorageLocations(t *testing.T) {
 					BackupLocations: []oadpv1alpha1.BackupLocation{
 						{
 							Velero: &velerov1.BackupStorageLocationSpec{
-								Provider: "aws",
+								Provider: string(oadpv1alpha1.DefaultPluginAWS),
 								StorageType: velerov1.StorageType{
 									ObjectStorage: &velerov1.ObjectStorageLocation{
 										Bucket: "test-aws-bucket",
@@ -421,7 +421,7 @@ func TestDPAReconciler_ValidateBackupStorageLocations(t *testing.T) {
 					BackupLocations: []oadpv1alpha1.BackupLocation{
 						{
 							Velero: &velerov1.BackupStorageLocationSpec{
-								Provider: "aws",
+								Provider: string(oadpv1alpha1.DefaultPluginAWS),
 								StorageType: velerov1.StorageType{
 									ObjectStorage: &velerov1.ObjectStorageLocation{
 										Bucket: "test-aws-bucket",
@@ -467,7 +467,7 @@ func TestDPAReconciler_ValidateBackupStorageLocations(t *testing.T) {
 					BackupLocations: []oadpv1alpha1.BackupLocation{
 						{
 							Velero: &velerov1.BackupStorageLocationSpec{
-								Provider: "azure",
+								Provider: string(oadpv1alpha1.DefaultPluginMicrosoftAzure),
 								StorageType: velerov1.StorageType{
 									ObjectStorage: &velerov1.ObjectStorageLocation{
 										Bucket: "test-azure-bucket",
@@ -509,7 +509,7 @@ func TestDPAReconciler_ValidateBackupStorageLocations(t *testing.T) {
 					BackupLocations: []oadpv1alpha1.BackupLocation{
 						{
 							Velero: &velerov1.BackupStorageLocationSpec{
-								Provider: "azure",
+								Provider: string(oadpv1alpha1.DefaultPluginMicrosoftAzure),
 								StorageType: velerov1.StorageType{
 									ObjectStorage: &velerov1.ObjectStorageLocation{
 										Bucket: "test-azure-bucket",
@@ -549,7 +549,7 @@ func TestDPAReconciler_ValidateBackupStorageLocations(t *testing.T) {
 					BackupLocations: []oadpv1alpha1.BackupLocation{
 						{
 							Velero: &velerov1.BackupStorageLocationSpec{
-								Provider: "gcp",
+								Provider: string(oadpv1alpha1.DefaultPluginGCP),
 								StorageType: velerov1.StorageType{
 									ObjectStorage: &velerov1.ObjectStorageLocation{},
 								},
@@ -586,7 +586,7 @@ func TestDPAReconciler_ValidateBackupStorageLocations(t *testing.T) {
 					BackupLocations: []oadpv1alpha1.BackupLocation{
 						{
 							Velero: &velerov1.BackupStorageLocationSpec{
-								Provider: "aws",
+								Provider: string(oadpv1alpha1.DefaultPluginAWS),
 								StorageType: velerov1.StorageType{
 									ObjectStorage: &velerov1.ObjectStorageLocation{
 										Bucket: "test-aws-bucket",
@@ -632,7 +632,7 @@ func TestDPAReconciler_ValidateBackupStorageLocations(t *testing.T) {
 					BackupLocations: []oadpv1alpha1.BackupLocation{
 						{
 							Velero: &velerov1.BackupStorageLocationSpec{
-								Provider: "aws",
+								Provider: string(oadpv1alpha1.DefaultPluginAWS),
 								StorageType: velerov1.StorageType{
 									ObjectStorage: &velerov1.ObjectStorageLocation{
 										Bucket: "test-aws-bucket",
@@ -676,7 +676,7 @@ func TestDPAReconciler_ValidateBackupStorageLocations(t *testing.T) {
 					BackupLocations: []oadpv1alpha1.BackupLocation{
 						{
 							Velero: &velerov1.BackupStorageLocationSpec{
-								Provider: "aws",
+								Provider: string(oadpv1alpha1.DefaultPluginAWS),
 								StorageType: velerov1.StorageType{
 									ObjectStorage: &velerov1.ObjectStorageLocation{
 										Bucket: "test-aws-bucket",
@@ -718,7 +718,7 @@ func TestDPAReconciler_ValidateBackupStorageLocations(t *testing.T) {
 					BackupLocations: []oadpv1alpha1.BackupLocation{
 						{
 							Velero: &velerov1.BackupStorageLocationSpec{
-								Provider: "gcp",
+								Provider: string(oadpv1alpha1.DefaultPluginGCP),
 								StorageType: velerov1.StorageType{
 									ObjectStorage: &velerov1.ObjectStorageLocation{
 										Bucket: "test-gcp-bucket",
@@ -757,7 +757,7 @@ func TestDPAReconciler_ValidateBackupStorageLocations(t *testing.T) {
 					BackupLocations: []oadpv1alpha1.BackupLocation{
 						{
 							Velero: &velerov1.BackupStorageLocationSpec{
-								Provider: "azure",
+								Provider: string(oadpv1alpha1.DefaultPluginMicrosoftAzure),
 								StorageType: velerov1.StorageType{
 									ObjectStorage: &velerov1.ObjectStorageLocation{
 										Bucket: "test-azure-bucket",
@@ -800,7 +800,7 @@ func TestDPAReconciler_ValidateBackupStorageLocations(t *testing.T) {
 					BackupLocations: []oadpv1alpha1.BackupLocation{
 						{
 							Velero: &velerov1.BackupStorageLocationSpec{
-								Provider: "aws",
+								Provider: string(oadpv1alpha1.DefaultPluginAWS),
 								StorageType: velerov1.StorageType{
 									ObjectStorage: &velerov1.ObjectStorageLocation{
 										Bucket: "test-aws-bucket",
@@ -821,7 +821,7 @@ func TestDPAReconciler_ValidateBackupStorageLocations(t *testing.T) {
 						},
 						{
 							Velero: &velerov1.BackupStorageLocationSpec{
-								Provider: "azure",
+								Provider: string(oadpv1alpha1.DefaultPluginMicrosoftAzure),
 								StorageType: velerov1.StorageType{
 									ObjectStorage: &velerov1.ObjectStorageLocation{
 										Bucket: "test-azure-bucket",
@@ -842,7 +842,7 @@ func TestDPAReconciler_ValidateBackupStorageLocations(t *testing.T) {
 						},
 						{
 							Velero: &velerov1.BackupStorageLocationSpec{
-								Provider: "gcp",
+								Provider: string(oadpv1alpha1.DefaultPluginGCP),
 								StorageType: velerov1.StorageType{
 									ObjectStorage: &velerov1.ObjectStorageLocation{
 										Bucket: "test-gcp-bucket",
@@ -903,7 +903,7 @@ func TestDPAReconciler_ValidateBackupStorageLocations(t *testing.T) {
 					BackupLocations: []oadpv1alpha1.BackupLocation{
 						{
 							Velero: &velerov1.BackupStorageLocationSpec{
-								Provider: "aws",
+								Provider: string(oadpv1alpha1.DefaultPluginAWS),
 								StorageType: velerov1.StorageType{
 									ObjectStorage: &velerov1.ObjectStorageLocation{
 										Bucket: "test-aws-bucket",
@@ -1047,7 +1047,7 @@ func TestDPAReconciler_ValidateBackupStorageLocations(t *testing.T) {
 					BackupLocations: []oadpv1alpha1.BackupLocation{
 						{
 							Velero: &velerov1.BackupStorageLocationSpec{
-								Provider: "aws",
+								Provider: string(oadpv1alpha1.DefaultPluginAWS),
 								StorageType: velerov1.StorageType{
 									ObjectStorage: &velerov1.ObjectStorageLocation{
 										Bucket: "test-aws-bucket",
@@ -1068,7 +1068,7 @@ func TestDPAReconciler_ValidateBackupStorageLocations(t *testing.T) {
 						},
 						{
 							Velero: &velerov1.BackupStorageLocationSpec{
-								Provider: "azure",
+								Provider: string(oadpv1alpha1.DefaultPluginMicrosoftAzure),
 								StorageType: velerov1.StorageType{
 									ObjectStorage: &velerov1.ObjectStorageLocation{
 										Bucket: "test-azure-bucket",
@@ -1089,7 +1089,7 @@ func TestDPAReconciler_ValidateBackupStorageLocations(t *testing.T) {
 						},
 						{
 							Velero: &velerov1.BackupStorageLocationSpec{
-								Provider: "gcp",
+								Provider: string(oadpv1alpha1.DefaultPluginGCP),
 								StorageType: velerov1.StorageType{
 									ObjectStorage: &velerov1.ObjectStorageLocation{
 										Bucket: "test-gcp-bucket",
@@ -1147,7 +1147,7 @@ func TestDPAReconciler_ValidateBackupStorageLocations(t *testing.T) {
 					BackupLocations: []oadpv1alpha1.BackupLocation{
 						{
 							Velero: &velerov1.BackupStorageLocationSpec{
-								Provider: "aws",
+								Provider: string(oadpv1alpha1.DefaultPluginAWS),
 								StorageType: velerov1.StorageType{
 									ObjectStorage: &velerov1.ObjectStorageLocation{
 										Bucket: "test-aws-bucket",
@@ -1188,7 +1188,7 @@ func TestDPAReconciler_ValidateBackupStorageLocations(t *testing.T) {
 					BackupLocations: []oadpv1alpha1.BackupLocation{
 						{
 							Velero: &velerov1.BackupStorageLocationSpec{
-								Provider: "aws",
+								Provider: string(oadpv1alpha1.DefaultPluginAWS),
 								StorageType: velerov1.StorageType{
 									ObjectStorage: &velerov1.ObjectStorageLocation{
 										Bucket: DiscoverableBucket,
@@ -1225,7 +1225,7 @@ func TestDPAReconciler_ValidateBackupStorageLocations(t *testing.T) {
 					BackupLocations: []oadpv1alpha1.BackupLocation{
 						{
 							Velero: &velerov1.BackupStorageLocationSpec{
-								Provider: "aws",
+								Provider: string(oadpv1alpha1.DefaultPluginAWS),
 								StorageType: velerov1.StorageType{
 									ObjectStorage: &velerov1.ObjectStorageLocation{
 										Bucket: "bucket",
@@ -1261,7 +1261,7 @@ func TestDPAReconciler_ValidateBackupStorageLocations(t *testing.T) {
 					BackupLocations: []oadpv1alpha1.BackupLocation{
 						{
 							Velero: &velerov1.BackupStorageLocationSpec{
-								Provider: "aws",
+								Provider: string(oadpv1alpha1.DefaultPluginAWS),
 								Config: map[string]string{
 									Profile:          "default",
 									S3ForcePathStyle: "true",
@@ -1301,7 +1301,7 @@ func TestDPAReconciler_ValidateBackupStorageLocations(t *testing.T) {
 					BackupLocations: []oadpv1alpha1.BackupLocation{
 						{
 							Velero: &velerov1.BackupStorageLocationSpec{
-								Provider: "aws",
+								Provider: string(oadpv1alpha1.DefaultPluginAWS),
 								Config: map[string]string{
 									Profile: "default",
 								},
@@ -1341,7 +1341,7 @@ func TestDPAReconciler_ValidateBackupStorageLocations(t *testing.T) {
 					BackupLocations: []oadpv1alpha1.BackupLocation{
 						{
 							Velero: &velerov1.BackupStorageLocationSpec{
-								Provider: "aws",
+								Provider: string(oadpv1alpha1.DefaultPluginAWS),
 								Config: map[string]string{
 									S3ForcePathStyle: "false",
 								},
@@ -1382,7 +1382,7 @@ func TestDPAReconciler_ValidateBackupStorageLocations(t *testing.T) {
 					BackupLocations: []oadpv1alpha1.BackupLocation{
 						{
 							Velero: &velerov1.BackupStorageLocationSpec{
-								Provider: "aws",
+								Provider: string(oadpv1alpha1.DefaultPluginAWS),
 								Config: map[string]string{
 									S3ForcePathStyle: "true",
 								},
@@ -1421,7 +1421,7 @@ func TestDPAReconciler_ValidateBackupStorageLocations(t *testing.T) {
 					BackupLocations: []oadpv1alpha1.BackupLocation{
 						{
 							Velero: &velerov1.BackupStorageLocationSpec{
-								Provider: "aws",
+								Provider: string(oadpv1alpha1.DefaultPluginAWS),
 								Config: map[string]string{
 									S3ForcePathStyle: "true",
 									Region:           "noobaa",
@@ -1462,7 +1462,7 @@ func TestDPAReconciler_ValidateBackupStorageLocations(t *testing.T) {
 					BackupLocations: []oadpv1alpha1.BackupLocation{
 						{
 							Velero: &velerov1.BackupStorageLocationSpec{
-								Provider: "aws",
+								Provider: string(oadpv1alpha1.DefaultPluginAWS),
 								Config: map[string]string{
 									S3ForcePathStyle: "true",
 								},
@@ -1546,7 +1546,7 @@ func TestDPAReconciler_updateBSLFromSpec(t *testing.T) {
 					BackupLocations: []oadpv1alpha1.BackupLocation{
 						{
 							Velero: &velerov1.BackupStorageLocationSpec{
-								Provider: "aws",
+								Provider: string(oadpv1alpha1.DefaultPluginAWS),
 								StorageType: velerov1.StorageType{
 									ObjectStorage: &velerov1.ObjectStorageLocation{
 										Bucket: "test-aws-bucket",
@@ -1590,7 +1590,7 @@ func TestDPAReconciler_updateBSLFromSpec(t *testing.T) {
 					}},
 				},
 				Spec: velerov1.BackupStorageLocationSpec{
-					Provider: "aws",
+					Provider: string(oadpv1alpha1.DefaultPluginAWS),
 					StorageType: velerov1.StorageType{
 						ObjectStorage: &velerov1.ObjectStorageLocation{
 							Bucket: "test-aws-bucket",
@@ -1629,7 +1629,7 @@ func TestDPAReconciler_updateBSLFromSpec(t *testing.T) {
 					BackupLocations: []oadpv1alpha1.BackupLocation{
 						{
 							Velero: &velerov1.BackupStorageLocationSpec{
-								Provider: "aws",
+								Provider: string(oadpv1alpha1.DefaultPluginAWS),
 								StorageType: velerov1.StorageType{
 									ObjectStorage: &velerov1.ObjectStorageLocation{
 										Bucket: "test-aws-bucket",
@@ -1670,7 +1670,7 @@ func TestDPAReconciler_updateBSLFromSpec(t *testing.T) {
 					}},
 				},
 				Spec: velerov1.BackupStorageLocationSpec{
-					Provider: "aws",
+					Provider: string(oadpv1alpha1.DefaultPluginAWS),
 					StorageType: velerov1.StorageType{
 						ObjectStorage: &velerov1.ObjectStorageLocation{
 							Bucket: "test-aws-bucket",
@@ -1705,7 +1705,7 @@ func TestDPAReconciler_updateBSLFromSpec(t *testing.T) {
 					BackupLocations: []oadpv1alpha1.BackupLocation{
 						{
 							Velero: &velerov1.BackupStorageLocationSpec{
-								Provider: "aws",
+								Provider: string(oadpv1alpha1.DefaultPluginAWS),
 								StorageType: velerov1.StorageType{
 									ObjectStorage: &velerov1.ObjectStorageLocation{
 										Bucket: "test-aws-bucket",
@@ -1750,7 +1750,7 @@ func TestDPAReconciler_updateBSLFromSpec(t *testing.T) {
 					}},
 				},
 				Spec: velerov1.BackupStorageLocationSpec{
-					Provider: "aws",
+					Provider: string(oadpv1alpha1.DefaultPluginAWS),
 					StorageType: velerov1.StorageType{
 						ObjectStorage: &velerov1.ObjectStorageLocation{
 							Bucket: "test-aws-bucket",
@@ -1819,17 +1819,17 @@ func TestDPAReconciler_ensureBackupLocationHasVeleroOrCloudStorage(t *testing.T)
 					BackupLocations: []oadpv1alpha1.BackupLocation{
 						{
 							Velero: &velerov1.BackupStorageLocationSpec{
-								Provider: "aws",
+								Provider: string(oadpv1alpha1.DefaultPluginAWS),
 							},
 						},
 						{
 							Velero: &velerov1.BackupStorageLocationSpec{
-								Provider: "azure",
+								Provider: string(oadpv1alpha1.DefaultPluginMicrosoftAzure),
 							},
 						},
 						{
 							Velero: &velerov1.BackupStorageLocationSpec{
-								Provider: "gcp",
+								Provider: string(oadpv1alpha1.DefaultPluginGCP),
 							},
 						},
 					},
@@ -1848,7 +1848,7 @@ func TestDPAReconciler_ensureBackupLocationHasVeleroOrCloudStorage(t *testing.T)
 					BackupLocations: []oadpv1alpha1.BackupLocation{
 						{
 							Velero: &velerov1.BackupStorageLocationSpec{
-								Provider: "aws",
+								Provider: string(oadpv1alpha1.DefaultPluginAWS),
 							},
 							CloudStorage: &oadpv1alpha1.CloudStorageLocation{
 								CloudStorageRef: corev1.LocalObjectReference{
@@ -1872,32 +1872,32 @@ func TestDPAReconciler_ensureBackupLocationHasVeleroOrCloudStorage(t *testing.T)
 					BackupLocations: []oadpv1alpha1.BackupLocation{
 						{
 							Velero: &velerov1.BackupStorageLocationSpec{
-								Provider: "aws",
+								Provider: string(oadpv1alpha1.DefaultPluginAWS),
 							},
 						},
 						{
 							Velero: &velerov1.BackupStorageLocationSpec{
-								Provider: "aws",
+								Provider: string(oadpv1alpha1.DefaultPluginAWS),
 							},
 						},
 						{
 							Velero: &velerov1.BackupStorageLocationSpec{
-								Provider: "azure",
+								Provider: string(oadpv1alpha1.DefaultPluginMicrosoftAzure),
 							},
 						},
 						{
 							Velero: &velerov1.BackupStorageLocationSpec{
-								Provider: "azure",
+								Provider: string(oadpv1alpha1.DefaultPluginMicrosoftAzure),
 							},
 						},
 						{
 							Velero: &velerov1.BackupStorageLocationSpec{
-								Provider: "gcp",
+								Provider: string(oadpv1alpha1.DefaultPluginGCP),
 							},
 						},
 						{
 							Velero: &velerov1.BackupStorageLocationSpec{
-								Provider: "gcp",
+								Provider: string(oadpv1alpha1.DefaultPluginGCP),
 							},
 						},
 					},
@@ -2127,7 +2127,7 @@ func TestDPAReconciler_ReconcileBackupStorageLocations(t *testing.T) {
 				Key: "credentials",
 			},
 			Name:     "test-cs",
-			Provider: "aws",
+			Provider: oadpv1alpha1.AWSBucketProvider,
 		},
 	}
 
@@ -2150,7 +2150,7 @@ func TestDPAReconciler_ReconcileBackupStorageLocations(t *testing.T) {
 					BackupLocations: []oadpv1alpha1.BackupLocation{
 						{
 							Velero: &velerov1.BackupStorageLocationSpec{
-								Provider: "aws",
+								Provider: string(oadpv1alpha1.DefaultPluginAWS),
 								Config: map[string]string{
 									Region: "us-east-1",
 								},
@@ -2269,7 +2269,7 @@ func TestDPAReconciler_ReconcileBackupStorageLocations(t *testing.T) {
 						BackupLocations: []oadpv1alpha1.BackupLocation{
 							{
 								Velero: &velerov1.BackupStorageLocationSpec{
-									Provider: "aws",
+									Provider: string(oadpv1alpha1.DefaultPluginAWS),
 									Config: map[string]string{
 										Region: "us-east-1",
 									},
@@ -2305,7 +2305,7 @@ func TestDPAReconciler_ReconcileBackupStorageLocations(t *testing.T) {
 					Namespace: "test-ns",
 				},
 				Spec: velerov1.BackupStorageLocationSpec{
-					Provider: "aws",
+					Provider: string(oadpv1alpha1.DefaultPluginAWS),
 					Config: map[string]string{
 						Region:            "us-east-1",
 						checksumAlgorithm: "",
@@ -2364,7 +2364,7 @@ func TestDPAReconciler_ReconcileBackupStorageLocations(t *testing.T) {
 						Namespace: "test-ns",
 					},
 					Spec: oadpv1alpha1.CloudStorageSpec{
-						Provider: "aws",
+						Provider: oadpv1alpha1.AWSBucketProvider,
 						CreationSecret: corev1.SecretKeySelector{
 							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "cloud-credentials",
@@ -2382,7 +2382,7 @@ func TestDPAReconciler_ReconcileBackupStorageLocations(t *testing.T) {
 					Namespace: "test-ns",
 				},
 				Spec: velerov1.BackupStorageLocationSpec{
-					Provider: "aws",
+					Provider: string(oadpv1alpha1.DefaultPluginAWS),
 					StorageType: velerov1.StorageType{
 						ObjectStorage: &velerov1.ObjectStorageLocation{
 							Prefix: "test-prefix",
@@ -2409,7 +2409,7 @@ func TestDPAReconciler_ReconcileBackupStorageLocations(t *testing.T) {
 						BackupLocations: []oadpv1alpha1.BackupLocation{
 							{
 								Velero: &velerov1.BackupStorageLocationSpec{
-									Provider: "aws",
+									Provider: string(oadpv1alpha1.DefaultPluginAWS),
 									Config: map[string]string{
 										Region: "us-east-1",
 									},
@@ -2447,7 +2447,7 @@ func TestDPAReconciler_ReconcileBackupStorageLocations(t *testing.T) {
 					Namespace: "test-ns",
 				},
 				Spec: velerov1.BackupStorageLocationSpec{
-					Provider: "aws",
+					Provider: string(oadpv1alpha1.DefaultPluginAWS),
 					Config: map[string]string{
 						Region:            "us-east-1",
 						checksumAlgorithm: "",
@@ -2509,7 +2509,7 @@ func TestDPAReconciler_ReconcileBackupStorageLocations(t *testing.T) {
 						Namespace: "test-ns",
 					},
 					Spec: oadpv1alpha1.CloudStorageSpec{
-						Provider: "aws",
+						Provider: oadpv1alpha1.AWSBucketProvider,
 						CreationSecret: corev1.SecretKeySelector{
 							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "cloud-credentials",
@@ -2529,7 +2529,7 @@ func TestDPAReconciler_ReconcileBackupStorageLocations(t *testing.T) {
 					Namespace: "test-ns",
 				},
 				Spec: velerov1.BackupStorageLocationSpec{
-					Provider: "aws",
+					Provider: string(oadpv1alpha1.DefaultPluginAWS),
 					StorageType: velerov1.StorageType{
 						ObjectStorage: &velerov1.ObjectStorageLocation{
 							Bucket: "test-bucket",

--- a/controllers/nodeagent_test.go
+++ b/controllers/nodeagent_test.go
@@ -1065,7 +1065,7 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 					BackupLocations: []oadpv1alpha1.BackupLocation{
 						{
 							Velero: &velerov1.BackupStorageLocationSpec{
-								Provider: AWSProvider,
+								Provider: string(oadpv1alpha1.DefaultPluginAWS),
 								StorageType: velerov1.StorageType{
 									ObjectStorage: &velerov1.ObjectStorageLocation{
 										Bucket: "aws-bucket",

--- a/controllers/registry.go
+++ b/controllers/registry.go
@@ -52,11 +52,7 @@ const (
 // provider specific object storage
 const (
 	S3                    = "s3"
-	Azure                 = "azure"
 	GCS                   = "gcs"
-	AWSProvider           = "aws"
-	AzureProvider         = "azure"
-	GCPProvider           = "gcp"
 	Region                = "region"
 	Profile               = "profile"
 	S3URL                 = "s3Url"
@@ -66,88 +62,6 @@ const (
 	StorageAccount        = "storageAccount"
 	ResourceGroup         = "resourceGroup"
 )
-
-// creating skeleton for provider based env var map
-var cloudProviderEnvVarMap = map[string][]corev1.EnvVar{
-	"aws": {
-		{
-			Name:  RegistryStorageEnvVarKey,
-			Value: S3,
-		},
-		{
-			Name:  RegistryStorageS3AccesskeyEnvVarKey,
-			Value: "",
-		},
-		{
-			Name:  RegistryStorageS3BucketEnvVarKey,
-			Value: "",
-		},
-		{
-			Name:  RegistryStorageS3RegionEnvVarKey,
-			Value: "",
-		},
-		{
-			Name:  RegistryStorageS3SecretkeyEnvVarKey,
-			Value: "",
-		},
-		{
-			Name:  RegistryStorageS3RegionendpointEnvVarKey,
-			Value: "",
-		},
-		{
-			Name:  RegistryStorageS3SkipverifyEnvVarKey,
-			Value: "",
-		},
-	},
-	"azure": {
-		{
-			Name:  RegistryStorageEnvVarKey,
-			Value: Azure,
-		},
-		{
-			Name:  RegistryStorageAzureContainerEnvVarKey,
-			Value: "",
-		},
-		{
-			Name:  RegistryStorageAzureAccountnameEnvVarKey,
-			Value: "",
-		},
-		{
-			Name:  RegistryStorageAzureAccountkeyEnvVarKey,
-			Value: "",
-		},
-		{
-			Name:  RegistryStorageAzureAADEndpointEnvVarKey,
-			Value: "",
-		},
-		{
-			Name:  RegistryStorageAzureSPNClientIDEnvVarKey,
-			Value: "",
-		},
-		{
-			Name:  RegistryStorageAzureSPNClientSecretEnvVarKey,
-			Value: "",
-		},
-		{
-			Name:  RegistryStorageAzureSPNTenantIDEnvVarKey,
-			Value: "",
-		},
-	},
-	"gcp": {
-		{
-			Name:  RegistryStorageEnvVarKey,
-			Value: GCS,
-		},
-		{
-			Name:  RegistryStorageGCSBucket,
-			Value: "",
-		},
-		{
-			Name:  RegistryStorageGCSKeyfile,
-			Value: "",
-		},
-	},
-}
 
 type azureCredentials struct {
 	subscriptionID     string
@@ -614,7 +528,7 @@ func (r *DPAReconciler) ReconcileRegistrySecrets(log logr.Logger) (bool, error) 
 	// Now for each of these bsl instances, create a registry secret
 	for _, bsl := range bslList.Items {
 		// skip for GCP as nothing is directly exposed in env vars
-		if bsl.Spec.Provider == GCPProvider {
+		if bsl.Spec.Provider == string(oadpv1alpha1.DefaultPluginGCP) {
 			continue
 		}
 		secret := corev1.Secret{
@@ -683,9 +597,9 @@ func (r *DPAReconciler) patchRegistrySecret(secret *corev1.Secret, bsl *velerov1
 	// to get around the immutable fields
 	provider := bsl.Spec.Provider
 	switch provider {
-	case AWSProvider:
+	case string(oadpv1alpha1.DefaultPluginAWS):
 		err = r.populateAWSRegistrySecret(bsl, secret)
-	case AzureProvider:
+	case string(oadpv1alpha1.DefaultPluginMicrosoftAzure):
 		err = r.populateAzureRegistrySecret(bsl, secret)
 	}
 

--- a/controllers/registry_test.go
+++ b/controllers/registry_test.go
@@ -147,10 +147,6 @@ var (
 	}
 )
 
-var testAWSEnvVar = cloudProviderEnvVarMap["aws"]
-var testAzureEnvVar = cloudProviderEnvVarMap["azure"]
-var testGCPEnvVar = cloudProviderEnvVarMap["gcp"]
-
 func TestDPAReconciler_getSecretNameAndKey(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -164,7 +160,7 @@ func TestDPAReconciler_getSecretNameAndKey(t *testing.T) {
 			name: "given provider secret, appropriate secret name and key are returned",
 			bsl: &oadpv1alpha1.BackupLocation{
 				Velero: &velerov1.BackupStorageLocationSpec{
-					Provider: AWSProvider,
+					Provider: string(oadpv1alpha1.DefaultPluginAWS),
 					Credential: &corev1.SecretKeySelector{
 						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "cloud-credentials-aws",
@@ -192,7 +188,7 @@ func TestDPAReconciler_getSecretNameAndKey(t *testing.T) {
 			name: "given no provider secret, appropriate secret name and key are returned",
 			bsl: &oadpv1alpha1.BackupLocation{
 				Velero: &velerov1.BackupStorageLocationSpec{
-					Provider: AWSProvider,
+					Provider: string(oadpv1alpha1.DefaultPluginAWS),
 					Config: map[string]string{
 						Region:                "aws-region",
 						S3URL:                 "https://sr-url-aws-domain.com",
@@ -446,7 +442,7 @@ func TestDPAReconciler_populateAzureRegistrySecret(t *testing.T) {
 					Namespace: "test-ns",
 				},
 				Spec: velerov1.BackupStorageLocationSpec{
-					Provider: AzureProvider,
+					Provider: string(oadpv1alpha1.DefaultPluginMicrosoftAzure),
 					StorageType: velerov1.StorageType{
 						ObjectStorage: &velerov1.ObjectStorageLocation{
 							Bucket: "azure-bucket",

--- a/controllers/validator_test.go
+++ b/controllers/validator_test.go
@@ -381,7 +381,7 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 					SnapshotLocations: []oadpv1alpha1.SnapshotLocation{
 						{
 							Velero: &v1.VolumeSnapshotLocationSpec{
-								Provider: "aws",
+								Provider: string(oadpv1alpha1.DefaultPluginAWS),
 								Config: map[string]string{
 									AWSRegion: "us-east-1",
 								},
@@ -429,7 +429,7 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 					SnapshotLocations: []oadpv1alpha1.SnapshotLocation{
 						{
 							Velero: &v1.VolumeSnapshotLocationSpec{
-								Provider: "aws",
+								Provider: string(oadpv1alpha1.DefaultPluginAWS),
 								Config: map[string]string{
 									AWSRegion: "us-east-1",
 								},
@@ -470,7 +470,7 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 					SnapshotLocations: []oadpv1alpha1.SnapshotLocation{
 						{
 							Velero: &v1.VolumeSnapshotLocationSpec{
-								Provider: "aws",
+								Provider: string(oadpv1alpha1.DefaultPluginAWS),
 								Config: map[string]string{
 									AWSRegion: "us-east-1",
 								},
@@ -494,7 +494,7 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 						Namespace: "test-ns",
 					},
 					Spec: oadpv1alpha1.CloudStorageSpec{
-						Provider: "aws",
+						Provider: oadpv1alpha1.AWSBucketProvider,
 					},
 				},
 			},
@@ -528,7 +528,7 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 					SnapshotLocations: []oadpv1alpha1.SnapshotLocation{
 						{
 							Velero: &v1.VolumeSnapshotLocationSpec{
-								Provider: "aws",
+								Provider: string(oadpv1alpha1.DefaultPluginAWS),
 								Config: map[string]string{
 									AWSRegion: "us-east-1",
 								},
@@ -552,7 +552,7 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 						Namespace: "test-ns",
 					},
 					Spec: oadpv1alpha1.CloudStorageSpec{
-						Provider: "aws",
+						Provider: oadpv1alpha1.AWSBucketProvider,
 					},
 				},
 				&corev1.Secret{
@@ -860,7 +860,7 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 					SnapshotLocations: []oadpv1alpha1.SnapshotLocation{
 						{
 							Velero: &v1.VolumeSnapshotLocationSpec{
-								Provider: "aws",
+								Provider: string(oadpv1alpha1.DefaultPluginAWS),
 								Config: map[string]string{
 									AWSRegion: "us-east-1",
 								},
@@ -1038,7 +1038,7 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 					SnapshotLocations: []oadpv1alpha1.SnapshotLocation{
 						{
 							Velero: &v1.VolumeSnapshotLocationSpec{
-								Provider: "aws",
+								Provider: string(oadpv1alpha1.DefaultPluginAWS),
 								Credential: &corev1.SecretKeySelector{
 									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "custom-vsl-credentials",

--- a/controllers/velero_test.go
+++ b/controllers/velero_test.go
@@ -1490,7 +1490,7 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 					BackupLocations: []oadpv1alpha1.BackupLocation{
 						{
 							Velero: &velerov1.BackupStorageLocationSpec{
-								Provider: AWSProvider,
+								Provider: string(oadpv1alpha1.DefaultPluginAWS),
 								StorageType: velerov1.StorageType{
 									ObjectStorage: &velerov1.ObjectStorageLocation{
 										Bucket: "aws-bucket",

--- a/controllers/vsl_test.go
+++ b/controllers/vsl_test.go
@@ -100,7 +100,7 @@ func TestDPAReconciler_ValidateVolumeSnapshotLocation(t *testing.T) {
 					SnapshotLocations: []oadpv1alpha1.SnapshotLocation{
 						{
 							Velero: &velerov1.VolumeSnapshotLocationSpec{
-								Provider: AWSProvider,
+								Provider: string(oadpv1alpha1.DefaultPluginAWS),
 								Config: map[string]string{
 									Region: "us-east-1",
 								},
@@ -138,7 +138,7 @@ func TestDPAReconciler_ValidateVolumeSnapshotLocation(t *testing.T) {
 					SnapshotLocations: []oadpv1alpha1.SnapshotLocation{
 						{
 							Velero: &velerov1.VolumeSnapshotLocationSpec{
-								Provider: AWSProvider,
+								Provider: string(oadpv1alpha1.DefaultPluginAWS),
 								Config: map[string]string{
 									Region: "us-east-1",
 								},
@@ -171,7 +171,7 @@ func TestDPAReconciler_ValidateVolumeSnapshotLocation(t *testing.T) {
 					SnapshotLocations: []oadpv1alpha1.SnapshotLocation{
 						{
 							Velero: &velerov1.VolumeSnapshotLocationSpec{
-								Provider: AWSProvider,
+								Provider: string(oadpv1alpha1.DefaultPluginAWS),
 							},
 						},
 					},
@@ -205,7 +205,7 @@ func TestDPAReconciler_ValidateVolumeSnapshotLocation(t *testing.T) {
 					SnapshotLocations: []oadpv1alpha1.SnapshotLocation{
 						{
 							Velero: &velerov1.VolumeSnapshotLocationSpec{
-								Provider: AWSProvider,
+								Provider: string(oadpv1alpha1.DefaultPluginAWS),
 								Config: map[string]string{
 									Region:     "us-east-1",
 									AWSProfile: "test-profile",
@@ -239,7 +239,7 @@ func TestDPAReconciler_ValidateVolumeSnapshotLocation(t *testing.T) {
 					SnapshotLocations: []oadpv1alpha1.SnapshotLocation{
 						{
 							Velero: &velerov1.VolumeSnapshotLocationSpec{
-								Provider: AWSProvider,
+								Provider: string(oadpv1alpha1.DefaultPluginAWS),
 								Config: map[string]string{
 									Region:         "us-east-1",
 									"invalid-test": "foo",
@@ -279,7 +279,7 @@ func TestDPAReconciler_ValidateVolumeSnapshotLocation(t *testing.T) {
 					SnapshotLocations: []oadpv1alpha1.SnapshotLocation{
 						{
 							Velero: &velerov1.VolumeSnapshotLocationSpec{
-								Provider: GCPProvider,
+								Provider: string(oadpv1alpha1.DefaultPluginGCP),
 							},
 						},
 					},
@@ -309,7 +309,7 @@ func TestDPAReconciler_ValidateVolumeSnapshotLocation(t *testing.T) {
 					SnapshotLocations: []oadpv1alpha1.SnapshotLocation{
 						{
 							Velero: &velerov1.VolumeSnapshotLocationSpec{
-								Provider: GCPProvider,
+								Provider: string(oadpv1alpha1.DefaultPluginGCP),
 							},
 						},
 					},
@@ -343,7 +343,7 @@ func TestDPAReconciler_ValidateVolumeSnapshotLocation(t *testing.T) {
 					SnapshotLocations: []oadpv1alpha1.SnapshotLocation{
 						{
 							Velero: &velerov1.VolumeSnapshotLocationSpec{
-								Provider: GCPProvider,
+								Provider: string(oadpv1alpha1.DefaultPluginGCP),
 								Config: map[string]string{
 									GCPSnapshotLocation: "test-location",
 								},
@@ -380,7 +380,7 @@ func TestDPAReconciler_ValidateVolumeSnapshotLocation(t *testing.T) {
 					SnapshotLocations: []oadpv1alpha1.SnapshotLocation{
 						{
 							Velero: &velerov1.VolumeSnapshotLocationSpec{
-								Provider: GCPProvider,
+								Provider: string(oadpv1alpha1.DefaultPluginGCP),
 								Config: map[string]string{
 									GCPProject: "alt-project",
 								},
@@ -413,7 +413,7 @@ func TestDPAReconciler_ValidateVolumeSnapshotLocation(t *testing.T) {
 					SnapshotLocations: []oadpv1alpha1.SnapshotLocation{
 						{
 							Velero: &velerov1.VolumeSnapshotLocationSpec{
-								Provider: GCPProvider,
+								Provider: string(oadpv1alpha1.DefaultPluginGCP),
 								Config: map[string]string{
 									"invalid-test": "foo",
 								},
@@ -452,7 +452,7 @@ func TestDPAReconciler_ValidateVolumeSnapshotLocation(t *testing.T) {
 					SnapshotLocations: []oadpv1alpha1.SnapshotLocation{
 						{
 							Velero: &velerov1.VolumeSnapshotLocationSpec{
-								Provider: AzureProvider,
+								Provider: string(oadpv1alpha1.DefaultPluginMicrosoftAzure),
 							},
 						},
 					},
@@ -482,7 +482,7 @@ func TestDPAReconciler_ValidateVolumeSnapshotLocation(t *testing.T) {
 					SnapshotLocations: []oadpv1alpha1.SnapshotLocation{
 						{
 							Velero: &velerov1.VolumeSnapshotLocationSpec{
-								Provider: AzureProvider,
+								Provider: string(oadpv1alpha1.DefaultPluginMicrosoftAzure),
 							},
 						},
 					},
@@ -516,7 +516,7 @@ func TestDPAReconciler_ValidateVolumeSnapshotLocation(t *testing.T) {
 					SnapshotLocations: []oadpv1alpha1.SnapshotLocation{
 						{
 							Velero: &velerov1.VolumeSnapshotLocationSpec{
-								Provider: AzureProvider,
+								Provider: string(oadpv1alpha1.DefaultPluginMicrosoftAzure),
 								Config: map[string]string{
 									AzureApiTimeout: "5m",
 								},
@@ -553,7 +553,7 @@ func TestDPAReconciler_ValidateVolumeSnapshotLocation(t *testing.T) {
 					SnapshotLocations: []oadpv1alpha1.SnapshotLocation{
 						{
 							Velero: &velerov1.VolumeSnapshotLocationSpec{
-								Provider: AzureProvider,
+								Provider: string(oadpv1alpha1.DefaultPluginMicrosoftAzure),
 								Config: map[string]string{
 									ResourceGroup: "test-rg",
 								},
@@ -590,7 +590,7 @@ func TestDPAReconciler_ValidateVolumeSnapshotLocation(t *testing.T) {
 					SnapshotLocations: []oadpv1alpha1.SnapshotLocation{
 						{
 							Velero: &velerov1.VolumeSnapshotLocationSpec{
-								Provider: AzureProvider,
+								Provider: string(oadpv1alpha1.DefaultPluginMicrosoftAzure),
 								Config: map[string]string{
 									AzureSubscriptionId: "test-alt-sub",
 								},
@@ -627,7 +627,7 @@ func TestDPAReconciler_ValidateVolumeSnapshotLocation(t *testing.T) {
 					SnapshotLocations: []oadpv1alpha1.SnapshotLocation{
 						{
 							Velero: &velerov1.VolumeSnapshotLocationSpec{
-								Provider: AzureProvider,
+								Provider: string(oadpv1alpha1.DefaultPluginMicrosoftAzure),
 								Config: map[string]string{
 									AzureIncremental: "false",
 								},
@@ -660,7 +660,7 @@ func TestDPAReconciler_ValidateVolumeSnapshotLocation(t *testing.T) {
 					SnapshotLocations: []oadpv1alpha1.SnapshotLocation{
 						{
 							Velero: &velerov1.VolumeSnapshotLocationSpec{
-								Provider: AzureProvider,
+								Provider: string(oadpv1alpha1.DefaultPluginMicrosoftAzure),
 								Config: map[string]string{
 									"invalid-test": "foo",
 								},
@@ -732,7 +732,7 @@ func TestDPAReconciler_ReconcileVolumeSnapshotLocations(t *testing.T) {
 					SnapshotLocations: []oadpv1alpha1.SnapshotLocation{
 						{
 							Velero: &velerov1.VolumeSnapshotLocationSpec{
-								Provider: AWSProvider,
+								Provider: string(oadpv1alpha1.DefaultPluginAWS),
 								Config: map[string]string{
 									Region: "us-east-1",
 								},

--- a/pkg/credentials/credentials.go
+++ b/pkg/credentials/credentials.go
@@ -336,16 +336,16 @@ func BslUsesShortLivedCredential(bls []oadpv1alpha1.BackupLocation, namespace st
 
 func SecretContainsShortLivedCredential(secretName, secretKey, provider, namespace string, config map[string]string) (bool, error) {
 	switch provider {
-	case "aws":
+	case string(oadpv1alpha1.DefaultPluginAWS):
 		// AWS credentials short lived are determined by enableSharedConfig
 		// if enableSharedConfig is not set, then we assume it is not short lived
 		// if enableSharedConfig is set, then we assume it is short lived
 		// Alternatively, we can check if the secret contains a session token
 		// TODO: check if secret contains session token
 		return false, nil
-	case "gcp":
+	case string(oadpv1alpha1.DefaultPluginGCP):
 		return gcpSecretAccountTypeIsShortLived(secretName, secretKey, namespace)
-	case "azure":
+	case string(oadpv1alpha1.DefaultPluginMicrosoftAzure):
 		// TODO: check if secret contains session token
 		return false, nil
 	}

--- a/pkg/credentials/credentials_test.go
+++ b/pkg/credentials/credentials_test.go
@@ -398,7 +398,7 @@ func TestSecretContainsShortLivedCredential(t *testing.T) {
   "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/SERVICE_ACCOUNT_EMAIL"
 }
 `,
-				provider: "gcp",
+				provider: string(oadpv1alpha1.DefaultPluginGCP),
 				config:   nil,
 			},
 			want:    false,
@@ -418,7 +418,7 @@ func TestSecretContainsShortLivedCredential(t *testing.T) {
   }
 }
 `,
-				provider: "gcp",
+				provider: string(oadpv1alpha1.DefaultPluginGCP),
 				config:   nil,
 			},
 			want:    true,


### PR DESCRIPTION
## Why the changes were made

Noted that we use one variable to define what plugins' names DPA accepts, and another in validators. I was afraid this could haunt us in the future.

## How to test the changes made

I ran commands like `grep -Inr '"aws"' .` and `grep -Inr "'aws'" .`  (ignoring `tests` folder) to make sure all occurrences were changed.
