### PR TITLE
oadp-1.4: Add legacy-aws default plugin reconcile e2e test. (#1568)

### DIFF
--- a/tests/e2e/dpa_deployment_suite_test.go
+++ b/tests/e2e/dpa_deployment_suite_test.go
@@ -19,6 +19,7 @@ import (
 
 type TestDPASpec struct {
 	BSLSecretName           string
+	DefaultPlugins          []oadpv1alpha1.DefaultPlugin // Overrides default plugins loaded from config
 	CustomPlugins           []oadpv1alpha1.CustomPlugin
 	SnapshotLocations       []oadpv1alpha1.SnapshotLocation
 	VeleroPodConfig         oadpv1alpha1.PodConfig
@@ -66,6 +67,9 @@ func createTestDPASpec(testSpec TestDPASpec) *oadpv1alpha1.DataProtectionApplica
 		},
 		SnapshotLocations:    testSpec.SnapshotLocations,
 		UnsupportedOverrides: testSpec.UnsupportedOverrides,
+	}
+	if len(testSpec.DefaultPlugins) > 0 {
+		dpaSpec.Configuration.Velero.DefaultPlugins = testSpec.DefaultPlugins
 	}
 	if testSpec.EnableNodeAgent {
 		dpaSpec.Configuration.NodeAgent = &oadpv1alpha1.NodeAgentConfig{
@@ -343,6 +347,12 @@ var _ = Describe("Configuration testing for DPA Custom Resource", func() {
 				BSLSecretName:           bslSecretName,
 				NoDefaultBackupLocation: true,
 				DoNotBackupImages:       true,
+			}),
+		}),
+		Entry("DPA CR with legacy-aws plugin", Label("aws", "ibmcloud"), InstallCase{
+			DpaSpec: createTestDPASpec(TestDPASpec{
+				BSLSecretName:  bslSecretName,
+				DefaultPlugins: []oadpv1alpha1.DefaultPlugin{oadpv1alpha1.DefaultPluginOpenShift, oadpv1alpha1.DefaultPluginLegacyAWS},
 			}),
 		}),
 		Entry("DPA CR with S3ForcePathStyle true", Label("aws"), InstallCase{


### PR DESCRIPTION
## Why the changes were made

<!-- Explain why this PR is important, what problems it fixes, link related issues -->
Add a new reconcile test to e2e that checks velero pod runs with legacy-aws image WITHOUT b/r tests.

cp #1568 
## How to test the changes made

<!-- Explain how the changes introduced by this PR can be tested and verified, with commands and pictures -->
ci works
