### PR TITLE
fix: Remove indirect import of AWS package

### DIFF
--- a/controllers/bsl.go
+++ b/controllers/bsl.go
@@ -284,7 +284,7 @@ func (r *DPAReconciler) updateBSLFromSpec(bsl *velerov1.BackupStorageLocation, b
 	if bslSpec.Provider == "aws" && bslSpec.Config != nil {
 		s3Url := bslSpec.Config["s3Url"]
 		if len(s3Url) > 0 {
-			if s3Url, err = common.StripDefaultPorts(s3Url); err == nil {
+			if s3Url, err = aws.StripDefaultPorts(s3Url); err == nil {
 				bslSpec.Config["s3Url"] = s3Url
 			}
 		}

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -2,14 +2,11 @@ package common
 
 import (
 	"fmt"
-	"net/http"
-	"net/url"
 	"os"
 	"regexp"
 	"sort"
 	"strings"
 
-	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/vmware-tanzu/velero/pkg/types"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -208,23 +205,6 @@ func CCOWorkflow() bool {
 		return true
 	}
 	return false
-}
-
-// StripDefaultPorts removes port 80 from HTTP URLs and 443 from HTTPS URLs.
-// Defer to the actual AWS SDK implementation to match its behavior exactly.
-func StripDefaultPorts(fromUrl string) (string, error) {
-	u, err := url.Parse(fromUrl)
-	if err != nil {
-		return "", err
-	}
-	r := http.Request{
-		URL: u,
-	}
-	request.SanitizeHostForHeader(&r)
-	if r.Host != "" {
-		r.URL.Host = r.Host
-	}
-	return r.URL.String(), nil
 }
 
 // GetImagePullPolicy get imagePullPolicy for a container, based on its image, if an override is not provided.

--- a/pkg/common/common_test.go
+++ b/pkg/common/common_test.go
@@ -107,51 +107,6 @@ func TestAppendTTMapAsCopy(t *testing.T) {
 	})
 }
 
-func TestStripDefaultPorts(t *testing.T) {
-	tests := []struct {
-		name string
-		base string
-		want string
-	}{
-		{
-			name: "port-free URL is returned unchanged",
-			base: "https://s3.region.cloud-object-storage.appdomain.cloud/bucket-name",
-			want: "https://s3.region.cloud-object-storage.appdomain.cloud/bucket-name",
-		},
-		{
-			name: "HTTPS port is removed from URL",
-			base: "https://s3.region.cloud-object-storage.appdomain.cloud:443/bucket-name",
-			want: "https://s3.region.cloud-object-storage.appdomain.cloud/bucket-name",
-		},
-		{
-			name: "HTTP port is removed from URL",
-			base: "http://s3.region.cloud-object-storage.appdomain.cloud:80/bucket-name",
-			want: "http://s3.region.cloud-object-storage.appdomain.cloud/bucket-name",
-		},
-		{
-			name: "alternate HTTP port is preserved",
-			base: "http://10.0.188.30:9000",
-			want: "http://10.0.188.30:9000",
-		},
-		{
-			name: "alternate HTTPS port is preserved",
-			base: "https://10.0.188.30:9000",
-			want: "https://10.0.188.30:9000",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := StripDefaultPorts(tt.base)
-			if err != nil {
-				t.Errorf("An error occurred: %v", err)
-			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("StripDefaultPorts() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 func TestGetImagePullPolicy(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Why the changes were made

While working on https://github.com/migtools/oadp-non-admin/issues/37, I will need to add `oadp-operator` as a import in `oadp-non-admin`. In my first test, while I just need to import `api/v1alpha1`, I noticed `github.com/aws/aws-sdk-go` was being added to `oadp-non-admin`'s `go.mod`. On inspecting I saw this:
```
github.com/aws/aws-sdk-go
This module is necessary because github.com/aws/aws-sdk-go/aws/request is imported in:

- github.com/migtools/oadp-non-admin/cmd
-- github.com/openshift/oadp-operator/api/v1alpha1
--- github.com/openshift/oadp-operator/pkg/common
```

This PR removes `github.com/aws/aws-sdk-go` from `pkg/common`

## How to test the changes made

Check that this change did not break any part.
