### PR TITLE
OADP-5362: Create or update CredentialsRequests to prevent outdated roleArn

### DIFF
--- a/bundle/manifests/oadp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/oadp-operator.clusterserviceversion.yaml
@@ -737,6 +737,8 @@ spec:
           - credentialsrequests
           verbs:
           - create
+          - update
+          - get
         - apiGroups:
           - oadp.openshift.io
           resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -20,6 +20,8 @@ rules:
   - credentialsrequests
   verbs:
   - create
+  - update
+  - get
 - apiGroups:
   - oadp.openshift.io
   resources:


### PR DESCRIPTION
Signed-off-by: Tiger Kaovilai <tkaovila@redhat.com>

## Why the changes were made

<!-- Explain why this PR is important, what problems it fixes, link related issues -->
Previously, Uninstalling operator, installing again with corrected role arn creates operator subscription with corrected rolearn but the credentialRequests in the cluster still contains outdated roleArn
This fixes the prior behavior by adding update calls to credentialsRequest
## How to test the changes made

<!-- Explain how the changes introduced by this PR can be tested and verified, with commands and pictures -->
Install ROSA STS cluster and install operator from operatorhub supply roleArn1 when installing from web console.
Uninstall operator and reinstall with roleArn2
replace CSV operator container with `ghcr.io/kaovilai/oadp-operator:createOrUpdateCredRequests`
Observe than secret cloud-credentials contains roleArn2.
