### PR TITLE
Update manifests to match non-admin PR139

### DIFF
--- a/bundle/manifests/oadp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/oadp-operator.clusterserviceversion.yaml
@@ -76,6 +76,37 @@ metadata:
         },
         {
           "apiVersion": "oadp.openshift.io/v1alpha1",
+          "kind": "NonAdminBackupStorageLocation",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/created-by": "oadp-nac",
+              "app.kubernetes.io/instance": "nonadminbackupstoragelocation-sample",
+              "app.kubernetes.io/managed-by": "kustomize",
+              "app.kubernetes.io/name": "nonadminbackupstoragelocation",
+              "app.kubernetes.io/part-of": "oadp-nac"
+            },
+            "name": "nonadminbackupstoragelocation-sample"
+          },
+          "spec": {
+            "backupStorageLocationSpec": {
+              "config": {
+                "checksumAlgorithm": "",
+                "region": "eu-central-1"
+              },
+              "credential": {
+                "key": "default",
+                "name": "cloud-credentials"
+              },
+              "objectStorage": {
+                "bucket": "my-bucket",
+                "prefix": "nac-test"
+              },
+              "provider": "aws"
+            }
+          }
+        },
+        {
+          "apiVersion": "oadp.openshift.io/v1alpha1",
           "kind": "NonAdminRestore",
           "metadata": {
             "labels": {
@@ -441,6 +472,9 @@ spec:
       kind: NonAdminBackup
       name: nonadminbackups.oadp.openshift.io
       version: v1alpha1
+    - kind: NonAdminBackupStorageLocation
+      name: nonadminbackupstoragelocations.oadp.openshift.io
+      version: v1alpha1
     - description: NonAdminRestore is the Schema for the nonadminrestores API
       displayName: Non Admin Restore
       kind: NonAdminRestore
@@ -628,6 +662,18 @@ spec:
       clusterPermissions:
       - rules:
         - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
           - oadp.openshift.io
           resources:
           - dataprotectionapplications
@@ -655,6 +701,32 @@ spec:
           - oadp.openshift.io
           resources:
           - nonadminbackups/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - oadp.openshift.io
+          resources:
+          - nonadminbackupstoragelocations
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - oadp.openshift.io
+          resources:
+          - nonadminbackupstoragelocations/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - oadp.openshift.io
+          resources:
+          - nonadminbackupstoragelocations/status
           verbs:
           - get
           - patch
@@ -697,6 +769,26 @@ spec:
           - patch
           - update
           - watch
+        - apiGroups:
+          - velero.io
+          resources:
+          - backupstoragelocations
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - velero.io
+          resources:
+          - backupstoragelocations/status
+          verbs:
+          - get
+          - patch
+          - update
         - apiGroups:
           - velero.io
           resources:

--- a/bundle/manifests/oadp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/oadp-operator.clusterserviceversion.yaml
@@ -472,7 +472,10 @@ spec:
       kind: NonAdminBackup
       name: nonadminbackups.oadp.openshift.io
       version: v1alpha1
-    - kind: NonAdminBackupStorageLocation
+    - description: NonAdminBackupStorageLocation is the Schema for the nonadminbackupstoragelocations
+        API
+      displayName: Non Admin BackupStorageLocation
+      kind: NonAdminBackupStorageLocation
       name: nonadminbackupstoragelocations.oadp.openshift.io
       version: v1alpha1
     - description: NonAdminRestore is the Schema for the nonadminrestores API

--- a/bundle/manifests/oadp.openshift.io_nonadminbackupstoragelocations.yaml
+++ b/bundle/manifests/oadp.openshift.io_nonadminbackupstoragelocations.yaml
@@ -203,12 +203,11 @@ spec:
                   type: object
                 type: array
               phase:
-                description: NonAdminBackupStorageLocationPhase is a simple one high-level
-                  summary of the lifecycle of an NonAdminBackupStorageLocation.
+                description: phase is a simple one high-level summary of the lifecycle
+                  of an NonAdminBackupStorageLocation.
                 enum:
                 - New
-                - Available
-                - Unavailable
+                - BackingOff
                 - Created
                 - Deleting
                 type: string

--- a/bundle/manifests/oadp.openshift.io_nonadminbackupstoragelocations.yaml
+++ b/bundle/manifests/oadp.openshift.io_nonadminbackupstoragelocations.yaml
@@ -1,0 +1,292 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  creationTimestamp: null
+  name: nonadminbackupstoragelocations.oadp.openshift.io
+spec:
+  group: oadp.openshift.io
+  names:
+    kind: NonAdminBackupStorageLocation
+    listKind: NonAdminBackupStorageLocationList
+    plural: nonadminbackupstoragelocations
+    shortNames:
+    - nabsl
+    singular: nonadminbackupstoragelocation
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: NonAdminBackupStorageLocation is the Schema for the nonadminbackupstoragelocations
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: NonAdminBackupStorageLocationSpec defines the desired state
+              of NonAdminBackupStorageLocation
+            properties:
+              backupStorageLocationSpec:
+                description: BackupStorageLocationSpec defines the desired state of
+                  a Velero BackupStorageLocation
+                properties:
+                  accessMode:
+                    description: AccessMode defines the permissions for the backup
+                      storage location.
+                    enum:
+                    - ReadOnly
+                    - ReadWrite
+                    type: string
+                  backupSyncPeriod:
+                    description: BackupSyncPeriod defines how frequently to sync backup
+                      API objects from object storage. A value of 0 disables sync.
+                    nullable: true
+                    type: string
+                  config:
+                    additionalProperties:
+                      type: string
+                    description: Config is for provider-specific configuration fields.
+                    type: object
+                  credential:
+                    description: Credential contains the credential information intended
+                      to be used with this location
+                    properties:
+                      key:
+                        description: The key of the secret to select from.  Must be
+                          a valid secret key.
+                        type: string
+                      name:
+                        default: ""
+                        description: |-
+                          Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
+                          TODO: Add other useful fields. apiVersion, kind, uid?
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                        type: string
+                      optional:
+                        description: Specify whether the Secret or its key must be
+                          defined
+                        type: boolean
+                    required:
+                    - key
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  default:
+                    description: Default indicates this location is the default backup
+                      storage location.
+                    type: boolean
+                  objectStorage:
+                    description: ObjectStorageLocation specifies the settings necessary
+                      to connect to a provider's object storage.
+                    properties:
+                      bucket:
+                        description: Bucket is the bucket to use for object storage.
+                        type: string
+                      caCert:
+                        description: CACert defines a CA bundle to use when verifying
+                          TLS connections to the provider.
+                        format: byte
+                        type: string
+                      prefix:
+                        description: Prefix is the path inside a bucket to use for
+                          Velero storage. Optional.
+                        type: string
+                    required:
+                    - bucket
+                    type: object
+                  provider:
+                    description: Provider is the provider of the backup storage.
+                    type: string
+                  validationFrequency:
+                    description: ValidationFrequency defines how frequently to validate
+                      the corresponding object storage. A value of 0 disables validation.
+                    nullable: true
+                    type: string
+                required:
+                - objectStorage
+                - provider
+                type: object
+            required:
+            - backupStorageLocationSpec
+            type: object
+          status:
+            description: NonAdminBackupStorageLocationStatus defines the observed
+              state of NonAdminBackupStorageLocation
+            properties:
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              phase:
+                description: NonAdminBackupStorageLocationPhase is a simple one high-level
+                  summary of the lifecycle of an NonAdminBackupStorageLocation.
+                enum:
+                - New
+                - Available
+                - Unavailable
+                - Created
+                - Deleting
+                type: string
+              veleroBackupStorageLocation:
+                description: VeleroBackupStorageLocation contains information of the
+                  related Velero backup object.
+                properties:
+                  nacuuid:
+                    description: nacuuid references the Velero BackupStorageLocation
+                      object by it's label containing same NACUUID.
+                    type: string
+                  name:
+                    description: references the Velero BackupStorageLocation object
+                      by it's name.
+                    type: string
+                  namespace:
+                    description: namespace references the Namespace in which Velero
+                      backup storage location exists.
+                    type: string
+                  status:
+                    description: status captures the current status of the Velero
+                      backup storage location.
+                    properties:
+                      accessMode:
+                        description: |-
+                          AccessMode is an unused field.
+
+
+                          Deprecated: there is now an AccessMode field on the Spec and this field
+                          will be removed entirely as of v2.0.
+                        enum:
+                        - ReadOnly
+                        - ReadWrite
+                        type: string
+                      lastSyncedRevision:
+                        description: |-
+                          LastSyncedRevision is the value of the `metadata/revision` file in the backup
+                          storage location the last time the BSL's contents were synced into the cluster.
+
+
+                          Deprecated: this field is no longer updated or used for detecting changes to
+                          the location's contents and will be removed entirely in v2.0.
+                        type: string
+                      lastSyncedTime:
+                        description: |-
+                          LastSyncedTime is the last time the contents of the location were synced into
+                          the cluster.
+                        format: date-time
+                        nullable: true
+                        type: string
+                      lastValidationTime:
+                        description: |-
+                          LastValidationTime is the last time the backup store location was validated
+                          the cluster.
+                        format: date-time
+                        nullable: true
+                        type: string
+                      message:
+                        description: Message is a message about the backup storage
+                          location's status.
+                        type: string
+                      phase:
+                        description: Phase is the current state of the BackupStorageLocation.
+                        enum:
+                        - Available
+                        - Unavailable
+                        type: string
+                    type: object
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/config/crd/bases/oadp.openshift.io_nonadminbackupstoragelocations.yaml
+++ b/config/crd/bases/oadp.openshift.io_nonadminbackupstoragelocations.yaml
@@ -203,12 +203,11 @@ spec:
                   type: object
                 type: array
               phase:
-                description: NonAdminBackupStorageLocationPhase is a simple one high-level
-                  summary of the lifecycle of an NonAdminBackupStorageLocation.
+                description: phase is a simple one high-level summary of the lifecycle
+                  of an NonAdminBackupStorageLocation.
                 enum:
                 - New
-                - Available
-                - Unavailable
+                - BackingOff
                 - Created
                 - Deleting
                 type: string

--- a/config/crd/bases/oadp.openshift.io_nonadminbackupstoragelocations.yaml
+++ b/config/crd/bases/oadp.openshift.io_nonadminbackupstoragelocations.yaml
@@ -1,0 +1,286 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: nonadminbackupstoragelocations.oadp.openshift.io
+spec:
+  group: oadp.openshift.io
+  names:
+    kind: NonAdminBackupStorageLocation
+    listKind: NonAdminBackupStorageLocationList
+    plural: nonadminbackupstoragelocations
+    shortNames:
+    - nabsl
+    singular: nonadminbackupstoragelocation
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: NonAdminBackupStorageLocation is the Schema for the nonadminbackupstoragelocations
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: NonAdminBackupStorageLocationSpec defines the desired state
+              of NonAdminBackupStorageLocation
+            properties:
+              backupStorageLocationSpec:
+                description: BackupStorageLocationSpec defines the desired state of
+                  a Velero BackupStorageLocation
+                properties:
+                  accessMode:
+                    description: AccessMode defines the permissions for the backup
+                      storage location.
+                    enum:
+                    - ReadOnly
+                    - ReadWrite
+                    type: string
+                  backupSyncPeriod:
+                    description: BackupSyncPeriod defines how frequently to sync backup
+                      API objects from object storage. A value of 0 disables sync.
+                    nullable: true
+                    type: string
+                  config:
+                    additionalProperties:
+                      type: string
+                    description: Config is for provider-specific configuration fields.
+                    type: object
+                  credential:
+                    description: Credential contains the credential information intended
+                      to be used with this location
+                    properties:
+                      key:
+                        description: The key of the secret to select from.  Must be
+                          a valid secret key.
+                        type: string
+                      name:
+                        default: ""
+                        description: |-
+                          Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
+                          TODO: Add other useful fields. apiVersion, kind, uid?
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                        type: string
+                      optional:
+                        description: Specify whether the Secret or its key must be
+                          defined
+                        type: boolean
+                    required:
+                    - key
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  default:
+                    description: Default indicates this location is the default backup
+                      storage location.
+                    type: boolean
+                  objectStorage:
+                    description: ObjectStorageLocation specifies the settings necessary
+                      to connect to a provider's object storage.
+                    properties:
+                      bucket:
+                        description: Bucket is the bucket to use for object storage.
+                        type: string
+                      caCert:
+                        description: CACert defines a CA bundle to use when verifying
+                          TLS connections to the provider.
+                        format: byte
+                        type: string
+                      prefix:
+                        description: Prefix is the path inside a bucket to use for
+                          Velero storage. Optional.
+                        type: string
+                    required:
+                    - bucket
+                    type: object
+                  provider:
+                    description: Provider is the provider of the backup storage.
+                    type: string
+                  validationFrequency:
+                    description: ValidationFrequency defines how frequently to validate
+                      the corresponding object storage. A value of 0 disables validation.
+                    nullable: true
+                    type: string
+                required:
+                - objectStorage
+                - provider
+                type: object
+            required:
+            - backupStorageLocationSpec
+            type: object
+          status:
+            description: NonAdminBackupStorageLocationStatus defines the observed
+              state of NonAdminBackupStorageLocation
+            properties:
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              phase:
+                description: NonAdminBackupStorageLocationPhase is a simple one high-level
+                  summary of the lifecycle of an NonAdminBackupStorageLocation.
+                enum:
+                - New
+                - Available
+                - Unavailable
+                - Created
+                - Deleting
+                type: string
+              veleroBackupStorageLocation:
+                description: VeleroBackupStorageLocation contains information of the
+                  related Velero backup object.
+                properties:
+                  nacuuid:
+                    description: nacuuid references the Velero BackupStorageLocation
+                      object by it's label containing same NACUUID.
+                    type: string
+                  name:
+                    description: references the Velero BackupStorageLocation object
+                      by it's name.
+                    type: string
+                  namespace:
+                    description: namespace references the Namespace in which Velero
+                      backup storage location exists.
+                    type: string
+                  status:
+                    description: status captures the current status of the Velero
+                      backup storage location.
+                    properties:
+                      accessMode:
+                        description: |-
+                          AccessMode is an unused field.
+
+
+                          Deprecated: there is now an AccessMode field on the Spec and this field
+                          will be removed entirely as of v2.0.
+                        enum:
+                        - ReadOnly
+                        - ReadWrite
+                        type: string
+                      lastSyncedRevision:
+                        description: |-
+                          LastSyncedRevision is the value of the `metadata/revision` file in the backup
+                          storage location the last time the BSL's contents were synced into the cluster.
+
+
+                          Deprecated: this field is no longer updated or used for detecting changes to
+                          the location's contents and will be removed entirely in v2.0.
+                        type: string
+                      lastSyncedTime:
+                        description: |-
+                          LastSyncedTime is the last time the contents of the location were synced into
+                          the cluster.
+                        format: date-time
+                        nullable: true
+                        type: string
+                      lastValidationTime:
+                        description: |-
+                          LastValidationTime is the last time the backup store location was validated
+                          the cluster.
+                        format: date-time
+                        nullable: true
+                        type: string
+                      message:
+                        description: Message is a message about the backup storage
+                          location's status.
+                        type: string
+                      phase:
+                        description: Phase is the current state of the BackupStorageLocation.
+                        enum:
+                        - Available
+                        - Unavailable
+                        type: string
+                    type: object
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -2,6 +2,7 @@
 # since it depends on service name and namespace that are out of this kustomize package.
 # It should be run by config/default
 resources:
+- bases/oadp.openshift.io_nonadminbackupstoragelocations.yaml
 - bases/oadp.openshift.io_dataprotectionapplications.yaml
 - bases/oadp.openshift.io_cloudstorages.yaml
 - bases/velero.io_backuprepositories.yaml

--- a/config/manifests/bases/oadp-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/oadp-operator.clusterserviceversion.yaml
@@ -385,6 +385,12 @@ spec:
       kind: NonAdminRestore
       name: nonadminrestores.oadp.openshift.io
       version: v1alpha1
+    - description: NonAdminBackupStorageLocation is the Schema for the nonadminbackupstoragelocations
+        API
+      displayName: Non Admin BackupStorageLocation
+      kind: NonAdminBackupStorageLocation
+      name: nonadminbackupstoragelocations.oadp.openshift.io
+      version: v1alpha1
     - description: The CloudStorage API automates the creation of a bucket for object
         storage.
       displayName: Cloud Storage

--- a/config/non-admin-controller_rbac/role.yaml
+++ b/config/non-admin-controller_rbac/role.yaml
@@ -5,6 +5,18 @@ metadata:
   name: non-admin-controller-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - oadp.openshift.io
   resources:
   - dataprotectionapplications
@@ -32,6 +44,32 @@ rules:
   - oadp.openshift.io
   resources:
   - nonadminbackups/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - oadp.openshift.io
+  resources:
+  - nonadminbackupstoragelocations
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - oadp.openshift.io
+  resources:
+  - nonadminbackupstoragelocations/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - oadp.openshift.io
+  resources:
+  - nonadminbackupstoragelocations/status
   verbs:
   - get
   - patch
@@ -74,6 +112,26 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - velero.io
+  resources:
+  - backupstoragelocations
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - velero.io
+  resources:
+  - backupstoragelocations/status
+  verbs:
+  - get
+  - patch
+  - update
 - apiGroups:
   - velero.io
   resources:

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -1,5 +1,6 @@
 ## Append samples of your project ##
 resources:
+- oadp_v1alpha1_nonadminbackupstoragelocation.yaml
 - oadp_v1alpha1_dataprotectionapplication.yaml
 - backupstoragelocation.yaml
 - deletebackuprequest.yaml

--- a/config/samples/oadp_v1alpha1_nonadminbackupstoragelocation.yaml
+++ b/config/samples/oadp_v1alpha1_nonadminbackupstoragelocation.yaml
@@ -1,0 +1,22 @@
+apiVersion: oadp.openshift.io/v1alpha1
+kind: NonAdminBackupStorageLocation
+metadata:
+  labels:
+    app.kubernetes.io/name: nonadminbackupstoragelocation
+    app.kubernetes.io/instance: nonadminbackupstoragelocation-sample
+    app.kubernetes.io/part-of: oadp-nac
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: oadp-nac
+  name: nonadminbackupstoragelocation-sample
+spec:
+  backupStorageLocationSpec:
+    config:
+      checksumAlgorithm: ''
+      region: eu-central-1
+    credential:
+      key: default
+      name: cloud-credentials
+    objectStorage:
+      bucket: my-bucket
+      prefix: nac-test
+    provider: aws


### PR DESCRIPTION
Updated manifests for the NonAdminBackupStorageLocation

## Why the changes were made

To allow https://github.com/migtools/oadp-non-admin/pull/139 passing.

## How to test the changes made

```shell
$ make update-non-admin-manifests
```