### PR TITLE
Adds missing NAC manifest change for the deleteBackup description

### DIFF
--- a/bundle/manifests/oadp.openshift.io_nonadminbackups.yaml
+++ b/bundle/manifests/oadp.openshift.io_nonadminbackups.yaml
@@ -523,8 +523,8 @@ spec:
                 type: object
               deleteBackup:
                 description: |-
-                  DeleteBackup removes the NonAdminBackup and its associated VeleroBackup from the cluster,
-                  as well as the corresponding object storage
+                  DeleteBackup removes the NonAdminBackup and its associated NonAdminRestores and VeleroBackup from the cluster,
+                  as well as the corresponding data in object storage
                 type: boolean
             required:
             - backupSpec

--- a/config/crd/bases/oadp.openshift.io_nonadminbackups.yaml
+++ b/config/crd/bases/oadp.openshift.io_nonadminbackups.yaml
@@ -523,8 +523,8 @@ spec:
                 type: object
               deleteBackup:
                 description: |-
-                  DeleteBackup removes the NonAdminBackup and its associated VeleroBackup from the cluster,
-                  as well as the corresponding object storage
+                  DeleteBackup removes the NonAdminBackup and its associated NonAdminRestores and VeleroBackup from the cluster,
+                  as well as the corresponding data in object storage
                 type: boolean
             required:
             - backupSpec


### PR DESCRIPTION
This was removed with the #1644, however the deleteBackup description should not be changed as part of the previous PR.

## Why the changes were made

To allow Non Admin PRs passing. The change was generated with the PR that was a bit older then master - on the NAC side.

## How to test the changes made

```shell
1. Rebased nac on the master branch
2. Generated this diff using $ update-non-admin-manifests
```