### PR TITLE
Make common function for updating BSL spec

### DIFF
--- a/api/v1alpha1/dataprotectionapplication_types.go
+++ b/api/v1alpha1/dataprotectionapplication_types.go
@@ -33,7 +33,6 @@ const ReconciledReasonError = "Error"
 const ReconcileCompleteMessage = "Reconcile complete"
 
 const OadpOperatorLabel = "openshift.io/oadp"
-const RegistryDeploymentLabel = "openshift.io/oadp-registry"
 
 // +kubebuilder:validation:Enum=aws;legacy-aws;gcp;azure;csi;vsm;openshift;kubevirt
 type DefaultPlugin string

--- a/internal/controller/bsl_test.go
+++ b/internal/controller/bsl_test.go
@@ -21,6 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
+	"github.com/openshift/oadp-operator/pkg/common"
 )
 
 // A bucket that region can be automatically discovered
@@ -1576,10 +1577,10 @@ func TestDPAReconciler_updateBSLFromSpec(t *testing.T) {
 						"app.kubernetes.io/name":     "oadp-operator-velero",
 						"app.kubernetes.io/instance": "foo" + "-1",
 						//"app.kubernetes.io/version":    "x.y.z",
-						"app.kubernetes.io/managed-by":       "oadp-operator",
-						"app.kubernetes.io/component":        "bsl",
-						oadpv1alpha1.OadpOperatorLabel:       "True",
-						oadpv1alpha1.RegistryDeploymentLabel: "True",
+						"app.kubernetes.io/managed-by": "oadp-operator",
+						"app.kubernetes.io/component":  "bsl",
+						oadpv1alpha1.OadpOperatorLabel: "True",
+						common.RegistryDeploymentLabel: "True",
 					},
 					OwnerReferences: []metav1.OwnerReference{{
 						APIVersion:         oadpv1alpha1.SchemeBuilder.GroupVersion.String(),
@@ -1656,10 +1657,10 @@ func TestDPAReconciler_updateBSLFromSpec(t *testing.T) {
 						"app.kubernetes.io/name":     "oadp-operator-velero",
 						"app.kubernetes.io/instance": "foo" + "-1",
 						//"app.kubernetes.io/version":    "x.y.z",
-						"app.kubernetes.io/managed-by":       "oadp-operator",
-						"app.kubernetes.io/component":        "bsl",
-						oadpv1alpha1.OadpOperatorLabel:       "True",
-						oadpv1alpha1.RegistryDeploymentLabel: "True",
+						"app.kubernetes.io/managed-by": "oadp-operator",
+						"app.kubernetes.io/component":  "bsl",
+						oadpv1alpha1.OadpOperatorLabel: "True",
+						common.RegistryDeploymentLabel: "True",
 					},
 					OwnerReferences: []metav1.OwnerReference{{
 						APIVersion:         oadpv1alpha1.SchemeBuilder.GroupVersion.String(),
@@ -1736,10 +1737,10 @@ func TestDPAReconciler_updateBSLFromSpec(t *testing.T) {
 						"app.kubernetes.io/name":     "oadp-operator-velero",
 						"app.kubernetes.io/instance": "foo" + "-1",
 						//"app.kubernetes.io/version":    "x.y.z",
-						"app.kubernetes.io/managed-by":       "oadp-operator",
-						"app.kubernetes.io/component":        "bsl",
-						oadpv1alpha1.OadpOperatorLabel:       "True",
-						oadpv1alpha1.RegistryDeploymentLabel: "True",
+						"app.kubernetes.io/managed-by": "oadp-operator",
+						"app.kubernetes.io/component":  "bsl",
+						oadpv1alpha1.OadpOperatorLabel: "True",
+						common.RegistryDeploymentLabel: "True",
 					},
 					OwnerReferences: []metav1.OwnerReference{{
 						APIVersion:         oadpv1alpha1.SchemeBuilder.GroupVersion.String(),

--- a/internal/controller/registry.go
+++ b/internal/controller/registry.go
@@ -160,10 +160,10 @@ type azureCredentials struct {
 
 func (r *DataProtectionApplicationReconciler) ReconcileRegistries(log logr.Logger) (bool, error) {
 	bslLabels := map[string]string{
-		"app.kubernetes.io/name":             common.OADPOperatorVelero,
-		"app.kubernetes.io/managed-by":       common.OADPOperator,
-		"app.kubernetes.io/component":        "bsl",
-		oadpv1alpha1.RegistryDeploymentLabel: "True",
+		"app.kubernetes.io/name":       common.OADPOperatorVelero,
+		"app.kubernetes.io/managed-by": common.OADPOperator,
+		"app.kubernetes.io/component":  "bsl",
+		common.RegistryDeploymentLabel: "True",
 	}
 	bslListOptions := client.MatchingLabels(bslLabels)
 	backupStorageLocationList := velerov1.BackupStorageLocationList{}

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -304,6 +304,8 @@ func ApplyUnsupportedServerArgsOverride(container *corev1.Container, unsupported
 }
 
 // UpdateBackupStorageLocation updates the BackupStorageLocation spec and config.
+//
+//nolint:unparam // Keeping error return type for making the public function flexible for future usage
 func UpdateBackupStorageLocation(bsl *velerov1.BackupStorageLocation, bslSpec velerov1.BackupStorageLocationSpec) error {
 	if bsl.ObjectMeta.Labels == nil {
 		bsl.ObjectMeta.Labels = make(map[string]string)


### PR DESCRIPTION
## Why the changes were made

With the self service project (Non Admin) it is required to update BSL spec based on the same conditions as OADP BSL spec would be updated. It makes sense to move out the logic from the bsl specific function to a common publicly available from which NABSL controller can also benefit.

## How to test the changes made

Run tests. New tests have been written to cover public function, old tests are also working proving that the function is correct.

This is required to fix https://github.com/migtools/oadp-non-admin/issues/188 on the Non-Admin side.