### PR TITLE
Update manifests to match non-admin PR148

### DIFF
--- a/bundle/manifests/oadp.openshift.io_nonadminbackups.yaml
+++ b/bundle/manifests/oadp.openshift.io_nonadminbackups.yaml
@@ -526,11 +526,6 @@ spec:
                   DeleteBackup removes the NonAdminBackup and its associated VeleroBackup from the cluster,
                   as well as the corresponding object storage
                 type: boolean
-              forceDeleteBackup:
-                description: |-
-                  ForceDeleteBackup removes the NonAdminBackup and its associated VeleroBackup from the cluster,
-                  regardless of whether deletion from object storage succeeds or fails
-                type: boolean
             required:
             - backupSpec
             type: object

--- a/config/crd/bases/oadp.openshift.io_nonadminbackups.yaml
+++ b/config/crd/bases/oadp.openshift.io_nonadminbackups.yaml
@@ -526,11 +526,6 @@ spec:
                   DeleteBackup removes the NonAdminBackup and its associated VeleroBackup from the cluster,
                   as well as the corresponding object storage
                 type: boolean
-              forceDeleteBackup:
-                description: |-
-                  ForceDeleteBackup removes the NonAdminBackup and its associated VeleroBackup from the cluster,
-                  regardless of whether deletion from object storage succeeds or fails
-                type: boolean
             required:
             - backupSpec
             type: object


### PR DESCRIPTION
With removal of forceBackup option from the Non Admin Backup spec it's necessary to update manifests.

## Why the changes were made

<!-- Explain why this PR is important, what problems it fixes, link related issues -->
To allow https://github.com/migtools/oadp-non-admin/pull/148 passing.

## How to test the changes made

<!-- Explain how the changes introduced by this PR can be tested and verified, with commands and pictures -->
```shell
$ make update-non-admin-manifests
```