### PR TITLE
fix: restrict vsl enforcement

### DIFF
--- a/internal/controller/validator.go
+++ b/internal/controller/validator.go
@@ -148,23 +148,27 @@ func (r *DataProtectionApplicationReconciler) ValidateDataProtectionCR(log logr.
 			// check if BSL name is enforced by the admin
 			// We do not support this, we restrict enforcing BSL name
 			if enforcedBackupSpec.StorageLocation != "" {
-				return false, fmt.Errorf(fmt.Sprintf(NACNonEnforceableErr, "spec.nonAdmin.enforcedBackupSpec.storageLocation"))
+				return false, fmt.Errorf(NACNonEnforceableErr, "spec.nonAdmin.enforcedBackupSpec.storageLocation")
+			}
+
+			if enforcedBackupSpec.VolumeSnapshotLocations != nil {
+				return false, fmt.Errorf(NACNonEnforceableErr, "spec.nonAdmin.enforcedBackupSpec.volumeSnapshotLocations")
 			}
 
 			if enforcedBackupSpec.IncludedNamespaces != nil {
-				return false, fmt.Errorf(fmt.Sprintf(NACNonEnforceableErr, "spec.nonAdmin.enforcedBackupSpec.includedNamespaces"))
+				return false, fmt.Errorf(NACNonEnforceableErr, "spec.nonAdmin.enforcedBackupSpec.includedNamespaces")
 			}
 
 			if enforcedBackupSpec.ExcludedNamespaces != nil {
-				return false, fmt.Errorf(fmt.Sprintf(NACNonEnforceableErr, "spec.nonAdmin.enforcedBackupSpec.excludedNamespaces"))
+				return false, fmt.Errorf(NACNonEnforceableErr, "spec.nonAdmin.enforcedBackupSpec.excludedNamespaces")
 			}
 
 			if enforcedBackupSpec.IncludeClusterResources != nil && *enforcedBackupSpec.IncludeClusterResources {
-				return false, fmt.Errorf(fmt.Sprintf(NACNonEnforceableErr+" as true, must be set to false if enforced by admins", "spec.nonAdmin.enforcedBackupSpec.includeClusterResources"))
+				return false, fmt.Errorf(NACNonEnforceableErr+" as true, must be set to false if enforced by admins", "spec.nonAdmin.enforcedBackupSpec.includeClusterResources")
 			}
 
 			if len(enforcedBackupSpec.IncludedClusterScopedResources) > 0 {
-				return false, fmt.Errorf(fmt.Sprintf(NACNonEnforceableErr+" and must remain empty", "spec.nonAdmin.enforcedBackupSpec.includedClusterScopedResources"))
+				return false, fmt.Errorf(NACNonEnforceableErr+" and must remain empty", "spec.nonAdmin.enforcedBackupSpec.includedClusterScopedResources")
 			}
 
 		}

--- a/internal/controller/validator_test.go
+++ b/internal/controller/validator_test.go
@@ -1533,6 +1533,32 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 			messageErr: fmt.Sprintf(NACNonEnforceableErr, "spec.nonAdmin.enforcedBackupSpec.storageLocation"),
 		},
 		{
+			name: "[Invalid] DPA CR: spec.nonAdmin.enforceBackupSpec.volumeSnapshotLocations set",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-DPA-CR",
+					Namespace: "test-ns",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{
+							NoDefaultBackupLocation: true,
+						},
+					},
+					BackupImages: ptr.To(false),
+					NonAdmin: &oadpv1alpha1.NonAdmin{
+						Enable: ptr.To(true),
+						EnforceBackupSpec: &velerov1.BackupSpec{
+							SnapshotVolumes:         ptr.To(false),
+							VolumeSnapshotLocations: []string{"foo-vsl", "bar-vsl"},
+						},
+					},
+				},
+			},
+			wantErr:    true,
+			messageErr: fmt.Sprintf(NACNonEnforceableErr, "spec.nonAdmin.enforcedBackupSpec.volumeSnapshotLocations"),
+		},
+		{
 			name: "[Invalid] DPA CR: spec.nonAdmin.enforceBackupSpec.includedNamespaces set",
 			dpa: &oadpv1alpha1.DataProtectionApplication{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## Why the changes were made

https://github.com/migtools/oadp-non-admin/issues/202

## How to test the changes made

Check that admin can not enforce VSLs in NABs spec.
