### PR TITLE
oadp-1.4: Fixes segmentation fault Container cross compile on macOS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # Build the manager binary
 FROM --platform=$BUILDPLATFORM quay.io/konveyor/builder:ubi9-latest AS builder
+ARG BUILDPLATFORM
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM quay.io/konveyor/builder:ubi9-latest AS builder
+FROM --platform=$BUILDPLATFORM quay.io/konveyor/builder:ubi9-latest AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/must-gather/Dockerfile
+++ b/must-gather/Dockerfile
@@ -1,15 +1,18 @@
-FROM quay.io/konveyor/builder:ubi9-v1.20 AS konveyor-builder
+FROM --platform=$BUILDPLATFORM quay.io/konveyor/builder:ubi9-v1.20 AS konveyor-builder
+ARG BUILDPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
 ARG RESTIC_BRANCH=konveyor-0.15.0
 ARG VELERO_BRANCH=konveyor-dev
 WORKDIR /build
 RUN curl --location --output velero.tgz https://github.com/openshift/velero/archive/refs/heads/${VELERO_BRANCH}.tar.gz && \
     tar -xzvf velero.tgz && cd velero-${VELERO_BRANCH} && \
     VELERO_COMMIT=$(git ls-remote https://github.com/openshift/velero HEAD | awk '{printf $1}') && \
-    CGO_ENABLED=0 GOOS=linux go build -a -mod=mod -ldflags '-extldflags "-static" -X github.com/vmware-tanzu/velero/pkg/buildinfo.Version='"${VELERO_BRANCH}"' -X github.com/vmware-tanzu/velero/pkg/buildinfo.GitSHA='"${VELERO_COMMIT}" -o /velero github.com/vmware-tanzu/velero/cmd/velero && \
+    CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -mod=mod -ldflags '-extldflags "-static" -X github.com/vmware-tanzu/velero/pkg/buildinfo.Version='"${VELERO_BRANCH}"' -X github.com/vmware-tanzu/velero/pkg/buildinfo.GitSHA='"${VELERO_COMMIT}" -o /velero github.com/vmware-tanzu/velero/cmd/velero && \
     cd .. && rm -rf velero.tgz velero-${VELERO_BRANCH} && \
     curl --location --output restic.tgz https://github.com/openshift/restic/archive/refs/heads/${RESTIC_BRANCH}.tar.gz && \
     tar -xzvf restic.tgz && cd restic-${RESTIC_BRANCH} && \
-    CGO_ENABLED=0 GOOS=linux go build -a -mod=mod -ldflags '-extldflags "-static"' -o /restic github.com/restic/restic/cmd/restic && \
+    CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -mod=mod -ldflags '-extldflags "-static"' -o /restic github.com/restic/restic/cmd/restic && \
     cd .. && rm -rf restic.tgz restic-${RESTIC_BRANCH}
 
 FROM registry.access.redhat.com/ubi9/go-toolset:1.20.10 AS gobuilder


### PR DESCRIPTION
```sh
9.676 internal/bytealg: /opt/app-root/src/go/pkg/tool/linux_amd64/asm: signal: segmentation fault (core dumped)
12.78 cloud.google.com/go/storage/internal: /opt/app-root/src/go/pkg/tool/linux_amd64/compile: signal: segmentation fault (core dumped)
```

similar to fix seen at https://github.com/replicatedhq/local-volume-provider/pull/66/files#diff-5b6228cfe643850b0b1c8d2b5d69430bb121272e145b651c2ff6a85c23895b4eR1
for https://github.com/replicatedhq/local-volume-provider/pull/65#issuecomment-2452514633

Similar to #1489 

Signed-off-by: Tiger Kaovilai <tkaovila@redhat.com>

## Why the changes were made

<!-- Explain why this PR is important, what problems it fixes, link related issues -->

## How to test the changes made

<!-- Explain how the changes introduced by this PR can be tested and verified, with commands and pictures -->
