### PR TITLE
Adding --ginkgo.junit-report flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,6 @@ tests/e2e/e2e.test
 tests/e2e/templates/*.yaml
 .DS_Store
 test-upgrade/
+junit_report.xml
 # `operator-sdk run bundle` caches files in this directory
 cache/

--- a/Makefile
+++ b/Makefile
@@ -596,6 +596,7 @@ test-e2e: test-e2e-setup install-ginkgo ## Run E2E tests against OADP operator i
 	--ginkgo.vv \
 	--ginkgo.no-color=$(OPENSHIFT_CI) \
 	--ginkgo.label-filter="$(TEST_FILTER)" \
+	--ginkgo.junit-report="junit_report.xml" \
 	--ginkgo.timeout=2h \
 	$(GINKGO_ARGS)
 


### PR DESCRIPTION
## Why the changes were made

Adding `--ginkgo.junit-report` flag to generate the junit XML file after test execution such that those results can be uploaded to the report portal.

## How to test the changes made

<!-- Explain how the changes introduced by this PR can be tested and verified, with commands and pictures -->
