### PR TITLE
Restrict enforcing NAB spec that are restricted for non-admin users

### DIFF
--- a/internal/controller/validator.go
+++ b/internal/controller/validator.go
@@ -16,6 +16,8 @@ import (
 	"github.com/openshift/oadp-operator/pkg/credentials"
 )
 
+const NACNonEnforceableErr = "DPA %s is non-enforceable by admins"
+
 // ValidateDataProtectionCR function validates the DPA CR, returns true if valid, false otherwise
 // it calls other validation functions to validate the DPA CR
 func (r *DataProtectionApplicationReconciler) ValidateDataProtectionCR(log logr.Logger) (bool, error) {
@@ -146,23 +148,23 @@ func (r *DataProtectionApplicationReconciler) ValidateDataProtectionCR(log logr.
 			// check if BSL name is enforced by the admin
 			// We do not support this, we restrict enforcing BSL name
 			if enforcedBackupSpec.StorageLocation != "" {
-				return false, fmt.Errorf("DPA spec.nonAdmin.enforcedBackupSpec.storageLocation is non-enforceable by admins")
+				return false, fmt.Errorf(fmt.Sprintf(NACNonEnforceableErr, "spec.nonAdmin.enforcedBackupSpec.storageLocation"))
 			}
 
 			if enforcedBackupSpec.IncludedNamespaces != nil {
-				return false, fmt.Errorf("DPA spec.nonAdmin.enforcedBackupSpec.includedNamespaces is non-enforceable by admins")
+				return false, fmt.Errorf(fmt.Sprintf(NACNonEnforceableErr, "spec.nonAdmin.enforcedBackupSpec.includedNamespaces"))
 			}
 
 			if enforcedBackupSpec.ExcludedNamespaces != nil {
-				return false, fmt.Errorf("DPA spec.nonAdmin.excludedNamespaces is non-enforceable by admins")
+				return false, fmt.Errorf(fmt.Sprintf(NACNonEnforceableErr, "spec.nonAdmin.enforcedBackupSpec.excludedNamespaces"))
 			}
 
 			if enforcedBackupSpec.IncludeClusterResources != nil && *enforcedBackupSpec.IncludeClusterResources {
-				return false, fmt.Errorf("DPA spec.nonAdmin.includeClusterResources cannot be set as true, must be set to false if enforced by admins")
+				return false, fmt.Errorf(fmt.Sprintf(NACNonEnforceableErr+" as true, must be set to false if enforced by admins", "spec.nonAdmin.enforcedBackupSpec.includeClusterResources"))
 			}
 
 			if len(enforcedBackupSpec.IncludedClusterScopedResources) > 0 {
-				return false, fmt.Errorf("DPA spec.nonAdmin.includedClusterScopedResources is non-enforceable by admins, only empty list is allowed")
+				return false, fmt.Errorf(fmt.Sprintf(NACNonEnforceableErr+" and must remain empty", "spec.nonAdmin.enforcedBackupSpec.includedClusterScopedResources"))
 			}
 
 		}

--- a/internal/controller/validator.go
+++ b/internal/controller/validator.go
@@ -148,9 +148,23 @@ func (r *DataProtectionApplicationReconciler) ValidateDataProtectionCR(log logr.
 			if enforcedBackupSpec.StorageLocation != "" {
 				return false, fmt.Errorf("DPA spec.nonAdmin.enforcedBackupSpec.storageLocation is non-enforceable by admins")
 			}
+
 			if enforcedBackupSpec.IncludedNamespaces != nil {
 				return false, fmt.Errorf("DPA spec.nonAdmin.enforcedBackupSpec.includedNamespaces is non-enforceable by admins")
 			}
+
+			if enforcedBackupSpec.ExcludedNamespaces != nil {
+				return false, fmt.Errorf("DPA spec.nonAdmin.excludedNamespaces is non-enforceable by admins")
+			}
+
+			if enforcedBackupSpec.IncludeClusterResources != nil && *enforcedBackupSpec.IncludeClusterResources {
+				return false, fmt.Errorf("DPA spec.nonAdmin.includeClusterResources cannot be set as true, must be set to false if enforced by admins")
+			}
+
+			if len(enforcedBackupSpec.IncludedClusterScopedResources) > 0 {
+				return false, fmt.Errorf("DPA spec.nonAdmin.includedClusterScopedResources is non-enforceable by admins, only empty list is allowed")
+			}
+
 		}
 
 	}

--- a/internal/controller/validator.go
+++ b/internal/controller/validator.go
@@ -148,6 +148,9 @@ func (r *DataProtectionApplicationReconciler) ValidateDataProtectionCR(log logr.
 			if enforcedBackupSpec.StorageLocation != "" {
 				return false, fmt.Errorf("DPA spec.nonAdmin.enforcedBackupSpec.storageLocation is non-enforceable by admins")
 			}
+			if enforcedBackupSpec.IncludedNamespaces != nil {
+				return false, fmt.Errorf("DPA spec.nonAdmin.enforcedBackupSpec.includedNamespaces is non-enforceable by admins")
+			}
 		}
 
 	}

--- a/internal/controller/validator.go
+++ b/internal/controller/validator.go
@@ -139,6 +139,17 @@ func (r *DataProtectionApplicationReconciler) ValidateDataProtectionCR(log logr.
 		}
 		// TODO should also validate that BSL backupSyncPeriod is not greater or equal to nonAdmin.backupSyncPeriod
 		// but BSL can not exist yet when we validate the value
+
+		enforcedBackupSpec := r.dpa.Spec.NonAdmin.EnforceBackupSpec
+
+		if enforcedBackupSpec != nil {
+			// check if BSL name is enforced by the admin
+			// We do not support this, we restrict enforcing BSL name
+			if enforcedBackupSpec.StorageLocation != "" {
+				return false, fmt.Errorf("enforcedBackupSpec.storageLocation is non-enforceable by admins")
+			}
+		}
+
 	}
 
 	return true, nil

--- a/internal/controller/validator.go
+++ b/internal/controller/validator.go
@@ -146,7 +146,7 @@ func (r *DataProtectionApplicationReconciler) ValidateDataProtectionCR(log logr.
 			// check if BSL name is enforced by the admin
 			// We do not support this, we restrict enforcing BSL name
 			if enforcedBackupSpec.StorageLocation != "" {
-				return false, fmt.Errorf("enforcedBackupSpec.storageLocation is non-enforceable by admins")
+				return false, fmt.Errorf("DPA spec.nonAdmin.enforcedBackupSpec.storageLocation is non-enforceable by admins")
 			}
 		}
 

--- a/internal/controller/validator_test.go
+++ b/internal/controller/validator_test.go
@@ -1499,8 +1499,7 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 					NonAdmin: &oadpv1alpha1.NonAdmin{
 						Enable: ptr.To(true),
 						EnforceBackupSpec: &velerov1.BackupSpec{
-							IncludedNamespaces: []string{"banana"},
-							SnapshotVolumes:    ptr.To(false),
+							SnapshotVolumes: ptr.To(false),
 						},
 					},
 				},
@@ -1523,15 +1522,40 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 					NonAdmin: &oadpv1alpha1.NonAdmin{
 						Enable: ptr.To(true),
 						EnforceBackupSpec: &velerov1.BackupSpec{
-							IncludedNamespaces: []string{"banana"},
-							SnapshotVolumes:    ptr.To(false),
-							StorageLocation:    "foo-bsl",
+							SnapshotVolumes: ptr.To(false),
+							StorageLocation: "foo-bsl",
 						},
 					},
 				},
 			},
 			wantErr:    true,
 			messageErr: "DPA spec.nonAdmin.enforcedBackupSpec.storageLocation is non-enforceable by admins",
+		},
+		{
+			name: "[Invalid] DPA CR: spec.nonAdmin.enforceBackupSpec.includedNamespaces set",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-DPA-CR",
+					Namespace: "test-ns",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{
+							NoDefaultBackupLocation: true,
+						},
+					},
+					BackupImages: ptr.To(false),
+					NonAdmin: &oadpv1alpha1.NonAdmin{
+						Enable: ptr.To(true),
+						EnforceBackupSpec: &velerov1.BackupSpec{
+							IncludedNamespaces: []string{"banana"},
+							SnapshotVolumes:    ptr.To(false),
+						},
+					},
+				},
+			},
+			wantErr:    true,
+			messageErr: "DPA spec.nonAdmin.enforcedBackupSpec.includedNamespaces is non-enforceable by admins",
 		},
 		{
 			name: "[valid] DPA CR: spec.nonAdmin.enforceRestoreSpec set",
@@ -1550,8 +1574,7 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 					NonAdmin: &oadpv1alpha1.NonAdmin{
 						Enable: ptr.To(true),
 						EnforceRestoreSpec: &velerov1.RestoreSpec{
-							IncludedNamespaces: []string{"banana"},
-							RestorePVs:         ptr.To(true),
+							RestorePVs: ptr.To(true),
 						},
 					},
 				},

--- a/internal/controller/validator_test.go
+++ b/internal/controller/validator_test.go
@@ -1507,6 +1507,33 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 			},
 		},
 		{
+			name: "[valid] DPA CR: spec.nonAdmin.enforceBackupSpec.storageLocation set",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-DPA-CR",
+					Namespace: "test-ns",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{
+							NoDefaultBackupLocation: true,
+						},
+					},
+					BackupImages: ptr.To(false),
+					NonAdmin: &oadpv1alpha1.NonAdmin{
+						Enable: ptr.To(true),
+						EnforceBackupSpec: &velerov1.BackupSpec{
+							IncludedNamespaces: []string{"banana"},
+							SnapshotVolumes:    ptr.To(false),
+							StorageLocation:    "foo-bsl",
+						},
+					},
+				},
+			},
+			wantErr:    true,
+			messageErr: "enforcedBackupSpec.storageLocation is non-enforceable by admins",
+		},
+		{
 			name: "[valid] DPA CR: spec.nonAdmin.enforceRestoreSpec set",
 			dpa: &oadpv1alpha1.DataProtectionApplication{
 				ObjectMeta: metav1.ObjectMeta{

--- a/internal/controller/validator_test.go
+++ b/internal/controller/validator_test.go
@@ -1507,7 +1507,7 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 			},
 		},
 		{
-			name: "[valid] DPA CR: spec.nonAdmin.enforceBackupSpec.storageLocation set",
+			name: "[Invalid] DPA CR: spec.nonAdmin.enforceBackupSpec.storageLocation set",
 			dpa: &oadpv1alpha1.DataProtectionApplication{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-DPA-CR",
@@ -1531,7 +1531,7 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 				},
 			},
 			wantErr:    true,
-			messageErr: "enforcedBackupSpec.storageLocation is non-enforceable by admins",
+			messageErr: "DPA spec.nonAdmin.enforcedBackupSpec.storageLocation is non-enforceable by admins",
 		},
 		{
 			name: "[valid] DPA CR: spec.nonAdmin.enforceRestoreSpec set",

--- a/internal/controller/validator_test.go
+++ b/internal/controller/validator_test.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -1529,7 +1530,7 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 				},
 			},
 			wantErr:    true,
-			messageErr: "DPA spec.nonAdmin.enforcedBackupSpec.storageLocation is non-enforceable by admins",
+			messageErr: fmt.Sprintf(NACNonEnforceableErr, "spec.nonAdmin.enforcedBackupSpec.storageLocation"),
 		},
 		{
 			name: "[Invalid] DPA CR: spec.nonAdmin.enforceBackupSpec.includedNamespaces set",
@@ -1555,7 +1556,33 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 				},
 			},
 			wantErr:    true,
-			messageErr: "DPA spec.nonAdmin.enforcedBackupSpec.includedNamespaces is non-enforceable by admins",
+			messageErr: fmt.Sprintf(NACNonEnforceableErr, "spec.nonAdmin.enforcedBackupSpec.includedNamespaces"),
+		},
+		{
+			name: "[Invalid] DPA CR: spec.nonAdmin.enforceBackupSpec.excludedNamespaces set",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-DPA-CR",
+					Namespace: "test-ns",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{
+							NoDefaultBackupLocation: true,
+						},
+					},
+					BackupImages: ptr.To(false),
+					NonAdmin: &oadpv1alpha1.NonAdmin{
+						Enable: ptr.To(true),
+						EnforceBackupSpec: &velerov1.BackupSpec{
+							ExcludedNamespaces: []string{"banana"},
+							SnapshotVolumes:    ptr.To(false),
+						},
+					},
+				},
+			},
+			wantErr:    true,
+			messageErr: fmt.Sprintf(NACNonEnforceableErr, "spec.nonAdmin.enforcedBackupSpec.excludedNamespaces"),
 		},
 		{
 			name: "[Invalid] DPA CR: spec.nonAdmin.enforceBackupSpec.includeClusterResources set",
@@ -1580,7 +1607,7 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 				},
 			},
 			wantErr:    true,
-			messageErr: "DPA spec.nonAdmin.includeClusterResources cannot be set as true, must be set to false if enforced by admins",
+			messageErr: fmt.Sprintf(NACNonEnforceableErr+" as true, must be set to false if enforced by admins", "spec.nonAdmin.enforcedBackupSpec.includeClusterResources"),
 		},
 		{
 			name: "[Invalid] DPA CR: spec.nonAdmin.enforceBackupSpec.includedClusterScopedResources set as a non-empty list",
@@ -1605,7 +1632,7 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 				},
 			},
 			wantErr:    true,
-			messageErr: "DPA spec.nonAdmin.includedClusterScopedResources is non-enforceable by admins, only empty list is allowed",
+			messageErr: fmt.Sprintf(NACNonEnforceableErr+" and must remain empty", "spec.nonAdmin.enforcedBackupSpec.includedClusterScopedResources"),
 		},
 		{
 			name: "[valid] DPA CR: spec.nonAdmin.enforceRestoreSpec set",

--- a/internal/controller/validator_test.go
+++ b/internal/controller/validator_test.go
@@ -1558,6 +1558,56 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 			messageErr: "DPA spec.nonAdmin.enforcedBackupSpec.includedNamespaces is non-enforceable by admins",
 		},
 		{
+			name: "[Invalid] DPA CR: spec.nonAdmin.enforceBackupSpec.includeClusterResources set",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-DPA-CR",
+					Namespace: "test-ns",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{
+							NoDefaultBackupLocation: true,
+						},
+					},
+					BackupImages: ptr.To(false),
+					NonAdmin: &oadpv1alpha1.NonAdmin{
+						Enable: ptr.To(true),
+						EnforceBackupSpec: &velerov1.BackupSpec{
+							IncludeClusterResources: ptr.To(true),
+						},
+					},
+				},
+			},
+			wantErr:    true,
+			messageErr: "DPA spec.nonAdmin.includeClusterResources cannot be set as true, must be set to false if enforced by admins",
+		},
+		{
+			name: "[Invalid] DPA CR: spec.nonAdmin.enforceBackupSpec.includedClusterScopedResources set as a non-empty list",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-DPA-CR",
+					Namespace: "test-ns",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{
+							NoDefaultBackupLocation: true,
+						},
+					},
+					BackupImages: ptr.To(false),
+					NonAdmin: &oadpv1alpha1.NonAdmin{
+						Enable: ptr.To(true),
+						EnforceBackupSpec: &velerov1.BackupSpec{
+							IncludedClusterScopedResources: []string{"foo", "bar"},
+						},
+					},
+				},
+			},
+			wantErr:    true,
+			messageErr: "DPA spec.nonAdmin.includedClusterScopedResources is non-enforceable by admins, only empty list is allowed",
+		},
+		{
 			name: "[valid] DPA CR: spec.nonAdmin.enforceRestoreSpec set",
 			dpa: &oadpv1alpha1.DataProtectionApplication{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## Why the changes were made

<!-- Explain why this PR is important, what problems it fixes, link related issues -->
Fixes https://github.com/migtools/oadp-non-admin/issues/184
Fixes https://github.com/migtools/oadp-non-admin/issues/200
Fixes https://github.com/migtools/oadp-non-admin/issues/201

Related to https://github.com/migtools/oadp-non-admin/pull/208

## How to test the changes made

<!-- Explain how the changes introduced by this PR can be tested and verified, with commands and pictures -->
- Try enforcing the BSL name,  excludedNamespaces, IncludeClusterResources as true, and non-empty IncludedClusterScopedResources for NABs 
- DPA should error out
