### PR TITLE
Update manifests for the non-admin-backup #117 - Queue information

### DIFF
--- a/bundle/manifests/oadp.openshift.io_nonadminbackups.yaml
+++ b/bundle/manifests/oadp.openshift.io_nonadminbackups.yaml
@@ -619,6 +619,19 @@ spec:
                 - Created
                 - Deleting
                 type: string
+              queueInfo:
+                description: |-
+                  QueueInfo holds the queue position for a specific VeleroBackup.
+                  It is used to estimate how many backups are scheduled before the given VeleroBackup in the OADP namespace.
+                  This number is not guaranteed to be accurate, but it should be close. It's inaccurate for cases when
+                  Velero pod is not running or being restarted after Backup object were created.
+                  It counts only VeleroBackups that are still subject to be handled by OADP/Velero.
+                properties:
+                  estimatedQueuePosition:
+                    type: integer
+                required:
+                - estimatedQueuePosition
+                type: object
               veleroBackup:
                 description: VeleroBackup contains information of the related Velero
                   backup object.

--- a/config/crd/bases/oadp.openshift.io_nonadminbackups.yaml
+++ b/config/crd/bases/oadp.openshift.io_nonadminbackups.yaml
@@ -619,6 +619,19 @@ spec:
                 - Created
                 - Deleting
                 type: string
+              queueInfo:
+                description: |-
+                  QueueInfo holds the queue position for a specific VeleroBackup.
+                  It is used to estimate how many backups are scheduled before the given VeleroBackup in the OADP namespace.
+                  This number is not guaranteed to be accurate, but it should be close. It's inaccurate for cases when
+                  Velero pod is not running or being restarted after Backup object were created.
+                  It counts only VeleroBackups that are still subject to be handled by OADP/Velero.
+                properties:
+                  estimatedQueuePosition:
+                    type: integer
+                required:
+                - estimatedQueuePosition
+                type: object
               veleroBackup:
                 description: VeleroBackup contains information of the related Velero
                   backup object.


### PR DESCRIPTION
Update Non Admin manifests to include information about estimated queue position of the NAB objects.

## Why the changes were made

<!-- Explain why this PR is important, what problems it fixes, link related issues -->
To be compatible  with https://github.com/migtools/oadp-non-admin/pull/117


## How to test the changes made

<!-- Explain how the changes introduced by this PR can be tested and verified, with commands and pictures -->
Generated by `$ make update-non-admin-manifests`
