### PR TITLE
OADP-5095: Always add STS SA token to velero/nodeagent

### DIFF
--- a/controllers/nodeagent_test.go
+++ b/controllers/nodeagent_test.go
@@ -330,6 +330,11 @@ func createTestBuiltNodeAgentDaemonSet(options TestBuiltNodeAgentDaemonSetOption
 									Name:      "certs",
 									MountPath: "/etc/ssl/certs",
 								},
+								{
+									Name:      "bound-sa-token",
+									MountPath: "/var/run/secrets/openshift/serviceaccount",
+									ReadOnly:  true,
+								},
 							},
 							Env: []corev1.EnvVar{
 								{
@@ -383,6 +388,23 @@ func createTestBuiltNodeAgentDaemonSet(options TestBuiltNodeAgentDaemonSetOption
 							Name: "certs",
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{},
+							},
+						},
+						{
+							Name: "bound-sa-token",
+							VolumeSource: corev1.VolumeSource{
+								Projected: &corev1.ProjectedVolumeSource{
+									Sources: []corev1.VolumeProjection{
+										{
+											ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+												Audience:          "openshift",
+												ExpirationSeconds: ptr.To(int64(3600)),
+												Path:              "token",
+											},
+										},
+									},
+									DefaultMode: ptr.To(common.DefaultProjectedPermission),
+								},
 							},
 						},
 					},

--- a/controllers/velero.go
+++ b/controllers/velero.go
@@ -241,8 +241,6 @@ func (r *DPAReconciler) customizeVeleroDeployment(veleroDeployment *appsv1.Deplo
 		}
 	}
 
-	hasShortLivedCredentials, err := credentials.BslUsesShortLivedCredential(dpa.Spec.BackupLocations, dpa.Namespace)
-
 	// Selector: veleroDeployment.Spec.Selector,
 	replicas := int32(1)
 	if value, present := os.LookupEnv(VeleroReplicaOverride); present {
@@ -261,28 +259,24 @@ func (r *DPAReconciler) customizeVeleroDeployment(veleroDeployment *appsv1.Deplo
 			VolumeSource: corev1.VolumeSource{
 				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},
-		})
-
-	if hasShortLivedCredentials {
-		veleroDeployment.Spec.Template.Spec.Volumes = append(veleroDeployment.Spec.Template.Spec.Volumes,
-			corev1.Volume{
-				Name: "bound-sa-token",
-				VolumeSource: corev1.VolumeSource{
-					Projected: &corev1.ProjectedVolumeSource{
-						Sources: []corev1.VolumeProjection{
-							{
-								ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
-									Audience:          "openshift",
-									ExpirationSeconds: ptr.To(int64(3600)),
-									Path:              "token",
-								},
+		},
+		// used for short-lived credentials, inert if not used
+		corev1.Volume{
+			Name: "bound-sa-token",
+			VolumeSource: corev1.VolumeSource{
+				Projected: &corev1.ProjectedVolumeSource{
+					Sources: []corev1.VolumeProjection{
+						{
+							ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+								Audience:          "openshift",
+								ExpirationSeconds: ptr.To(int64(3600)),
+								Path:              "token",
 							},
 						},
 					},
 				},
 			},
-		)
-	}
+		})
 	// add any default init containers here if needed eg: setup-certificate-secret
 	// When you do this
 	// - please use common.GetImagePullPolicy function to set the ImagePullPolicy, and
@@ -319,7 +313,7 @@ func (r *DPAReconciler) customizeVeleroDeployment(veleroDeployment *appsv1.Deplo
 			break
 		}
 	}
-	if err := r.customizeVeleroContainer(veleroDeployment, veleroContainer, hasShortLivedCredentials, prometheusPort); err != nil {
+	if err := r.customizeVeleroContainer(veleroDeployment, veleroContainer, prometheusPort); err != nil {
 		return err
 	}
 
@@ -506,7 +500,7 @@ func (r *DPAReconciler) appendPluginSpecificSpecs(veleroDeployment *appsv1.Deplo
 	}
 }
 
-func (r *DPAReconciler) customizeVeleroContainer(veleroDeployment *appsv1.Deployment, veleroContainer *corev1.Container, hasShortLivedCredentials bool, prometheusPort *int) error {
+func (r *DPAReconciler) customizeVeleroContainer(veleroDeployment *appsv1.Deployment, veleroContainer *corev1.Container, prometheusPort *int) error {
 	dpa := r.dpa
 	if veleroContainer == nil {
 		return fmt.Errorf("could not find velero container in Deployment")
@@ -529,16 +523,13 @@ func (r *DPAReconciler) customizeVeleroContainer(veleroDeployment *appsv1.Deploy
 			Name:      "certs",
 			MountPath: "/etc/ssl/certs",
 		},
+		// used for short-lived credentials, inert if not used
+		corev1.VolumeMount{
+			Name:      "bound-sa-token",
+			MountPath: "/var/run/secrets/openshift/serviceaccount",
+			ReadOnly:  true,
+		},
 	)
-
-	if hasShortLivedCredentials {
-		veleroContainer.VolumeMounts = append(veleroContainer.VolumeMounts,
-			corev1.VolumeMount{
-				Name:      "bound-sa-token",
-				MountPath: "/var/run/secrets/openshift/serviceaccount",
-				ReadOnly:  true,
-			})
-	}
 	// append velero PodConfig envs to container
 	if dpa.Spec.Configuration != nil && dpa.Spec.Configuration.Velero != nil && dpa.Spec.Configuration.Velero.PodConfig != nil && dpa.Spec.Configuration.Velero.PodConfig.Env != nil {
 		veleroContainer.Env = common.AppendUniqueEnvVars(veleroContainer.Env, dpa.Spec.Configuration.Velero.PodConfig.Env)

--- a/controllers/velero_test.go
+++ b/controllers/velero_test.go
@@ -97,6 +97,7 @@ var (
 		{Name: "plugins", MountPath: "/plugins"},
 		{Name: "scratch", MountPath: "/scratch"},
 		{Name: "certs", MountPath: "/etc/ssl/certs"},
+		{Name: "bound-sa-token", MountPath: "/var/run/secrets/openshift/serviceaccount", ReadOnly: true},
 	}
 
 	baseVolumes = []corev1.Volume{
@@ -111,6 +112,23 @@ var (
 		{
 			Name:         "certs",
 			VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+		},
+		{
+			Name: "bound-sa-token",
+			VolumeSource: corev1.VolumeSource{
+				Projected: &corev1.ProjectedVolumeSource{
+					Sources: []corev1.VolumeProjection{
+						{
+							ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+								Audience:          "openshift",
+								ExpirationSeconds: ptr.To(int64(3600)),
+								Path:              "token",
+							},
+						},
+					},
+					DefaultMode: ptr.To(common.DefaultProjectedPermission),
+				},
+			},
 		},
 	}
 	baseContainer = corev1.Container{
@@ -1446,28 +1464,8 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 			veleroDeployment: testVeleroDeployment.DeepCopy(),
 			wantVeleroDeployment: createTestBuiltVeleroDeployment(TestBuiltVeleroDeploymentOptions{
 				initContainers: []corev1.Container{pluginContainer(common.VeleroPluginForAWS, common.AWSPluginImage)},
-				volumes: []corev1.Volume{
-					{
-						Name: "bound-sa-token",
-						VolumeSource: corev1.VolumeSource{
-							Projected: &corev1.ProjectedVolumeSource{
-								DefaultMode: ptr.To(int32(0644)),
-								Sources: []corev1.VolumeProjection{
-									{
-										ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
-											Audience:          "openshift",
-											ExpirationSeconds: ptr.To(int64(3600)),
-											Path:              "token",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-				volumeMounts: []corev1.VolumeMount{
-					{Name: "bound-sa-token", MountPath: "/var/run/secrets/openshift/serviceaccount", ReadOnly: true},
-				},
+				volumes:        []corev1.Volume{},
+				volumeMounts:   []corev1.VolumeMount{},
 				args: []string{
 					defaultFileSystemBackupTimeout,
 					defaultRestoreResourcePriorities,

--- a/pkg/credentials/credentials_test.go
+++ b/pkg/credentials/credentials_test.go
@@ -1,15 +1,11 @@
 package credentials
 
 import (
-	"context"
 	"testing"
 
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
 	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
-	"github.com/openshift/oadp-operator/pkg/client"
 	"github.com/openshift/oadp-operator/pkg/common"
 )
 
@@ -365,105 +361,6 @@ func TestCredentials_getPluginImage(t *testing.T) {
 			gotImage := GetPluginImage(tt.pluginName, tt.dpa)
 			if gotImage != tt.wantImage {
 				t.Errorf("Expected plugin image %v did not match %v", tt.wantImage, gotImage)
-			}
-		})
-	}
-}
-
-func TestSecretContainsShortLivedCredential(t *testing.T) {
-	type args struct {
-		decodedSecret string
-		provider      string
-		config        map[string]string
-	}
-	tests := []struct {
-		name    string
-		args    args
-		want    bool
-		wantErr bool
-	}{
-		{
-			name: "given gcp decoded with service_account, should return false",
-			args: args{
-				decodedSecret: `{
-  "type": "service_account",
-  "project_id": "PROJECT_ID",
-  "private_key_id": "KEY_ID",
-  "private_key": "-----BEGIN PRIVATE KEY-----\nPRIVATE_KEY\n-----END PRIVATE KEY-----\n",
-  "client_email": "SERVICE_ACCOUNT_EMAIL",
-  "client_id": "CLIENT_ID",
-  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
-  "token_uri": "https://accounts.google.com/o/oauth2/token",
-  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
-  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/SERVICE_ACCOUNT_EMAIL"
-}
-`,
-				provider: "gcp",
-				config:   nil,
-			},
-			want:    false,
-			wantErr: false,
-		},
-		{
-			name: "given gcp decoded with external_account, should return true",
-			args: args{
-				decodedSecret: `{
-  "type": "external_account",
-  "audience": "//iam.googleapis.com/locations/global/workforcePools/WORKFORCE_POOL_ID/providers/PROVIDER_ID",
-  "subject_token_type": "urn:ietf:params:oauth:token-type:id_token",
-  "token_url": "https://sts.googleapis.com/v1/token",
-  "workforce_pool_user_project": "WORKFORCE_POOL_USER_PROJECT",
-  "credential_source": {
-    "file": "PATH_TO_OIDC_CREDENTIALS_FILE"
-  }
-}
-`,
-				provider: "gcp",
-				config:   nil,
-			},
-			want:    true,
-			wantErr: false,
-		},
-	}
-	testEnv := &envtest.Environment{}
-	//start testEnv
-	cfg, err := testEnv.Start()
-	if err != nil {
-		t.Fatalf("failed to start testEnv: %v", err)
-	}
-	defer testEnv.Stop()
-	_, err = client.NewClientFromConfig(cfg)
-	if err != nil {
-		t.Fatalf("failed to create client: %v", err)
-	}
-	namespace := "test-ns"
-	secretName := "test-secret"
-	secretKey := "cloud"
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ns := corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: namespace,
-				},
-			}
-			err = client.CreateOrUpdate(context.Background(), &ns)
-			secret := &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-secret",
-					Namespace: namespace,
-				},
-				Data: map[string][]byte{
-					secretKey: []byte(tt.args.decodedSecret),
-				},
-			}
-			err = client.CreateOrUpdate(context.Background(), secret)
-			if err != nil {
-				t.Fatalf("failed to create secret: %v", err)
-			}
-			if got, err := SecretContainsShortLivedCredential(secretName, secretKey, tt.args.provider, namespace, tt.args.config); got != tt.want {
-				t.Errorf("SecretContainsShortLivedCredential() = %v, want %v", got, tt.want)
-			} else if err != nil && !tt.wantErr {
-				t.Errorf("SecretContainsShortLivedCredential() = %v, want %v", err, tt.wantErr)
 			}
 		})
 	}


### PR DESCRIPTION
## Why the changes were made

<!-- Explain why this PR is important, what problems it fixes, link related issues -->
This PR adds STS SA token to nodeAgents.
Additionally, the STS check before adding STS SA token to velero is removed.

This follows [other operators](https://github.com/openshift/cluster-ingress-operator/blob/8bf1b3637232b08bdb220d8f62698a5b27c21fc9/manifests/02-deployment.yaml#L86-L88) and our own oadp-operator deployment which do not check before adding these volumeMounts.

This may unblock GCP WIF, Azure, and AWS STS for kopia/datamover. We may need to double check podified datamover if there's a way to configure these volume mounts expected.

## How to test the changes made
Ensure everything works as normal, watch this PR's e2e succeed for non-STS cases.
<!-- Explain how the changes introduced by this PR can be tested and verified, with commands and pictures -->
Follows https://github.com/openshift/oadp-operator/wiki/GCP-WIF-Authentication-on-OpenShift

<details><summary>Dev test result</summary>
<p>

```
    ccoctl gcp create-service-accounts --name=tkaovila-oadp-sa \
    --project=$GCP_PROJECT_ID \
    --credentials-requests-dir=oadp-credrequest \
    --workload-identity-pool=tkaovila-20241120-wif \
    --workload-identity-provider=tkaovila-20241120-wif

❯ oc apply -f manifests/openshift-adp-cloud-credentials-gcp-credentials.yaml

echo 'apiVersion: oadp.openshift.io/v1alpha1
kind: DataProtectionApplication
metadata:
  name: tiger-dpa
  namespace: openshift-adp
spec:
  backupLocations:
    - velero:
        provider: gcp
        default: true
        credential:
          key: service_account.json
          name: cloud-credentials-gcp 
        objectStorage:
          bucket: tkaovila-bucket 
          prefix: "20241120"
  configuration:
    velero:
      defaultPlugins:
      - openshift
      - gcp
      - csi
    nodeAgent:
      enable: true
      uploaderType: kopia' | oc create -f -

❯ oc exec -n openshift-adp daemonsets/node-agent -- ls /var/run/secrets/openshift/serviceaccount/token
/var/run/secrets/openshift/serviceaccount/token

❯ oc apply -f /Users/tiger/oadp-operator/tests/e2e/sample-applications/mongo-persistent/mongo-persistent-csi.yaml  
namespace/mongo-persistent created
serviceaccount/mongo-persistent-sa created
securitycontextconstraints.security.openshift.io/mongo-persistent-scc created
imagestream.image.openshift.io/todolist-mongo-go created
deployment.apps/mongo created
service/mongo created
Warning: apps.openshift.io/v1 DeploymentConfig is deprecated in v4.14+, unavailable in v4.10000+
deploymentconfig.apps.openshift.io/todolist created
service/todolist created
route.route.openshift.io/todolist-route created

~/OCP/manifests/20241120-gcp-wif
❯ oc apply -f /Users/tiger/oadp-operator/tests/e2e/sample-applications/mongo-persistent/pvc/gcp.yaml 
persistentvolumeclaim/mongo created

velero create backup mongo-wif-kopia --default-volumes-to-fs-backup --include-namespaces=mongo-persistent

velero describe backup won't work due to WIF not supporting signedURL
```
```
❯ oc get backup mongo-wif-kopia -oyaml
apiVersion: velero.io/v1
kind: Backup
metadata:
  annotations:
    velero.io/resource-timeout: 10m0s
    velero.io/source-cluster-k8s-gitversion: v1.30.5
    velero.io/source-cluster-k8s-major-version: "1"
    velero.io/source-cluster-k8s-minor-version: "30"
  creationTimestamp: "2024-11-27T03:18:24Z"
  generation: 6
  labels:
    velero.io/storage-location: tiger-dpa-1
  name: mongo-wif-kopia
  namespace: openshift-adp
  resourceVersion: "4688179"
  uid: f411e477-2c65-4e1f-8607-9ec160580625
spec:
  csiSnapshotTimeout: 10m0s
  defaultVolumesToFsBackup: true
  hooks: {}
  includedNamespaces:
  - mongo-persistent
  itemOperationTimeout: 4h0m0s
  metadata: {}
  snapshotMoveData: false
  storageLocation: tiger-dpa-1
  ttl: 720h0m0s
status:
  completionTimestamp: "2024-11-27T03:18:47Z"
  expiration: "2024-12-27T03:18:24Z"
  formatVersion: 1.1.0
  hookStatus: {}
  phase: Completed
  progress:
    itemsBackedUp: 72
    totalItems: 72
  startTimestamp: "2024-11-27T03:18:24Z"
  version: 1

❯ oc get podvolumebackups.velero.io mongo-wif-kopia-fdxlf -oyaml
apiVersion: velero.io/v1
kind: PodVolumeBackup
metadata:
  annotations:
    velero.io/pvc-name: mongo
  creationTimestamp: "2024-11-27T03:18:37Z"
  generateName: mongo-wif-kopia-
  generation: 5
  labels:
    velero.io/backup-name: mongo-wif-kopia
    velero.io/backup-uid: f411e477-2c65-4e1f-8607-9ec160580625
    velero.io/pvc-uid: fa1536ea-27b2-46f1-ae5a-bd1fcb88347d
  name: mongo-wif-kopia-fdxlf
  namespace: openshift-adp
  ownerReferences:
  - apiVersion: velero.io/v1
    controller: true
    kind: Backup
    name: mongo-wif-kopia
    uid: f411e477-2c65-4e1f-8607-9ec160580625
  resourceVersion: "4688156"
  uid: fe71c6e5-3265-4077-8ff1-308ec6a40801
spec:
  backupStorageLocation: tiger-dpa-1
  node: tkaovila-20241120-wif-6p7db-worker-b-4s7sw
  pod:
    kind: Pod
    name: mongo-6866977c96-jlbms
    namespace: mongo-persistent
    uid: b856d396-4544-4946-adc4-27933a95cd47
  repoIdentifier: ""
  tags:
    backup: mongo-wif-kopia
    backup-uid: f411e477-2c65-4e1f-8607-9ec160580625
    ns: mongo-persistent
    pod: mongo-6866977c96-jlbms
    pod-uid: b856d396-4544-4946-adc4-27933a95cd47
    pvc-uid: fa1536ea-27b2-46f1-ae5a-bd1fcb88347d
    volume: mongo-data
  uploaderType: kopia
  volume: mongo-data
status:
  completionTimestamp: "2024-11-27T03:18:44Z"
  path: /host_pods/b856d396-4544-4946-adc4-27933a95cd47/volumes/kubernetes.io~csi/pvc-fa1536ea-27b2-46f1-ae5a-bd1fcb88347d/mount
  phase: Completed
  progress:
    bytesDone: 210318546
    totalBytes: 210318546
  snapshotID: f94b93aea42d0475a43751c78c8efa93
  startTimestamp: "2024-11-27T03:18:37Z"

~/OCP/manifests/20241120-gcp-wif
❯ gcloud storage ls gs://tkaovila-bucket/20241120/kopia/mongo-persistent
gs://tkaovila-bucket/20241120/kopia/mongo-persistent/_log_20241127031836_2346_1732677516_1732677516_1_d055b4d177109c9c947066b2a56e634a
gs://tkaovila-bucket/20241120/kopia/mongo-persistent/_log_20241127031842_8761_1732677522_1732677524_1_0ae220ac9651a9fe46731f62ef71895f
gs://tkaovila-bucket/20241120/kopia/mongo-persistent/kopia.blobcfg
gs://tkaovila-bucket/20241120/kopia/mongo-persistent/kopia.repository
gs://tkaovila-bucket/20241120/kopia/mongo-persistent/p1f5bdf53a9ac7804e9149bc94052a36a-s6c349b52301d781612f
gs://tkaovila-bucket/20241120/kopia/mongo-persistent/q5f46aeecbc8457455f088412a8cc3959-s6c349b52301d781612f
gs://tkaovila-bucket/20241120/kopia/mongo-persistent/qd1db860fea61949ec980a7af558926d0-sdf746449b89952dd12f
gs://tkaovila-bucket/20241120/kopia/mongo-persistent/qf770398a4b97b42429120e5bfea212f5-s272e42180801eaa912f
gs://tkaovila-bucket/20241120/kopia/mongo-persistent/xn0_6718333d3fe50c03b86dd4daa073e0b1-s6c349b52301d781612f-c1
gs://tkaovila-bucket/20241120/kopia/mongo-persistent/xn0_73f02c442286bb7d9b33ac2c766cb942-sdf746449b89952dd12f-c1
gs://tkaovila-bucket/20241120/kopia/mongo-persistent/xn0_f5607dbdfa9caf3256574072537629fe-s272e42180801eaa912f-c1


❯ velero create backup mongo-wif-kopia-mover --snapshot-move-data --include-namespaces=mongo-persistent
❯ oc get backup mongo-wif-kopia-mover -oyaml 
apiVersion: velero.io/v1
kind: Backup
metadata:
  annotations:
    velero.io/resource-timeout: 10m0s
    velero.io/source-cluster-k8s-gitversion: v1.30.5
    velero.io/source-cluster-k8s-major-version: "1"
    velero.io/source-cluster-k8s-minor-version: "30"
  creationTimestamp: "2024-11-27T03:38:20Z"
  generation: 7
  labels:
    velero.io/storage-location: tiger-dpa-1
  name: mongo-wif-kopia-mover
  namespace: openshift-adp
  resourceVersion: "4698371"
  uid: 7c162fec-a3d6-4df8-ada1-c3dd9eb7a3ff
spec:
  csiSnapshotTimeout: 10m0s
  defaultVolumesToFsBackup: false
  hooks: {}
  includedNamespaces:
  - mongo-persistent
  itemOperationTimeout: 4h0m0s
  metadata: {}
  snapshotMoveData: true
  storageLocation: tiger-dpa-1
  ttl: 720h0m0s
status:
  backupItemOperationsAttempted: 1
  backupItemOperationsCompleted: 1
  completionTimestamp: "2024-11-27T03:40:00Z"
  expiration: "2024-12-27T03:38:20Z"
  formatVersion: 1.1.0
  hookStatus: {}
  phase: Completed
  progress:
    itemsBackedUp: 72
    totalItems: 72
  startTimestamp: "2024-11-27T03:38:20Z"
  version: 1

notice that there are now more files than before in repo.. meaning data move was successful.
❯ gcloud storage ls gs://tkaovila-bucket/20241120/kopia/mongo-persistent 
gs://tkaovila-bucket/20241120/kopia/mongo-persistent/_log_20241127031836_2346_1732677516_1732677516_1_d055b4d177109c9c947066b2a56e634a
gs://tkaovila-bucket/20241120/kopia/mongo-persistent/_log_20241127031842_8761_1732677522_1732677524_1_0ae220ac9651a9fe46731f62ef71895f
gs://tkaovila-bucket/20241120/kopia/mongo-persistent/_log_20241127033945_c23c_1732678785_1732678787_1_3305b84dc9b532d03383ff5ffedbe548
gs://tkaovila-bucket/20241120/kopia/mongo-persistent/kopia.blobcfg
gs://tkaovila-bucket/20241120/kopia/mongo-persistent/kopia.repository
gs://tkaovila-bucket/20241120/kopia/mongo-persistent/p1f5bdf53a9ac7804e9149bc94052a36a-s6c349b52301d781612f
gs://tkaovila-bucket/20241120/kopia/mongo-persistent/pbf424a64cab2bb6660583c62ae7cc422-s7ec00a37d6d97bd512f
gs://tkaovila-bucket/20241120/kopia/mongo-persistent/q5f46aeecbc8457455f088412a8cc3959-s6c349b52301d781612f
gs://tkaovila-bucket/20241120/kopia/mongo-persistent/q8983c3d0937fd283fbcfd78ff3d6d017-s481219e56566d53512f
gs://tkaovila-bucket/20241120/kopia/mongo-persistent/qd1db860fea61949ec980a7af558926d0-sdf746449b89952dd12f
gs://tkaovila-bucket/20241120/kopia/mongo-persistent/qea3a3ea9ad90535bf113afd79fb7372c-s7ec00a37d6d97bd512f
gs://tkaovila-bucket/20241120/kopia/mongo-persistent/qf770398a4b97b42429120e5bfea212f5-s272e42180801eaa912f
gs://tkaovila-bucket/20241120/kopia/mongo-persistent/xn0_668c298eecf849ef05583475eabb3051-s481219e56566d53512f-c1
gs://tkaovila-bucket/20241120/kopia/mongo-persistent/xn0_6718333d3fe50c03b86dd4daa073e0b1-s6c349b52301d781612f-c1
gs://tkaovila-bucket/20241120/kopia/mongo-persistent/xn0_6d2eeab99a77f5981fcacdcf9c5f7ecf-s7ec00a37d6d97bd512f-c1
gs://tkaovila-bucket/20241120/kopia/mongo-persistent/xn0_73f02c442286bb7d9b33ac2c766cb942-sdf746449b89952dd12f-c1
gs://tkaovila-bucket/20241120/kopia/mongo-persistent/xn0_f5607dbdfa9caf3256574072537629fe-s272e42180801eaa912f-c1
```

</p>
</details> 
