### PR TITLE
OADP-5470: skip VSL secret data check on credentialsFile

### DIFF
--- a/controllers/vsl.go
+++ b/controllers/vsl.go
@@ -300,6 +300,10 @@ func (r *DPAReconciler) ensureVslSecretDataExists(vsl *oadpv1alpha1.SnapshotLoca
 		}
 		// Check if the VSL secret key configured in the DPA exists with a secret data
 		if vsl.Velero != nil {
+			// if using credentialsFile return nil, don't check default secret data key
+			if vsl.Velero.Config[CredentialsFileKey] != "" {
+				return nil
+			}
 			_, _, err := r.getSecretNameAndKey(vsl.Velero.Config, vsl.Velero.Credential, oadpv1alpha1.DefaultPlugin(vsl.Velero.Provider))
 			if err != nil {
 				return err


### PR DESCRIPTION
Signed-off-by: Tiger Kaovilai <tkaovila@redhat.com>

## Why the changes were made
To fix [OADP-5470](https://issues.redhat.com//browse/OADP-5470)
<!-- Explain why this PR is important, what problems it fixes, link related issues -->

## How to test the changes made
Create DPA with VSL like in https://issues.redhat.com/browse/OADP-5470
<!-- Explain how the changes introduced by this PR can be tested and verified, with commands and pictures -->

Due to time constraints, we're going to start manually testing this patch and additional unit/e2e will be added in a follow up PR. 
