### PR TITLE
Update manifests for the OADP master to sync with oadp non-admin

### DIFF
--- a/bundle/manifests/oadp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/oadp-operator.clusterserviceversion.yaml
@@ -873,6 +873,58 @@ spec:
           - patch
           - update
         - apiGroups:
+          - oadp.openshift.io
+          resources:
+          - nonadminbackups
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - oadp.openshift.io
+          resources:
+          - nonadminbackups/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - oadp.openshift.io
+          resources:
+          - nonadminbackups/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - oadp.openshift.io
+          resources:
+          - nonadminrestores
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - oadp.openshift.io
+          resources:
+          - nonadminrestores/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - oadp.openshift.io
+          resources:
+          - nonadminrestores/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
           - route.openshift.io
           resources:
           - routes
@@ -908,6 +960,42 @@ spec:
           - velero.io
           resources:
           - '*'
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - velero.io
+          resources:
+          - backups
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - velero.io
+          resources:
+          - deletebackuprequests
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - velero.io
+          resources:
+          - restores
           verbs:
           - create
           - delete

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -154,6 +154,58 @@ rules:
   - patch
   - update
 - apiGroups:
+  - oadp.openshift.io
+  resources:
+  - nonadminbackups
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - oadp.openshift.io
+  resources:
+  - nonadminbackups/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - oadp.openshift.io
+  resources:
+  - nonadminbackups/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - oadp.openshift.io
+  resources:
+  - nonadminrestores
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - oadp.openshift.io
+  resources:
+  - nonadminrestores/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - oadp.openshift.io
+  resources:
+  - nonadminrestores/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
   - route.openshift.io
   resources:
   - routes
@@ -189,6 +241,42 @@ rules:
   - velero.io
   resources:
   - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - velero.io
+  resources:
+  - backups
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - velero.io
+  resources:
+  - deletebackuprequests
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - velero.io
+  resources:
+  - restores
   verbs:
   - create
   - delete


### PR DESCRIPTION
Updates the manifests and rbac to align with current master branch of the oadp-non-admin project.

## Why the changes were made

To allow oadp-non-admin CI jobs passing.

## How to test the changes made

Ran make manifests pointing to the latest version of non-admin with use of go 1.22.7