### PR TITLE
fix: NAC project domain

### DIFF
--- a/bundle/manifests/oadp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/oadp-operator.clusterserviceversion.yaml
@@ -5,23 +5,6 @@ metadata:
     alm-examples: |-
       [
         {
-          "apiVersion": "nac.oadp.openshift.io/v1alpha1",
-          "kind": "NonAdminBackup",
-          "metadata": {
-            "labels": {
-              "app.kubernetes.io/created-by": "oadp-operator",
-              "app.kubernetes.io/instance": "nonadminbackup-sample",
-              "app.kubernetes.io/managed-by": "kustomize",
-              "app.kubernetes.io/name": "nonadminbackup",
-              "app.kubernetes.io/part-of": "oadp-operator"
-            },
-            "name": "nonadminbackup-sample"
-          },
-          "spec": {
-            "backupSpec": {}
-          }
-        },
-        {
           "apiVersion": "oadp.openshift.io/v1alpha1",
           "kind": "DataProtectionApplication",
           "metadata": {
@@ -72,6 +55,23 @@ metadata:
                 }
               }
             ]
+          }
+        },
+        {
+          "apiVersion": "oadp.openshift.io/v1alpha1",
+          "kind": "NonAdminBackup",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/created-by": "oadp-operator",
+              "app.kubernetes.io/instance": "nonadminbackup-sample",
+              "app.kubernetes.io/managed-by": "kustomize",
+              "app.kubernetes.io/name": "nonadminbackup",
+              "app.kubernetes.io/part-of": "oadp-operator"
+            },
+            "name": "nonadminbackup-sample"
+          },
+          "spec": {
+            "backupSpec": {}
           }
         },
         {
@@ -420,7 +420,7 @@ spec:
     - description: NonAdminBackup is the Schema for the nonadminbackups API
       displayName: Non Admin Backup
       kind: NonAdminBackup
-      name: nonadminbackups.nac.oadp.openshift.io
+      name: nonadminbackups.oadp.openshift.io
       version: v1alpha1
     - description: A velero pod volume backup is a restic backup of persistent volumes
         attached to a running pod.
@@ -604,7 +604,7 @@ spec:
       clusterPermissions:
       - rules:
         - apiGroups:
-          - nac.oadp.openshift.io
+          - oadp.openshift.io
           resources:
           - nonadminbackups
           verbs:
@@ -616,13 +616,13 @@ spec:
           - update
           - watch
         - apiGroups:
-          - nac.oadp.openshift.io
+          - oadp.openshift.io
           resources:
           - nonadminbackups/finalizers
           verbs:
           - update
         - apiGroups:
-          - nac.oadp.openshift.io
+          - oadp.openshift.io
           resources:
           - nonadminbackups/status
           verbs:

--- a/bundle/manifests/oadp.openshift.io_nonadminbackups.yaml
+++ b/bundle/manifests/oadp.openshift.io_nonadminbackups.yaml
@@ -4,9 +4,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
   creationTimestamp: null
-  name: nonadminbackups.nac.oadp.openshift.io
+  name: nonadminbackups.oadp.openshift.io
 spec:
-  group: nac.oadp.openshift.io
+  group: oadp.openshift.io
   names:
     kind: NonAdminBackup
     listKind: NonAdminBackupList

--- a/config/crd/bases/oadp.openshift.io_nonadminbackups.yaml
+++ b/config/crd/bases/oadp.openshift.io_nonadminbackups.yaml
@@ -4,9 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-  name: nonadminbackups.nac.oadp.openshift.io
+  name: nonadminbackups.oadp.openshift.io
 spec:
-  group: nac.oadp.openshift.io
+  group: oadp.openshift.io
   names:
     kind: NonAdminBackup
     listKind: NonAdminBackupList

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -17,7 +17,7 @@ resources:
 - bases/velero.io_schedules.yaml
 - bases/velero.io_serverstatusrequests.yaml
 - bases/velero.io_volumesnapshotlocations.yaml
-- bases/nac.oadp.openshift.io_nonadminbackups.yaml
+- bases/oadp.openshift.io_nonadminbackups.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
 patchesStrategicMerge:

--- a/config/manifests/bases/oadp-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/oadp-operator.clusterserviceversion.yaml
@@ -404,7 +404,7 @@ spec:
     - description: NonAdminBackup is the Schema for the nonadminbackups API
       displayName: Non Admin Backup
       kind: NonAdminBackup
-      name: nonadminbackups.nac.oadp.openshift.io
+      name: nonadminbackups.oadp.openshift.io
       version: v1alpha1
   description: |
     **OpenShift API for Data Protection (OADP)** operator sets up and installs

--- a/config/non-admin-controller_rbac/role.yaml
+++ b/config/non-admin-controller_rbac/role.yaml
@@ -5,7 +5,7 @@ metadata:
   name: non-admin-controller-role
 rules:
 - apiGroups:
-  - nac.oadp.openshift.io
+  - oadp.openshift.io
   resources:
   - nonadminbackups
   verbs:
@@ -17,13 +17,13 @@ rules:
   - update
   - watch
 - apiGroups:
-  - nac.oadp.openshift.io
+  - oadp.openshift.io
   resources:
   - nonadminbackups/finalizers
   verbs:
   - update
 - apiGroups:
-  - nac.oadp.openshift.io
+  - oadp.openshift.io
   resources:
   - nonadminbackups/status
   verbs:

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -12,5 +12,5 @@ resources:
 - schedule.yaml
 - serverstatusrequest.yaml
 - volumesnapshotlocation.yaml
-- nac_v1alpha1_nonadminbackup.yaml
+- oadp_v1alpha1_nonadminbackup.yaml
 #+kubebuilder:scaffold:manifestskustomizesamples

--- a/config/samples/oadp_v1alpha1_nonadminbackup.yaml
+++ b/config/samples/oadp_v1alpha1_nonadminbackup.yaml
@@ -1,4 +1,4 @@
-apiVersion: nac.oadp.openshift.io/v1alpha1
+apiVersion: oadp.openshift.io/v1alpha1
 kind: NonAdminBackup
 metadata:
   labels:


### PR DESCRIPTION
## Why the changes were made

OADP Operator is responsible for installing the NAC CRDs, using oadp as a group makes it clear that the CRD/resource is part of the OADP ecosystem.

## How to test the changes made

Check all places where changed (`grep -Inr "nac.oadp.openshift.io" .`)

Follow [install-from-source](https://github.com/migtools/oadp-non-admin/blob/master/docs/CONTRIBUTING.md#install-from-source) NAC testing documentation, pointing my NAC fork branch [`fix/project-domain`](https://github.com/mateusoliveira43/oadp-non-admin/tree/fix/project-domain) and this branch.
