### PR TITLE
Fix OADP-5183: Ensure containers are all using FallbackToLogsOnError in terminationMessagePolicy

### DIFF
--- a/bundle/manifests/oadp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/oadp-operator.clusterserviceversion.yaml
@@ -972,6 +972,7 @@ spec:
                     path: /healthz
                     port: 8081
                   periodSeconds: 10
+                terminationMessagePolicy: FallbackToLogsOnError
                 volumeMounts:
                 - mountPath: /var/run/secrets/openshift/serviceaccount
                   name: bound-sa-token

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -67,6 +67,7 @@ spec:
         image: controller:latest
         imagePullPolicy: Always
         name: manager
+        terminationMessagePolicy: FallbackToLogsOnError
         securityContext:
           allowPrivilegeEscalation: false
         startupProbe:

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -14,7 +14,7 @@ func setContainerDefaults(container *corev1.Container) {
 		container.TerminationMessagePath = "/dev/termination-log"
 	}
 	if container.TerminationMessagePolicy == "" {
-		container.TerminationMessagePolicy = corev1.TerminationMessageReadFile
+		container.TerminationMessagePolicy = corev1.TerminationMessageFallbackToLogsOnError
 	}
 	for i := range container.Ports {
 		if container.Ports[i].Protocol == "" {

--- a/controllers/nodeagent_test.go
+++ b/controllers/nodeagent_test.go
@@ -294,7 +294,7 @@ func createTestBuiltNodeAgentDaemonSet(options TestBuiltNodeAgentDaemonSetOption
 							Image:                    common.VeleroImage,
 							ImagePullPolicy:          corev1.PullAlways,
 							TerminationMessagePath:   "/dev/termination-log",
-							TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+							TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 							SecurityContext:          &corev1.SecurityContext{Privileged: ptr.To(true)},
 							Ports: []corev1.ContainerPort{
 								{

--- a/controllers/nonadmin_controller.go
+++ b/controllers/nonadmin_controller.go
@@ -163,10 +163,11 @@ func ensureRequiredSpecs(deploymentObject *appsv1.Deployment, image string, imag
 	nonAdminContainerFound := false
 	if len(deploymentObject.Spec.Template.Spec.Containers) == 0 {
 		deploymentObject.Spec.Template.Spec.Containers = []corev1.Container{{
-			Name:            nonAdminObjectName,
-			Image:           image,
-			ImagePullPolicy: imagePullPolicy,
-			Env:             []corev1.EnvVar{namespaceEnvVar},
+			Name:                     nonAdminObjectName,
+			Image:                    image,
+			ImagePullPolicy:          imagePullPolicy,
+			Env:                      []corev1.EnvVar{namespaceEnvVar},
+			TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 		}}
 		nonAdminContainerFound = true
 	} else {

--- a/controllers/nonadmin_controller.go
+++ b/controllers/nonadmin_controller.go
@@ -176,6 +176,7 @@ func ensureRequiredSpecs(deploymentObject *appsv1.Deployment, image string, imag
 				nonAdminContainer.Image = image
 				nonAdminContainer.ImagePullPolicy = imagePullPolicy
 				nonAdminContainer.Env = []corev1.EnvVar{namespaceEnvVar}
+				nonAdminContainer.TerminationMessagePolicy = corev1.TerminationMessageFallbackToLogsOnError
 				nonAdminContainerFound = true
 				break
 			}

--- a/controllers/velero.go
+++ b/controllers/velero.go
@@ -425,7 +425,7 @@ func (r *DPAReconciler) appendPluginSpecificSpecs(veleroDeployment *appsv1.Deplo
 					ImagePullPolicy:          imagePullPolicy,
 					Resources:                init_container_resources,
 					TerminationMessagePath:   "/dev/termination-log",
-					TerminationMessagePolicy: "File",
+					TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							MountPath: "/target",
@@ -494,7 +494,7 @@ func (r *DPAReconciler) appendPluginSpecificSpecs(veleroDeployment *appsv1.Deplo
 					ImagePullPolicy:          imagePullPolicy,
 					Resources:                init_container_resources,
 					TerminationMessagePath:   "/dev/termination-log",
-					TerminationMessagePolicy: "File",
+					TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							MountPath: "/target",

--- a/controllers/velero_test.go
+++ b/controllers/velero_test.go
@@ -124,7 +124,7 @@ var (
 			},
 		},
 		TerminationMessagePath:   "/dev/termination-log",
-		TerminationMessagePolicy: "File",
+		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 		VolumeMounts: []corev1.VolumeMount{
 			{MountPath: "/target", Name: "plugins"},
 		},
@@ -385,7 +385,7 @@ func createTestBuiltVeleroDeployment(options TestBuiltVeleroDeploymentOptions) *
 							Image:                    common.VeleroImage,
 							ImagePullPolicy:          corev1.PullAlways,
 							TerminationMessagePath:   "/dev/termination-log",
-							TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+							TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 							Ports: []corev1.ContainerPort{{
 								Name:          "metrics",
 								ContainerPort: 8085,


### PR DESCRIPTION
## Why the changes were made

<!-- Explain why this PR is important, what problems it fixes, link related issues -->

Ensure containers are all using FallbackToLogsOnError in terminationMessagePolicy

Related JIRA: https://issues.redhat.com/browse/OADP-5183

## How to test the changes made

<!-- Explain how the changes introduced by this PR can be tested and verified, with commands and pictures -->

- Install Operator and create basic DPA deploying Velero, Node-Agent and NAC Pods, alongside the OADP Operator pod in install NS
- Use the Certsuite tool to test the changes: https://github.com/redhat-best-practices-for-k8s/certsuite 
- You need to check wether the PR changes pass for the observability test: `observability-termination-policy`
- Follow the setup docs: https://redhat-best-practices-for-k8s.github.io/certsuite/configuration/ 
- And then run the relevant test for our pods, For this PR to be tested, run: 
```
spampatt@spampatt-mac certsuite [main]$ ./certsuite run -l "observability-termination-policy" -c certsuite_config.yml
```
- You can see results under the `results/` (logs, results html etc)
- Should look like:
<img width="1572" alt="Screenshot 2024-11-13 at 5 07 05 PM" src="https://github.com/user-attachments/assets/c9ea266e-ed95-4cd7-b299-6bd4bb51372f">

