### PR TITLE
fix: NAC install validation

### DIFF
--- a/controllers/dpa_controller.go
+++ b/controllers/dpa_controller.go
@@ -45,13 +45,13 @@ import (
 // DPAReconciler reconciles a Velero object
 type DPAReconciler struct {
 	client.Client
-	Scheme         *runtime.Scheme
-	Log            logr.Logger
-	Context        context.Context
-	NamespacedName types.NamespacedName
-	EventRecorder  record.EventRecorder
-	dpa            *oadpv1alpha1.DataProtectionApplication
-	OADPNamespace  string
+	Scheme            *runtime.Scheme
+	Log               logr.Logger
+	Context           context.Context
+	NamespacedName    types.NamespacedName
+	EventRecorder     record.EventRecorder
+	dpa               *oadpv1alpha1.DataProtectionApplication
+	ClusterWideClient client.Client
 }
 
 var debugMode = os.Getenv("DEBUG") == "true"
@@ -149,7 +149,7 @@ func (r *DPAReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&routev1.Route{}).
 		Owns(&corev1.ConfigMap{}).
 		Watches(&corev1.Secret{}, &labelHandler{}).
-		WithEventFilter(veleroPredicate(r.Scheme, r.OADPNamespace)).
+		WithEventFilter(veleroPredicate(r.Scheme)).
 		Complete(r)
 }
 

--- a/controllers/dpa_controller.go
+++ b/controllers/dpa_controller.go
@@ -51,6 +51,7 @@ type DPAReconciler struct {
 	NamespacedName types.NamespacedName
 	EventRecorder  record.EventRecorder
 	dpa            *oadpv1alpha1.DataProtectionApplication
+	OADPNamespace  string
 }
 
 var debugMode = os.Getenv("DEBUG") == "true"
@@ -148,7 +149,7 @@ func (r *DPAReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&routev1.Route{}).
 		Owns(&corev1.ConfigMap{}).
 		Watches(&corev1.Secret{}, &labelHandler{}).
-		WithEventFilter(veleroPredicate(r.Scheme)).
+		WithEventFilter(veleroPredicate(r.Scheme, r.OADPNamespace)).
 		Complete(r)
 }
 

--- a/controllers/nonadmin_controller.go
+++ b/controllers/nonadmin_controller.go
@@ -10,7 +10,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8serror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -85,17 +84,15 @@ func (r *DPAReconciler) ReconcileNonAdminController(log logr.Logger) (bool, erro
 		return true, nil
 	}
 
-	selector, err := fields.ParseSelector(fmt.Sprintf("metadata.namespace!=%s", r.NamespacedName.Namespace))
-	if err != nil {
-		return false, err
-	}
 	dpaList := &oadpv1alpha1.DataProtectionApplicationList{}
-	err = r.List(r.Context, dpaList, &client.ListOptions{FieldSelector: selector})
+	err := r.List(r.Context, dpaList)
 	if err != nil {
 		return false, err
 	}
+	r.Log.Info("number of DPAs fetched: ", "number of DPAs", len(dpaList.Items))
+	r.Log.Info("DPA list fetched:\n", "DPAs", dpaList.Items)
 	for _, dpa := range dpaList.Items {
-		if (&DPAReconciler{dpa: &dpa}).checkNonAdminEnabled() {
+		if dpa.Namespace != r.NamespacedName.Namespace && (&DPAReconciler{dpa: &dpa}).checkNonAdminEnabled() {
 			return false, fmt.Errorf("only a single instance of Non-Admin Controller can be installed across the entire cluster. Non-Admin controller is also configured to be installed in %s namespace", dpa.Namespace)
 		}
 	}

--- a/controllers/nonadmin_controller.go
+++ b/controllers/nonadmin_controller.go
@@ -96,7 +96,7 @@ func (r *DPAReconciler) ReconcileNonAdminController(log logr.Logger) (bool, erro
 	}
 	for _, dpa := range dpaList.Items {
 		if (&DPAReconciler{dpa: &dpa}).checkNonAdminEnabled() {
-			return false, fmt.Errorf("only one NAC can be installed in the whole cluster")
+			return false, fmt.Errorf("only a single instance of Non-Admin Controller can be installed across the entire cluster. Non-Admin controller is also configured to be installed in %s namespace", dpa.Namespace)
 		}
 	}
 

--- a/controllers/nonadmin_controller_test.go
+++ b/controllers/nonadmin_controller_test.go
@@ -21,14 +21,12 @@ import (
 const defaultNonAdminImage = "quay.io/konveyor/oadp-non-admin:latest"
 
 type ReconcileNonAdminControllerScenario struct {
-	namespace              string
-	dpa                    string
-	errMessage             string
-	eventWords             []string
-	nonAdminEnabled        bool
-	deployment             *appsv1.Deployment
-	anotherNamespace       string
-	anotherNonAdminEnabled bool
+	namespace       string
+	dpa             string
+	errMessage      string
+	eventWords      []string
+	nonAdminEnabled bool
+	deployment      *appsv1.Deployment
 }
 
 func createTestDeployment(namespace string) *appsv1.Deployment {
@@ -101,31 +99,6 @@ func runReconcileNonAdminControllerTest(
 		gomega.Expect(k8sClient.Create(ctx, scenario.deployment)).To(gomega.Succeed())
 	}
 
-	if len(scenario.anotherNamespace) > 0 {
-		namespace := &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: scenario.anotherNamespace,
-			},
-		}
-		gomega.Expect(k8sClient.Create(ctx, namespace)).To(gomega.Succeed())
-		dpa := &oadpv1alpha1.DataProtectionApplication{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      scenario.dpa,
-				Namespace: scenario.anotherNamespace,
-			},
-			Spec: oadpv1alpha1.DataProtectionApplicationSpec{
-				Configuration: &oadpv1alpha1.ApplicationConfig{},
-				NonAdmin: &oadpv1alpha1.NonAdmin{
-					Enable: ptr.To(scenario.anotherNonAdminEnabled),
-				},
-				UnsupportedOverrides: map[oadpv1alpha1.UnsupportedImageKey]string{
-					oadpv1alpha1.TechPreviewAck: "true",
-				},
-			},
-		}
-		gomega.Expect(k8sClient.Create(ctx, dpa)).To(gomega.Succeed())
-	}
-
 	os.Setenv("RELATED_IMAGE_NON_ADMIN_CONTROLLER", envVarValue)
 	event := record.NewFakeRecorder(5)
 	r := &DPAReconciler{
@@ -136,9 +109,8 @@ func runReconcileNonAdminControllerTest(
 			Name:      scenario.dpa,
 			Namespace: scenario.namespace,
 		},
-		EventRecorder:     event,
-		dpa:               dpa,
-		ClusterWideClient: k8sClient,
+		EventRecorder: event,
+		dpa:           dpa,
 	}
 	result, err := r.ReconcileNonAdminController(logr.Discard())
 
@@ -200,23 +172,6 @@ var _ = ginkgo.Describe("Test ReconcileNonAdminController function", func() {
 			},
 		}
 		gomega.Expect(k8sClient.Delete(ctx, namespace)).To(gomega.Succeed())
-
-		if len(currentTestScenario.anotherNamespace) > 0 {
-			dpa := &oadpv1alpha1.DataProtectionApplication{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      currentTestScenario.dpa,
-					Namespace: currentTestScenario.anotherNamespace,
-				},
-			}
-			gomega.Expect(k8sClient.Delete(ctx, dpa)).To(gomega.Succeed())
-
-			namespace := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: currentTestScenario.anotherNamespace,
-				},
-			}
-			gomega.Expect(k8sClient.Delete(ctx, namespace)).To(gomega.Succeed())
-		}
 	})
 
 	ginkgo.DescribeTable("Reconcile is true",
@@ -247,14 +202,6 @@ var _ = ginkgo.Describe("Test ReconcileNonAdminController function", func() {
 			namespace:       "test-4",
 			dpa:             "test-4-dpa",
 			nonAdminEnabled: false,
-		}),
-		ginkgo.Entry("Should create non admin deployment with DPAs in other namespaces", ReconcileNonAdminControllerScenario{
-			namespace:              "test-5",
-			dpa:                    "test-5-dpa",
-			eventWords:             []string{"Normal", "NonAdminDeploymentReconciled", "created"},
-			nonAdminEnabled:        true,
-			anotherNamespace:       "test-6",
-			anotherNonAdminEnabled: false,
 		}),
 	)
 
@@ -289,14 +236,6 @@ var _ = ginkgo.Describe("Test ReconcileNonAdminController function", func() {
 					},
 				},
 			},
-		}),
-		ginkgo.Entry("Should error because non admin is enabled in another namespace", ReconcileNonAdminControllerScenario{
-			namespace:              "test-error-2",
-			dpa:                    "test-error-2-dpa",
-			errMessage:             "only a single instance of Non-Admin Controller can be installed across the entire cluster. Non-Admin controller is also configured to be installed in test-error-3 namespace",
-			nonAdminEnabled:        true,
-			anotherNamespace:       "test-error-3",
-			anotherNonAdminEnabled: true,
 		}),
 	)
 })

--- a/controllers/nonadmin_controller_test.go
+++ b/controllers/nonadmin_controller_test.go
@@ -136,8 +136,9 @@ func runReconcileNonAdminControllerTest(
 			Name:      scenario.dpa,
 			Namespace: scenario.namespace,
 		},
-		EventRecorder: event,
-		dpa:           dpa,
+		EventRecorder:     event,
+		dpa:               dpa,
+		ClusterWideClient: k8sClient,
 	}
 	result, err := r.ReconcileNonAdminController(logr.Discard())
 

--- a/controllers/nonadmin_controller_test.go
+++ b/controllers/nonadmin_controller_test.go
@@ -305,8 +305,22 @@ func TestDPAReconcilerCheckNonAdminEnabled(t *testing.T) {
 		dpa    *oadpv1alpha1.DataProtectionApplication
 	}{
 		{
-			name:   "DPA has non admin feature enable: true return true",
+			name:   "DPA has non admin feature enable: true and tech-preview-ack return true",
 			result: true,
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					NonAdmin: &oadpv1alpha1.NonAdmin{
+						Enable: ptr.To(true),
+					},
+					UnsupportedOverrides: map[oadpv1alpha1.UnsupportedImageKey]string{
+						oadpv1alpha1.TechPreviewAck: TrueVal,
+					},
+				},
+			},
+		},
+		{
+			name:   "DPA has non admin feature enable: true without tech-preview-ack return false",
+			result: false,
 			dpa: &oadpv1alpha1.DataProtectionApplication{
 				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
 					NonAdmin: &oadpv1alpha1.NonAdmin{

--- a/controllers/predicate.go
+++ b/controllers/predicate.go
@@ -9,22 +9,22 @@ import (
 	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
 )
 
-func veleroPredicate(scheme *runtime.Scheme, namespace string) predicate.Predicate {
+func veleroPredicate(scheme *runtime.Scheme) predicate.Predicate {
 	return predicate.Funcs{
 		// Update returns true if the Update event should be processed
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			if e.ObjectOld.GetGeneration() == e.ObjectNew.GetGeneration() {
 				return false
 			}
-			return isObjectOurs(scheme, e.ObjectOld, namespace)
+			return isObjectOurs(scheme, e.ObjectOld)
 		},
 		// Create returns true if the Create event should be processed
 		CreateFunc: func(e event.CreateEvent) bool {
-			return isObjectOurs(scheme, e.Object, namespace)
+			return isObjectOurs(scheme, e.Object)
 		},
 		// Delete returns true if the Delete event should be processed
 		DeleteFunc: func(e event.DeleteEvent) bool {
-			return !e.DeleteStateUnknown && isObjectOurs(scheme, e.Object, namespace)
+			return !e.DeleteStateUnknown && isObjectOurs(scheme, e.Object)
 		},
 	}
 }
@@ -32,10 +32,7 @@ func veleroPredicate(scheme *runtime.Scheme, namespace string) predicate.Predica
 // isObjectOurs returns true if the object is ours.
 // it first checks if the object has our group, version, and kind
 // else it will check for non empty OadpOperatorlabel labels
-func isObjectOurs(scheme *runtime.Scheme, object client.Object, namespace string) bool {
-	if object.GetNamespace() != namespace {
-		return false
-	}
+func isObjectOurs(scheme *runtime.Scheme, object client.Object) bool {
 	objGVKs, _, err := scheme.ObjectKinds(object)
 	if err != nil {
 		return false

--- a/controllers/predicate.go
+++ b/controllers/predicate.go
@@ -9,22 +9,22 @@ import (
 	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
 )
 
-func veleroPredicate(scheme *runtime.Scheme) predicate.Predicate {
+func veleroPredicate(scheme *runtime.Scheme, namespace string) predicate.Predicate {
 	return predicate.Funcs{
 		// Update returns true if the Update event should be processed
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			if e.ObjectOld.GetGeneration() == e.ObjectNew.GetGeneration() {
 				return false
 			}
-			return isObjectOurs(scheme, e.ObjectOld)
+			return isObjectOurs(scheme, e.ObjectOld, namespace)
 		},
 		// Create returns true if the Create event should be processed
 		CreateFunc: func(e event.CreateEvent) bool {
-			return isObjectOurs(scheme, e.Object)
+			return isObjectOurs(scheme, e.Object, namespace)
 		},
 		// Delete returns true if the Delete event should be processed
 		DeleteFunc: func(e event.DeleteEvent) bool {
-			return !e.DeleteStateUnknown && isObjectOurs(scheme, e.Object)
+			return !e.DeleteStateUnknown && isObjectOurs(scheme, e.Object, namespace)
 		},
 	}
 }
@@ -32,7 +32,10 @@ func veleroPredicate(scheme *runtime.Scheme) predicate.Predicate {
 // isObjectOurs returns true if the object is ours.
 // it first checks if the object has our group, version, and kind
 // else it will check for non empty OadpOperatorlabel labels
-func isObjectOurs(scheme *runtime.Scheme, object client.Object) bool {
+func isObjectOurs(scheme *runtime.Scheme, object client.Object, namespace string) bool {
+	if object.GetNamespace() != namespace {
+		return false
+	}
 	objGVKs, _, err := scheme.ObjectKinds(object)
 	if err != nil {
 		return false

--- a/controllers/validator.go
+++ b/controllers/validator.go
@@ -22,7 +22,7 @@ func (r *DPAReconciler) ValidateDataProtectionCR(log logr.Logger) (bool, error) 
 		return false, err
 	}
 	if len(dpaList.Items) > 1 {
-		return false, errors.New("only one DPA CR can exist per OADP namespace")
+		return false, errors.New("only one DPA CR can exist per OADP installation namespace")
 	}
 
 	if r.dpa.Spec.Configuration == nil || r.dpa.Spec.Configuration.Velero == nil {

--- a/controllers/validator.go
+++ b/controllers/validator.go
@@ -7,6 +7,7 @@ import (
 
 	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
 	"github.com/openshift/oadp-operator/pkg/credentials"
@@ -15,26 +16,32 @@ import (
 // ValidateDataProtectionCR function validates the DPA CR, returns true if valid, false otherwise
 // it calls other validation functions to validate the DPA CR
 func (r *DPAReconciler) ValidateDataProtectionCR(log logr.Logger) (bool, error) {
+	dpaList := &oadpv1alpha1.DataProtectionApplicationList{}
+	err := r.List(r.Context, dpaList, &client.ListOptions{Namespace: r.NamespacedName.Namespace})
+	if err != nil {
+		return false, err
+	}
+	if len(dpaList.Items) > 1 {
+		return false, errors.New("only one DPA CR can exist per OADP namespace")
+	}
 
-	dpa := r.dpa
-
-	if dpa.Spec.Configuration == nil || dpa.Spec.Configuration.Velero == nil {
+	if r.dpa.Spec.Configuration == nil || r.dpa.Spec.Configuration.Velero == nil {
 		return false, errors.New("DPA CR Velero configuration cannot be nil")
 	}
 
-	if dpa.Spec.Configuration.Restic != nil && dpa.Spec.Configuration.NodeAgent != nil {
+	if r.dpa.Spec.Configuration.Restic != nil && r.dpa.Spec.Configuration.NodeAgent != nil {
 		return false, errors.New("DPA CR cannot have restic (deprecated in OADP 1.3) as well as nodeAgent options at the same time")
 	}
 
-	if dpa.Spec.Configuration.Velero.NoDefaultBackupLocation {
-		if len(dpa.Spec.BackupLocations) != 0 {
+	if r.dpa.Spec.Configuration.Velero.NoDefaultBackupLocation {
+		if len(r.dpa.Spec.BackupLocations) != 0 {
 			return false, errors.New("DPA CR Velero configuration cannot have backup locations if noDefaultBackupLocation is set")
 		}
-		if dpa.BackupImages() {
+		if r.dpa.BackupImages() {
 			return false, errors.New("backupImages needs to be set to false when noDefaultBackupLocation is set")
 		}
 	} else {
-		if len(dpa.Spec.BackupLocations) == 0 {
+		if len(r.dpa.Spec.BackupLocations) == 0 {
 			return false, errors.New("no backupstoragelocations configured, ensure a backupstoragelocation has been configured or use the noDefaultBackupLocation flag")
 		}
 	}
@@ -47,11 +54,11 @@ func (r *DPAReconciler) ValidateDataProtectionCR(log logr.Logger) (bool, error) 
 	}
 
 	// check for VSM/Volsync DataMover (OADP 1.2 or below) syntax
-	if dpa.Spec.Features != nil && dpa.Spec.Features.DataMover != nil {
+	if r.dpa.Spec.Features != nil && r.dpa.Spec.Features.DataMover != nil {
 		return false, errors.New("Delete vsm from spec.configuration.velero.defaultPlugins and dataMover object from spec.features. Use Velero Built-in Data Mover instead")
 	}
 
-	if val, found := dpa.Spec.UnsupportedOverrides[oadpv1alpha1.OperatorTypeKey]; found && val != oadpv1alpha1.OperatorTypeMTC {
+	if val, found := r.dpa.Spec.UnsupportedOverrides[oadpv1alpha1.OperatorTypeKey]; found && val != oadpv1alpha1.OperatorTypeMTC {
 		return false, errors.New("only mtc operator type override is supported")
 	}
 
@@ -65,25 +72,22 @@ func (r *DPAReconciler) ValidateDataProtectionCR(log logr.Logger) (bool, error) 
 		return false, err
 	}
 
-	if _, err := getResticResourceReqs(dpa); err != nil {
+	if _, err := getResticResourceReqs(r.dpa); err != nil {
 		return false, err
 	}
-	if _, err := getNodeAgentResourceReqs(dpa); err != nil {
+	if _, err := getNodeAgentResourceReqs(r.dpa); err != nil {
 		return false, err
 	}
 
 	// validate non-admin enable and tech-preview-ack
-	if r.checkNonAdminEnabled() {
-		if !(dpa.Spec.UnsupportedOverrides[oadpv1alpha1.TechPreviewAck] == TrueVal) {
+	if r.dpa.Spec.NonAdmin != nil && r.dpa.Spec.NonAdmin.Enable != nil && *r.dpa.Spec.NonAdmin.Enable {
+		if !(r.dpa.Spec.UnsupportedOverrides[oadpv1alpha1.TechPreviewAck] == TrueVal) {
 			return false, errors.New("in order to enable/disable the non-admin feature please set dpa.spec.unsupportedOverrides[tech-preview-ack]: 'true'")
 		}
 	}
 
 	return true, nil
 }
-
-// empty struct to use as map value
-type empty struct{}
 
 // For later: Move this code into validator.go when more need for validation arises
 // TODO: if multiple default plugins exist, ensure we validate all of them.

--- a/controllers/validator_test.go
+++ b/controllers/validator_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1482,9 +1483,15 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 						},
 					},
 				},
+				&appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "non-admin-controller",
+						Namespace: "test-another-ns",
+					},
+				},
 			},
 			wantErr:    true,
-			messageErr: "only a single instance of Non-Admin Controller can be installed across the entire cluster. Non-Admin controller is also configured to be installed in test-another-ns namespace",
+			messageErr: "only a single instance of Non-Admin Controller can be installed across the entire cluster. Non-Admin controller is already configured and installed in test-another-ns namespace",
 		},
 		{
 			name: "given invalid DPA CR aws and legacy-aws plugins both specified",

--- a/controllers/validator_test.go
+++ b/controllers/validator_test.go
@@ -25,6 +25,27 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 		messageErr string
 	}{
 		{
+			name: "[invalid] DPA CR: multiple DPAs in same namespace",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-DPA-CR",
+					Namespace: "test-ns",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{},
+			},
+			objects: []client.Object{
+				&oadpv1alpha1.DataProtectionApplication{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "another-DPA-CR",
+						Namespace: "test-ns",
+					},
+					Spec: oadpv1alpha1.DataProtectionApplicationSpec{},
+				},
+			},
+			wantErr:    true,
+			messageErr: "only one DPA CR can exist per OADP installation namespace",
+		},
+		{
 			name: "given valid DPA CR, no default backup location, no backup images, no error case",
 			dpa: &oadpv1alpha1.DataProtectionApplication{
 				ObjectMeta: metav1.ObjectMeta{

--- a/main.go
+++ b/main.go
@@ -220,6 +220,7 @@ func main() {
 
 	dpaClientScheme := runtime.NewScheme()
 	utilruntime.Must(oadpv1alpha1.AddToScheme(dpaClientScheme))
+	utilruntime.Must(appsv1.AddToScheme(dpaClientScheme))
 	dpaClient, err := client.New(kubeconf, client.Options{
 		Scheme: dpaClientScheme,
 	})

--- a/main.go
+++ b/main.go
@@ -44,7 +44,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/cache"
+	// "sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -171,11 +171,11 @@ func main() {
 		RenewDeadline:          &leConfig.RenewDeadline.Duration,
 		RetryPeriod:            &leConfig.RetryPeriod.Duration,
 		LeaderElectionID:       "oadp.openshift.io",
-		Cache: cache.Options{
-			DefaultNamespaces: map[string]cache.Config{
-				watchNamespace: {},
-			},
-		},
+		// Cache: cache.Options{
+		// 	DefaultNamespaces: map[string]cache.Config{
+		// 		watchNamespace: {},
+		// 	},
+		// },
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
@@ -222,6 +222,7 @@ func main() {
 		Client:        mgr.GetClient(),
 		Scheme:        mgr.GetScheme(),
 		EventRecorder: mgr.GetEventRecorderFor("DPA-controller"),
+		OADPNamespace: watchNamespace,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "DataProtectionApplication")
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -44,7 +44,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
-	// "sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -171,11 +171,11 @@ func main() {
 		RenewDeadline:          &leConfig.RenewDeadline.Duration,
 		RetryPeriod:            &leConfig.RetryPeriod.Duration,
 		LeaderElectionID:       "oadp.openshift.io",
-		// Cache: cache.Options{
-		// 	DefaultNamespaces: map[string]cache.Config{
-		// 		watchNamespace: {},
-		// 	},
-		// },
+		Cache: cache.Options{
+			DefaultNamespaces: map[string]cache.Config{
+				watchNamespace: {},
+			},
+		},
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
@@ -218,11 +218,21 @@ func main() {
 		os.Exit(1)
 	}
 
+	dpaClientScheme := runtime.NewScheme()
+	utilruntime.Must(oadpv1alpha1.AddToScheme(dpaClientScheme))
+	dpaClient, err := client.New(kubeconf, client.Options{
+		Scheme: dpaClientScheme,
+	})
+	if err != nil {
+		setupLog.Error(err, "unable to create Kubernetes client")
+		os.Exit(1)
+	}
+
 	if err = (&controllers.DPAReconciler{
-		Client:        mgr.GetClient(),
-		Scheme:        mgr.GetScheme(),
-		EventRecorder: mgr.GetEventRecorderFor("DPA-controller"),
-		OADPNamespace: watchNamespace,
+		Client:            mgr.GetClient(),
+		Scheme:            mgr.GetScheme(),
+		EventRecorder:     mgr.GetEventRecorderFor("DPA-controller"),
+		ClusterWideClient: dpaClient,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "DataProtectionApplication")
 		os.Exit(1)


### PR DESCRIPTION
## Why the changes were made

Only allow one NAC install per cluster.

Related to https://github.com/migtools/oadp-non-admin/pull/107

Also, add validation for only allowing one DPA per OADP installation namespace.

## How to test the changes made

Deploy 2 (or more) OADP operators (`make deploy-olm`) in different namespaces. Create 2 (or more) DPAs in those namespaces with NAC enabled. Only one NAC should be deployed and DPAs should have error in their statuses.
