### PR TITLE
add a blockmode version of 3csivol

### DIFF
--- a/tests/e2e/sample-applications/minimal-8csivol/build/minimal-block-3csivol/Dockerfile
+++ b/tests/e2e/sample-applications/minimal-8csivol/build/minimal-block-3csivol/Dockerfile
@@ -1,0 +1,7 @@
+FROM fedora
+USER root
+RUN dnf install -y e2fsprogs
+RUN mkdir -p /mnt/volume1
+RUN mkdir -p /mnt/volume2
+RUN mkdir -p /mnt/volume3
+USER 1001

--- a/tests/e2e/sample-applications/minimal-8csivol/minimal-block-3csivol.yaml
+++ b/tests/e2e/sample-applications/minimal-8csivol/minimal-block-3csivol.yaml
@@ -1,0 +1,143 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: minimal-block-3csivol
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: minimal-block-3csivol-sa
+  namespace: minimal-block-3csivol
+---
+# the command `oc adm policy add-scc-to-user privileged -z default -n minimal-block-3csivol
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: default-privileged-binding
+  namespace: minimal-block-3csivol
+subjects:
+- kind: ServiceAccount
+  name: default
+roleRef:
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minimal-block-3csivol
+  namespace: minimal-block-3csivol
+spec:
+  serviceAccountName: default
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minimal-block-3csivol
+  template:
+    metadata:
+      labels:
+        app: minimal-block-3csivol
+    spec:
+      containers:
+        - image: quay.io/migtools/3csivol-block2:latest
+          resources:
+            requests:
+              cpu: 100m
+              memory: 100Mi
+            limits:
+              cpu: 100m
+              memory: 100Mi
+          name: setup-block-device
+          securityContext:
+            privileged: true
+            runAsUser: 0
+          command:
+            - "sh"
+            - "-c"
+            - |
+              ls -la /dev/xvdx*
+              for i in {1..3}; do
+                DEVICE="/dev/xvdx$i"
+                MOUNT_POINT="/mnt/volume$i"
+                if [ ! -e $DEVICE ]; then
+                  echo "$DEVICE does not exist."
+                  exit 1
+                fi
+                if dumpe2fs -h $DEVICE 2>/dev/null; then
+                  echo "Filesystem already exists on $DEVICE"
+                else
+                  echo "Formatting $DEVICE"
+                  mkfs.ext4 $DEVICE
+                  echo $?
+                fi
+                echo "Mounting $DEVICE in the $MOUNT_POINT"
+                mount $DEVICE $MOUNT_POINT
+                echo $?
+                echo $(date +%s) > $MOUNT_POINT/format_timestamp
+                dd if=/dev/zero of=$MOUNT_POINT/binary_$(date +%s).file bs=1024 count=1024
+              done
+              while true; do
+                ls -l /mnt/volume*/* | grep -v lost+found | grep -v total
+                sleep 10
+              done
+          volumeDevices:
+          - name:  block-volume-pv-1
+            devicePath: /dev/xvdx1
+          - name:  block-volume-pv-2
+            devicePath: /dev/xvdx2
+          - name:  block-volume-pv-3
+            devicePath: /dev/xvdx3
+      volumes:
+      - name: block-volume-pv-1
+        persistentVolumeClaim:
+          claimName: block-volume-pv-1
+          volumeMode: Block
+      - name: block-volume-pv-2
+        persistentVolumeClaim:
+          claimName: block-volume-pv-2
+          volumeMode: Block
+      - name: block-volume-pv-3
+        persistentVolumeClaim:
+          claimName: block-volume-pv-3
+          volumeMode: Block
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: block-volume-pv-1
+  namespace: minimal-block-3csivol
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+  volumeMode: Block
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: block-volume-pv-2
+  namespace: minimal-block-3csivol
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+  volumeMode: Block
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: block-volume-pv-3
+  namespace: minimal-block-3csivol
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+  volumeMode: Block


### PR DESCRIPTION
## Why the changes were made

Scott and I had the requirement to test blockMode volumes with datamover to inspect the path of the blockmode device on the nodeagent and node.

There is no need to add this to CI atm.

## How to test the changes made

oc create -f $file
