### PR TITLE
Remove multiple single quotes from message field

### DIFF
--- a/internal/controller/validator.go
+++ b/internal/controller/validator.go
@@ -85,7 +85,7 @@ func (r *DataProtectionApplicationReconciler) ValidateDataProtectionCR(log logr.
 	// validate non-admin enable and tech-preview-ack
 	if r.dpa.Spec.NonAdmin != nil && r.dpa.Spec.NonAdmin.Enable != nil && *r.dpa.Spec.NonAdmin.Enable {
 		if !(r.dpa.Spec.UnsupportedOverrides[oadpv1alpha1.TechPreviewAck] == TrueVal) {
-			return false, errors.New("in order to enable/disable the non-admin feature please set dpa.spec.unsupportedOverrides[tech-preview-ack]: 'true'")
+			return false, errors.New("in order to enable/disable the non-admin feature please set dpa.spec.unsupportedOverrides[tech-preview-ack]: \"true\"")
 		}
 
 		dpaList := &oadpv1alpha1.DataProtectionApplicationList{}

--- a/internal/controller/validator_test.go
+++ b/internal/controller/validator_test.go
@@ -1416,7 +1416,7 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 				},
 			},
 			wantErr:    true,
-			messageErr: "in order to enable/disable the non-admin feature please set dpa.spec.unsupportedOverrides[tech-preview-ack]: 'true'",
+			messageErr: "in order to enable/disable the non-admin feature please set dpa.spec.unsupportedOverrides[tech-preview-ack]: \"true\"",
 		},
 		{
 			name: "[valid] DPA CR: spec.nonAdmin.enable true, spec.unsupportedOverrides.tech-preview-ack true string",


### PR DESCRIPTION
## Why the changes were made

<!-- Explain why this PR is important, what problems it fixes, link related issues -->
Current output:- 
```
status:
    conditions:
    - lastTransitionTime: "2025-01-28T13:25:27Z"
      message: 'in order to enable/disable the non-admin feature please set dpa.spec.unsupportedOverrides[tech-preview-ack]:
        ''true'''
      reason: Error
      status: "False"
      type: Reconciled
```

## How to test the changes made

1. Deploy OADP operator from this branch. 
2. Create a dpa with nodeAgent enabled
3. Verify the dpa has error related to missing tech-preview-ack 


Output after the fix:- 

```
status:
    conditions:
    - lastTransitionTime: "2025-01-30T07:35:44Z"
      message: 'in order to enable/disable the non-admin feature please set dpa.spec.unsupportedOverrides[tech-preview-ack]:
        "true"'
      reason: Error
      status: "False"
      type: Reconciled
```

<!-- Explain how the changes introduced by this PR can be tested and verified, with commands and pictures -->
