### PR TITLE
OADP-5106: Add legacy-aws default plugin reconcile e2e test.

### DIFF
--- a/tests/e2e/dpa_deployment_suite_test.go
+++ b/tests/e2e/dpa_deployment_suite_test.go
@@ -20,6 +20,7 @@ import (
 
 type TestDPASpec struct {
 	BSLSecretName           string
+	DefaultPlugins          []oadpv1alpha1.DefaultPlugin // Overrides default plugins loaded from config
 	CustomPlugins           []oadpv1alpha1.CustomPlugin
 	SnapshotLocations       []oadpv1alpha1.SnapshotLocation
 	VeleroPodConfig         oadpv1alpha1.PodConfig
@@ -66,6 +67,9 @@ func createTestDPASpec(testSpec TestDPASpec) *oadpv1alpha1.DataProtectionApplica
 		},
 		SnapshotLocations:    testSpec.SnapshotLocations,
 		UnsupportedOverrides: dpaCR.UnsupportedOverrides,
+	}
+	if len(testSpec.DefaultPlugins) > 0 {
+		dpaSpec.Configuration.Velero.DefaultPlugins = testSpec.DefaultPlugins
 	}
 	if testSpec.EnableNodeAgent {
 		dpaSpec.Configuration.NodeAgent = &oadpv1alpha1.NodeAgentConfig{
@@ -342,6 +346,12 @@ var _ = ginkgo.Describe("Configuration testing for DPA Custom Resource", func() 
 				BSLSecretName:           bslSecretName,
 				NoDefaultBackupLocation: true,
 				DoNotBackupImages:       true,
+			}),
+		}),
+		ginkgo.Entry("DPA CR with legacy-aws plugin", ginkgo.Label("aws", "ibmcloud"), InstallCase{
+			DpaSpec: createTestDPASpec(TestDPASpec{
+				BSLSecretName:  bslSecretName,
+				DefaultPlugins: []oadpv1alpha1.DefaultPlugin{oadpv1alpha1.DefaultPluginOpenShift, oadpv1alpha1.DefaultPluginLegacyAWS},
 			}),
 		}),
 		ginkgo.Entry("DPA CR with S3ForcePathStyle true", ginkgo.Label("aws"), InstallCase{


### PR DESCRIPTION
- **Add legacy-aws default plugin reconcile e2e test.**

## Why the changes were made

<!-- Explain why this PR is important, what problems it fixes, link related issues -->

To check that reconcile against legacy-aws works.

This will go in after #1565 

## How to test the changes made

<!-- Explain how the changes introduced by this PR can be tested and verified, with commands and pictures -->
