### PR TITLE
Pass LogLevel to NAC deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ test-upgrade/
 junit_report.xml
 # `operator-sdk run bundle` caches files in this directory
 cache/
+# debug files
+debug.test*

--- a/internal/controller/nonadmin_controller.go
+++ b/internal/controller/nonadmin_controller.go
@@ -160,7 +160,10 @@ func ensureRequiredSpecs(deploymentObject *appsv1.Deployment, dpa *oadpv1alpha1.
 			Name: common.LogLevelEnvVar,
 			Value: func() string {
 				// these levels are already validated in another controller.
-				level, _ := logrus.ParseLevel(dpa.Spec.Configuration.Velero.LogLevel)
+				level, err := logrus.ParseLevel(dpa.Spec.Configuration.Velero.LogLevel)
+				if err != nil {
+					return ""
+				}
 				return strconv.FormatUint(uint64(level), 10)
 			}(),
 		})

--- a/internal/controller/nonadmin_controller.go
+++ b/internal/controller/nonadmin_controller.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"strconv"
 
 	"github.com/go-logr/logr"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/exp/maps"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -147,9 +149,21 @@ func ensureRequiredLabels(deploymentObject *appsv1.Deployment) {
 }
 
 func ensureRequiredSpecs(deploymentObject *appsv1.Deployment, dpa *oadpv1alpha1.DataProtectionApplication, image string, imagePullPolicy corev1.PullPolicy) error {
-	namespaceEnvVar := corev1.EnvVar{
-		Name:  "WATCH_NAMESPACE",
-		Value: deploymentObject.Namespace,
+	envVars := []corev1.EnvVar{
+		{
+			Name:  "WATCH_NAMESPACE", // TODO: fix, this is only used to indicate oadp ns, and is not actually used for watching ns.
+			Value: deploymentObject.Namespace,
+		},
+	}
+	if dpa.Spec.Configuration != nil && dpa.Spec.Configuration.Velero != nil {
+		envVars = append(envVars, corev1.EnvVar{
+			Name: common.LogLevelEnvVar,
+			Value: func() string {
+				// these levels are already validated in another controller.
+				level, _ := logrus.ParseLevel(dpa.Spec.Configuration.Velero.LogLevel)
+				return strconv.FormatUint(uint64(level), 10)
+			}(),
+		})
 	}
 	if len(dpaResourceVersion) == 0 ||
 		!reflect.DeepEqual(dpa.Spec.NonAdmin, previousNonAdminConfiguration) {
@@ -187,7 +201,7 @@ func ensureRequiredSpecs(deploymentObject *appsv1.Deployment, dpa *oadpv1alpha1.
 			Name:                     nonAdminObjectName,
 			Image:                    image,
 			ImagePullPolicy:          imagePullPolicy,
-			Env:                      []corev1.EnvVar{namespaceEnvVar},
+			Env:                      envVars,
 			TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 		}}
 		nonAdminContainerFound = true
@@ -197,7 +211,7 @@ func ensureRequiredSpecs(deploymentObject *appsv1.Deployment, dpa *oadpv1alpha1.
 				nonAdminContainer := &deploymentObject.Spec.Template.Spec.Containers[index]
 				nonAdminContainer.Image = image
 				nonAdminContainer.ImagePullPolicy = imagePullPolicy
-				nonAdminContainer.Env = []corev1.EnvVar{namespaceEnvVar}
+				nonAdminContainer.Env = envVars
 				nonAdminContainer.TerminationMessagePolicy = corev1.TerminationMessageFallbackToLogsOnError
 				nonAdminContainerFound = true
 				break

--- a/internal/controller/nonadmin_controller_test.go
+++ b/internal/controller/nonadmin_controller_test.go
@@ -379,12 +379,16 @@ func TestEnsureRequiredSpecs(t *testing.T) {
 		if env.Name == common.LogLevelEnvVar {
 			// check that we get expected int value string from the level set in config
 			if expectedLevel, err := logrus.ParseLevel(""); err != nil {
-				// we expect logrus.ParseLevel("") to err here but still provide valid expectedLevel of 0
+				// we expect logrus.ParseLevel("") to err here and returns 0
 				if err == nil {
 					t.Error("Expected err when level is empty from logrus.ParseLevel")
 				}
-				// We ignored the err in ensureRequiredSpecs as the returned expectedLevel of 0 is still a valid level.
-				if env.Value != strconv.FormatUint(uint64(expectedLevel), 10) {
+				// The returned expectedLevel of 0 is panic level
+				if expectedLevel != logrus.PanicLevel {
+					t.Errorf("unexpected logrus.ParseLevel('') return value")
+				}
+				// we ignore and return empty string instead, and nac deployment will handle defaulting
+				if env.Value != "" {
 					t.Errorf("log level unexpected")
 				}
 			}

--- a/internal/controller/nonadmin_controller_test.go
+++ b/internal/controller/nonadmin_controller_test.go
@@ -3,11 +3,13 @@ package controller
 import (
 	"context"
 	"os"
+	"strconv"
 	"testing"
 
 	"github.com/go-logr/logr"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
 	"github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -17,6 +19,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
+	"github.com/openshift/oadp-operator/pkg/common"
 )
 
 const defaultNonAdminImage = "quay.io/konveyor/oadp-non-admin:latest"
@@ -292,6 +295,11 @@ func TestEnsureRequiredSpecs(t *testing.T) {
 			ResourceVersion: "123456789",
 		},
 		Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+			Configuration: &oadpv1alpha1.ApplicationConfig{
+				Velero: &oadpv1alpha1.VeleroConfig{
+					LogLevel: logrus.DebugLevel.String(),
+				},
+			},
 			NonAdmin: &oadpv1alpha1.NonAdmin{
 				Enable: ptr.To(true),
 			},
@@ -313,6 +321,19 @@ func TestEnsureRequiredSpecs(t *testing.T) {
 	if len(deployment.Spec.Template.Annotations[dpaResourceVersionAnnotation]) == 0 {
 		t.Errorf("Deployment does not have Annotation")
 	}
+	for _, env := range deployment.Spec.Template.Spec.Containers[0].Env {
+		if env.Name == common.LogLevelEnvVar {
+			// check that we get expected int value string from the level set in config
+			if expectedLevel, err := logrus.ParseLevel(logrus.DebugLevel.String()); err != nil {
+				t.Errorf("Unable to parse loglevel expected")
+			} else {
+				if env.Value != strconv.FormatUint(uint64(expectedLevel), 10) {
+					t.Errorf("log level unexpected")
+				}
+			}
+		}
+	}
+
 	previousDPAAnnotationValue := deployment.DeepCopy().Spec.Template.Annotations[dpaResourceVersionAnnotation]
 	updatedDPA := &oadpv1alpha1.DataProtectionApplication{
 		ObjectMeta: metav1.ObjectMeta{
@@ -336,6 +357,9 @@ func TestEnsureRequiredSpecs(t *testing.T) {
 			ResourceVersion: "987654321",
 		},
 		Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+			Configuration: &oadpv1alpha1.ApplicationConfig{
+				Velero: &oadpv1alpha1.VeleroConfig{},
+			},
 			NonAdmin: &oadpv1alpha1.NonAdmin{
 				Enable: ptr.To(true),
 				EnforceBackupSpec: &v1.BackupSpec{
@@ -350,6 +374,21 @@ func TestEnsureRequiredSpecs(t *testing.T) {
 	}
 	if previousDPAAnnotationValue == deployment.Spec.Template.Annotations[dpaResourceVersionAnnotation] {
 		t.Errorf("Deployment does not have different Annotation")
+	}
+	for _, env := range deployment.Spec.Template.Spec.Containers[0].Env {
+		if env.Name == common.LogLevelEnvVar {
+			// check that we get expected int value string from the level set in config
+			if expectedLevel, err := logrus.ParseLevel(""); err != nil {
+				// we expect logrus.ParseLevel("") to err here but still provide valid expectedLevel of 0
+				if err == nil {
+					t.Error("Expected err when level is empty from logrus.ParseLevel")
+				}
+				// We ignored the err in ensureRequiredSpecs as the returned expectedLevel of 0 is still a valid level.
+				if env.Value != strconv.FormatUint(uint64(expectedLevel), 10) {
+					t.Errorf("log level unexpected")
+				}
+			}
+		}
 	}
 	previousDPAAnnotationValue = deployment.DeepCopy().Spec.Template.Annotations[dpaResourceVersionAnnotation]
 	updatedDPA = &oadpv1alpha1.DataProtectionApplication{

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -95,6 +95,7 @@ const (
 	HTTPProxyEnvVar                = "HTTP_PROXY"
 	HTTPSProxyEnvVar               = "HTTPS_PROXY"
 	NoProxyEnvVar                  = "NO_PROXY"
+	LogLevelEnvVar                 = "LOG_LEVEL"
 )
 
 // Unsupported Server Args annotation keys


### PR DESCRIPTION

Signed-off-by: Tiger Kaovilai <tkaovila@redhat.com>

## Why the changes were made
To help solve https://github.com/migtools/oadp-non-admin/issues/51
<!-- Explain why this PR is important, what problems it fixes, link related issues -->

## How to test the changes made

<!-- Explain how the changes introduced by this PR can be tested and verified, with commands and pictures -->
See that NAC deployment would have the LOG_LEVEL env with appropriate logrus loglevel int value passed as string.
