### PR TITLE
Restrict enforcing NAR spec that are restricted for non-admin users

### DIFF
--- a/internal/controller/validator.go
+++ b/internal/controller/validator.go
@@ -173,6 +173,26 @@ func (r *DataProtectionApplicationReconciler) ValidateDataProtectionCR(log logr.
 
 		}
 
+		enforcedRestoreSpec := r.dpa.Spec.NonAdmin.EnforceRestoreSpec
+
+		if enforcedRestoreSpec != nil {
+			if len(enforcedRestoreSpec.ScheduleName) > 0 {
+				return false, fmt.Errorf(NACNonEnforceableErr, "spec.nonAdmin.enforcedRestoreSpec.scheduleName")
+			}
+
+			if enforcedRestoreSpec.IncludedNamespaces != nil {
+				return false, fmt.Errorf(NACNonEnforceableErr, "spec.nonAdmin.enforcedRestoreSpec.includedNamespaces")
+			}
+
+			if enforcedRestoreSpec.ExcludedNamespaces != nil {
+				return false, fmt.Errorf(NACNonEnforceableErr, "spec.nonAdmin.enforcedRestoreSpec.excludedNamespaces")
+			}
+
+			if enforcedRestoreSpec.NamespaceMapping != nil {
+				return false, fmt.Errorf(NACNonEnforceableErr, "spec.nonAdmin.enforcedRestoreSpec.namespaceMapping")
+			}
+		}
+
 	}
 
 	return true, nil

--- a/internal/controller/validator_test.go
+++ b/internal/controller/validator_test.go
@@ -1684,6 +1684,112 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 			},
 		},
 		{
+			name: "[invalid] DPA CR: spec.nonAdmin.enforceRestoreSpec.scheduleName is set",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-DPA-CR",
+					Namespace: "test-ns",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{
+							NoDefaultBackupLocation: true,
+						},
+					},
+					BackupImages: ptr.To(false),
+					NonAdmin: &oadpv1alpha1.NonAdmin{
+						Enable: ptr.To(true),
+						EnforceRestoreSpec: &velerov1.RestoreSpec{
+							ScheduleName: "foo-schedule-set",
+							RestorePVs:   ptr.To(true),
+						},
+					},
+				},
+			},
+			wantErr:    true,
+			messageErr: fmt.Sprintf(NACNonEnforceableErr, "spec.nonAdmin.enforcedRestoreSpec.scheduleName"),
+		},
+		{
+			name: "[invalid] DPA CR: spec.nonAdmin.enforceRestoreSpec.includedNamespaces is set",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-DPA-CR",
+					Namespace: "test-ns",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{
+							NoDefaultBackupLocation: true,
+						},
+					},
+					BackupImages: ptr.To(false),
+					NonAdmin: &oadpv1alpha1.NonAdmin{
+						Enable: ptr.To(true),
+						EnforceRestoreSpec: &velerov1.RestoreSpec{
+							IncludedNamespaces: []string{"included-ns-foo"},
+							RestorePVs:         ptr.To(true),
+						},
+					},
+				},
+			},
+			wantErr:    true,
+			messageErr: fmt.Sprintf(NACNonEnforceableErr, "spec.nonAdmin.enforcedRestoreSpec.includedNamespaces"),
+		},
+		{
+			name: "[invalid] DPA CR: spec.nonAdmin.enforceRestoreSpec.excludedNamespaces is set",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-DPA-CR",
+					Namespace: "test-ns",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{
+							NoDefaultBackupLocation: true,
+						},
+					},
+					BackupImages: ptr.To(false),
+					NonAdmin: &oadpv1alpha1.NonAdmin{
+						Enable: ptr.To(true),
+						EnforceRestoreSpec: &velerov1.RestoreSpec{
+							ExcludedNamespaces: []string{"excluded-ns-foo"},
+							RestorePVs:         ptr.To(true),
+						},
+					},
+				},
+			},
+			wantErr:    true,
+			messageErr: fmt.Sprintf(NACNonEnforceableErr, "spec.nonAdmin.enforcedRestoreSpec.excludedNamespaces"),
+		},
+		{
+			name: "[invalid] DPA CR: spec.nonAdmin.enforceRestoreSpec.namespaceMapping is set",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-DPA-CR",
+					Namespace: "test-ns",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{
+							NoDefaultBackupLocation: true,
+						},
+					},
+					BackupImages: ptr.To(false),
+					NonAdmin: &oadpv1alpha1.NonAdmin{
+						Enable: ptr.To(true),
+						EnforceRestoreSpec: &velerov1.RestoreSpec{
+							NamespaceMapping: map[string]string{
+								"foo-ns-1": "bar-ns-2",
+							},
+							RestorePVs: ptr.To(true),
+						},
+					},
+				},
+			},
+			wantErr:    true,
+			messageErr: fmt.Sprintf(NACNonEnforceableErr, "spec.nonAdmin.enforcedRestoreSpec.namespaceMapping"),
+		},
+		{
 			name: "[valid] DPA CR: spec.nonAdmin.enable true",
 			dpa: &oadpv1alpha1.DataProtectionApplication{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## Why the changes were made

<!-- Explain why this PR is important, what problems it fixes, link related issues -->
Fix part of https://github.com/migtools/oadp-non-admin/issues/151
Related to https://github.com/migtools/oadp-non-admin/pull/227

## How to test the changes made

<!-- Explain how the changes introduced by this PR can be tested and verified, with commands and pictures -->
- Try enforcing NAR restore spec values for scheduleName, includedNamespaces, excludedNamespaces and namespacMapping
- DPA should error out with a relevant err message
