### PR TITLE
OADP-1338: Show more DPA info with 'oc get'

### DIFF
--- a/api/v1alpha1/oadp_types.go
+++ b/api/v1alpha1/oadp_types.go
@@ -603,6 +603,8 @@ type DataProtectionApplicationStatus struct {
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 //+kubebuilder:resource:path=dataprotectionapplications,shortName=dpa
+// +kubebuilder:printcolumn:name="Reconciled",type="string",JSONPath=".status.conditions[0].status",description="DataProtectionApplication Reconciled status"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="DataProtectionApplication creation timestamp"
 
 // DataProtectionApplication is the Schema for the dpa API
 type DataProtectionApplication struct {

--- a/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
@@ -16,7 +16,16 @@ spec:
     singular: dataprotectionapplication
   scope: Namespaced
   versions:
-    - name: v1alpha1
+    - additionalPrinterColumns:
+        - description: DataProtectionApplication Reconciled status
+          jsonPath: .status.conditions[0].status
+          name: Reconciled
+          type: string
+        - description: DataProtectionApplication creation timestamp
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha1
       schema:
         openAPIV3Schema:
           description: DataProtectionApplication is the Schema for the dpa API

--- a/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
@@ -16,7 +16,16 @@ spec:
     singular: dataprotectionapplication
   scope: Namespaced
   versions:
-    - name: v1alpha1
+    - additionalPrinterColumns:
+        - description: DataProtectionApplication Reconciled status
+          jsonPath: .status.conditions[0].status
+          name: Reconciled
+          type: string
+        - description: DataProtectionApplication creation timestamp
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha1
       schema:
         openAPIV3Schema:
           description: DataProtectionApplication is the Schema for the dpa API

--- a/docs/install_olm.md
+++ b/docs/install_olm.md
@@ -91,16 +91,13 @@ spec:
 
 * Verify the DPA has been reconciled successfully:
 
-  ```
-  oc get dpa dpa-sample -n openshift-adp -o jsonpath='{.status}'
-  ```
-
-  Example Output:
-  ```
-  {"conditions":[{"lastTransitionTime":"2023-10-27T01:23:57Z","message":"Reconcile complete","reason":"Complete","status":"True","type":"Reconciled"}]}
+  ```console
+  $ oc get dpa dpa-sample -n openshift-adp
+  NAME            RECONCILED   AGE
+  dpa-sample      True         2m51s
   ```
 
-  **Note**: the `type` is set to `Reconciled` and `status` is set to `True`.
+  **Note**: `RECONCILED` column must be `True`.
 
 * To verify all of the correct resources have been created, the following command
 `oc get all -n openshift-adp` should look similar to:


### PR DESCRIPTION
## Why the changes were made

Improve users experience.

## How to test the changes made

Install OADP from master and this branch and compare `oc get dpa` outputs.

On master branch, you should see something like this
```console
$ oc get dpa -n openshift-adp
NAME            AGE
velero-sample   2m6s
```

And on this branch, you should see something like this
```console
$ oc get dpa -n openshift-adp
NAME            RECONCILED   AGE
velero-sample   True         2m51s
```

> **Warning:** if more conditions are added to DPA, this solution may break. My advise is to change DPA status to have reconciled information as a fixed field, like Backup status phase