### PR TITLE
[oadp-1.4] OADP-4995: Add support for legacy aws plugin

### DIFF
--- a/api/v1alpha1/oadp_types.go
+++ b/api/v1alpha1/oadp_types.go
@@ -35,10 +35,11 @@ const ReconcileCompleteMessage = "Reconcile complete"
 const OadpOperatorLabel = "openshift.io/oadp"
 const RegistryDeploymentLabel = "openshift.io/oadp-registry"
 
-// +kubebuilder:validation:Enum=aws;gcp;azure;csi;vsm;openshift;kubevirt
+// +kubebuilder:validation:Enum=aws;legacy-aws;gcp;azure;csi;vsm;openshift;kubevirt
 type DefaultPlugin string
 
 const DefaultPluginAWS DefaultPlugin = "aws"
+const DefaultPluginLegacyAWS DefaultPlugin = "legacy-aws"
 const DefaultPluginGCP DefaultPlugin = "gcp"
 const DefaultPluginMicrosoftAzure DefaultPlugin = "azure"
 const DefaultPluginCSI DefaultPlugin = "csi"
@@ -56,6 +57,7 @@ type UnsupportedImageKey string
 
 const VeleroImageKey UnsupportedImageKey = "veleroImageFqin"
 const AWSPluginImageKey UnsupportedImageKey = "awsPluginImageFqin"
+const LegacyAWSPluginImageKey UnsupportedImageKey = "legacyAWSPluginImageFqin"
 const OpenShiftPluginImageKey UnsupportedImageKey = "openshiftPluginImageFqin"
 const AzurePluginImageKey UnsupportedImageKey = "azurePluginImageFqin"
 const GCPPluginImageKey UnsupportedImageKey = "gcpPluginImageFqin"
@@ -345,6 +347,7 @@ type DataProtectionApplicationSpec struct {
 	// Available keys are:
 	//   - veleroImageFqin
 	//   - awsPluginImageFqin
+	//   - legacyAWSPluginImageFqin
 	//   - openshiftPluginImageFqin
 	//   - azurePluginImageFqin
 	//   - gcpPluginImageFqin

--- a/bundle/manifests/oadp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/oadp-operator.clusterserviceversion.yaml
@@ -153,7 +153,7 @@ metadata:
       Cloud Provider,Developer Tools,Modernization & Migration,OpenShift Optional,Storage
     certified: "false"
     containerImage: quay.io/konveyor/oadp-operator:oadp-1.4
-    createdAt: "2024-05-29T17:22:16Z"
+
     description: OADP (OpenShift API for Data Protection) operator sets up and installs
       Data Protection Applications on the OpenShift platform.
     features.operators.openshift.io/cnf: "false"
@@ -856,6 +856,8 @@ spec:
                   value: quay.io/konveyor/openshift-velero-plugin:oadp-1.4
                 - name: RELATED_IMAGE_VELERO_PLUGIN_FOR_AWS
                   value: quay.io/konveyor/velero-plugin-for-aws:oadp-1.4
+                - name: RELATED_IMAGE_VELERO_PLUGIN_FOR_LEGACY_AWS
+                  value: quay.io/konveyor/velero-plugin-for-legacy-aws:oadp-1.4
                 - name: RELATED_IMAGE_VELERO_PLUGIN_FOR_MICROSOFT_AZURE
                   value: quay.io/konveyor/velero-plugin-for-microsoft-azure:oadp-1.4
                 - name: RELATED_IMAGE_VELERO_PLUGIN_FOR_GCP
@@ -1005,6 +1007,8 @@ spec:
     name: openshift-velero-plugin
   - image: quay.io/konveyor/velero-plugin-for-aws:oadp-1.4
     name: velero-plugin-for-aws
+  - image: quay.io/konveyor/velero-plugin-for-legacy-aws:oadp-1.4
+    name: velero-plugin-for-legacy-aws
   - image: quay.io/konveyor/velero-plugin-for-microsoft-azure:oadp-1.4
     name: velero-plugin-for-microsoft-azure
   - image: quay.io/konveyor/velero-plugin-for-gcp:oadp-1.4

--- a/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
@@ -824,6 +824,7 @@ spec:
                           items:
                             enum:
                               - aws
+                              - legacy-aws
                               - gcp
                               - azure
                               - csi
@@ -1318,6 +1319,7 @@ spec:
                     Available keys are:
                       - veleroImageFqin
                       - awsPluginImageFqin
+                      - legacyAWSPluginImageFqin
                       - openshiftPluginImageFqin
                       - azurePluginImageFqin
                       - gcpPluginImageFqin

--- a/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
@@ -824,6 +824,7 @@ spec:
                           items:
                             enum:
                               - aws
+                              - legacy-aws
                               - gcp
                               - azure
                               - csi
@@ -1318,6 +1319,7 @@ spec:
                     Available keys are:
                       - veleroImageFqin
                       - awsPluginImageFqin
+                      - legacyAWSPluginImageFqin
                       - openshiftPluginImageFqin
                       - azurePluginImageFqin
                       - gcpPluginImageFqin

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -50,6 +50,8 @@ spec:
             value: quay.io/konveyor/openshift-velero-plugin:oadp-1.4
           - name: RELATED_IMAGE_VELERO_PLUGIN_FOR_AWS
             value: quay.io/konveyor/velero-plugin-for-aws:oadp-1.4
+          - name: RELATED_IMAGE_VELERO_PLUGIN_FOR_LEGACY_AWS
+            value: quay.io/konveyor/velero-plugin-for-legacy-aws:oadp-1.4
           - name: RELATED_IMAGE_VELERO_PLUGIN_FOR_MICROSOFT_AZURE
             value: quay.io/konveyor/velero-plugin-for-microsoft-azure:oadp-1.4
           - name: RELATED_IMAGE_VELERO_PLUGIN_FOR_GCP

--- a/controllers/bsl.go
+++ b/controllers/bsl.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-logr/logr"
 	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
 	"github.com/openshift/oadp-operator/pkg/common"
+	"github.com/openshift/oadp-operator/pkg/credentials"
 	"github.com/openshift/oadp-operator/pkg/storage/aws"
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -399,9 +400,9 @@ func (r *DPAReconciler) validateGCPBackupStorageLocation(bslSpec velerov1.Backup
 	return nil
 }
 
-func pluginExistsInVeleroCR(configuredPlugins []oadpv1alpha1.DefaultPlugin, expectedPlugin oadpv1alpha1.DefaultPlugin) bool {
+func pluginExistsInVeleroCR(configuredPlugins []oadpv1alpha1.DefaultPlugin, expectedProvider string) bool {
 	for _, plugin := range configuredPlugins {
-		if plugin == expectedPlugin {
+		if credentials.PluginSpecificFields[plugin].ProviderName == expectedProvider {
 			return true
 		}
 	}
@@ -413,7 +414,7 @@ func (r *DPAReconciler) validateProviderPluginAndSecret(bslSpec velerov1.BackupS
 		return nil
 	}
 	// check for existence of provider plugin and warn if the plugin is absent
-	if !pluginExistsInVeleroCR(dpa.Spec.Configuration.Velero.DefaultPlugins, oadpv1alpha1.DefaultPlugin(bslSpec.Provider)) {
+	if !pluginExistsInVeleroCR(dpa.Spec.Configuration.Velero.DefaultPlugins, bslSpec.Provider) {
 		r.Log.Info(fmt.Sprintf("%s backupstoragelocation is configured but velero plugin for %s is not present", bslSpec.Provider, bslSpec.Provider))
 		//TODO: set warning condition on Velero CR
 	}

--- a/controllers/validator.go
+++ b/controllers/validator.go
@@ -105,9 +105,19 @@ func (r *DPAReconciler) ValidateVeleroPlugins(log logr.Logger) (bool, error) {
 		}
 	}
 
+	foundAWSPlugin := false
+	foundLegacyAWSPlugin := false
 	for _, plugin := range dpa.Spec.Configuration.Velero.DefaultPlugins {
 		pluginSpecificMap, ok := credentials.PluginSpecificFields[plugin]
-		pluginNeedsCheck, foundInBSLorVSL := providerNeedsDefaultCreds[string(plugin)]
+		pluginNeedsCheck, foundInBSLorVSL := providerNeedsDefaultCreds[pluginSpecificMap.ProviderName]
+
+		// "aws" and "legacy-aws" cannot both be specified
+		if plugin == oadpv1alpha1.DefaultPluginAWS {
+			foundAWSPlugin = true
+		}
+		if plugin == oadpv1alpha1.DefaultPluginLegacyAWS {
+			foundLegacyAWSPlugin = true
+		}
 
 		if foundInVSL := snapshotLocationsProviders[string(plugin)]; foundInVSL {
 			pluginNeedsCheck = true
@@ -152,5 +162,10 @@ func (r *DPAReconciler) ValidateVeleroPlugins(log logr.Logger) (bool, error) {
 			}
 		}
 	}
+
+	if foundAWSPlugin && foundLegacyAWSPlugin {
+		return false, fmt.Errorf("%s and %s can not be both specified in DPA spec.configuration.velero.defaultPlugins", oadpv1alpha1.DefaultPluginAWS, oadpv1alpha1.DefaultPluginLegacyAWS)
+	}
+
 	return true, nil
 }

--- a/controllers/velero_test.go
+++ b/controllers/velero_test.go
@@ -1365,6 +1365,37 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 			}),
 		},
 		{
+			name: "valid DPA CR with legacy aws plugin, Velero Deployment is built with legacy aws plugin",
+			dpa: createTestDpaWith(
+				nil,
+				oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{
+							DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
+								oadpv1alpha1.DefaultPluginLegacyAWS,
+							},
+						},
+					},
+				},
+			),
+			veleroDeployment: testVeleroDeployment.DeepCopy(),
+			wantVeleroDeployment: createTestBuiltVeleroDeployment(TestBuiltVeleroDeploymentOptions{
+				initContainers: []corev1.Container{pluginContainer(common.VeleroPluginForLegacyAWS, common.LegacyAWSPluginImage)},
+				volumes:        []corev1.Volume{deploymentVolumeSecret("cloud-credentials")},
+				volumeMounts: []corev1.VolumeMount{
+					{Name: "cloud-credentials", MountPath: "/credentials"},
+				},
+				env: append(baseEnvVars, []corev1.EnvVar{
+					{Name: common.AWSSharedCredentialsFileEnvKey, Value: "/credentials/cloud"},
+				}...),
+				args: []string{
+					defaultFileSystemBackupTimeout,
+					defaultRestoreResourcePriorities,
+					defaultDisableInformerCache,
+				},
+			}),
+		},
+		{
 			name: "valid DPA CR with aws and kubevirt plugin, Velero Deployment is built with aws and kubevirt plugin",
 			dpa: createTestDpaWith(
 				nil,
@@ -1982,7 +2013,7 @@ func TestDPAReconciler_noDefaultCredentials(t *testing.T) {
 		wantErr             bool
 	}{
 		{
-			name: "dpa with all plugins but with noDefualtBackupLocation should not require default credentials",
+			name: "dpa with all plugins but with noDefaultBackupLocation should not require default credentials",
 			args: args{
 				dpa: oadpv1alpha1.DataProtectionApplication{
 					ObjectMeta: metav1.ObjectMeta{
@@ -2000,9 +2031,9 @@ func TestDPAReconciler_noDefaultCredentials(t *testing.T) {
 				},
 			},
 			want: map[string]bool{
-				"velero-plugin-for-aws":             false,
-				"velero-plugin-for-gcp":             false,
-				"velero-plugin-for-microsoft-azure": false,
+				"aws":   false,
+				"gcp":   false,
+				"azure": false,
 			},
 			wantHasCloudStorage: false,
 			wantErr:             false,

--- a/controllers/vsl.go
+++ b/controllers/vsl.go
@@ -308,7 +308,7 @@ func (r *DPAReconciler) ReconcileVolumeSnapshotLocations(log logr.Logger) (bool,
 
 func containsPlugin(d []oadpv1alpha1.DefaultPlugin, value string) bool {
 	for _, elem := range d {
-		if string(elem) == value {
+		if credentials.PluginSpecificFields[elem].ProviderName == value {
 			return true
 		}
 	}

--- a/deploy/disconnected-prep.sh
+++ b/deploy/disconnected-prep.sh
@@ -17,6 +17,7 @@ IMAGES=(
   "helper"
   "gcpplugin"
   "awsplugin"
+  "legacyawsplugin"
   "azureplugin"
   "registry"
 )
@@ -28,6 +29,7 @@ IMG_MAP[velero_repo]="velero"
 IMG_MAP[helper_repo]="velero-restore-helper"
 IMG_MAP[gcpplugin_repo]="velero-plugin-for-gcp"
 IMG_MAP[awsplugin_repo]="velero-plugin-for-aws"
+IMG_MAP[legacyawsplugin_repo]="velero-plugin-for-legacy-aws"
 IMG_MAP[azureplugin_repo]="velero-plugin-for-microsoft-azure"
 IMG_MAP[registry_repo]="registry"
 
@@ -71,12 +73,14 @@ for f in bundle/manifests/oadp-operator.clusterserviceversion.yaml
   sed -i "s,/velero-restore-helper:.*,/velero-restore-helper@sha256:${IMG_MAP[helper_sha]},g"                                ${f}
   sed -i "s,/openshift-velero-plugin:.*,/openshift-velero-plugin@sha256:${IMG_MAP[plugin_sha]},g"                                          ${f}
   sed -i "s,/velero-plugin-for-aws:.*,/velero-plugin-for-aws@sha256:${IMG_MAP[awsplugin_sha]},g"                                           ${f}
+  sed -i "s,/velero-plugin-for-legacy-aws:.*,/velero-plugin-for-legacy-aws@sha256:${IMG_MAP[legacyawsplugin_sha]},g"                                           ${f}
   sed -i "s,/velero-plugin-for-microsoft-azure:.*,/velero-plugin-for-microsoft-azure@sha256:${IMG_MAP[azureplugin_sha]},g"                 ${f}
   sed -i "s,/velero-plugin-for-gcp:.*,/velero-plugin-for-gcp@sha256:${IMG_MAP[gcpplugin_sha]},g"                                           ${f}
   sed -i "s,/registry:.*,/registry@sha256:${IMG_MAP[registry_sha]},g"                                                                      ${f}
   sed -i 's,value: velero-restore-helper,value: velero-restore-helper@sha256,g'                                              ${f}
   sed -i 's,value: velero-plugin-for-gcp,value: velero-plugin-for-gcp@sha256,g'                                                            ${f}
   sed -i 's,value: velero-plugin-for-aws,value: velero-plugin-for-aws@sha256,g'                                                            ${f}
+  sed -i 's,value: velero-plugin-for-legacy-aws,value: velero-plugin-for-legacy-aws@sha256,g'                                                            ${f}
   sed -i 's,value: velero-plugin-for-microsoft-azure,value: velero-plugin-for-microsoft-azure@sha256,g'                                    ${f}
   sed -i 's,value: velero$,value: velero@sha256,g'                                                                                         ${f}
   sed -i 's,value: openshift-velero-plugin$,value: openshift-velero-plugin@sha256,g'                                                       ${f}
@@ -86,6 +90,7 @@ for f in bundle/manifests/oadp-operator.clusterserviceversion.yaml
   sed -i "/VELERO_RESTORE_HELPER_TAG/,/^ *[^:]*:/s/value: .*/value: ${IMG_MAP[helper_sha]}/"                                                                  ${f}
   sed -i "/VELERO_GCP_PLUGIN_TAG/,/^ *[^:]*:/s/value: .*/value: ${IMG_MAP[gcpplugin_sha]}/"                                                                          ${f}
   sed -i "/VELERO_AWS_PLUGIN_TAG/,/^ *[^:]*:/s/value: .*/value: ${IMG_MAP[awsplugin_sha]}/"                                                                          ${f}
+  sed -i "/VELERO_LEGACY_AWS_PLUGIN_TAG/,/^ *[^:]*:/s/value: .*/value: ${IMG_MAP[legacyawsplugin_sha]}/"                                                                          ${f}
   sed -i "/VELERO_AZURE_PLUGIN_TAG/,/^ *[^:]*:/s/value: .*/value: ${IMG_MAP[azureplugin_sha]}/"                                                                      ${f}
   sed -i "/VELERO_REGISTRY_TAG/,/^ *[^:]*:/s/value: .*/value: ${IMG_MAP[registry_sha]}/"                                                                             ${f}
 if [[ "$f" =~ .*clusterserviceversion.* ]] && ! grep -q infrastructure-features ${f}; then

--- a/docs/config/plugins.md
+++ b/docs/config/plugins.md
@@ -8,8 +8,10 @@ There are mainly two categories of Velero plugins that can be specified while
 installing Velero:
 
 1. `defaultPlugins`:<br>
-   There are six types of default Velero plugins can be installed: 
+   There are several types of default Velero plugins can be installed:
    - `AWS` [Plugins for AWS
+](https://github.com/vmware-tanzu/velero-plugin-for-aws)
+   - `Legacy AWS` [Plugins for Legacy AWS
 ](https://github.com/vmware-tanzu/velero-plugin-for-aws)
    - `GCP` [Plugins for Google Cloud Platform](https://github.com/vmware-tanzu/velero-plugin-for-gcp)
    - `Azure` [Plugins for Microsoft Azure](https://github.com/vmware-tanzu/velero-plugin-for-microsoft-azure)
@@ -17,6 +19,8 @@ installing Velero:
    - `CSI` [Plugins for CSI](https://github.com/vmware-tanzu/velero-plugin-for-csi)
    - `kubevirt` [Plugins for Kubevirt](https://github.com/kubevirt/kubevirt-velero-plugin)
    - `VSM (OADP 1.2 or below)` [Plugin for Volume-Snapshot-Mover](https://github.com/migtools/velero-plugin-for-vsm)
+
+   Note that only one of `AWS` and `Legacy AWS` may be installed at the same time. `Legacy AWS` is intended for use with certain S3 providers that do not support the V2 AWS SDK APIs used in the `AWS` plugin.
 
    For installation, 
    you need to specify them in the `oadp_v1alpha1_dpa.yaml` file 
@@ -37,7 +41,21 @@ installing Velero:
           - gcp
    ```
    The above specification will install Velero with four of the default plugins.
-   
+
+   ```
+    apiVersion: oadp.openshift.io/v1alpha1
+    kind: DataProtectionApplication
+    metadata:
+      name: dpa-sample
+    spec:
+      configuration:
+        velero:
+          defaultPlugins:
+          - openshift
+          - legacy-aws
+   ```
+   The above specification will install Velero with two of the default plugins.
+
 2. `customPlugins`:<br>
    For installation of custom Velero plugins, you need to specify the plugin 
    `image` and plugin `name` in the `oadp_v1alpha1_dpa.yaml` file during 

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -64,6 +64,7 @@ const (
 	VeleroImage          = "quay.io/konveyor/velero:latest"
 	OpenshiftPluginImage = "quay.io/konveyor/openshift-velero-plugin:latest"
 	AWSPluginImage       = "quay.io/konveyor/velero-plugin-for-aws:latest"
+	LegacyAWSPluginImage = "quay.io/konveyor/velero-plugin-for-legacy-aws:latest"
 	AzurePluginImage     = "quay.io/konveyor/velero-plugin-for-microsoft-azure:latest"
 	GCPPluginImage       = "quay.io/konveyor/velero-plugin-for-gcp:latest"
 	RegistryImage        = "quay.io/konveyor/registry:latest"
@@ -73,6 +74,7 @@ const (
 // Plugin names
 const (
 	VeleroPluginForAWS       = "velero-plugin-for-aws"
+	VeleroPluginForLegacyAWS = "velero-plugin-for-legacy-aws"
 	VeleroPluginForAzure     = "velero-plugin-for-microsoft-azure"
 	VeleroPluginForGCP       = "velero-plugin-for-gcp"
 	VeleroPluginForOpenshift = "openshift-velero-plugin"

--- a/pkg/credentials/credentials_test.go
+++ b/pkg/credentials/credentials_test.go
@@ -16,7 +16,7 @@ func TestCredentials_getPluginImage(t *testing.T) {
 	tests := []struct {
 		name       string
 		dpa        *oadpv1alpha1.DataProtectionApplication
-		pluginName string
+		pluginName oadpv1alpha1.DefaultPlugin
 		wantImage  string
 		setEnvVars map[string]string
 	}{
@@ -41,7 +41,7 @@ func TestCredentials_getPluginImage(t *testing.T) {
 					},
 				},
 			},
-			pluginName: common.VeleroPluginForAWS,
+			pluginName: oadpv1alpha1.DefaultPluginAWS,
 			wantImage:  "test-image",
 			setEnvVars: make(map[string]string),
 		},
@@ -62,7 +62,7 @@ func TestCredentials_getPluginImage(t *testing.T) {
 					},
 				},
 			},
-			pluginName: common.VeleroPluginForAWS,
+			pluginName: oadpv1alpha1.DefaultPluginAWS,
 			wantImage:  common.AWSPluginImage,
 			setEnvVars: make(map[string]string),
 		},
@@ -83,13 +83,86 @@ func TestCredentials_getPluginImage(t *testing.T) {
 					},
 				},
 			},
-			pluginName: common.VeleroPluginForAWS,
+			pluginName: oadpv1alpha1.DefaultPluginAWS,
 			wantImage:  "quay.io/konveyor/velero-plugin-for-aws:latest",
 			setEnvVars: map[string]string{
 				"REGISTRY":               "quay.io",
 				"PROJECT":                "konveyor",
 				"VELERO_AWS_PLUGIN_REPO": "velero-plugin-for-aws",
 				"VELERO_AWS_PLUGIN_TAG":  "latest",
+			},
+		},
+
+		// Legacy AWS tests
+		{
+			name: "given legacy aws plugin override, custom aws image should be returned",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-Velero-CR",
+					Namespace: "test-ns",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{
+							DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
+								oadpv1alpha1.DefaultPluginLegacyAWS,
+							},
+						},
+					},
+					UnsupportedOverrides: map[oadpv1alpha1.UnsupportedImageKey]string{
+						oadpv1alpha1.LegacyAWSPluginImageKey: "test-image",
+					},
+				},
+			},
+			pluginName: oadpv1alpha1.DefaultPluginLegacyAWS,
+			wantImage:  "test-image",
+			setEnvVars: make(map[string]string),
+		},
+		{
+			name: "given default Velero CR with no env var, default legacy aws image should be returned",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-Velero-CR",
+					Namespace: "test-ns",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{
+							DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
+								oadpv1alpha1.DefaultPluginLegacyAWS,
+							},
+						},
+					},
+				},
+			},
+			pluginName: oadpv1alpha1.DefaultPluginLegacyAWS,
+			wantImage:  common.LegacyAWSPluginImage,
+			setEnvVars: make(map[string]string),
+		},
+		{
+			name: "given default Velero CR with env var set, image should be built via env vars",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-Velero-CR",
+					Namespace: "test-ns",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{
+							DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
+								oadpv1alpha1.DefaultPluginLegacyAWS,
+							},
+						},
+					},
+				},
+			},
+			pluginName: oadpv1alpha1.DefaultPluginLegacyAWS,
+			wantImage:  "quay.io/konveyor/velero-plugin-for-legacy-aws:latest",
+			setEnvVars: map[string]string{
+				"REGISTRY":                      "quay.io",
+				"PROJECT":                       "konveyor",
+				"VELERO_LEGACY_AWS_PLUGIN_REPO": "velero-plugin-for-legacy-aws",
+				"VELERO_LEGACY_AWS_PLUGIN_TAG":  "latest",
 			},
 		},
 
@@ -114,7 +187,7 @@ func TestCredentials_getPluginImage(t *testing.T) {
 					},
 				},
 			},
-			pluginName: common.VeleroPluginForOpenshift,
+			pluginName: oadpv1alpha1.DefaultPluginOpenShift,
 			wantImage:  "test-image",
 			setEnvVars: make(map[string]string),
 		},
@@ -135,7 +208,7 @@ func TestCredentials_getPluginImage(t *testing.T) {
 					},
 				},
 			},
-			pluginName: common.VeleroPluginForOpenshift,
+			pluginName: oadpv1alpha1.DefaultPluginOpenShift,
 			wantImage:  common.OpenshiftPluginImage,
 			setEnvVars: make(map[string]string),
 		},
@@ -156,7 +229,7 @@ func TestCredentials_getPluginImage(t *testing.T) {
 					},
 				},
 			},
-			pluginName: common.VeleroPluginForOpenshift,
+			pluginName: oadpv1alpha1.DefaultPluginOpenShift,
 			wantImage:  "quay.io/konveyor/openshift-velero-plugin:latest",
 			setEnvVars: map[string]string{
 				"REGISTRY":                     "quay.io",
@@ -187,7 +260,7 @@ func TestCredentials_getPluginImage(t *testing.T) {
 					},
 				},
 			},
-			pluginName: common.VeleroPluginForGCP,
+			pluginName: oadpv1alpha1.DefaultPluginGCP,
 			wantImage:  "test-image",
 			setEnvVars: make(map[string]string),
 		},
@@ -208,7 +281,7 @@ func TestCredentials_getPluginImage(t *testing.T) {
 					},
 				},
 			},
-			pluginName: common.VeleroPluginForGCP,
+			pluginName: oadpv1alpha1.DefaultPluginGCP,
 			wantImage:  common.GCPPluginImage,
 			setEnvVars: make(map[string]string),
 		},
@@ -229,7 +302,7 @@ func TestCredentials_getPluginImage(t *testing.T) {
 					},
 				},
 			},
-			pluginName: common.VeleroPluginForGCP,
+			pluginName: oadpv1alpha1.DefaultPluginGCP,
 			wantImage:  "quay.io/konveyor/velero-plugin-for-gcp:latest",
 			setEnvVars: map[string]string{
 				"REGISTRY":               "quay.io",
@@ -260,7 +333,7 @@ func TestCredentials_getPluginImage(t *testing.T) {
 					},
 				},
 			},
-			pluginName: common.VeleroPluginForAzure,
+			pluginName: oadpv1alpha1.DefaultPluginMicrosoftAzure,
 			wantImage:  "test-image",
 			setEnvVars: make(map[string]string),
 		},
@@ -281,7 +354,7 @@ func TestCredentials_getPluginImage(t *testing.T) {
 					},
 				},
 			},
-			pluginName: common.VeleroPluginForAzure,
+			pluginName: oadpv1alpha1.DefaultPluginMicrosoftAzure,
 			wantImage:  common.AzurePluginImage,
 			setEnvVars: make(map[string]string),
 		},
@@ -302,7 +375,7 @@ func TestCredentials_getPluginImage(t *testing.T) {
 					},
 				},
 			},
-			pluginName: common.VeleroPluginForAzure,
+			pluginName: oadpv1alpha1.DefaultPluginMicrosoftAzure,
 			wantImage:  "quay.io/konveyor/velero-plugin-for-microsoft-azure:latest",
 			setEnvVars: map[string]string{
 				"REGISTRY":                 "quay.io",
@@ -329,7 +402,7 @@ func TestCredentials_getPluginImage(t *testing.T) {
 					},
 				},
 			},
-			pluginName: common.KubeVirtPlugin,
+			pluginName: oadpv1alpha1.DefaultPluginKubeVirt,
 			wantImage:  "quay.io/konveyor/kubevirt-velero-plugin:v0.7.0",
 		},
 		{
@@ -349,7 +422,7 @@ func TestCredentials_getPluginImage(t *testing.T) {
 					},
 				},
 			},
-			pluginName: common.KubeVirtPlugin,
+			pluginName: oadpv1alpha1.DefaultPluginKubeVirt,
 			wantImage:  "quay.io/kubevirt/kubevirt-velero-plugin:latest",
 			setEnvVars: map[string]string{
 				"RELATED_IMAGE_KUBEVIRT_VELERO_PLUGIN": "quay.io/kubevirt/kubevirt-velero-plugin:latest",


### PR DESCRIPTION
## Why the changes were made

<!-- Explain why this PR is important, what problems it fixes, link related issues -->
Certain s3 providers don't support the AWS SDK v2 updates made in velero-plugin-for-aws v1.9+ (OADP 1.4+). This PR provides the ability to use the v1.8 plugin in a newer OADP environment.


## How to test the changes made

<!-- Explain how the changes introduced by this PR can be tested and verified, with commands and pictures -->
In the DPA DefaultPlugins section, use legacy-aws instead of aws. S3 providers that work with the regular aws plugin should still work here. S3 providers that error out in various ways with the regular plugin should also work.