### PR TITLE
Enable unparam flag in linter: Resolve unused func params

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -105,8 +105,8 @@ linters:
     # - staticcheck
     # - stylecheck
     # - unconvert
-    # - unparam
-    - unused
+    - unparam
+    # - unused
     - usestdlibvars
   fast: false
 

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -106,7 +106,7 @@ linters:
     # - stylecheck
     # - unconvert
     # - unparam
-    # - unused
+    - unused
     - usestdlibvars
   fast: false
 

--- a/internal/controller/bsl.go
+++ b/internal/controller/bsl.go
@@ -132,7 +132,7 @@ func (r *DataProtectionApplicationReconciler) ReconcileBackupStorageLocations(lo
 		if bslSpec.Velero != nil {
 			secretName, _, _ = r.getSecretNameAndKey(bslSpec.Velero.Config, bslSpec.Velero.Credential, oadpv1alpha1.DefaultPlugin(bslSpec.Velero.Provider))
 		}
-		err := r.UpdateCredentialsSecretLabels(secretName, dpa.Namespace, dpa.Name)
+		err := r.UpdateCredentialsSecretLabels(secretName, dpa.Name)
 		if err != nil {
 			return false, err
 		}
@@ -229,9 +229,8 @@ func (r *DataProtectionApplicationReconciler) ReconcileBackupStorageLocations(lo
 	return true, nil
 }
 
-func (r *DataProtectionApplicationReconciler) UpdateCredentialsSecretLabels(secretName string, namespace string, dpaName string) error {
-	// todo: lot of calls supply this, needs combing
-	_ = namespace
+func (r *DataProtectionApplicationReconciler) UpdateCredentialsSecretLabels(secretName string, dpaName string) error {
+
 	var secret corev1.Secret
 	secret, err := r.getProviderSecret(secretName)
 	if err != nil {

--- a/internal/controller/bsl.go
+++ b/internal/controller/bsl.go
@@ -132,7 +132,7 @@ func (r *DataProtectionApplicationReconciler) ReconcileBackupStorageLocations(lo
 		if bslSpec.Velero != nil {
 			secretName, _, _ = r.getSecretNameAndKey(bslSpec.Velero.Config, bslSpec.Velero.Credential, oadpv1alpha1.DefaultPlugin(bslSpec.Velero.Provider))
 		}
-		_, err := r.UpdateCredentialsSecretLabels(secretName, dpa.Namespace, dpa.Name)
+		err := r.UpdateCredentialsSecretLabels(secretName, dpa.Namespace, dpa.Name)
 		if err != nil {
 			return false, err
 		}
@@ -229,16 +229,16 @@ func (r *DataProtectionApplicationReconciler) ReconcileBackupStorageLocations(lo
 	return true, nil
 }
 
-func (r *DataProtectionApplicationReconciler) UpdateCredentialsSecretLabels(secretName string, namespace string, dpaName string) (bool, error) {
+func (r *DataProtectionApplicationReconciler) UpdateCredentialsSecretLabels(secretName string, namespace string, dpaName string) error {
 	// todo: lot of calls supply this, needs combing
 	_ = namespace
 	var secret corev1.Secret
 	secret, err := r.getProviderSecret(secretName)
 	if err != nil {
-		return false, err
+		return err
 	}
 	if secret.Name == "" {
-		return false, errors.New("secret not found")
+		return errors.New("secret not found")
 	}
 	needPatch := false
 	originalSecret := secret.DeepCopy()
@@ -256,12 +256,12 @@ func (r *DataProtectionApplicationReconciler) UpdateCredentialsSecretLabels(secr
 	if needPatch {
 		err = r.Client.Patch(r.Context, &secret, client.MergeFrom(originalSecret))
 		if err != nil {
-			return false, err
+			return err
 		}
 
 		r.EventRecorder.Event(&secret, corev1.EventTypeNormal, "SecretLabelled", fmt.Sprintf("Secret %s has been labelled", secretName))
 	}
-	return true, nil
+	return nil
 }
 
 func (r *DataProtectionApplicationReconciler) updateBSLFromSpec(bsl *velerov1.BackupStorageLocation, bslSpec velerov1.BackupStorageLocationSpec) error {

--- a/internal/controller/bsl.go
+++ b/internal/controller/bsl.go
@@ -230,6 +230,8 @@ func (r *DataProtectionApplicationReconciler) ReconcileBackupStorageLocations(lo
 }
 
 func (r *DataProtectionApplicationReconciler) UpdateCredentialsSecretLabels(secretName string, namespace string, dpaName string) (bool, error) {
+	// todo: lot of calls supply this, needs combing
+	_ = namespace
 	var secret corev1.Secret
 	secret, err := r.getProviderSecret(secretName)
 	if err != nil {

--- a/internal/controller/bsl_test.go
+++ b/internal/controller/bsl_test.go
@@ -1518,6 +1518,8 @@ func TestDPAReconciler_ValidateBackupStorageLocations(t *testing.T) {
 }
 
 func newContextForTest(name string) context.Context {
+	// todo: used a lot, combing needed
+	_ = name
 	return context.TODO()
 }
 

--- a/internal/controller/bsl_test.go
+++ b/internal/controller/bsl_test.go
@@ -1497,7 +1497,7 @@ func TestDPAReconciler_ValidateBackupStorageLocations(t *testing.T) {
 				Client:  fakeClient,
 				Scheme:  fakeClient.Scheme(),
 				Log:     logr.Discard(),
-				Context: newContextForTest(tt.name),
+				Context: newContextForTest(),
 				NamespacedName: types.NamespacedName{
 					Namespace: tt.dpa.Namespace,
 					Name:      tt.dpa.Name,
@@ -1517,9 +1517,7 @@ func TestDPAReconciler_ValidateBackupStorageLocations(t *testing.T) {
 	}
 }
 
-func newContextForTest(name string) context.Context {
-	// todo: used a lot, combing needed
-	_ = name
+func newContextForTest() context.Context {
 	return context.TODO()
 }
 
@@ -2207,7 +2205,7 @@ func TestDPAReconciler_ReconcileBackupStorageLocations(t *testing.T) {
 				Client:  fakeClient,
 				Scheme:  fakeClient.Scheme(),
 				Log:     logr.Discard(),
-				Context: newContextForTest(tt.name),
+				Context: newContextForTest(),
 				NamespacedName: types.NamespacedName{
 					Namespace: tt.dpa.Namespace,
 					Name:      tt.dpa.Name,
@@ -2559,7 +2557,7 @@ func TestDPAReconciler_ReconcileBackupStorageLocations(t *testing.T) {
 				Client:  fakeClient,
 				Scheme:  fakeClient.Scheme(),
 				Log:     logr.Discard(),
-				Context: newContextForTest(tt.name),
+				Context: newContextForTest(),
 				NamespacedName: types.NamespacedName{
 					Namespace: tt.objects[0].GetNamespace(),
 					Name:      tt.objects[0].GetName(),

--- a/internal/controller/monitor_test.go
+++ b/internal/controller/monitor_test.go
@@ -152,7 +152,7 @@ func TestDPAReconciler_updateVeleroMetricsSVC(t *testing.T) {
 				Client:  fakeClient,
 				Scheme:  fakeClient.Scheme(),
 				Log:     logr.Discard(),
-				Context: newContextForTest(tt.name),
+				Context: newContextForTest(),
 				NamespacedName: types.NamespacedName{
 					Namespace: tt.svc.Namespace,
 					Name:      tt.svc.Name,

--- a/internal/controller/nodeagent.go
+++ b/internal/controller/nodeagent.go
@@ -409,9 +409,7 @@ func (r *DataProtectionApplicationReconciler) customizeNodeAgentDaemonset(ds *ap
 					if err := r.Get(r.Context, types.NamespacedName{Namespace: dpa.Namespace, Name: configMapName}, &unsupportedServerArgsCM); err != nil {
 						return nil, err
 					}
-					if err := common.ApplyUnsupportedServerArgsOverride(nodeAgentContainer, unsupportedServerArgsCM, common.NodeAgent); err != nil {
-						return nil, err
-					}
+					common.ApplyUnsupportedServerArgsOverride(nodeAgentContainer, unsupportedServerArgsCM, common.NodeAgent)
 				}
 			}
 

--- a/internal/controller/nodeagent_test.go
+++ b/internal/controller/nodeagent_test.go
@@ -1223,7 +1223,7 @@ func TestDPAReconciler_updateFsRestoreHelperCM(t *testing.T) {
 				Client:  fakeClient,
 				Scheme:  fakeClient.Scheme(),
 				Log:     logr.Discard(),
-				Context: newContextForTest(tt.name),
+				Context: newContextForTest(),
 				NamespacedName: types.NamespacedName{
 					Namespace: tt.dpa.Namespace,
 					Name:      tt.dpa.Name,
@@ -1297,7 +1297,7 @@ func TestDPAReconciler_getPlatformType(t *testing.T) {
 				Client:  fakeClient,
 				Scheme:  fakeClient.Scheme(),
 				Log:     logr.Discard(),
-				Context: newContextForTest(tt.name),
+				Context: newContextForTest(),
 				NamespacedName: types.NamespacedName{
 					Namespace: tt.dpa.Namespace,
 					Name:      tt.dpa.Name,

--- a/internal/controller/registry_test.go
+++ b/internal/controller/registry_test.go
@@ -221,7 +221,7 @@ func TestDPAReconciler_getSecretNameAndKey(t *testing.T) {
 				Client:        fakeClient,
 				Scheme:        fakeClient.Scheme(),
 				Log:           logr.Discard(),
-				Context:       newContextForTest(tt.name),
+				Context:       newContextForTest(),
 				EventRecorder: record.NewFakeRecorder(10),
 			}
 
@@ -310,7 +310,7 @@ func TestDPAReconciler_getSecretNameAndKeyFromCloudStorage(t *testing.T) {
 				Client:        fakeClient,
 				Scheme:        fakeClient.Scheme(),
 				Log:           logr.Discard(),
-				Context:       newContextForTest(tt.name),
+				Context:       newContextForTest(),
 				EventRecorder: record.NewFakeRecorder(10),
 			}
 
@@ -401,7 +401,7 @@ func TestDPAReconciler_populateAWSRegistrySecret(t *testing.T) {
 				Client:  fakeClient,
 				Scheme:  fakeClient.Scheme(),
 				Log:     logr.Discard(),
-				Context: newContextForTest(tt.name),
+				Context: newContextForTest(),
 				NamespacedName: types.NamespacedName{
 					Namespace: tt.bsl.Namespace,
 					Name:      tt.bsl.Name,
@@ -491,7 +491,7 @@ func TestDPAReconciler_populateAzureRegistrySecret(t *testing.T) {
 				Client:  fakeClient,
 				Scheme:  fakeClient.Scheme(),
 				Log:     logr.Discard(),
-				Context: newContextForTest(tt.name),
+				Context: newContextForTest(),
 				NamespacedName: types.NamespacedName{
 					Namespace: tt.bsl.Namespace,
 					Name:      tt.bsl.Name,

--- a/internal/controller/validator.go
+++ b/internal/controller/validator.go
@@ -128,6 +128,10 @@ func (r *DataProtectionApplicationReconciler) ValidateDataProtectionCR(log logr.
 // TODO: if multiple default plugins exist, ensure we validate all of them.
 // Right now its sequential validation
 func (r *DataProtectionApplicationReconciler) ValidateVeleroPlugins(log logr.Logger) (bool, error) {
+
+	// Under todo
+	_ = log
+
 	dpa := r.dpa
 
 	providerNeedsDefaultCreds, hasCloudStorage, err := r.noDefaultCredentials()

--- a/internal/controller/validator.go
+++ b/internal/controller/validator.go
@@ -65,7 +65,7 @@ func (r *DataProtectionApplicationReconciler) ValidateDataProtectionCR(log logr.
 		return false, errors.New("only mtc operator type override is supported")
 	}
 
-	if _, err := r.ValidateVeleroPlugins(r.Log); err != nil {
+	if _, err := r.ValidateVeleroPlugins(); err != nil {
 		return false, err
 	}
 
@@ -127,10 +127,7 @@ func (r *DataProtectionApplicationReconciler) ValidateDataProtectionCR(log logr.
 // For later: Move this code into validator.go when more need for validation arises
 // TODO: if multiple default plugins exist, ensure we validate all of them.
 // Right now its sequential validation
-func (r *DataProtectionApplicationReconciler) ValidateVeleroPlugins(log logr.Logger) (bool, error) {
-
-	// Under todo
-	_ = log
+func (r *DataProtectionApplicationReconciler) ValidateVeleroPlugins() (bool, error) {
 
 	dpa := r.dpa
 

--- a/internal/controller/validator_test.go
+++ b/internal/controller/validator_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
-	v1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -403,7 +403,7 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 					},
 					SnapshotLocations: []oadpv1alpha1.SnapshotLocation{
 						{
-							Velero: &v1.VolumeSnapshotLocationSpec{
+							Velero: &velerov1.VolumeSnapshotLocationSpec{
 								Provider: "aws",
 								Config: map[string]string{
 									AWSRegion: "us-east-1",
@@ -451,7 +451,7 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 					},
 					SnapshotLocations: []oadpv1alpha1.SnapshotLocation{
 						{
-							Velero: &v1.VolumeSnapshotLocationSpec{
+							Velero: &velerov1.VolumeSnapshotLocationSpec{
 								Provider: "aws",
 								Config: map[string]string{
 									AWSRegion: "us-east-1",
@@ -492,7 +492,7 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 					},
 					SnapshotLocations: []oadpv1alpha1.SnapshotLocation{
 						{
-							Velero: &v1.VolumeSnapshotLocationSpec{
+							Velero: &velerov1.VolumeSnapshotLocationSpec{
 								Provider: "aws",
 								Config: map[string]string{
 									AWSRegion: "us-east-1",
@@ -550,7 +550,7 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 					},
 					SnapshotLocations: []oadpv1alpha1.SnapshotLocation{
 						{
-							Velero: &v1.VolumeSnapshotLocationSpec{
+							Velero: &velerov1.VolumeSnapshotLocationSpec{
 								Provider: "aws",
 								Config: map[string]string{
 									AWSRegion: "us-east-1",
@@ -598,9 +598,9 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
 					BackupLocations: []oadpv1alpha1.BackupLocation{
 						{
-							Velero: &v1.BackupStorageLocationSpec{
-								StorageType: v1.StorageType{
-									ObjectStorage: &v1.ObjectStorageLocation{
+							Velero: &velerov1.BackupStorageLocationSpec{
+								StorageType: velerov1.StorageType{
+									ObjectStorage: &velerov1.ObjectStorageLocation{
 										Bucket: "test-bucket",
 										Prefix: "test-prefix",
 									},
@@ -646,9 +646,9 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
 					BackupLocations: []oadpv1alpha1.BackupLocation{
 						{
-							Velero: &v1.BackupStorageLocationSpec{
-								StorageType: v1.StorageType{
-									ObjectStorage: &v1.ObjectStorageLocation{
+							Velero: &velerov1.BackupStorageLocationSpec{
+								StorageType: velerov1.StorageType{
+									ObjectStorage: &velerov1.ObjectStorageLocation{
 										Bucket: "test-bucket",
 										Prefix: "test-prefix",
 									},
@@ -682,9 +682,9 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
 					BackupLocations: []oadpv1alpha1.BackupLocation{
 						{
-							Velero: &v1.BackupStorageLocationSpec{
-								StorageType: v1.StorageType{
-									ObjectStorage: &v1.ObjectStorageLocation{
+							Velero: &velerov1.BackupStorageLocationSpec{
+								StorageType: velerov1.StorageType{
+									ObjectStorage: &velerov1.ObjectStorageLocation{
 										Bucket: "test-bucket",
 										Prefix: "test-prefix",
 									},
@@ -716,7 +716,7 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
 					SnapshotLocations: []oadpv1alpha1.SnapshotLocation{
 						{
-							Velero: &v1.VolumeSnapshotLocationSpec{
+							Velero: &velerov1.VolumeSnapshotLocationSpec{
 								Provider: "velerio.io/gcp",
 							},
 						},
@@ -744,9 +744,9 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
 					BackupLocations: []oadpv1alpha1.BackupLocation{
 						{
-							Velero: &v1.BackupStorageLocationSpec{
-								StorageType: v1.StorageType{
-									ObjectStorage: &v1.ObjectStorageLocation{
+							Velero: &velerov1.BackupStorageLocationSpec{
+								StorageType: velerov1.StorageType{
+									ObjectStorage: &velerov1.ObjectStorageLocation{
 										Bucket: "test-bucket",
 										Prefix: "test-prefix",
 									},
@@ -796,9 +796,9 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
 					BackupLocations: []oadpv1alpha1.BackupLocation{
 						{
-							Velero: &v1.BackupStorageLocationSpec{
-								StorageType: v1.StorageType{
-									ObjectStorage: &v1.ObjectStorageLocation{
+							Velero: &velerov1.BackupStorageLocationSpec{
+								StorageType: velerov1.StorageType{
+									ObjectStorage: &velerov1.ObjectStorageLocation{
 										Bucket: "test-bucket",
 										Prefix: "test-prefix",
 									},
@@ -817,9 +817,9 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 							},
 						},
 						{
-							Velero: &v1.BackupStorageLocationSpec{
-								StorageType: v1.StorageType{
-									ObjectStorage: &v1.ObjectStorageLocation{
+							Velero: &velerov1.BackupStorageLocationSpec{
+								StorageType: velerov1.StorageType{
+									ObjectStorage: &velerov1.ObjectStorageLocation{
 										Bucket: "test-bucket",
 										Prefix: "test-prefix",
 									},
@@ -858,9 +858,9 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
 					BackupLocations: []oadpv1alpha1.BackupLocation{
 						{
-							Velero: &v1.BackupStorageLocationSpec{
-								StorageType: v1.StorageType{
-									ObjectStorage: &v1.ObjectStorageLocation{
+							Velero: &velerov1.BackupStorageLocationSpec{
+								StorageType: velerov1.StorageType{
+									ObjectStorage: &velerov1.ObjectStorageLocation{
 										Bucket: "test-bucket",
 										Prefix: "test-prefix",
 									},
@@ -882,7 +882,7 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 					},
 					SnapshotLocations: []oadpv1alpha1.SnapshotLocation{
 						{
-							Velero: &v1.VolumeSnapshotLocationSpec{
+							Velero: &velerov1.VolumeSnapshotLocationSpec{
 								Provider: "aws",
 								Config: map[string]string{
 									AWSRegion: "us-east-1",
@@ -920,9 +920,9 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
 					BackupLocations: []oadpv1alpha1.BackupLocation{
 						{
-							Velero: &v1.BackupStorageLocationSpec{
-								StorageType: v1.StorageType{
-									ObjectStorage: &v1.ObjectStorageLocation{
+							Velero: &velerov1.BackupStorageLocationSpec{
+								StorageType: velerov1.StorageType{
+									ObjectStorage: &velerov1.ObjectStorageLocation{
 										Bucket: "test-bucket",
 										Prefix: "test-prefix",
 									},
@@ -943,7 +943,7 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 					},
 					SnapshotLocations: []oadpv1alpha1.SnapshotLocation{
 						{
-							Velero: &v1.VolumeSnapshotLocationSpec{
+							Velero: &velerov1.VolumeSnapshotLocationSpec{
 								Provider: "velero.io/aws",
 							},
 						},
@@ -971,9 +971,9 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
 					BackupLocations: []oadpv1alpha1.BackupLocation{
 						{
-							Velero: &v1.BackupStorageLocationSpec{
-								StorageType: v1.StorageType{
-									ObjectStorage: &v1.ObjectStorageLocation{
+							Velero: &velerov1.BackupStorageLocationSpec{
+								StorageType: velerov1.StorageType{
+									ObjectStorage: &velerov1.ObjectStorageLocation{
 										Bucket: "test-bucket",
 										Prefix: "test-prefix",
 									},
@@ -994,7 +994,7 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 					},
 					SnapshotLocations: []oadpv1alpha1.SnapshotLocation{
 						{
-							Velero: &v1.VolumeSnapshotLocationSpec{
+							Velero: &velerov1.VolumeSnapshotLocationSpec{
 								Provider: "velero.io/aws",
 								Credential: &corev1.SecretKeySelector{
 									LocalObjectReference: corev1.LocalObjectReference{
@@ -1036,9 +1036,9 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
 					BackupLocations: []oadpv1alpha1.BackupLocation{
 						{
-							Velero: &v1.BackupStorageLocationSpec{
-								StorageType: v1.StorageType{
-									ObjectStorage: &v1.ObjectStorageLocation{
+							Velero: &velerov1.BackupStorageLocationSpec{
+								StorageType: velerov1.StorageType{
+									ObjectStorage: &velerov1.ObjectStorageLocation{
 										Bucket: "test-bucket",
 										Prefix: "test-prefix",
 									},
@@ -1060,7 +1060,7 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 					},
 					SnapshotLocations: []oadpv1alpha1.SnapshotLocation{
 						{
-							Velero: &v1.VolumeSnapshotLocationSpec{
+							Velero: &velerov1.VolumeSnapshotLocationSpec{
 								Provider: "aws",
 								Credential: &corev1.SecretKeySelector{
 									LocalObjectReference: corev1.LocalObjectReference{
@@ -1192,9 +1192,9 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
 					BackupLocations: []oadpv1alpha1.BackupLocation{
 						{
-							Velero: &v1.BackupStorageLocationSpec{
-								StorageType: v1.StorageType{
-									ObjectStorage: &v1.ObjectStorageLocation{
+							Velero: &velerov1.BackupStorageLocationSpec{
+								StorageType: velerov1.StorageType{
+									ObjectStorage: &velerov1.ObjectStorageLocation{
 										Bucket: "test-bucket",
 										Prefix: "test-prefix",
 									},
@@ -1244,9 +1244,9 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
 					BackupLocations: []oadpv1alpha1.BackupLocation{
 						{
-							Velero: &v1.BackupStorageLocationSpec{
-								StorageType: v1.StorageType{
-									ObjectStorage: &v1.ObjectStorageLocation{
+							Velero: &velerov1.BackupStorageLocationSpec{
+								StorageType: velerov1.StorageType{
+									ObjectStorage: &velerov1.ObjectStorageLocation{
 										Bucket: "test-bucket",
 										Prefix: "test-prefix",
 									},
@@ -1296,9 +1296,9 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
 					BackupLocations: []oadpv1alpha1.BackupLocation{
 						{
-							Velero: &v1.BackupStorageLocationSpec{
-								StorageType: v1.StorageType{
-									ObjectStorage: &v1.ObjectStorageLocation{
+							Velero: &velerov1.BackupStorageLocationSpec{
+								StorageType: velerov1.StorageType{
+									ObjectStorage: &velerov1.ObjectStorageLocation{
 										Bucket: "test-bucket",
 										Prefix: "test-prefix",
 									},
@@ -1348,9 +1348,9 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
 					BackupLocations: []oadpv1alpha1.BackupLocation{
 						{
-							Velero: &v1.BackupStorageLocationSpec{
-								StorageType: v1.StorageType{
-									ObjectStorage: &v1.ObjectStorageLocation{
+							Velero: &velerov1.BackupStorageLocationSpec{
+								StorageType: velerov1.StorageType{
+									ObjectStorage: &velerov1.ObjectStorageLocation{
 										Bucket: "test-bucket",
 										Prefix: "test-prefix",
 									},
@@ -1497,7 +1497,7 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 					BackupImages: ptr.To(false),
 					NonAdmin: &oadpv1alpha1.NonAdmin{
 						Enable: ptr.To(true),
-						EnforceBackupSpec: &v1.BackupSpec{
+						EnforceBackupSpec: &velerov1.BackupSpec{
 							IncludedNamespaces: []string{"banana"},
 							SnapshotVolumes:    ptr.To(false),
 						},
@@ -1521,7 +1521,7 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 					BackupImages: ptr.To(false),
 					NonAdmin: &oadpv1alpha1.NonAdmin{
 						Enable: ptr.To(true),
-						EnforceRestoreSpec: &v1.RestoreSpec{
+						EnforceRestoreSpec: &velerov1.RestoreSpec{
 							IncludedNamespaces: []string{"banana"},
 							RestorePVs:         ptr.To(true),
 						},

--- a/internal/controller/validator_test.go
+++ b/internal/controller/validator_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
-	"github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	v1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -1562,7 +1562,7 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 			ClusterWideClient: fakeClient,
 			Scheme:            fakeClient.Scheme(),
 			Log:               logr.Discard(),
-			Context:           newContextForTest(tt.name),
+			Context:           newContextForTest(),
 			NamespacedName: types.NamespacedName{
 				Namespace: tt.dpa.Namespace,
 				Name:      tt.dpa.Name,

--- a/internal/controller/velero.go
+++ b/internal/controller/velero.go
@@ -136,17 +136,17 @@ func (r *DataProtectionApplicationReconciler) ReconcileVeleroDeployment(log logr
 	return true, nil
 }
 
-func (r *DataProtectionApplicationReconciler) veleroServiceAccount() (*corev1.ServiceAccount, error) {
+func (r *DataProtectionApplicationReconciler) veleroServiceAccount() *corev1.ServiceAccount {
 	annotations := make(map[string]string)
 	sa := install.ServiceAccount(r.dpa.Namespace, annotations)
 	sa.Labels = getDpaAppLabels(r.dpa)
-	return sa, nil
+	return sa
 }
 
-func (r *DataProtectionApplicationReconciler) veleroClusterRoleBinding() (*rbacv1.ClusterRoleBinding, error) {
+func (r *DataProtectionApplicationReconciler) veleroClusterRoleBinding() *rbacv1.ClusterRoleBinding {
 	crb := install.ClusterRoleBinding(r.dpa.Namespace)
 	crb.Labels = getDpaAppLabels(r.dpa)
-	return crb, nil
+	return crb
 }
 
 // Build VELERO Deployment

--- a/internal/controller/velero.go
+++ b/internal/controller/velero.go
@@ -313,7 +313,7 @@ func (r *DataProtectionApplicationReconciler) customizeVeleroDeployment(veleroDe
 			break
 		}
 	}
-	if err := r.customizeVeleroContainer(veleroDeployment, veleroContainer, prometheusPort); err != nil {
+	if err := r.customizeVeleroContainer(veleroContainer, prometheusPort); err != nil {
 		return err
 	}
 
@@ -498,7 +498,7 @@ func (r *DataProtectionApplicationReconciler) appendPluginSpecificSpecs(veleroDe
 	}
 }
 
-func (r *DataProtectionApplicationReconciler) customizeVeleroContainer(veleroDeployment *appsv1.Deployment, veleroContainer *corev1.Container, prometheusPort *int) error {
+func (r *DataProtectionApplicationReconciler) customizeVeleroContainer(veleroContainer *corev1.Container, prometheusPort *int) error {
 	dpa := r.dpa
 	if veleroContainer == nil {
 		return fmt.Errorf("could not find velero container in Deployment")

--- a/internal/controller/velero.go
+++ b/internal/controller/velero.go
@@ -390,9 +390,7 @@ func (r *DataProtectionApplicationReconciler) customizeVeleroDeployment(veleroDe
 			if err := r.Get(r.Context, types.NamespacedName{Namespace: dpa.Namespace, Name: configMapName}, &unsupportedServerArgsCM); err != nil {
 				return err
 			}
-			if err := common.ApplyUnsupportedServerArgsOverride(veleroContainer, unsupportedServerArgsCM, common.Velero); err != nil {
-				return err
-			}
+			common.ApplyUnsupportedServerArgsOverride(veleroContainer, unsupportedServerArgsCM, common.Velero)
 		}
 	}
 

--- a/internal/controller/velero_test.go
+++ b/internal/controller/velero_test.go
@@ -1990,7 +1990,7 @@ func Test_validateVeleroPlugins(t *testing.T) {
 			dpa:           tt.dpa,
 		}
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := r.ValidateVeleroPlugins(r.Log)
+			result, err := r.ValidateVeleroPlugins()
 			if err != nil {
 				t.Errorf("ValidateVeleroPlugins() error = %v", err)
 			}

--- a/internal/controller/velero_test.go
+++ b/internal/controller/velero_test.go
@@ -1981,7 +1981,7 @@ func Test_validateVeleroPlugins(t *testing.T) {
 			Client:  fakeClient,
 			Scheme:  fakeClient.Scheme(),
 			Log:     logr.Discard(),
-			Context: newContextForTest(tt.name),
+			Context: newContextForTest(),
 			NamespacedName: types.NamespacedName{
 				Namespace: tt.dpa.Namespace,
 				Name:      tt.dpa.Name,

--- a/internal/controller/vsl.go
+++ b/internal/controller/vsl.go
@@ -59,13 +59,13 @@ func (r *DataProtectionApplicationReconciler) LabelVSLSecrets(log logr.Logger) (
 		case "aws":
 			if vsl.Velero.Credential != nil {
 				secretName := vsl.Velero.Credential.Name
-				err := r.UpdateCredentialsSecretLabels(secretName, dpa.Namespace, dpa.Name)
+				err := r.UpdateCredentialsSecretLabels(secretName, dpa.Name)
 				if err != nil {
 					return false, err
 				}
 			} else {
 				secretName := credentials.PluginSpecificFields[oadpv1alpha1.DefaultPluginAWS].SecretName
-				err := r.UpdateCredentialsSecretLabels(secretName, dpa.Namespace, dpa.Name)
+				err := r.UpdateCredentialsSecretLabels(secretName, dpa.Name)
 				if err != nil {
 					return false, err
 				}
@@ -73,13 +73,13 @@ func (r *DataProtectionApplicationReconciler) LabelVSLSecrets(log logr.Logger) (
 		case "gcp":
 			if vsl.Velero.Credential != nil {
 				secretName := vsl.Velero.Credential.Name
-				err := r.UpdateCredentialsSecretLabels(secretName, dpa.Namespace, dpa.Name)
+				err := r.UpdateCredentialsSecretLabels(secretName, dpa.Name)
 				if err != nil {
 					return false, err
 				}
 			} else {
 				secretName := credentials.PluginSpecificFields[oadpv1alpha1.DefaultPluginGCP].SecretName
-				err := r.UpdateCredentialsSecretLabels(secretName, dpa.Namespace, dpa.Name)
+				err := r.UpdateCredentialsSecretLabels(secretName, dpa.Name)
 				if err != nil {
 					return false, err
 				}
@@ -87,13 +87,13 @@ func (r *DataProtectionApplicationReconciler) LabelVSLSecrets(log logr.Logger) (
 		case "azure":
 			if vsl.Velero.Credential != nil {
 				secretName := vsl.Velero.Credential.Name
-				err := r.UpdateCredentialsSecretLabels(secretName, dpa.Namespace, dpa.Name)
+				err := r.UpdateCredentialsSecretLabels(secretName, dpa.Name)
 				if err != nil {
 					return false, err
 				}
 			} else {
 				secretName := credentials.PluginSpecificFields[oadpv1alpha1.DefaultPluginMicrosoftAzure].SecretName
-				err := r.UpdateCredentialsSecretLabels(secretName, dpa.Namespace, dpa.Name)
+				err := r.UpdateCredentialsSecretLabels(secretName, dpa.Name)
 				if err != nil {
 					return false, err
 				}

--- a/internal/controller/vsl.go
+++ b/internal/controller/vsl.go
@@ -59,13 +59,13 @@ func (r *DataProtectionApplicationReconciler) LabelVSLSecrets(log logr.Logger) (
 		case "aws":
 			if vsl.Velero.Credential != nil {
 				secretName := vsl.Velero.Credential.Name
-				_, err := r.UpdateCredentialsSecretLabels(secretName, dpa.Namespace, dpa.Name)
+				err := r.UpdateCredentialsSecretLabels(secretName, dpa.Namespace, dpa.Name)
 				if err != nil {
 					return false, err
 				}
 			} else {
 				secretName := credentials.PluginSpecificFields[oadpv1alpha1.DefaultPluginAWS].SecretName
-				_, err := r.UpdateCredentialsSecretLabels(secretName, dpa.Namespace, dpa.Name)
+				err := r.UpdateCredentialsSecretLabels(secretName, dpa.Namespace, dpa.Name)
 				if err != nil {
 					return false, err
 				}
@@ -73,13 +73,13 @@ func (r *DataProtectionApplicationReconciler) LabelVSLSecrets(log logr.Logger) (
 		case "gcp":
 			if vsl.Velero.Credential != nil {
 				secretName := vsl.Velero.Credential.Name
-				_, err := r.UpdateCredentialsSecretLabels(secretName, dpa.Namespace, dpa.Name)
+				err := r.UpdateCredentialsSecretLabels(secretName, dpa.Namespace, dpa.Name)
 				if err != nil {
 					return false, err
 				}
 			} else {
 				secretName := credentials.PluginSpecificFields[oadpv1alpha1.DefaultPluginGCP].SecretName
-				_, err := r.UpdateCredentialsSecretLabels(secretName, dpa.Namespace, dpa.Name)
+				err := r.UpdateCredentialsSecretLabels(secretName, dpa.Namespace, dpa.Name)
 				if err != nil {
 					return false, err
 				}
@@ -87,13 +87,13 @@ func (r *DataProtectionApplicationReconciler) LabelVSLSecrets(log logr.Logger) (
 		case "azure":
 			if vsl.Velero.Credential != nil {
 				secretName := vsl.Velero.Credential.Name
-				_, err := r.UpdateCredentialsSecretLabels(secretName, dpa.Namespace, dpa.Name)
+				err := r.UpdateCredentialsSecretLabels(secretName, dpa.Namespace, dpa.Name)
 				if err != nil {
 					return false, err
 				}
 			} else {
 				secretName := credentials.PluginSpecificFields[oadpv1alpha1.DefaultPluginMicrosoftAzure].SecretName
-				_, err := r.UpdateCredentialsSecretLabels(secretName, dpa.Namespace, dpa.Name)
+				err := r.UpdateCredentialsSecretLabels(secretName, dpa.Namespace, dpa.Name)
 				if err != nil {
 					return false, err
 				}

--- a/internal/controller/vsl_test.go
+++ b/internal/controller/vsl_test.go
@@ -690,7 +690,7 @@ func TestDPAReconciler_ValidateVolumeSnapshotLocation(t *testing.T) {
 				Client:  fakeClient,
 				Scheme:  fakeClient.Scheme(),
 				Log:     logr.Discard(),
-				Context: newContextForTest(tt.name),
+				Context: newContextForTest(),
 				NamespacedName: types.NamespacedName{
 					Namespace: tt.dpa.Namespace,
 					Name:      tt.dpa.Name,
@@ -755,7 +755,7 @@ func TestDPAReconciler_ReconcileVolumeSnapshotLocations(t *testing.T) {
 				Client:  fakeClient,
 				Scheme:  fakeClient.Scheme(),
 				Log:     logr.Discard(),
-				Context: newContextForTest(tt.name),
+				Context: newContextForTest(),
 				NamespacedName: types.NamespacedName{
 					Namespace: tt.dpa.Namespace,
 					Name:      tt.dpa.Name,

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -286,7 +286,7 @@ func GenerateCliArgsFromConfigMap(configMap *corev1.ConfigMap, cliSubCommand ...
 }
 
 // Apply Override unsupported Node agent Server Args
-func ApplyUnsupportedServerArgsOverride(container *corev1.Container, unsupportedServerArgsCM corev1.ConfigMap, serverType string) error {
+func ApplyUnsupportedServerArgsOverride(container *corev1.Container, unsupportedServerArgsCM corev1.ConfigMap, serverType string) {
 
 	switch serverType {
 	case NodeAgent:
@@ -297,5 +297,4 @@ func ApplyUnsupportedServerArgsOverride(container *corev1.Container, unsupported
 		// if server args is set, override the default server args
 		container.Args = GenerateCliArgsFromConfigMap(&unsupportedServerArgsCM, "server")
 	}
-	return nil
 }

--- a/tests/e2e/backup_restore_suite_test.go
+++ b/tests/e2e/backup_restore_suite_test.go
@@ -54,7 +54,7 @@ func todoListReady(preBackupState bool, twoVol bool, database string) Verificati
 func prepareBackupAndRestore(brCase BackupRestoreCase, updateLastInstallTime func()) (string, string) {
 	updateLastInstallTime()
 
-	err := dpaCR.CreateOrUpdate(runTimeClientForSuiteRun, dpaCR.Build(brCase.BackupRestoreType))
+	err := dpaCR.CreateOrUpdate(dpaCR.Build(brCase.BackupRestoreType))
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	log.Print("Checking if DPA is reconciled")

--- a/tests/e2e/backup_restore_suite_test.go
+++ b/tests/e2e/backup_restore_suite_test.go
@@ -93,7 +93,7 @@ func prepareBackupAndRestore(brCase BackupRestoreCase, updateLastInstallTime fun
 	return backupName, restoreName
 }
 
-func runApplicationBackupAndRestore(brCase ApplicationBackupRestoreCase, expectedErr error, updateLastBRcase func(brCase ApplicationBackupRestoreCase), updateLastInstallTime func()) {
+func runApplicationBackupAndRestore(brCase ApplicationBackupRestoreCase, updateLastBRcase func(brCase ApplicationBackupRestoreCase), updateLastInstallTime func()) {
 	updateLastBRcase(brCase)
 
 	// create DPA
@@ -298,7 +298,7 @@ var _ = ginkgo.Describe("Backup and restore tests", func() {
 			if ginkgo.CurrentSpecReport().NumAttempts > 1 && !knownFlake {
 				ginkgo.Fail("No known FLAKE found in a previous run, marking test as failed.")
 			}
-			runApplicationBackupAndRestore(brCase, expectedErr, updateLastBRcase, updateLastInstallTime)
+			runApplicationBackupAndRestore(brCase, updateLastBRcase, updateLastInstallTime)
 		},
 		ginkgo.Entry("MySQL application CSI", ginkgo.FlakeAttempts(flakeAttempts), ApplicationBackupRestoreCase{
 			ApplicationTemplate: "./sample-applications/mysql-persistent/mysql-persistent-csi.yaml",

--- a/tests/e2e/dpa_deployment_suite_test.go
+++ b/tests/e2e/dpa_deployment_suite_test.go
@@ -192,7 +192,7 @@ var _ = ginkgo.Describe("Configuration testing for DPA Custom Resource", func() 
 				gomega.Eventually(dpaCR.BSLsAreAvailable(), time.Minute*3, time.Second*5).Should(gomega.BeTrue())
 				for _, bsl := range installCase.DpaSpec.BackupLocations {
 					log.Printf("Checking for BSL spec")
-					gomega.Expect(dpaCR.DoesBSLSpecMatchesDpa(namespace, *bsl.Velero)).To(gomega.BeTrue())
+					gomega.Expect(dpaCR.DoesBSLSpecMatchesDpa(*bsl.Velero)).To(gomega.BeTrue())
 				}
 			} else {
 				log.Println("Checking no BSLs are deployed")
@@ -205,7 +205,7 @@ var _ = ginkgo.Describe("Configuration testing for DPA Custom Resource", func() 
 				// Velero does not change status of VSL objects. Users can only confirm if VSLs are correct configured when running a native snapshot backup/restore
 				for _, vsl := range installCase.DpaSpec.SnapshotLocations {
 					log.Printf("Checking for VSL spec")
-					gomega.Expect(dpaCR.DoesVSLSpecMatchesDpa(namespace, *vsl.Velero)).To(gomega.BeTrue())
+					gomega.Expect(dpaCR.DoesVSLSpecMatchesDpa(*vsl.Velero)).To(gomega.BeTrue())
 				}
 			} else {
 				log.Println("Checking no VSLs are deployed")

--- a/tests/e2e/dpa_deployment_suite_test.go
+++ b/tests/e2e/dpa_deployment_suite_test.go
@@ -145,7 +145,7 @@ var _ = ginkgo.Describe("Configuration testing for DPA Custom Resource", func() 
 	ginkgo.DescribeTable("DPA reconciled to true",
 		func(installCase InstallCase) {
 			lastInstallTime = time.Now()
-			err := dpaCR.CreateOrUpdate(runTimeClientForSuiteRun, installCase.DpaSpec)
+			err := dpaCR.CreateOrUpdate(installCase.DpaSpec)
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 			gomega.Eventually(dpaCR.IsReconciledTrue(), time.Minute*2, time.Second*5).Should(gomega.BeTrue())
@@ -373,7 +373,7 @@ var _ = ginkgo.Describe("Configuration testing for DPA Custom Resource", func() 
 	ginkgo.DescribeTable("DPA reconciled to false",
 		func(installCase InstallCase, message string) {
 			lastInstallTime = time.Now()
-			err := dpaCR.CreateOrUpdate(runTimeClientForSuiteRun, installCase.DpaSpec)
+			err := dpaCR.CreateOrUpdate(installCase.DpaSpec)
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 			log.Printf("Test case expected to error. Waiting for the error to show in DPA Status")
@@ -391,7 +391,7 @@ var _ = ginkgo.Describe("Configuration testing for DPA Custom Resource", func() 
 	ginkgo.DescribeTable("DPA Deletion test",
 		func() {
 			log.Printf("Creating DPA")
-			err := dpaCR.CreateOrUpdate(runTimeClientForSuiteRun, dpaCR.Build(lib.KOPIA))
+			err := dpaCR.CreateOrUpdate(dpaCR.Build(lib.KOPIA))
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			log.Printf("Waiting for velero Pod to be running")
 			gomega.Eventually(lib.VeleroPodIsRunning(kubernetesClientForSuiteRun, namespace), time.Minute*3, time.Second*5).Should(gomega.BeTrue())

--- a/tests/e2e/lib/dpa_helpers.go
+++ b/tests/e2e/lib/dpa_helpers.go
@@ -148,7 +148,7 @@ func (v *DpaCustomResource) Get() (*oadpv1alpha1.DataProtectionApplication, erro
 	return &dpa, nil
 }
 
-func (v *DpaCustomResource) CreateOrUpdate(c client.Client, spec *oadpv1alpha1.DataProtectionApplicationSpec) error {
+func (v *DpaCustomResource) CreateOrUpdate(spec *oadpv1alpha1.DataProtectionApplicationSpec) error {
 	// for debugging
 	// prettyPrint, _ := json.MarshalIndent(spec, "", "  ")
 	// log.Printf("DPA with spec\n%s\n", prettyPrint)

--- a/tests/e2e/lib/dpa_helpers.go
+++ b/tests/e2e/lib/dpa_helpers.go
@@ -308,7 +308,7 @@ func (v *DpaCustomResource) BSLsAreUpdated(updateTime time.Time) wait.ConditionF
 }
 
 // check if bsl matches the spec
-func (v *DpaCustomResource) DoesBSLSpecMatchesDpa(namespace string, dpaBSLSpec velero.BackupStorageLocationSpec) (bool, error) {
+func (v *DpaCustomResource) DoesBSLSpecMatchesDpa(dpaBSLSpec velero.BackupStorageLocationSpec) (bool, error) {
 	bsls, err := v.ListBSLs()
 	if err != nil {
 		return false, err
@@ -345,7 +345,7 @@ func (v *DpaCustomResource) ListVSLs() (*velero.VolumeSnapshotLocationList, erro
 }
 
 // check if vsl matches the spec
-func (v *DpaCustomResource) DoesVSLSpecMatchesDpa(namespace string, dpaVSLSpec velero.VolumeSnapshotLocationSpec) (bool, error) {
+func (v *DpaCustomResource) DoesVSLSpecMatchesDpa(dpaVSLSpec velero.VolumeSnapshotLocationSpec) (bool, error) {
 	vsls, err := v.ListVSLs()
 	if err != nil {
 		return false, err

--- a/tests/e2e/lib/k8s_common_helpers.go
+++ b/tests/e2e/lib/k8s_common_helpers.go
@@ -216,15 +216,17 @@ func SavePodLogs(clientset *kubernetes.Clientset, namespace, dir string) error {
 		err = os.MkdirAll(podDir, 0755)
 		if err != nil {
 			log.Printf("Error creating pod directory: %v", err)
+			return err
 		}
 		for _, container := range pod.Spec.Containers {
 			logs, err := GetPodContainerLogs(clientset, namespace, pod.Name, container.Name)
 			if err != nil {
-				return nil
+				return err
 			}
 			err = os.WriteFile(podDir+"/"+container.Name+".log", []byte(logs), 0644)
 			if err != nil {
 				log.Printf("Error writing pod logs: %v", err)
+				return err
 			}
 		}
 	}

--- a/tests/e2e/lib/k8s_common_helpers.go
+++ b/tests/e2e/lib/k8s_common_helpers.go
@@ -209,7 +209,7 @@ func GetFirstPodByLabel(clientset *kubernetes.Clientset, namespace string, label
 func SavePodLogs(clientset *kubernetes.Clientset, namespace, dir string) error {
 	podList, err := clientset.CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{})
 	if err != nil {
-		return nil
+		return err
 	}
 	for _, pod := range podList.Items {
 		podDir := fmt.Sprintf("%s/%s/%s", dir, namespace, pod.Name)

--- a/tests/e2e/must-gather_suite_test.go
+++ b/tests/e2e/must-gather_suite_test.go
@@ -31,7 +31,7 @@ var _ = ginkgo.Describe("Backup and restore tests with must-gather", func() {
 			if ginkgo.CurrentSpecReport().NumAttempts > 1 && !knownFlake {
 				ginkgo.Fail("No known FLAKE found in a previous run, marking test as failed.")
 			}
-			runApplicationBackupAndRestore(brCase, expectedErr, updateLastBRcase, updateLastInstallTime)
+			runApplicationBackupAndRestore(brCase, updateLastBRcase, updateLastInstallTime)
 
 			baseReportDir := artifact_dir + "/" + brCase.Name
 			err := os.MkdirAll(baseReportDir, 0755)

--- a/tests/e2e/upgrade_suite_test.go
+++ b/tests/e2e/upgrade_suite_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
-	"github.com/operator-framework/api/pkg/operators/v1"
+	v1 "github.com/operator-framework/api/pkg/operators/v1"
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -109,7 +109,7 @@ var _ = ginkgo.Describe("OADP upgrade scenarios", ginkgo.Ordered, func() {
 					},
 				},
 			}
-			err = dpaCR.CreateOrUpdate(runTimeClientForSuiteRun, dpaSpec)
+			err = dpaCR.CreateOrUpdate(dpaSpec)
 			gomega.Expect(err).To(gomega.BeNil())
 
 			// check that DPA is reconciled true

--- a/tests/e2e/upgrade_suite_test.go
+++ b/tests/e2e/upgrade_suite_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
-	v1 "github.com/operator-framework/api/pkg/operators/v1"
+	operatorv1 "github.com/operator-framework/api/pkg/operators/v1"
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -29,18 +29,18 @@ var _ = ginkgo.Describe("OADP upgrade scenarios", ginkgo.Ordered, func() {
 		func(scenario channelUpgradeCase) {
 			// Create OperatorGroup and Subscription with previous channel stable-1.4
 			log.Print("Checking if OperatorGroup needs to be created")
-			operatorGroupList := v1.OperatorGroupList{}
+			operatorGroupList := operatorv1.OperatorGroupList{}
 			err := runTimeClientForSuiteRun.List(context.Background(), &operatorGroupList, client.InNamespace(namespace))
 			gomega.Expect(err).To(gomega.BeNil())
 			gomega.Expect(len(operatorGroupList.Items) > 1).To(gomega.BeFalse())
 			if len(operatorGroupList.Items) == 0 {
 				log.Print("Creating OperatorGroup oadp-operator-group")
-				operatorGroup := v1.OperatorGroup{
+				operatorGroup := operatorv1.OperatorGroup{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "oadp-operator-group",
 						Namespace: namespace,
 					},
-					Spec: v1.OperatorGroupSpec{
+					Spec: operatorv1.OperatorGroupSpec{
 						TargetNamespaces: []string{namespace},
 					},
 				}

--- a/tests/e2e/virt_backup_restore_suite_test.go
+++ b/tests/e2e/virt_backup_restore_suite_test.go
@@ -79,7 +79,7 @@ type VmBackupRestoreCase struct {
 	PowerState string
 }
 
-func runVmBackupAndRestore(brCase VmBackupRestoreCase, expectedErr error, updateLastBRcase func(brCase VmBackupRestoreCase), updateLastInstallTime func(), v *lib.VirtOperator) {
+func runVmBackupAndRestore(brCase VmBackupRestoreCase, updateLastBRcase func(brCase VmBackupRestoreCase), v *lib.VirtOperator) {
 	updateLastBRcase(brCase)
 
 	// Create DPA
@@ -162,9 +162,6 @@ var _ = ginkgo.Describe("VM backup and restore tests", ginkgo.Ordered, func() {
 	updateLastBRcase := func(brCase VmBackupRestoreCase) {
 		lastBRCase = brCase
 	}
-	updateLastInstallTime := func() {
-		lastInstallTime = time.Now()
-	}
 
 	var _ = ginkgo.BeforeAll(func() {
 		v, err = lib.GetVirtOperator(runTimeClientForSuiteRun, kubernetesClientForSuiteRun, dynamicClientForSuiteRun, useUpstreamHco)
@@ -238,7 +235,7 @@ var _ = ginkgo.Describe("VM backup and restore tests", ginkgo.Ordered, func() {
 
 	ginkgo.DescribeTable("Backup and restore virtual machines",
 		func(brCase VmBackupRestoreCase, expectedError error) {
-			runVmBackupAndRestore(brCase, expectedError, updateLastBRcase, updateLastInstallTime, v)
+			runVmBackupAndRestore(brCase, updateLastBRcase, v)
 		},
 
 		ginkgo.Entry("no-application CSI datamover backup and restore, CirrOS VM", ginkgo.Label("virt"), VmBackupRestoreCase{


### PR DESCRIPTION
## Why the changes were made

Attempting a fix for #1595.
- Enabling unparam flag for golang-ci to catch unused params
- Removing unused params instances

## How to test the changes made

ci/prow/unit-test should now check for unused params.
