### PR TITLE
Fix deploy-olm failing on docker build without `--load`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -240,7 +240,7 @@ ifneq ($(CLUSTER_TYPE),)
 	DOCKER_BUILD_ARGS = --platform=$(CLUSTER_OS)/$(CLUSTER_ARCH)
 endif
 docker-build: ## Build docker image with the manager.
-	$(CONTAINER_TOOL) build -t $(IMG) . $(DOCKER_BUILD_ARGS)
+	$(CONTAINER_TOOL) build --load -t $(IMG) . $(DOCKER_BUILD_ARGS)
 
 docker-push: ## Push docker image with the manager.
 	$(CONTAINER_TOOL) push ${IMG}
@@ -384,7 +384,7 @@ nullable-crds-config:
 
 .PHONY: bundle-build
 bundle-build: ## Build the bundle image.
-	$(CONTAINER_TOOL) build -f bundle.Dockerfile -t $(BUNDLE_IMG) . $(DOCKER_BUILD_ARGS)
+	$(CONTAINER_TOOL) build --load -f bundle.Dockerfile -t $(BUNDLE_IMG) . $(DOCKER_BUILD_ARGS)
 
 .PHONY: bundle-push
 bundle-push: ## Push the bundle image.


### PR DESCRIPTION
## Why the changes were made
This is because docker build has become aliased to docker buildx build whose default no longer load build result to docker images which mean subsequent call to `docker-push` target fails, such as when `make deploy-olm`
<!-- Explain why this PR is important, what problems it fixes, link related issues -->

We are getting rid of error highlighted in red like below.
```diff
WARNING: No output specified with docker-container driver. Build result will only remain in the build cache. To push result image into registry use --push or to load image into docker use --load
/Applications/Xcode.app/Contents/Developer/usr/bin/make docker-push IMG=ttl.sh/oadp-operator-bundle-a5cd6de2:1h
docker push ttl.sh/oadp-operator-bundle-a5cd6de2:1h
-Error response from daemon: failed to find image ttl.sh/oadp-operator-bundle-a5cd6de2:1h: ttl.sh/oadp-operator-bundle-a5cd6de2:1h: image not known
-make[2]: *** [docker-push] Error 1
-make[1]: *** [bundle-push] Error 2
```

https://docs.docker.com/reference/cli/docker/buildx/build/#load

## How to test the changes made

checkout and see that podman build can also accept this param and not fail. (I did, it worked.)
