### PR TITLE
OADP future releases and versions

### DIFF
--- a/PARTNERS.md
+++ b/PARTNERS.md
@@ -48,6 +48,7 @@ to OCP 4.19.
 
 **Note:** This automatic upgrade will also be supported from OCP 4.18 to OCP 4.20.
 
+```mermaid
 sequenceDiagram
     participant Customer
     participant OCP 4.18
@@ -67,9 +68,11 @@ sequenceDiagram
     OADP 1.5-->>Customer: Running on 4.19 with OADP-1.5
 
     Note over Customer: Automatic upgrade complete
+```
 
 ### Customer upgrades to OCP 4.19 while on OADP's stable-1.4 channel
 
+```mermaid
 sequenceDiagram
     participant Customer
     participant OCP 4.18
@@ -88,6 +91,7 @@ sequenceDiagram
     OADP 1.5-->>Customer: Running on 4.19 with OADP-1.5
 
     Note over Customer:  Upgrade complete
+```
 
 ### Customer attempts a manual upgrade to OADP 1.5.x while on OCP 4.18
 

--- a/PARTNERS.md
+++ b/PARTNERS.md
@@ -1,7 +1,9 @@
 # OADP Partner Information
 
 ## Important Announcement: Version Support Changes
-Starting in 2025, OADP will implement a streamlined version support policy. Red Hat will support only one version of OADP per OpenShift version to ensure better stability and maintainability.
+Starting in 2025, OADP will implement a streamlined version support policy. 
+Red Hat will support only one version of OADP per OpenShift version to ensure 
+better stability and maintainability.
 
 ## Version Mapping
 
@@ -12,7 +14,7 @@ Starting in 2025, OADP will implement a streamlined version support policy. Red 
 | 4.15              | 1.3, 1.4     | v1.12, v1.14   | released                      |
 | 4.16              | 1.4          | v1.14          | released                      | 
 | 4.17              | 1.4          | v1.14          | released                      |
-| 4.18              | 1.4          | v1.14          | Q1 2025                       |
+| 4.18              | 1.4          | v1.14          | released                      |
 | 4.19              | 1.5          | v1.16          | Q2 2025                       |
 | 4.20              | 1.5          | v1.16          | Q4 2025                       |
 | 4.21              | 1.6          | v1.18          | Q1 2026                       |
@@ -20,8 +22,13 @@ Starting in 2025, OADP will implement a streamlined version support policy. Red 
 * [1] Release timelines are estimates,and versions are subject to change.
 
 ## Impact on Partners
-- Partners must align their integration testing with the specific OADP version corresponding to their target OpenShift version
-    - Unreleased OADP builds are available via the branches of this oadp-operator repository.  The next release will be available for install via the `master` branch until such time the next release branch is created, the `oadp-1.<version>` branch will be made available for install.
+- Partners must align their integration testing with the specific OADP version corresponding 
+to their target OpenShift version
+    - Unreleased OADP builds are available via the branches of this oadp-operator 
+    repository.  The next release will be available for install via the `master` 
+    branch until such time the next release branch is created, the `oadp-1.<version>+1` 
+    branch will be made available for install.
+     - latest branched version is [oadp-1.4](https://github.com/openshift/oadp-operator/tree/oadp-1.4)
 
 ## Action Items for Partners
 1. Update your test matrices to reflect the new version pairing strategy
@@ -34,41 +41,11 @@ Starting in 2025, OADP will implement a streamlined version support policy. Red 
 - [Red Hat Partner Program](https://connect.redhat.com/)
 - [Contact Red Hat Support](https://access.redhat.com/support)
 
----
-Last Updated: November 2024
-
-Note: Release timelines are subject to change.
-
 
 ## Upgrade workflow
 ### Automatic upgrade: 
 
-While customers are on OCP 4.18, they can update the channel to stable and the operator will automatically upgrade to OADP 1.5.x when the cluster is upgraded 
-to OCP 4.19.
-
-**Note:** This automatic upgrade will also be supported from OCP 4.18 to OCP 4.20.
-
-```mermaid
-sequenceDiagram
-    participant Customer
-    participant OCP 4.18
-    participant OCP 4.19
-    participant OADP 1.4
-    participant OADP 1.5
-
-    Note over OADP 1.5: Version 1.5.0 requires >= OCP 4.19
-    Note over Customer,OCP 4.18: Customer has OADP 1.4.x installed...
-    Note over Customer,OCP 4.18: Customer updates channel to stable
-
-
-    Customer->>OCP 4.18: Initiate OCP upgrade
-    OCP 4.18->>OCP 4.19: Upgrade cluster
-    OCP 4.19->>OLM: Reports new version 4.19
-    OLM->>OADP 1.5: Trigger automatic upgrade to OADP 1.5.x
-    OADP 1.5-->>Customer: Running on 4.19 with OADP-1.5
-
-    Note over Customer: Automatic upgrade complete
-```
+Automatic upgrades are expected to be available in OADP 1.6.0 once OADP can move from sqllite catalogs to [file based catalogs](https://olm.operatorframework.io/docs/reference/file-based-catalogs/).
 
 ### Customer upgrades to OCP 4.19 while on OADP's stable-1.4 channel
 
@@ -92,9 +69,7 @@ sequenceDiagram
 
     Note over Customer:  Upgrade complete
 ```
+---
+Last Updated: March 2025
 
-### Customer attempts a manual upgrade to OADP 1.5.x while on OCP 4.18
-
-Even though both OADP 1.4.x and OADP 1.5.x will be available via the *stable* 
-channel, a customer will not see OADP 1.5.x listed as an available version 
-to upgrade to.  
+Note: Release timelines are subject to change.

--- a/PARTNERS.md
+++ b/PARTNERS.md
@@ -1,0 +1,49 @@
+# OADP Partner Information
+
+## Important Announcement: Version Support Changes
+Starting in 2024, OADP will implement a streamlined version support policy. Red Hat will support only one version of OADP per OpenShift version to ensure better stability and maintainability.
+
+## Version Mapping
+
+### Current and Planned Supported Versions
+| OpenShift Version | OADP Version | Velero Version |
+|-------------------|--------------|----------------|
+| 4.22             | 1.6          | v1.18          |
+| 4.21             | 1.6          | v1.18          |
+| 4.20             | 1.5          | v1.16          |
+| 4.19             | 1.5          | v1.16          |
+| 4.18             | 1.4          | v1.14          |
+| 4.17             | 1.4          | v1.14          |
+| 4.16             | 1.4          | v1.14          |
+| 4.15             | 1.3, 1.4     | v1.12, v1.14    |
+| 4.14             | 1.3, 1.4     | v1.12, v1.14   |
+
+
+### Future Release Planning
+| OpenShift Version | Planned OADP Version | Estimated Release Timeline |
+|-------------------|---------------------|-------------------------|
+| 4.18             | 1.4                 | Q1 2024                |
+| 4.19             | 1.5                 | Q3 2025                |
+| 4.20             | 1.5                 | Q1 2026                |
+| 4.21             | 1.6                 | Q3 2026                |
+| 4.22             | 1.6                 | Q1 2026                |
+
+## Impact on Partners
+- Partners must align their integration testing with the specific OADP version corresponding to their target OpenShift version
+    - Unreleased OADP builds are available via the branches of this oadp-operator repository.  The next release will be available for install via the `master` branch until such time the next release branch is created, the `oadp-1.5` branch will be made available for install.
+
+## Action Items for Partners
+1. Update your test matrices to reflect the new version pairing strategy
+2. Determine if installing development builds from the openshift git repository is acceptable for testing and certification efforts.  If a downstream build is required, please contact your Red Hat partner manager for guidance.
+3. Update documentation to reflect supported version combinations
+4. Communicate these changes to customers using your backup solutions
+
+
+## Additional Resources
+- [Red Hat Partner Program](https://connect.redhat.com/)
+- [Contact Red Hat Support](https://access.redhat.com/support)
+
+---
+Last Updated: November 2024
+
+Note: Release timelines are subject to change.

--- a/PARTNERS.md
+++ b/PARTNERS.md
@@ -62,7 +62,7 @@ sequenceDiagram
 
     Customer->>OCP 4.18: Initiate OCP upgrade
     OCP 4.18->>OCP 4.19: Upgrade cluster
-    OCP 4.19->>OADP 1.4: OADP 1.4 is not supported, DPA moves to error state
+    OCP 4.19->>OADP 1.4: OADP 1.4 is not supported on OCP 4.19
     Customer->>OCP 4.19: Customer updates channel from stable 1.4 to stable
     OLM->>OADP 1.5: Manual or Automatic upgrade to OADP 1.5.x
     OADP 1.5-->>Customer: Running on 4.19 with OADP-1.5

--- a/PARTNERS.md
+++ b/PARTNERS.md
@@ -6,31 +6,22 @@ Starting in 2025, OADP will implement a streamlined version support policy. Red 
 ## Version Mapping
 
 ### Current and Planned Supported Versions
-| OpenShift Version | OADP Version | Velero Version |
-|-------------------|--------------|----------------|
-| 4.22             | 1.6          | v1.18          |
-| 4.21             | 1.6          | v1.18          |
-| 4.20             | 1.5          | v1.16          |
-| 4.19             | 1.5          | v1.16          |
-| 4.18             | 1.4          | v1.14          |
-| 4.17             | 1.4          | v1.14          |
-| 4.16             | 1.4          | v1.14          |
-| 4.15             | 1.3, 1.4     | v1.12, v1.14    |
-| 4.14             | 1.3, 1.4     | v1.12, v1.14   |
+| OpenShift Version | OADP Version | Velero Version | Estimated Release Timeline [1]|
+|-------------------|--------------|----------------|-------------------------------|
+| 4.14              | 1.3, 1.4     | v1.12, v1.14   | released                      |
+| 4.15              | 1.3, 1.4     | v1.12, v1.14   | released                      |
+| 4.16              | 1.4          | v1.14          | released                      | 
+| 4.17              | 1.4          | v1.14          | released                      |
+| 4.18              | 1.4          | v1.14          | Q1 2025                       |
+| 4.19              | 1.5          | v1.16          | Q3 2025                       |
+| 4.20              | 1.5          | v1.16          | Q1 2026                       |
+| 4.21              | 1.6          | v1.18          | Q3 2026                       |
 
-
-### Future Release Planning
-| OpenShift Version | Planned OADP Version | Estimated Release Timeline |
-|-------------------|---------------------|-------------------------|
-| 4.18             | 1.4                 | Q1 2025                |
-| 4.19             | 1.5                 | Q3 2025                |
-| 4.20             | 1.5                 | Q1 2026                |
-| 4.21             | 1.6                 | Q3 2026                |
-| 4.22             | 1.6                 | Q1 2027                |
+* [1] Release timelines and versions are subject to change.
 
 ## Impact on Partners
 - Partners must align their integration testing with the specific OADP version corresponding to their target OpenShift version
-    - Unreleased OADP builds are available via the branches of this oadp-operator repository.  The next release will be available for install via the `master` branch until such time the next release branch is created, the `oadp-1.5` branch will be made available for install.
+    - Unreleased OADP builds are available via the branches of this oadp-operator repository.  The next release will be available for install via the `master` branch until such time the next release branch is created, the `oadp-1.<version>` branch will be made available for install.
 
 ## Action Items for Partners
 1. Update your test matrices to reflect the new version pairing strategy

--- a/PARTNERS.md
+++ b/PARTNERS.md
@@ -26,7 +26,7 @@ Starting in 2024, OADP will implement a streamlined version support policy. Red 
 | 4.19             | 1.5                 | Q3 2025                |
 | 4.20             | 1.5                 | Q1 2026                |
 | 4.21             | 1.6                 | Q3 2026                |
-| 4.22             | 1.6                 | Q1 2026                |
+| 4.22             | 1.6                 | Q1 2027                |
 
 ## Impact on Partners
 - Partners must align their integration testing with the specific OADP version corresponding to their target OpenShift version

--- a/PARTNERS.md
+++ b/PARTNERS.md
@@ -38,3 +38,59 @@ Starting in 2025, OADP will implement a streamlined version support policy. Red 
 Last Updated: November 2024
 
 Note: Release timelines are subject to change.
+
+
+## Upgrade workflow
+### Automatic upgrade: 
+
+While customers are on OCP 4.18, they can update the channel to stable and the operator will automatically upgrade to OADP 1.5.x when the cluster is upgraded 
+to OCP 4.19.
+
+**Note:** This automatic upgrade will also be supported from OCP 4.18 to OCP 4.20.
+
+sequenceDiagram
+    participant Customer
+    participant OCP 4.18
+    participant OCP 4.19
+    participant OADP 1.4
+    participant OADP 1.5
+
+    Note over OADP 1.5: Version 1.5.0 requires >= OCP 4.19
+    Note over Customer,OCP 4.18: Customer has OADP 1.4.x installed...
+    Note over Customer,OCP 4.18: Customer updates channel to stable
+
+
+    Customer->>OCP 4.18: Initiate OCP upgrade
+    OCP 4.18->>OCP 4.19: Upgrade cluster
+    OCP 4.19->>OLM: Reports new version 4.19
+    OLM->>OADP 1.5: Trigger automatic upgrade to OADP 1.5.x
+    OADP 1.5-->>Customer: Running on 4.19 with OADP-1.5
+
+    Note over Customer: Automatic upgrade complete
+
+### Customer upgrades to OCP 4.19 while on OADP's stable-1.4 channel
+
+sequenceDiagram
+    participant Customer
+    participant OCP 4.18
+    participant OCP 4.19
+    participant OADP 1.4
+    participant OADP 1.5
+
+    Note over OADP 1.5: Version 1.5.0 requires >= OCP 4.19
+    Note over Customer,OCP 4.19: Customer has OADP 1.4.x installed...
+
+    Customer->>OCP 4.18: Initiate OCP upgrade
+    OCP 4.18->>OCP 4.19: Upgrade cluster
+    OCP 4.19->>OADP 1.4: OADP 1.4 is not supported, DPA moves to error state
+    Customer->>OCP 4.19: Customer updates channel from stable 1.4 to stable
+    OLM->>OADP 1.5: Manual or Automatic upgrade to OADP 1.5.x
+    OADP 1.5-->>Customer: Running on 4.19 with OADP-1.5
+
+    Note over Customer:  Upgrade complete
+
+### Customer attempts a manual upgrade to OADP 1.5.x while on OCP 4.18
+
+Even though both OADP 1.4.x and OADP 1.5.x will be available via the *stable* 
+channel, a customer will not see OADP 1.5.x listed as an available version 
+to upgrade to.  

--- a/PARTNERS.md
+++ b/PARTNERS.md
@@ -22,7 +22,7 @@ Starting in 2024, OADP will implement a streamlined version support policy. Red 
 ### Future Release Planning
 | OpenShift Version | Planned OADP Version | Estimated Release Timeline |
 |-------------------|---------------------|-------------------------|
-| 4.18             | 1.4                 | Q1 2024                |
+| 4.18             | 1.4                 | Q1 2025                |
 | 4.19             | 1.5                 | Q3 2025                |
 | 4.20             | 1.5                 | Q1 2026                |
 | 4.21             | 1.6                 | Q3 2026                |

--- a/PARTNERS.md
+++ b/PARTNERS.md
@@ -13,11 +13,11 @@ Starting in 2025, OADP will implement a streamlined version support policy. Red 
 | 4.16              | 1.4          | v1.14          | released                      | 
 | 4.17              | 1.4          | v1.14          | released                      |
 | 4.18              | 1.4          | v1.14          | Q1 2025                       |
-| 4.19              | 1.5          | v1.16          | Q3 2025                       |
-| 4.20              | 1.5          | v1.16          | Q1 2026                       |
-| 4.21              | 1.6          | v1.18          | Q3 2026                       |
+| 4.19              | 1.5          | v1.16          | Q2 2025                       |
+| 4.20              | 1.5          | v1.16          | Q4 2025                       |
+| 4.21              | 1.6          | v1.18          | Q1 2026                       |
 
-* [1] Release timelines and versions are subject to change.
+* [1] Release timelines are estimates,and versions are subject to change.
 
 ## Impact on Partners
 - Partners must align their integration testing with the specific OADP version corresponding to their target OpenShift version

--- a/PARTNERS.md
+++ b/PARTNERS.md
@@ -1,7 +1,7 @@
 # OADP Partner Information
 
 ## Important Announcement: Version Support Changes
-Starting in 2024, OADP will implement a streamlined version support policy. Red Hat will support only one version of OADP per OpenShift version to ensure better stability and maintainability.
+Starting in 2025, OADP will implement a streamlined version support policy. Red Hat will support only one version of OADP per OpenShift version to ensure better stability and maintainability.
 
 ## Version Mapping
 


### PR DESCRIPTION
## Why the changes were made

* OADP needs to better communicate version version pairings to customers and partners
* OADP needs to move to support only one version per OCP release to avoid olm install issues.

## Requirements for this change
* effective for OADP-1.5 on OCP 4.19 +

- [ ] Ensure upgrade works and is allowed ( generally ) 
  - [ ] Specifically 
    - [ ] 4.18 ->  4.19  and 4.18 -> 4.20
    - [ ] OADP-1.4 -> OADP-1.5
- [ ] CRD version bump check - [DPA, $other]
  - [ ] formal process / audit of CRD's to determine if a version bump is required. 
- [ ] [Deprecation](https://olm.operatorframework.io/docs/reference/file-based-catalogs/#olmdeprecations) notice OADP-1.4 on OCP 4.19
- [ ] Subscription Channel - map out channels and discuss.   Discuss channel name.
  - [ ] channel name is `stable`  

## How to test the changes made

read it! https://github.com/weshayutin/oadp-operator/blob/oadp_partner_versions/PARTNERS.md