### PR TITLE
Fix dpa CRD manifest

### DIFF
--- a/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
@@ -12,168 +12,1303 @@ spec:
     listKind: DataProtectionApplicationList
     plural: dataprotectionapplications
     shortNames:
-    - dpa
+      - dpa
     singular: dataprotectionapplication
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: DataProtectionApplication Reconciled status
-      jsonPath: .status.conditions[0].status
-      name: Reconciled
-      type: string
-    - description: DataProtectionApplication creation timestamp
-      jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: |-
-          DataProtectionApplication represents configuration to install a data protection
-          application to safely backup and restore, perform disaster recovery and migrate
-          Kubernetes cluster resources and persistent volumes.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: DataProtectionApplicationSpec defines the desired state of
-              Velero
-            properties:
-              backupImages:
-                description: backupImages is used to specify whether you want to deploy
-                  a registry for enabling backup and restore of images
-                type: boolean
-              backupLocations:
-                description: backupLocations defines the list of desired configuration
-                  to use for BackupStorageLocations
-                items:
-                  description: BackupLocation defines the configuration for the DPA
-                    backup storage
-                  properties:
-                    bucket:
-                      description: CloudStorageLocation defines BackupStorageLocation
-                        using bucket referenced by CloudStorage CR.
-                      properties:
-                        backupSyncPeriod:
-                          description: backupSyncPeriod defines how frequently to
-                            sync backup API objects from object storage. A value of
-                            0 disables sync.
-                          nullable: true
-                          type: string
-                        caCert:
-                          description: CACert defines a CA bundle to use when verifying
-                            TLS connections to the provider.
-                          format: byte
-                          type: string
-                        cloudStorageRef:
-                          description: |-
-                            LocalObjectReference contains enough information to let you locate the
-                            referenced object inside the same namespace.
-                          properties:
-                            name:
-                              default: ""
-                              description: |-
-                                Name of the referent.
-                                This field is effectively required, but due to backwards compatibility is
-                                allowed to be empty. Instances of this type with an empty value here are
-                                almost certainly wrong.
-                                TODO: Add other useful fields. apiVersion, kind, uid?
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
-                              type: string
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        config:
-                          additionalProperties:
+    - additionalPrinterColumns:
+        - description: DataProtectionApplication Reconciled status
+          jsonPath: .status.conditions[0].status
+          name: Reconciled
+          type: string
+        - description: DataProtectionApplication creation timestamp
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: |-
+            DataProtectionApplication represents configuration to install a data protection
+            application to safely backup and restore, perform disaster recovery and migrate
+            Kubernetes cluster resources and persistent volumes.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DataProtectionApplicationSpec defines the desired state of Velero
+              properties:
+                backupImages:
+                  description: backupImages is used to specify whether you want to deploy a registry for enabling backup and restore of images
+                  type: boolean
+                backupLocations:
+                  description: backupLocations defines the list of desired configuration to use for BackupStorageLocations
+                  items:
+                    description: BackupLocation defines the configuration for the DPA backup storage
+                    properties:
+                      bucket:
+                        description: CloudStorageLocation defines BackupStorageLocation using bucket referenced by CloudStorage CR.
+                        properties:
+                          backupSyncPeriod:
+                            description: backupSyncPeriod defines how frequently to sync backup API objects from object storage. A value of 0 disables sync.
+                            nullable: true
                             type: string
-                          description: config is for provider-specific configuration
-                            fields.
-                          type: object
-                        credential:
-                          description: credential contains the credential information
-                            intended to be used with this location
-                          properties:
-                            key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
+                          caCert:
+                            description: CACert defines a CA bundle to use when verifying TLS connections to the provider.
+                            format: byte
+                            type: string
+                          cloudStorageRef:
+                            description: |-
+                              LocalObjectReference contains enough information to let you locate the
+                              referenced object inside the same namespace.
+                            properties:
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  TODO: Add other useful fields. apiVersion, kind, uid?
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          config:
+                            additionalProperties:
                               type: string
-                            name:
-                              default: ""
-                              description: |-
-                                Name of the referent.
-                                This field is effectively required, but due to backwards compatibility is
-                                allowed to be empty. Instances of this type with an empty value here are
-                                almost certainly wrong.
-                                TODO: Add other useful fields. apiVersion, kind, uid?
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                            description: config is for provider-specific configuration fields.
+                            type: object
+                          credential:
+                            description: credential contains the credential information intended to be used with this location
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must be a valid secret key.
+                                type: string
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  TODO: Add other useful fields. apiVersion, kind, uid?
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key must be defined
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          default:
+                            description: default indicates this location is the default backup storage location.
+                            type: boolean
+                          prefix:
+                            description: Prefix is the path inside a bucket to use for Velero storage. Optional.
+                            type: string
+                        required:
+                          - cloudStorageRef
+                        type: object
+                      name:
+                        type: string
+                      velero:
+                        description: BackupStorageLocationSpec defines the desired state of a Velero BackupStorageLocation
+                        properties:
+                          accessMode:
+                            description: AccessMode defines the permissions for the backup storage location.
+                            enum:
+                              - ReadOnly
+                              - ReadWrite
+                            type: string
+                          backupSyncPeriod:
+                            description: BackupSyncPeriod defines how frequently to sync backup API objects from object storage. A value of 0 disables sync.
+                            nullable: true
+                            type: string
+                          config:
+                            additionalProperties:
                               type: string
-                            optional:
-                              description: Specify whether the Secret or its key must
-                                be defined
-                              type: boolean
-                          required:
-                          - key
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        default:
-                          description: default indicates this location is the default
-                            backup storage location.
+                            description: Config is for provider-specific configuration fields.
+                            type: object
+                          credential:
+                            description: Credential contains the credential information intended to be used with this location
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must be a valid secret key.
+                                type: string
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  TODO: Add other useful fields. apiVersion, kind, uid?
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key must be defined
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          default:
+                            description: Default indicates this location is the default backup storage location.
+                            type: boolean
+                          objectStorage:
+                            description: ObjectStorageLocation specifies the settings necessary to connect to a provider's object storage.
+                            properties:
+                              bucket:
+                                description: Bucket is the bucket to use for object storage.
+                                type: string
+                              caCert:
+                                description: CACert defines a CA bundle to use when verifying TLS connections to the provider.
+                                format: byte
+                                type: string
+                              prefix:
+                                description: Prefix is the path inside a bucket to use for Velero storage. Optional.
+                                type: string
+                            required:
+                              - bucket
+                            type: object
+                          provider:
+                            description: Provider is the provider of the backup storage.
+                            type: string
+                          validationFrequency:
+                            description: ValidationFrequency defines how frequently to validate the corresponding object storage. A value of 0 disables validation.
+                            nullable: true
+                            type: string
+                        required:
+                          - objectStorage
+                          - provider
+                        type: object
+                    type: object
+                  type: array
+                configuration:
+                  description: configuration is used to configure the data protection application's server config
+                  properties:
+                    nodeAgent:
+                      description: NodeAgent is needed to allow selection between kopia or restic
+                      properties:
+                        enable:
+                          description: |-
+                            enable defines a boolean pointer whether we want the daemonset to
+                            exist or not
                           type: boolean
-                        prefix:
-                          description: Prefix is the path inside a bucket to use for
-                            Velero storage. Optional.
+                        podConfig:
+                          description: Pod specific configuration
+                          properties:
+                            env:
+                              description: env defines the list of environment variables to be supplied to podSpec
+                              items:
+                                description: EnvVar represents an environment variable present in a Container.
+                                properties:
+                                  name:
+                                    description: Name of the environment variable. Must be a C_IDENTIFIER.
+                                    type: string
+                                  value:
+                                    description: |-
+                                      Variable references $(VAR_NAME) are expanded
+                                      using the previously defined environment variables in the container and
+                                      any service environment variables. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                      "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless of whether the variable
+                                      exists or not.
+                                      Defaults to "".
+                                    type: string
+                                  valueFrom:
+                                    description: Source for the environment variable's value. Cannot be used if value is not empty.
+                                    properties:
+                                      configMapKeyRef:
+                                        description: Selects a key of a ConfigMap.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap or its key must be defined
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      fieldRef:
+                                        description: |-
+                                          Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                          spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select in the specified API version.
+                                            type: string
+                                        required:
+                                          - fieldPath
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      resourceFieldRef:
+                                        description: |-
+                                          Selects a resource of the container: only resources limits and requests
+                                          (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            description: Specifies the output format of the exposed resources, defaults to "1"
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                          - resource
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      secretKeyRef:
+                                        description: Selects a key of a secret in the pod's namespace
+                                        properties:
+                                          key:
+                                            description: The key of the secret to select from.  Must be a valid secret key.
+                                            type: string
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret or its key must be defined
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                            labels:
+                              additionalProperties:
+                                type: string
+                              description: labels to add to pods
+                              type: object
+                            nodeSelector:
+                              additionalProperties:
+                                type: string
+                              description: nodeSelector defines the nodeSelector to be supplied to podSpec
+                              type: object
+                            resourceAllocations:
+                              description: resourceAllocations defines the CPU, Memory and ephemeral-storage resource allocations for the Pod
+                              nullable: true
+                              properties:
+                                claims:
+                                  description: |-
+                                    Claims lists the names of resources, defined in spec.resourceClaims,
+                                    that are used by this container.
+
+
+                                    This is an alpha field and requires enabling the
+                                    DynamicResourceAllocation feature gate.
+
+
+                                    This field is immutable. It can only be set for containers.
+                                  items:
+                                    description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                                    properties:
+                                      name:
+                                        description: |-
+                                          Name must match the name of one entry in pod.spec.resourceClaims of
+                                          the Pod where this field is used. It makes that resource available
+                                          inside a container.
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - name
+                                  x-kubernetes-list-type: map
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: |-
+                                    Limits describes the maximum amount of compute resources allowed.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: |-
+                                    Requests describes the minimum amount of compute resources required.
+                                    If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                    otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  type: object
+                              type: object
+                            tolerations:
+                              description: tolerations defines the list of tolerations to be applied to daemonset
+                              items:
+                                description: |-
+                                  The pod this Toleration is attached to tolerates any taint that matches
+                                  the triple <key,value,effect> using the matching operator <operator>.
+                                properties:
+                                  effect:
+                                    description: |-
+                                      Effect indicates the taint effect to match. Empty means match all taint effects.
+                                      When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                    type: string
+                                  key:
+                                    description: |-
+                                      Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                      If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      Operator represents a key's relationship to the value.
+                                      Valid operators are Exists and Equal. Defaults to Equal.
+                                      Exists is equivalent to wildcard for value, so that a pod can
+                                      tolerate all taints of a particular category.
+                                    type: string
+                                  tolerationSeconds:
+                                    description: |-
+                                      TolerationSeconds represents the period of time the toleration (which must be
+                                      of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                      it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                      negative values will be treated as 0 (evict immediately) by the system.
+                                    format: int64
+                                    type: integer
+                                  value:
+                                    description: |-
+                                      Value is the taint value the toleration matches to.
+                                      If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        supplementalGroups:
+                          description: supplementalGroups defines the linux groups to be applied to the NodeAgent Pod
+                          items:
+                            format: int64
+                            type: integer
+                          type: array
+                        timeout:
+                          description: timeout defines the NodeAgent timeout, default value is 1h
+                          type: string
+                        uploaderType:
+                          description: The type of uploader to transfer the data of pod volumes, the supported values are 'restic' or 'kopia'
+                          enum:
+                            - restic
+                            - kopia
                           type: string
                       required:
-                      - cloudStorageRef
+                        - uploaderType
                       type: object
-                    name:
-                      type: string
+                    restic:
+                      description: |-
+                        (deprecation warning) ResticConfig is the configuration for restic DaemonSet.
+                        restic is for backwards compatibility and is replaced by the nodeAgent
+                        restic will be removed in the future
+                      properties:
+                        enable:
+                          description: |-
+                            enable defines a boolean pointer whether we want the daemonset to
+                            exist or not
+                          type: boolean
+                        podConfig:
+                          description: Pod specific configuration
+                          properties:
+                            env:
+                              description: env defines the list of environment variables to be supplied to podSpec
+                              items:
+                                description: EnvVar represents an environment variable present in a Container.
+                                properties:
+                                  name:
+                                    description: Name of the environment variable. Must be a C_IDENTIFIER.
+                                    type: string
+                                  value:
+                                    description: |-
+                                      Variable references $(VAR_NAME) are expanded
+                                      using the previously defined environment variables in the container and
+                                      any service environment variables. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                      "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless of whether the variable
+                                      exists or not.
+                                      Defaults to "".
+                                    type: string
+                                  valueFrom:
+                                    description: Source for the environment variable's value. Cannot be used if value is not empty.
+                                    properties:
+                                      configMapKeyRef:
+                                        description: Selects a key of a ConfigMap.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap or its key must be defined
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      fieldRef:
+                                        description: |-
+                                          Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                          spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select in the specified API version.
+                                            type: string
+                                        required:
+                                          - fieldPath
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      resourceFieldRef:
+                                        description: |-
+                                          Selects a resource of the container: only resources limits and requests
+                                          (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            description: Specifies the output format of the exposed resources, defaults to "1"
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                          - resource
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      secretKeyRef:
+                                        description: Selects a key of a secret in the pod's namespace
+                                        properties:
+                                          key:
+                                            description: The key of the secret to select from.  Must be a valid secret key.
+                                            type: string
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret or its key must be defined
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                            labels:
+                              additionalProperties:
+                                type: string
+                              description: labels to add to pods
+                              type: object
+                            nodeSelector:
+                              additionalProperties:
+                                type: string
+                              description: nodeSelector defines the nodeSelector to be supplied to podSpec
+                              type: object
+                            resourceAllocations:
+                              description: resourceAllocations defines the CPU, Memory and ephemeral-storage resource allocations for the Pod
+                              nullable: true
+                              properties:
+                                claims:
+                                  description: |-
+                                    Claims lists the names of resources, defined in spec.resourceClaims,
+                                    that are used by this container.
+
+
+                                    This is an alpha field and requires enabling the
+                                    DynamicResourceAllocation feature gate.
+
+
+                                    This field is immutable. It can only be set for containers.
+                                  items:
+                                    description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                                    properties:
+                                      name:
+                                        description: |-
+                                          Name must match the name of one entry in pod.spec.resourceClaims of
+                                          the Pod where this field is used. It makes that resource available
+                                          inside a container.
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - name
+                                  x-kubernetes-list-type: map
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                    nullable: true
+                                  description: |-
+                                    Limits describes the maximum amount of compute resources allowed.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  type: object
+                                  nullable: true
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                    nullable: true
+                                  description: |-
+                                    Requests describes the minimum amount of compute resources required.
+                                    If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                    otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  type: object
+                                  nullable: true
+                              type: object
+                            tolerations:
+                              description: tolerations defines the list of tolerations to be applied to daemonset
+                              items:
+                                description: |-
+                                  The pod this Toleration is attached to tolerates any taint that matches
+                                  the triple <key,value,effect> using the matching operator <operator>.
+                                properties:
+                                  effect:
+                                    description: |-
+                                      Effect indicates the taint effect to match. Empty means match all taint effects.
+                                      When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                    type: string
+                                  key:
+                                    description: |-
+                                      Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                      If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      Operator represents a key's relationship to the value.
+                                      Valid operators are Exists and Equal. Defaults to Equal.
+                                      Exists is equivalent to wildcard for value, so that a pod can
+                                      tolerate all taints of a particular category.
+                                    type: string
+                                  tolerationSeconds:
+                                    description: |-
+                                      TolerationSeconds represents the period of time the toleration (which must be
+                                      of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                      it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                      negative values will be treated as 0 (evict immediately) by the system.
+                                    format: int64
+                                    type: integer
+                                  value:
+                                    description: |-
+                                      Value is the taint value the toleration matches to.
+                                      If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        supplementalGroups:
+                          description: supplementalGroups defines the linux groups to be applied to the NodeAgent Pod
+                          items:
+                            format: int64
+                            type: integer
+                          type: array
+                        timeout:
+                          description: timeout defines the NodeAgent timeout, default value is 1h
+                          type: string
+                      type: object
                     velero:
-                      description: BackupStorageLocationSpec defines the desired state
-                        of a Velero BackupStorageLocation
+                      properties:
+                        args:
+                          description: Velero args are settings to customize velero server arguments. Overrides values in other fields.
+                          properties:
+                            add_dir_header:
+                              description: If true, adds the file directory to the header of the log messages
+                              type: boolean
+                            alsologtostderr:
+                              description: log to standard error as well as files (no effect when -logtostderr=true)
+                              type: boolean
+                            backup-sync-period:
+                              description: How often (in nanoseconds) to ensure all Velero backups in object storage exist as Backup API objects in the cluster. This is the default sync period if none is explicitly specified for a backup storage location.
+                              format: int64
+                              type: integer
+                            client-burst:
+                              description: Maximum number of requests by the server to the Kubernetes API in a short period of time.
+                              type: integer
+                            client-page-size:
+                              description: Page size of requests by the server to the Kubernetes API when listing objects during a backup. Set to 0 to disable paging.
+                              type: integer
+                            client-qps:
+                              description: |-
+                                Maximum number of requests per second by the server to the Kubernetes API once the burst limit has been reached.
+                                this will be validated as a valid float32
+                              type: string
+                            colorized:
+                              description: Show colored output in TTY
+                              type: boolean
+                            default-backup-ttl:
+                              description: How long (in nanoseconds) to wait by default before backups can be garbage collected. (default is 720 hours)
+                              format: int64
+                              type: integer
+                            default-item-operation-timeout:
+                              description: How long (in nanoseconds) to wait on asynchronous BackupItemActions and RestoreItemActions to complete before timing out. (default is 1 hour)
+                              format: int64
+                              type: integer
+                            default-repo-maintain-frequency:
+                              description: How often (in nanoseconds) 'maintain' is run for backup repositories by default.
+                              format: int64
+                              type: integer
+                            default-volumes-to-fs-backup:
+                              description: Backup all volumes with pod volume file system backup by default.
+                              type: boolean
+                            disabled-controllers:
+                              description: List of controllers to disable on startup. Valid values are backup,backup-operations,backup-deletion,backup-finalizer,backup-sync,download-request,gc,backup-repo,restore,restore-operations,schedule,server-status-request
+                              enum:
+                                - backup
+                                - backup-operations
+                                - backup-deletion
+                                - backup-finalizer
+                                - backup-sync
+                                - download-request
+                                - gc
+                                - backup-repo
+                                - restore
+                                - restore-operations
+                                - schedule
+                                - server-status-request
+                              items:
+                                type: string
+                              type: array
+                            fs-backup-timeout:
+                              description: How long (in nanoseconds) pod volume file system backups/restores should be allowed to run before timing out. (default is 4 hours)
+                              format: int64
+                              type: integer
+                            garbage-collection-frequency:
+                              description: How often (in nanoseconds) garbage collection checks for expired backups. (default is 1 hour)
+                              format: int64
+                              type: integer
+                            item-operation-sync-frequency:
+                              description: How often (in nanoseconds) to check status on backup/restore operations after backup/restore processing.
+                              format: int64
+                              type: integer
+                            log-format:
+                              description: The format for log output. Valid values are text, json. (default text)
+                              enum:
+                                - text
+                                - json
+                              type: string
+                            log_backtrace_at:
+                              description: when logging hits line file:N, emit a stack trace
+                              type: string
+                            log_dir:
+                              description: If non-empty, write log files in this directory (no effect when -logtostderr=true)
+                              type: string
+                            log_file:
+                              description: If non-empty, use this log file (no effect when -logtostderr=true)
+                              type: string
+                            log_file_max_size:
+                              description: Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
+                              format: int64
+                              minimum: 0
+                              type: integer
+                            logtostderr:
+                              description: |-
+                                Boolean flags. Not handled atomically because the flag.Value interface
+                                does not let us avoid the =true, and that shorthand is necessary for
+                                compatibility. TODO: does this matter enough to fix? Seems unlikely.
+                              type: boolean
+                            max-concurrent-k8s-connections:
+                              description: Max concurrent connections number that Velero can create with kube-apiserver. Default is 30. (default 30)
+                              type: integer
+                            metrics-address:
+                              description: The address to expose prometheus metrics
+                              type: string
+                            one_output:
+                              description: If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
+                              type: boolean
+                            profiler-address:
+                              description: The address to expose the pprof profiler.
+                              type: string
+                            resource-timeout:
+                              description: How long (in nanoseconds) to wait for resource processes which are not covered by other specific timeout parameters. (default is 10 minutes)
+                              format: int64
+                              type: integer
+                            restore-resource-priorities:
+                              description: Desired order of resource restores, the priority list contains two parts which are split by "-" element. The resources before "-" element are restored first as high priorities, the resources after "-" element are restored last as low priorities, and any resource not in the list will be restored alphabetically between the high and low priorities. (default securitycontextconstraints,customresourcedefinitions,klusterletconfigs.config.open-cluster-management.io,managedcluster.cluster.open-cluster-management.io,namespaces,roles,rolebindings,clusterrolebindings,klusterletaddonconfig.agent.open-cluster-management.io,managedclusteraddon.addon.open-cluster-management.io,storageclasses,volumesnapshotclass.snapshot.storage.k8s.io,volumesnapshotcontents.snapshot.storage.k8s.io,volumesnapshots.snapshot.storage.k8s.io,datauploads.velero.io,persistentvolumes,persistentvolumeclaims,serviceaccounts,secrets,configmaps,limitranges,pods,replicasets.apps,clusterclasses.cluster.x-k8s.io,endpoints,services,-,clusterbootstraps.run.tanzu.vmware.com,clusters.cluster.x-k8s.io,clusterresourcesets.addons.cluster.x-k8s.io)
+                              type: string
+                            skip_headers:
+                              description: If true, avoid header prefixes in the log messages
+                              type: boolean
+                            skip_log_headers:
+                              description: If true, avoid headers when opening log files (no effect when -logtostderr=true)
+                              type: boolean
+                            stderrthreshold:
+                              description: logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
+                              type: integer
+                            store-validation-frequency:
+                              description: How often (in nanoseconds) to verify if the storage is valid. Optional. Set this to `0` to disable sync. (default is 1 minute)
+                              format: int64
+                              type: integer
+                            terminating-resource-timeout:
+                              description: How long (in nanoseconds) to wait on persistent volumes and namespaces to terminate during a restore before timing out.
+                              format: int64
+                              type: integer
+                            v:
+                              description: number for the log level verbosity
+                              type: integer
+                            vmodule:
+                              description: comma-separated list of pattern=N settings for file-filtered logging
+                              type: string
+                          type: object
+                        client-burst:
+                          description: maximum number of requests by the server to the Kubernetes API in a short period of time. (default 100)
+                          type: integer
+                        client-qps:
+                          description: maximum number of requests per second by the server to the Kubernetes API once the burst limit has been reached. (default 100)
+                          type: integer
+                        customPlugins:
+                          description: customPlugins defines the custom plugin to be installed with Velero
+                          items:
+                            properties:
+                              image:
+                                type: string
+                              name:
+                                type: string
+                            required:
+                              - image
+                              - name
+                            type: object
+                          type: array
+                        defaultItemOperationTimeout:
+                          description: How long to wait on asynchronous BackupItemActions and RestoreItemActions to complete before timing out. Default value is 1h.
+                          type: string
+                        defaultPlugins:
+                          items:
+                            enum:
+                              - aws
+                              - legacy-aws
+                              - gcp
+                              - azure
+                              - csi
+                              - vsm
+                              - openshift
+                              - kubevirt
+                            type: string
+                          type: array
+                        defaultSnapshotMoveData:
+                          description: Specify whether CSI snapshot data should be moved to backup storage by default
+                          type: boolean
+                        defaultVolumesToFSBackup:
+                          description: Use pod volume file system backup by default for volumes
+                          type: boolean
+                        disableInformerCache:
+                          description: Disable informer cache for Get calls on restore. With this enabled, it will speed up restore in cases where there are backup resources which already exist in the cluster, but for very large clusters this will increase velero memory usage. Default is false.
+                          type: boolean
+                        featureFlags:
+                          description: featureFlags defines the list of features to enable for Velero instance
+                          items:
+                            type: string
+                          type: array
+                        itemOperationSyncFrequency:
+                          description: How often to check status on async backup/restore operations after backup processing. Default value is 2m.
+                          type: string
+                        logLevel:
+                          description: Velero server's log level (use debug for the most logging, leave unset for velero default)
+                          enum:
+                            - trace
+                            - debug
+                            - info
+                            - warning
+                            - error
+                            - fatal
+                            - panic
+                          type: string
+                        noDefaultBackupLocation:
+                          description: If you need to install Velero without a default backup storage location noDefaultBackupLocation flag is required for confirmation
+                          type: boolean
+                        podConfig:
+                          description: Pod specific configuration
+                          properties:
+                            env:
+                              description: env defines the list of environment variables to be supplied to podSpec
+                              items:
+                                description: EnvVar represents an environment variable present in a Container.
+                                properties:
+                                  name:
+                                    description: Name of the environment variable. Must be a C_IDENTIFIER.
+                                    type: string
+                                  value:
+                                    description: |-
+                                      Variable references $(VAR_NAME) are expanded
+                                      using the previously defined environment variables in the container and
+                                      any service environment variables. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                      "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless of whether the variable
+                                      exists or not.
+                                      Defaults to "".
+                                    type: string
+                                  valueFrom:
+                                    description: Source for the environment variable's value. Cannot be used if value is not empty.
+                                    properties:
+                                      configMapKeyRef:
+                                        description: Selects a key of a ConfigMap.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap or its key must be defined
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      fieldRef:
+                                        description: |-
+                                          Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                          spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select in the specified API version.
+                                            type: string
+                                        required:
+                                          - fieldPath
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      resourceFieldRef:
+                                        description: |-
+                                          Selects a resource of the container: only resources limits and requests
+                                          (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            description: Specifies the output format of the exposed resources, defaults to "1"
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                          - resource
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      secretKeyRef:
+                                        description: Selects a key of a secret in the pod's namespace
+                                        properties:
+                                          key:
+                                            description: The key of the secret to select from.  Must be a valid secret key.
+                                            type: string
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret or its key must be defined
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                            labels:
+                              additionalProperties:
+                                type: string
+                              description: labels to add to pods
+                              type: object
+                            nodeSelector:
+                              additionalProperties:
+                                type: string
+                              description: nodeSelector defines the nodeSelector to be supplied to podSpec
+                              type: object
+                            resourceAllocations:
+                              description: resourceAllocations defines the CPU, Memory and ephemeral-storage resource allocations for the Pod
+                              nullable: true
+                              properties:
+                                claims:
+                                  description: |-
+                                    Claims lists the names of resources, defined in spec.resourceClaims,
+                                    that are used by this container.
+
+
+                                    This is an alpha field and requires enabling the
+                                    DynamicResourceAllocation feature gate.
+
+
+                                    This field is immutable. It can only be set for containers.
+                                  items:
+                                    description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                                    properties:
+                                      name:
+                                        description: |-
+                                          Name must match the name of one entry in pod.spec.resourceClaims of
+                                          the Pod where this field is used. It makes that resource available
+                                          inside a container.
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - name
+                                  x-kubernetes-list-type: map
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                    nullable: true
+                                  description: |-
+                                    Limits describes the maximum amount of compute resources allowed.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  type: object
+                                  nullable: true
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                    nullable: true
+                                  description: |-
+                                    Requests describes the minimum amount of compute resources required.
+                                    If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                    otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  type: object
+                                  nullable: true
+                              type: object
+                            tolerations:
+                              description: tolerations defines the list of tolerations to be applied to daemonset
+                              items:
+                                description: |-
+                                  The pod this Toleration is attached to tolerates any taint that matches
+                                  the triple <key,value,effect> using the matching operator <operator>.
+                                properties:
+                                  effect:
+                                    description: |-
+                                      Effect indicates the taint effect to match. Empty means match all taint effects.
+                                      When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                    type: string
+                                  key:
+                                    description: |-
+                                      Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                      If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      Operator represents a key's relationship to the value.
+                                      Valid operators are Exists and Equal. Defaults to Equal.
+                                      Exists is equivalent to wildcard for value, so that a pod can
+                                      tolerate all taints of a particular category.
+                                    type: string
+                                  tolerationSeconds:
+                                    description: |-
+                                      TolerationSeconds represents the period of time the toleration (which must be
+                                      of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                      it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                      negative values will be treated as 0 (evict immediately) by the system.
+                                    format: int64
+                                    type: integer
+                                  value:
+                                    description: |-
+                                      Value is the taint value the toleration matches to.
+                                      If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        resourceTimeout:
+                          description: |-
+                            resourceTimeout defines how long to wait for several Velero resources before timeout occurs,
+                            such as Velero CRD availability, volumeSnapshot deletion, and repo availability.
+                            Default is 10m
+                          type: string
+                        restoreResourcesVersionPriority:
+                          description: |-
+                            restoreResourceVersionPriority represents a configmap that will be created if defined for use in conjunction with EnableAPIGroupVersions feature flag
+                            Defining this field automatically add EnableAPIGroupVersions to the velero server feature flag
+                          type: string
+                      type: object
+                  type: object
+                features:
+                  description: features defines the configuration for the DPA to enable the OADP tech preview features
+                  properties:
+                    dataMover:
+                      description: |-
+                        (do not use warning) dataMover is for backwards compatibility and
+                        will be removed in the future. Use Velero Built-in Data Mover instead
+                      properties:
+                        credentialName:
+                          description: User supplied Restic Secret name
+                          type: string
+                        enable:
+                          description: enable flag is used to specify whether you want to deploy the volume snapshot mover controller
+                          type: boolean
+                        maxConcurrentBackupVolumes:
+                          description: the number of batched volumeSnapshotBackups that can be inProgress at once, default value is 10
+                          type: string
+                        maxConcurrentRestoreVolumes:
+                          description: the number of batched volumeSnapshotRestores that can be inProgress at once, default value is 10
+                          type: string
+                        pruneInterval:
+                          description: defines how often (in days) to prune the datamover snapshots from the repository
+                          type: string
+                        schedule:
+                          description: |-
+                            schedule is a cronspec (https://en.wikipedia.org/wiki/Cron#Overview) that
+                            can be used to schedule datamover(volsync) synchronization to occur at regular, time-based
+                            intervals. For example, in order to enforce datamover SnapshotRetainPolicy at a regular interval you need to
+                            specify this Schedule trigger as a cron expression, by default the trigger is a manual trigger. For more details
+                            on Volsync triggers, refer: https://volsync.readthedocs.io/en/stable/usage/triggers.html
+                          pattern: ^(\d+|\*)(/\d+)?(\s+(\d+|\*)(/\d+)?){4}$
+                          type: string
+                        snapshotRetainPolicy:
+                          description: defines the parameters that can be specified for retention of datamover snapshots
+                          properties:
+                            daily:
+                              description: Daily defines the number of snapshots to be kept daily
+                              type: string
+                            hourly:
+                              description: Hourly defines the number of snapshots to be kept hourly
+                              type: string
+                            monthly:
+                              description: Monthly defines the number of snapshots to be kept monthly
+                              type: string
+                            weekly:
+                              description: Weekly defines the number of snapshots to be kept weekly
+                              type: string
+                            within:
+                              description: Within defines the number of snapshots to be kept Within the given time period
+                              type: string
+                            yearly:
+                              description: Yearly defines the number of snapshots to be kept yearly
+                              type: string
+                          type: object
+                        timeout:
+                          description: User supplied timeout to be used for VolumeSnapshotBackup and VolumeSnapshotRestore to complete, default value is 10m
+                          type: string
+                        volumeOptionsForStorageClasses:
+                          additionalProperties:
+                            properties:
+                              destinationVolumeOptions:
+                                description: VolumeOptions defines configurations for VolSync options
+                                properties:
+                                  accessMode:
+                                    description: |-
+                                      accessMode can be used to override the accessMode of the source or
+                                      destination PVC
+                                    type: string
+                                  cacheAccessMode:
+                                    description: cacheAccessMode is the access mode to be used to provision the cache volume
+                                    type: string
+                                  cacheCapacity:
+                                    description: cacheCapacity determines the size of the restic metadata cache volume
+                                    type: string
+                                  cacheStorageClassName:
+                                    description: |-
+                                      cacheStorageClassName is the storageClass that should be used when provisioning
+                                      the data mover cache volume
+                                    type: string
+                                  storageClassName:
+                                    description: |-
+                                      storageClassName can be used to override the StorageClass of the source
+                                      or destination PVC
+                                    type: string
+                                type: object
+                              sourceVolumeOptions:
+                                description: VolumeOptions defines configurations for VolSync options
+                                properties:
+                                  accessMode:
+                                    description: |-
+                                      accessMode can be used to override the accessMode of the source or
+                                      destination PVC
+                                    type: string
+                                  cacheAccessMode:
+                                    description: cacheAccessMode is the access mode to be used to provision the cache volume
+                                    type: string
+                                  cacheCapacity:
+                                    description: cacheCapacity determines the size of the restic metadata cache volume
+                                    type: string
+                                  cacheStorageClassName:
+                                    description: |-
+                                      cacheStorageClassName is the storageClass that should be used when provisioning
+                                      the data mover cache volume
+                                    type: string
+                                  storageClassName:
+                                    description: |-
+                                      storageClassName can be used to override the StorageClass of the source
+                                      or destination PVC
+                                    type: string
+                                type: object
+                            type: object
+                          description: defines configurations for data mover volume options for a storageClass
+                          type: object
+                      type: object
+                  type: object
+                imagePullPolicy:
+                  description: |-
+                    which imagePullPolicy to use in all container images used by OADP.
+                    By default, for images with sha256 or sha512 digest, OADP uses IfNotPresent and uses Always for all other images.
+                  enum:
+                    - Always
+                    - IfNotPresent
+                    - Never
+                  type: string
+                nonAdmin:
+                  description: nonAdmin defines the configuration for the DPA to enable backup and restore operations for non-admin users
+                  properties:
+                    backupSyncPeriod:
+                      description: |-
+                        BackupSyncPeriod specifies the interval at which backups from the OADP namespace are synchronized with non-admin namespaces.
+                        A value of 0 disables sync.
+                        By default 2m
+                      type: string
+                    enable:
+                      description: Enables non admin feature, by default is disabled
+                      type: boolean
+                    enforceBSLSpec:
+                      description: which backupstoragelocation spec field values to enforce
                       properties:
                         accessMode:
-                          description: AccessMode defines the permissions for the
-                            backup storage location.
+                          description: AccessMode defines the permissions for the backup storage location.
                           enum:
-                          - ReadOnly
-                          - ReadWrite
+                            - ReadOnly
+                            - ReadWrite
                           type: string
                         backupSyncPeriod:
-                          description: BackupSyncPeriod defines how frequently to
-                            sync backup API objects from object storage. A value of
-                            0 disables sync.
+                          description: BackupSyncPeriod defines how frequently to sync backup API objects from object storage. A value of 0 disables sync.
                           nullable: true
                           type: string
                         config:
                           additionalProperties:
                             type: string
-                          description: Config is for provider-specific configuration
-                            fields.
+                          description: Config is for provider-specific configuration fields.
                           type: object
                         credential:
-                          description: Credential contains the credential information
-                            intended to be used with this location
+                          description: Credential contains the credential information intended to be used with this location
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
+                              description: The key of the secret to select from.  Must be a valid secret key.
                               type: string
                             name:
                               default: ""
@@ -187,1729 +1322,333 @@ spec:
                                 TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
-                                be defined
+                              description: Specify whether the Secret or its key must be defined
                               type: boolean
                           required:
-                          - key
+                            - key
                           type: object
                           x-kubernetes-map-type: atomic
-                        default:
-                          description: Default indicates this location is the default
-                            backup storage location.
-                          type: boolean
                         objectStorage:
-                          description: ObjectStorageLocation specifies the settings
-                            necessary to connect to a provider's object storage.
+                          description: ObjectStorageLocation defines the enforced values for the Velero ObjectStorageLocation
+                          nullable: true
                           properties:
                             bucket:
-                              description: Bucket is the bucket to use for object
-                                storage.
+                              description: Bucket is the bucket to use for object storage.
                               type: string
                             caCert:
-                              description: CACert defines a CA bundle to use when
-                                verifying TLS connections to the provider.
+                              description: CACert defines a CA bundle to use when verifying TLS connections to the provider.
                               format: byte
                               type: string
                             prefix:
-                              description: Prefix is the path inside a bucket to use
-                                for Velero storage. Optional.
+                              description: Prefix is the path inside a bucket to use for Velero storage. Optional.
                               type: string
-                          required:
-                          - bucket
                           type: object
                         provider:
                           description: Provider is the provider of the backup storage.
                           type: string
                         validationFrequency:
-                          description: ValidationFrequency defines how frequently
-                            to validate the corresponding object storage. A value
-                            of 0 disables validation.
+                          description: ValidationFrequency defines how frequently to validate the corresponding object storage. A value of 0 disables validation.
                           nullable: true
                           type: string
-                      required:
-                      - objectStorage
-                      - provider
                       type: object
-                  type: object
-                type: array
-              configuration:
-                description: configuration is used to configure the data protection
-                  application's server config
-                properties:
-                  nodeAgent:
-                    description: NodeAgent is needed to allow selection between kopia
-                      or restic
-                    properties:
-                      enable:
-                        description: |-
-                          enable defines a boolean pointer whether we want the daemonset to
-                          exist or not
-                        type: boolean
-                      podConfig:
-                        description: Pod specific configuration
-                        properties:
-                          env:
-                            description: env defines the list of environment variables
-                              to be supplied to podSpec
-                            items:
-                              description: EnvVar represents an environment variable
-                                present in a Container.
-                              properties:
-                                name:
-                                  description: Name of the environment variable. Must
-                                    be a C_IDENTIFIER.
-                                  type: string
-                                value:
-                                  description: |-
-                                    Variable references $(VAR_NAME) are expanded
-                                    using the previously defined environment variables in the container and
-                                    any service environment variables. If a variable cannot be resolved,
-                                    the reference in the input string will be unchanged. Double $$ are reduced
-                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                                    "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                                    Escaped references will never be expanded, regardless of whether the variable
-                                    exists or not.
-                                    Defaults to "".
-                                  type: string
-                                valueFrom:
-                                  description: Source for the environment variable's
-                                    value. Cannot be used if value is not empty.
-                                  properties:
-                                    configMapKeyRef:
-                                      description: Selects a key of a ConfigMap.
-                                      properties:
-                                        key:
-                                          description: The key to select.
-                                          type: string
-                                        name:
-                                          default: ""
-                                          description: |-
-                                            Name of the referent.
-                                            This field is effectively required, but due to backwards compatibility is
-                                            allowed to be empty. Instances of this type with an empty value here are
-                                            almost certainly wrong.
-                                            TODO: Add other useful fields. apiVersion, kind, uid?
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
-                                          type: string
-                                        optional:
-                                          description: Specify whether the ConfigMap
-                                            or its key must be defined
-                                          type: boolean
-                                      required:
-                                      - key
-                                      type: object
-                                      x-kubernetes-map-type: atomic
-                                    fieldRef:
-                                      description: |-
-                                        Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                        spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
-                                      properties:
-                                        apiVersion:
-                                          description: Version of the schema the FieldPath
-                                            is written in terms of, defaults to "v1".
-                                          type: string
-                                        fieldPath:
-                                          description: Path of the field to select
-                                            in the specified API version.
-                                          type: string
-                                      required:
-                                      - fieldPath
-                                      type: object
-                                      x-kubernetes-map-type: atomic
-                                    resourceFieldRef:
-                                      description: |-
-                                        Selects a resource of the container: only resources limits and requests
-                                        (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
-                                      properties:
-                                        containerName:
-                                          description: 'Container name: required for
-                                            volumes, optional for env vars'
-                                          type: string
-                                        divisor:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          description: Specifies the output format
-                                            of the exposed resources, defaults to
-                                            "1"
-                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                          x-kubernetes-int-or-string: true
-                                        resource:
-                                          description: 'Required: resource to select'
-                                          type: string
-                                      required:
-                                      - resource
-                                      type: object
-                                      x-kubernetes-map-type: atomic
-                                    secretKeyRef:
-                                      description: Selects a key of a secret in the
-                                        pod's namespace
-                                      properties:
-                                        key:
-                                          description: The key of the secret to select
-                                            from.  Must be a valid secret key.
-                                          type: string
-                                        name:
-                                          default: ""
-                                          description: |-
-                                            Name of the referent.
-                                            This field is effectively required, but due to backwards compatibility is
-                                            allowed to be empty. Instances of this type with an empty value here are
-                                            almost certainly wrong.
-                                            TODO: Add other useful fields. apiVersion, kind, uid?
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
-                                          type: string
-                                        optional:
-                                          description: Specify whether the Secret
-                                            or its key must be defined
-                                          type: boolean
-                                      required:
-                                      - key
-                                      type: object
-                                      x-kubernetes-map-type: atomic
-                                  type: object
-                              required:
-                              - name
-                              type: object
-                            type: array
-                          labels:
-                            additionalProperties:
-                              type: string
-                            description: labels to add to pods
-                            type: object
-                          nodeSelector:
-                            additionalProperties:
-                              type: string
-                            description: nodeSelector defines the nodeSelector to
-                              be supplied to podSpec
-                            type: object
-                          resourceAllocations:
-                            description: resourceAllocations defines the CPU, Memory
-                              and ephemeral-storage resource allocations for the Pod
-                            nullable: true
-                            properties:
-                              claims:
-                                description: |-
-                                  Claims lists the names of resources, defined in spec.resourceClaims,
-                                  that are used by this container.
-
-
-                                  This is an alpha field and requires enabling the
-                                  DynamicResourceAllocation feature gate.
-
-
-                                  This field is immutable. It can only be set for containers.
-                                items:
-                                  description: ResourceClaim references one entry
-                                    in PodSpec.ResourceClaims.
-                                  properties:
-                                    name:
-                                      description: |-
-                                        Name must match the name of one entry in pod.spec.resourceClaims of
-                                        the Pod where this field is used. It makes that resource available
-                                        inside a container.
-                                      type: string
-                                  required:
-                                  - name
-                                  type: object
-                                type: array
-                                x-kubernetes-list-map-keys:
-                                - name
-                                x-kubernetes-list-type: map
-                              limits:
-                                additionalProperties:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                                description: |-
-                                  Limits describes the maximum amount of compute resources allowed.
-                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                                type: object
-                              requests:
-                                additionalProperties:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                                description: |-
-                                  Requests describes the minimum amount of compute resources required.
-                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                                type: object
-                            type: object
-                          tolerations:
-                            description: tolerations defines the list of tolerations
-                              to be applied to daemonset
-                            items:
-                              description: |-
-                                The pod this Toleration is attached to tolerates any taint that matches
-                                the triple <key,value,effect> using the matching operator <operator>.
-                              properties:
-                                effect:
-                                  description: |-
-                                    Effect indicates the taint effect to match. Empty means match all taint effects.
-                                    When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
-                                  type: string
-                                key:
-                                  description: |-
-                                    Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                                    If the key is empty, operator must be Exists; this combination means to match all values and all keys.
-                                  type: string
-                                operator:
-                                  description: |-
-                                    Operator represents a key's relationship to the value.
-                                    Valid operators are Exists and Equal. Defaults to Equal.
-                                    Exists is equivalent to wildcard for value, so that a pod can
-                                    tolerate all taints of a particular category.
-                                  type: string
-                                tolerationSeconds:
-                                  description: |-
-                                    TolerationSeconds represents the period of time the toleration (which must be
-                                    of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                                    it is not set, which means tolerate the taint forever (do not evict). Zero and
-                                    negative values will be treated as 0 (evict immediately) by the system.
-                                  format: int64
-                                  type: integer
-                                value:
-                                  description: |-
-                                    Value is the taint value the toleration matches to.
-                                    If the operator is Exists, the value should be empty, otherwise just a regular string.
-                                  type: string
-                              type: object
-                            type: array
-                        type: object
-                      supplementalGroups:
-                        description: supplementalGroups defines the linux groups to
-                          be applied to the NodeAgent Pod
-                        items:
-                          format: int64
-                          type: integer
-                        type: array
-                      timeout:
-                        description: timeout defines the NodeAgent timeout, default
-                          value is 1h
-                        type: string
-                      uploaderType:
-                        description: The type of uploader to transfer the data of
-                          pod volumes, the supported values are 'restic' or 'kopia'
-                        enum:
-                        - restic
-                        - kopia
-                        type: string
-                    required:
-                    - uploaderType
-                    type: object
-                  restic:
-                    description: |-
-                      (deprecation warning) ResticConfig is the configuration for restic DaemonSet.
-                      restic is for backwards compatibility and is replaced by the nodeAgent
-                      restic will be removed in the future
-                    properties:
-                      enable:
-                        description: |-
-                          enable defines a boolean pointer whether we want the daemonset to
-                          exist or not
-                        type: boolean
-                      podConfig:
-                        description: Pod specific configuration
-                        properties:
-                          env:
-                            description: env defines the list of environment variables
-                              to be supplied to podSpec
-                            items:
-                              description: EnvVar represents an environment variable
-                                present in a Container.
-                              properties:
-                                name:
-                                  description: Name of the environment variable. Must
-                                    be a C_IDENTIFIER.
-                                  type: string
-                                value:
-                                  description: |-
-                                    Variable references $(VAR_NAME) are expanded
-                                    using the previously defined environment variables in the container and
-                                    any service environment variables. If a variable cannot be resolved,
-                                    the reference in the input string will be unchanged. Double $$ are reduced
-                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                                    "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                                    Escaped references will never be expanded, regardless of whether the variable
-                                    exists or not.
-                                    Defaults to "".
-                                  type: string
-                                valueFrom:
-                                  description: Source for the environment variable's
-                                    value. Cannot be used if value is not empty.
-                                  properties:
-                                    configMapKeyRef:
-                                      description: Selects a key of a ConfigMap.
-                                      properties:
-                                        key:
-                                          description: The key to select.
-                                          type: string
-                                        name:
-                                          default: ""
-                                          description: |-
-                                            Name of the referent.
-                                            This field is effectively required, but due to backwards compatibility is
-                                            allowed to be empty. Instances of this type with an empty value here are
-                                            almost certainly wrong.
-                                            TODO: Add other useful fields. apiVersion, kind, uid?
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
-                                          type: string
-                                        optional:
-                                          description: Specify whether the ConfigMap
-                                            or its key must be defined
-                                          type: boolean
-                                      required:
-                                      - key
-                                      type: object
-                                      x-kubernetes-map-type: atomic
-                                    fieldRef:
-                                      description: |-
-                                        Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                        spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
-                                      properties:
-                                        apiVersion:
-                                          description: Version of the schema the FieldPath
-                                            is written in terms of, defaults to "v1".
-                                          type: string
-                                        fieldPath:
-                                          description: Path of the field to select
-                                            in the specified API version.
-                                          type: string
-                                      required:
-                                      - fieldPath
-                                      type: object
-                                      x-kubernetes-map-type: atomic
-                                    resourceFieldRef:
-                                      description: |-
-                                        Selects a resource of the container: only resources limits and requests
-                                        (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
-                                      properties:
-                                        containerName:
-                                          description: 'Container name: required for
-                                            volumes, optional for env vars'
-                                          type: string
-                                        divisor:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          description: Specifies the output format
-                                            of the exposed resources, defaults to
-                                            "1"
-                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                          x-kubernetes-int-or-string: true
-                                        resource:
-                                          description: 'Required: resource to select'
-                                          type: string
-                                      required:
-                                      - resource
-                                      type: object
-                                      x-kubernetes-map-type: atomic
-                                    secretKeyRef:
-                                      description: Selects a key of a secret in the
-                                        pod's namespace
-                                      properties:
-                                        key:
-                                          description: The key of the secret to select
-                                            from.  Must be a valid secret key.
-                                          type: string
-                                        name:
-                                          default: ""
-                                          description: |-
-                                            Name of the referent.
-                                            This field is effectively required, but due to backwards compatibility is
-                                            allowed to be empty. Instances of this type with an empty value here are
-                                            almost certainly wrong.
-                                            TODO: Add other useful fields. apiVersion, kind, uid?
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
-                                          type: string
-                                        optional:
-                                          description: Specify whether the Secret
-                                            or its key must be defined
-                                          type: boolean
-                                      required:
-                                      - key
-                                      type: object
-                                      x-kubernetes-map-type: atomic
-                                  type: object
-                              required:
-                              - name
-                              type: object
-                            type: array
-                          labels:
-                            additionalProperties:
-                              type: string
-                            description: labels to add to pods
-                            type: object
-                          nodeSelector:
-                            additionalProperties:
-                              type: string
-                            description: nodeSelector defines the nodeSelector to
-                              be supplied to podSpec
-                            type: object
-                          resourceAllocations:
-                            description: resourceAllocations defines the CPU, Memory
-                              and ephemeral-storage resource allocations for the Pod
-                            nullable: true
-                            properties:
-                              claims:
-                                description: |-
-                                  Claims lists the names of resources, defined in spec.resourceClaims,
-                                  that are used by this container.
-
-
-                                  This is an alpha field and requires enabling the
-                                  DynamicResourceAllocation feature gate.
-
-
-                                  This field is immutable. It can only be set for containers.
-                                items:
-                                  description: ResourceClaim references one entry
-                                    in PodSpec.ResourceClaims.
-                                  properties:
-                                    name:
-                                      description: |-
-                                        Name must match the name of one entry in pod.spec.resourceClaims of
-                                        the Pod where this field is used. It makes that resource available
-                                        inside a container.
-                                      type: string
-                                  required:
-                                  - name
-                                  type: object
-                                type: array
-                                x-kubernetes-list-map-keys:
-                                - name
-                                x-kubernetes-list-type: map
-                              limits:
-                                additionalProperties:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                                description: |-
-                                  Limits describes the maximum amount of compute resources allowed.
-                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                                type: object
-                              requests:
-                                additionalProperties:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                                description: |-
-                                  Requests describes the minimum amount of compute resources required.
-                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                                type: object
-                            type: object
-                          tolerations:
-                            description: tolerations defines the list of tolerations
-                              to be applied to daemonset
-                            items:
-                              description: |-
-                                The pod this Toleration is attached to tolerates any taint that matches
-                                the triple <key,value,effect> using the matching operator <operator>.
-                              properties:
-                                effect:
-                                  description: |-
-                                    Effect indicates the taint effect to match. Empty means match all taint effects.
-                                    When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
-                                  type: string
-                                key:
-                                  description: |-
-                                    Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                                    If the key is empty, operator must be Exists; this combination means to match all values and all keys.
-                                  type: string
-                                operator:
-                                  description: |-
-                                    Operator represents a key's relationship to the value.
-                                    Valid operators are Exists and Equal. Defaults to Equal.
-                                    Exists is equivalent to wildcard for value, so that a pod can
-                                    tolerate all taints of a particular category.
-                                  type: string
-                                tolerationSeconds:
-                                  description: |-
-                                    TolerationSeconds represents the period of time the toleration (which must be
-                                    of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                                    it is not set, which means tolerate the taint forever (do not evict). Zero and
-                                    negative values will be treated as 0 (evict immediately) by the system.
-                                  format: int64
-                                  type: integer
-                                value:
-                                  description: |-
-                                    Value is the taint value the toleration matches to.
-                                    If the operator is Exists, the value should be empty, otherwise just a regular string.
-                                  type: string
-                              type: object
-                            type: array
-                        type: object
-                      supplementalGroups:
-                        description: supplementalGroups defines the linux groups to
-                          be applied to the NodeAgent Pod
-                        items:
-                          format: int64
-                          type: integer
-                        type: array
-                      timeout:
-                        description: timeout defines the NodeAgent timeout, default
-                          value is 1h
-                        type: string
-                    type: object
-                  velero:
-                    properties:
-                      args:
-                        description: Velero args are settings to customize velero
-                          server arguments. Overrides values in other fields.
-                        properties:
-                          add_dir_header:
-                            description: If true, adds the file directory to the header
-                              of the log messages
-                            type: boolean
-                          alsologtostderr:
-                            description: log to standard error as well as files (no
-                              effect when -logtostderr=true)
-                            type: boolean
-                          backup-sync-period:
-                            description: How often (in nanoseconds) to ensure all
-                              Velero backups in object storage exist as Backup API
-                              objects in the cluster. This is the default sync period
-                              if none is explicitly specified for a backup storage
-                              location.
-                            format: int64
-                            type: integer
-                          client-burst:
-                            description: Maximum number of requests by the server
-                              to the Kubernetes API in a short period of time.
-                            type: integer
-                          client-page-size:
-                            description: Page size of requests by the server to the
-                              Kubernetes API when listing objects during a backup.
-                              Set to 0 to disable paging.
-                            type: integer
-                          client-qps:
-                            description: |-
-                              Maximum number of requests per second by the server to the Kubernetes API once the burst limit has been reached.
-                              this will be validated as a valid float32
-                            type: string
-                          colorized:
-                            description: Show colored output in TTY
-                            type: boolean
-                          default-backup-ttl:
-                            description: How long (in nanoseconds) to wait by default
-                              before backups can be garbage collected. (default is
-                              720 hours)
-                            format: int64
-                            type: integer
-                          default-item-operation-timeout:
-                            description: How long (in nanoseconds) to wait on asynchronous
-                              BackupItemActions and RestoreItemActions to complete
-                              before timing out. (default is 1 hour)
-                            format: int64
-                            type: integer
-                          default-repo-maintain-frequency:
-                            description: How often (in nanoseconds) 'maintain' is
-                              run for backup repositories by default.
-                            format: int64
-                            type: integer
-                          default-volumes-to-fs-backup:
-                            description: Backup all volumes with pod volume file system
-                              backup by default.
-                            type: boolean
-                          disabled-controllers:
-                            description: List of controllers to disable on startup.
-                              Valid values are backup,backup-operations,backup-deletion,backup-finalizer,backup-sync,download-request,gc,backup-repo,restore,restore-operations,schedule,server-status-request
-                            enum:
-                            - backup
-                            - backup-operations
-                            - backup-deletion
-                            - backup-finalizer
-                            - backup-sync
-                            - download-request
-                            - gc
-                            - backup-repo
-                            - restore
-                            - restore-operations
-                            - schedule
-                            - server-status-request
-                            items:
-                              type: string
-                            type: array
-                          fs-backup-timeout:
-                            description: How long (in nanoseconds) pod volume file
-                              system backups/restores should be allowed to run before
-                              timing out. (default is 4 hours)
-                            format: int64
-                            type: integer
-                          garbage-collection-frequency:
-                            description: How often (in nanoseconds) garbage collection
-                              checks for expired backups. (default is 1 hour)
-                            format: int64
-                            type: integer
-                          item-operation-sync-frequency:
-                            description: How often (in nanoseconds) to check status
-                              on backup/restore operations after backup/restore processing.
-                            format: int64
-                            type: integer
-                          log-format:
-                            description: The format for log output. Valid values are
-                              text, json. (default text)
-                            enum:
-                            - text
-                            - json
-                            type: string
-                          log_backtrace_at:
-                            description: when logging hits line file:N, emit a stack
-                              trace
-                            type: string
-                          log_dir:
-                            description: If non-empty, write log files in this directory
-                              (no effect when -logtostderr=true)
-                            type: string
-                          log_file:
-                            description: If non-empty, use this log file (no effect
-                              when -logtostderr=true)
-                            type: string
-                          log_file_max_size:
-                            description: Defines the maximum size a log file can grow
-                              to (no effect when -logtostderr=true). Unit is megabytes.
-                              If the value is 0, the maximum file size is unlimited.
-                              (default 1800)
-                            format: int64
-                            minimum: 0
-                            type: integer
-                          logtostderr:
-                            description: |-
-                              Boolean flags. Not handled atomically because the flag.Value interface
-                              does not let us avoid the =true, and that shorthand is necessary for
-                              compatibility. TODO: does this matter enough to fix? Seems unlikely.
-                            type: boolean
-                          max-concurrent-k8s-connections:
-                            description: Max concurrent connections number that Velero
-                              can create with kube-apiserver. Default is 30. (default
-                              30)
-                            type: integer
-                          metrics-address:
-                            description: The address to expose prometheus metrics
-                            type: string
-                          one_output:
-                            description: If true, only write logs to their native
-                              severity level (vs also writing to each lower severity
-                              level; no effect when -logtostderr=true)
-                            type: boolean
-                          profiler-address:
-                            description: The address to expose the pprof profiler.
-                            type: string
-                          resource-timeout:
-                            description: How long (in nanoseconds) to wait for resource
-                              processes which are not covered by other specific timeout
-                              parameters. (default is 10 minutes)
-                            format: int64
-                            type: integer
-                          restore-resource-priorities:
-                            description: Desired order of resource restores, the priority
-                              list contains two parts which are split by "-" element.
-                              The resources before "-" element are restored first
-                              as high priorities, the resources after "-" element
-                              are restored last as low priorities, and any resource
-                              not in the list will be restored alphabetically between
-                              the high and low priorities. (default securitycontextconstraints,customresourcedefinitions,klusterletconfigs.config.open-cluster-management.io,managedcluster.cluster.open-cluster-management.io,namespaces,roles,rolebindings,clusterrolebindings,klusterletaddonconfig.agent.open-cluster-management.io,managedclusteraddon.addon.open-cluster-management.io,storageclasses,volumesnapshotclass.snapshot.storage.k8s.io,volumesnapshotcontents.snapshot.storage.k8s.io,volumesnapshots.snapshot.storage.k8s.io,datauploads.velero.io,persistentvolumes,persistentvolumeclaims,serviceaccounts,secrets,configmaps,limitranges,pods,replicasets.apps,clusterclasses.cluster.x-k8s.io,endpoints,services,-,clusterbootstraps.run.tanzu.vmware.com,clusters.cluster.x-k8s.io,clusterresourcesets.addons.cluster.x-k8s.io)
-                            type: string
-                          skip_headers:
-                            description: If true, avoid header prefixes in the log
-                              messages
-                            type: boolean
-                          skip_log_headers:
-                            description: If true, avoid headers when opening log files
-                              (no effect when -logtostderr=true)
-                            type: boolean
-                          stderrthreshold:
-                            description: logs at or above this threshold go to stderr
-                              when writing to files and stderr (no effect when -logtostderr=true
-                              or -alsologtostderr=false) (default 2)
-                            type: integer
-                          store-validation-frequency:
-                            description: How often (in nanoseconds) to verify if the
-                              storage is valid. Optional. Set this to `0` to disable
-                              sync. (default is 1 minute)
-                            format: int64
-                            type: integer
-                          terminating-resource-timeout:
-                            description: How long (in nanoseconds) to wait on persistent
-                              volumes and namespaces to terminate during a restore
-                              before timing out.
-                            format: int64
-                            type: integer
-                          v:
-                            description: number for the log level verbosity
-                            type: integer
-                          vmodule:
-                            description: comma-separated list of pattern=N settings
-                              for file-filtered logging
-                            type: string
-                        type: object
-                      client-burst:
-                        description: maximum number of requests by the server to the
-                          Kubernetes API in a short period of time. (default 100)
-                        type: integer
-                      client-qps:
-                        description: maximum number of requests per second by the
-                          server to the Kubernetes API once the burst limit has been
-                          reached. (default 100)
-                        type: integer
-                      customPlugins:
-                        description: customPlugins defines the custom plugin to be
-                          installed with Velero
-                        items:
-                          properties:
-                            image:
-                              type: string
-                            name:
-                              type: string
-                          required:
-                          - image
-                          - name
-                          type: object
-                        type: array
-                      defaultItemOperationTimeout:
-                        description: How long to wait on asynchronous BackupItemActions
-                          and RestoreItemActions to complete before timing out. Default
-                          value is 1h.
-                        type: string
-                      defaultPlugins:
-                        items:
-                          enum:
-                          - aws
-                          - legacy-aws
-                          - gcp
-                          - azure
-                          - csi
-                          - vsm
-                          - openshift
-                          - kubevirt
-                          type: string
-                        type: array
-                      defaultSnapshotMoveData:
-                        description: Specify whether CSI snapshot data should be moved
-                          to backup storage by default
-                        type: boolean
-                      defaultVolumesToFSBackup:
-                        description: Use pod volume file system backup by default
-                          for volumes
-                        type: boolean
-                      disableInformerCache:
-                        description: Disable informer cache for Get calls on restore.
-                          With this enabled, it will speed up restore in cases where
-                          there are backup resources which already exist in the cluster,
-                          but for very large clusters this will increase velero memory
-                          usage. Default is false.
-                        type: boolean
-                      featureFlags:
-                        description: featureFlags defines the list of features to
-                          enable for Velero instance
-                        items:
-                          type: string
-                        type: array
-                      itemOperationSyncFrequency:
-                        description: How often to check status on async backup/restore
-                          operations after backup processing. Default value is 2m.
-                        type: string
-                      logLevel:
-                        description: Velero server's log level (use debug for the
-                          most logging, leave unset for velero default)
-                        enum:
-                        - trace
-                        - debug
-                        - info
-                        - warning
-                        - error
-                        - fatal
-                        - panic
-                        type: string
-                      noDefaultBackupLocation:
-                        description: If you need to install Velero without a default
-                          backup storage location noDefaultBackupLocation flag is
-                          required for confirmation
-                        type: boolean
-                      podConfig:
-                        description: Pod specific configuration
-                        properties:
-                          env:
-                            description: env defines the list of environment variables
-                              to be supplied to podSpec
-                            items:
-                              description: EnvVar represents an environment variable
-                                present in a Container.
-                              properties:
-                                name:
-                                  description: Name of the environment variable. Must
-                                    be a C_IDENTIFIER.
-                                  type: string
-                                value:
-                                  description: |-
-                                    Variable references $(VAR_NAME) are expanded
-                                    using the previously defined environment variables in the container and
-                                    any service environment variables. If a variable cannot be resolved,
-                                    the reference in the input string will be unchanged. Double $$ are reduced
-                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                                    "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                                    Escaped references will never be expanded, regardless of whether the variable
-                                    exists or not.
-                                    Defaults to "".
-                                  type: string
-                                valueFrom:
-                                  description: Source for the environment variable's
-                                    value. Cannot be used if value is not empty.
-                                  properties:
-                                    configMapKeyRef:
-                                      description: Selects a key of a ConfigMap.
-                                      properties:
-                                        key:
-                                          description: The key to select.
-                                          type: string
-                                        name:
-                                          default: ""
-                                          description: |-
-                                            Name of the referent.
-                                            This field is effectively required, but due to backwards compatibility is
-                                            allowed to be empty. Instances of this type with an empty value here are
-                                            almost certainly wrong.
-                                            TODO: Add other useful fields. apiVersion, kind, uid?
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
-                                          type: string
-                                        optional:
-                                          description: Specify whether the ConfigMap
-                                            or its key must be defined
-                                          type: boolean
-                                      required:
-                                      - key
-                                      type: object
-                                      x-kubernetes-map-type: atomic
-                                    fieldRef:
-                                      description: |-
-                                        Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                        spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
-                                      properties:
-                                        apiVersion:
-                                          description: Version of the schema the FieldPath
-                                            is written in terms of, defaults to "v1".
-                                          type: string
-                                        fieldPath:
-                                          description: Path of the field to select
-                                            in the specified API version.
-                                          type: string
-                                      required:
-                                      - fieldPath
-                                      type: object
-                                      x-kubernetes-map-type: atomic
-                                    resourceFieldRef:
-                                      description: |-
-                                        Selects a resource of the container: only resources limits and requests
-                                        (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
-                                      properties:
-                                        containerName:
-                                          description: 'Container name: required for
-                                            volumes, optional for env vars'
-                                          type: string
-                                        divisor:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          description: Specifies the output format
-                                            of the exposed resources, defaults to
-                                            "1"
-                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                          x-kubernetes-int-or-string: true
-                                        resource:
-                                          description: 'Required: resource to select'
-                                          type: string
-                                      required:
-                                      - resource
-                                      type: object
-                                      x-kubernetes-map-type: atomic
-                                    secretKeyRef:
-                                      description: Selects a key of a secret in the
-                                        pod's namespace
-                                      properties:
-                                        key:
-                                          description: The key of the secret to select
-                                            from.  Must be a valid secret key.
-                                          type: string
-                                        name:
-                                          default: ""
-                                          description: |-
-                                            Name of the referent.
-                                            This field is effectively required, but due to backwards compatibility is
-                                            allowed to be empty. Instances of this type with an empty value here are
-                                            almost certainly wrong.
-                                            TODO: Add other useful fields. apiVersion, kind, uid?
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
-                                          type: string
-                                        optional:
-                                          description: Specify whether the Secret
-                                            or its key must be defined
-                                          type: boolean
-                                      required:
-                                      - key
-                                      type: object
-                                      x-kubernetes-map-type: atomic
-                                  type: object
-                              required:
-                              - name
-                              type: object
-                            type: array
-                          labels:
-                            additionalProperties:
-                              type: string
-                            description: labels to add to pods
-                            type: object
-                          nodeSelector:
-                            additionalProperties:
-                              type: string
-                            description: nodeSelector defines the nodeSelector to
-                              be supplied to podSpec
-                            type: object
-                          resourceAllocations:
-                            description: resourceAllocations defines the CPU, Memory
-                              and ephemeral-storage resource allocations for the Pod
-                            nullable: true
-                            properties:
-                              claims:
-                                description: |-
-                                  Claims lists the names of resources, defined in spec.resourceClaims,
-                                  that are used by this container.
-
-
-                                  This is an alpha field and requires enabling the
-                                  DynamicResourceAllocation feature gate.
-
-
-                                  This field is immutable. It can only be set for containers.
-                                items:
-                                  description: ResourceClaim references one entry
-                                    in PodSpec.ResourceClaims.
-                                  properties:
-                                    name:
-                                      description: |-
-                                        Name must match the name of one entry in pod.spec.resourceClaims of
-                                        the Pod where this field is used. It makes that resource available
-                                        inside a container.
-                                      type: string
-                                  required:
-                                  - name
-                                  type: object
-                                type: array
-                                x-kubernetes-list-map-keys:
-                                - name
-                                x-kubernetes-list-type: map
-                              limits:
-                                additionalProperties:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                                description: |-
-                                  Limits describes the maximum amount of compute resources allowed.
-                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                                type: object
-                              requests:
-                                additionalProperties:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                                description: |-
-                                  Requests describes the minimum amount of compute resources required.
-                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                                type: object
-                            type: object
-                          tolerations:
-                            description: tolerations defines the list of tolerations
-                              to be applied to daemonset
-                            items:
-                              description: |-
-                                The pod this Toleration is attached to tolerates any taint that matches
-                                the triple <key,value,effect> using the matching operator <operator>.
-                              properties:
-                                effect:
-                                  description: |-
-                                    Effect indicates the taint effect to match. Empty means match all taint effects.
-                                    When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
-                                  type: string
-                                key:
-                                  description: |-
-                                    Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                                    If the key is empty, operator must be Exists; this combination means to match all values and all keys.
-                                  type: string
-                                operator:
-                                  description: |-
-                                    Operator represents a key's relationship to the value.
-                                    Valid operators are Exists and Equal. Defaults to Equal.
-                                    Exists is equivalent to wildcard for value, so that a pod can
-                                    tolerate all taints of a particular category.
-                                  type: string
-                                tolerationSeconds:
-                                  description: |-
-                                    TolerationSeconds represents the period of time the toleration (which must be
-                                    of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                                    it is not set, which means tolerate the taint forever (do not evict). Zero and
-                                    negative values will be treated as 0 (evict immediately) by the system.
-                                  format: int64
-                                  type: integer
-                                value:
-                                  description: |-
-                                    Value is the taint value the toleration matches to.
-                                    If the operator is Exists, the value should be empty, otherwise just a regular string.
-                                  type: string
-                              type: object
-                            type: array
-                        type: object
-                      resourceTimeout:
-                        description: |-
-                          resourceTimeout defines how long to wait for several Velero resources before timeout occurs,
-                          such as Velero CRD availability, volumeSnapshot deletion, and repo availability.
-                          Default is 10m
-                        type: string
-                      restoreResourcesVersionPriority:
-                        description: |-
-                          restoreResourceVersionPriority represents a configmap that will be created if defined for use in conjunction with EnableAPIGroupVersions feature flag
-                          Defining this field automatically add EnableAPIGroupVersions to the velero server feature flag
-                        type: string
-                    type: object
-                type: object
-              features:
-                description: features defines the configuration for the DPA to enable
-                  the OADP tech preview features
-                properties:
-                  dataMover:
-                    description: |-
-                      (do not use warning) dataMover is for backwards compatibility and
-                      will be removed in the future. Use Velero Built-in Data Mover instead
-                    properties:
-                      credentialName:
-                        description: User supplied Restic Secret name
-                        type: string
-                      enable:
-                        description: enable flag is used to specify whether you want
-                          to deploy the volume snapshot mover controller
-                        type: boolean
-                      maxConcurrentBackupVolumes:
-                        description: the number of batched volumeSnapshotBackups that
-                          can be inProgress at once, default value is 10
-                        type: string
-                      maxConcurrentRestoreVolumes:
-                        description: the number of batched volumeSnapshotRestores
-                          that can be inProgress at once, default value is 10
-                        type: string
-                      pruneInterval:
-                        description: defines how often (in days) to prune the datamover
-                          snapshots from the repository
-                        type: string
-                      schedule:
-                        description: |-
-                          schedule is a cronspec (https://en.wikipedia.org/wiki/Cron#Overview) that
-                          can be used to schedule datamover(volsync) synchronization to occur at regular, time-based
-                          intervals. For example, in order to enforce datamover SnapshotRetainPolicy at a regular interval you need to
-                          specify this Schedule trigger as a cron expression, by default the trigger is a manual trigger. For more details
-                          on Volsync triggers, refer: https://volsync.readthedocs.io/en/stable/usage/triggers.html
-                        pattern: ^(\d+|\*)(/\d+)?(\s+(\d+|\*)(/\d+)?){4}$
-                        type: string
-                      snapshotRetainPolicy:
-                        description: defines the parameters that can be specified
-                          for retention of datamover snapshots
-                        properties:
-                          daily:
-                            description: Daily defines the number of snapshots to
-                              be kept daily
-                            type: string
-                          hourly:
-                            description: Hourly defines the number of snapshots to
-                              be kept hourly
-                            type: string
-                          monthly:
-                            description: Monthly defines the number of snapshots to
-                              be kept monthly
-                            type: string
-                          weekly:
-                            description: Weekly defines the number of snapshots to
-                              be kept weekly
-                            type: string
-                          within:
-                            description: Within defines the number of snapshots to
-                              be kept Within the given time period
-                            type: string
-                          yearly:
-                            description: Yearly defines the number of snapshots to
-                              be kept yearly
-                            type: string
-                        type: object
-                      timeout:
-                        description: User supplied timeout to be used for VolumeSnapshotBackup
-                          and VolumeSnapshotRestore to complete, default value is
-                          10m
-                        type: string
-                      volumeOptionsForStorageClasses:
-                        additionalProperties:
-                          properties:
-                            destinationVolumeOptions:
-                              description: VolumeOptions defines configurations for
-                                VolSync options
-                              properties:
-                                accessMode:
-                                  description: |-
-                                    accessMode can be used to override the accessMode of the source or
-                                    destination PVC
-                                  type: string
-                                cacheAccessMode:
-                                  description: cacheAccessMode is the access mode
-                                    to be used to provision the cache volume
-                                  type: string
-                                cacheCapacity:
-                                  description: cacheCapacity determines the size of
-                                    the restic metadata cache volume
-                                  type: string
-                                cacheStorageClassName:
-                                  description: |-
-                                    cacheStorageClassName is the storageClass that should be used when provisioning
-                                    the data mover cache volume
-                                  type: string
-                                storageClassName:
-                                  description: |-
-                                    storageClassName can be used to override the StorageClass of the source
-                                    or destination PVC
-                                  type: string
-                              type: object
-                            sourceVolumeOptions:
-                              description: VolumeOptions defines configurations for
-                                VolSync options
-                              properties:
-                                accessMode:
-                                  description: |-
-                                    accessMode can be used to override the accessMode of the source or
-                                    destination PVC
-                                  type: string
-                                cacheAccessMode:
-                                  description: cacheAccessMode is the access mode
-                                    to be used to provision the cache volume
-                                  type: string
-                                cacheCapacity:
-                                  description: cacheCapacity determines the size of
-                                    the restic metadata cache volume
-                                  type: string
-                                cacheStorageClassName:
-                                  description: |-
-                                    cacheStorageClassName is the storageClass that should be used when provisioning
-                                    the data mover cache volume
-                                  type: string
-                                storageClassName:
-                                  description: |-
-                                    storageClassName can be used to override the StorageClass of the source
-                                    or destination PVC
-                                  type: string
-                              type: object
-                          type: object
-                        description: defines configurations for data mover volume
-                          options for a storageClass
-                        type: object
-                    type: object
-                type: object
-              imagePullPolicy:
-                description: |-
-                  which imagePullPolicy to use in all container images used by OADP.
-                  By default, for images with sha256 or sha512 digest, OADP uses IfNotPresent and uses Always for all other images.
-                enum:
-                - Always
-                - IfNotPresent
-                - Never
-                type: string
-              nonAdmin:
-                description: nonAdmin defines the configuration for the DPA to enable
-                  backup and restore operations for non-admin users
-                properties:
-                  backupSyncPeriod:
-                    description: |-
-                      BackupSyncPeriod specifies the interval at which backups from the OADP namespace are synchronized with non-admin namespaces.
-                      A value of 0 disables sync.
-                      By default 2m
-                    type: string
-                  enable:
-                    description: Enables non admin feature, by default is disabled
-                    type: boolean
-                  enforceBSLSpec:
-                    description: which backupstoragelocation spec field values to
-                      enforce
-                    properties:
-                      accessMode:
-                        description: AccessMode defines the permissions for the backup
-                          storage location.
-                        enum:
-                        - ReadOnly
-                        - ReadWrite
-                        type: string
-                      backupSyncPeriod:
-                        description: BackupSyncPeriod defines how frequently to sync
-                          backup API objects from object storage. A value of 0 disables
-                          sync.
-                        nullable: true
-                        type: string
-                      config:
-                        additionalProperties:
-                          type: string
-                        description: Config is for provider-specific configuration
-                          fields.
-                        type: object
-                      credential:
-                        description: Credential contains the credential information
-                          intended to be used with this location
-                        properties:
-                          key:
-                            description: The key of the secret to select from.  Must
-                              be a valid secret key.
-                            type: string
-                          name:
-                            default: ""
-                            description: |-
-                              Name of the referent.
-                              This field is effectively required, but due to backwards compatibility is
-                              allowed to be empty. Instances of this type with an empty value here are
-                              almost certainly wrong.
-                              TODO: Add other useful fields. apiVersion, kind, uid?
-                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
-                            type: string
-                          optional:
-                            description: Specify whether the Secret or its key must
-                              be defined
-                            type: boolean
-                        required:
-                        - key
-                        type: object
-                        x-kubernetes-map-type: atomic
-                      objectStorage:
-                        description: ObjectStorageLocation defines the enforced values
-                          for the Velero ObjectStorageLocation
-                        nullable: true
-                        properties:
-                          bucket:
-                            description: Bucket is the bucket to use for object storage.
-                            type: string
-                          caCert:
-                            description: CACert defines a CA bundle to use when verifying
-                              TLS connections to the provider.
-                            format: byte
-                            type: string
-                          prefix:
-                            description: Prefix is the path inside a bucket to use
-                              for Velero storage. Optional.
-                            type: string
-                        type: object
-                      provider:
-                        description: Provider is the provider of the backup storage.
-                        type: string
-                      validationFrequency:
-                        description: ValidationFrequency defines how frequently to
-                          validate the corresponding object storage. A value of 0
-                          disables validation.
-                        nullable: true
-                        type: string
-                    type: object
-                  enforceBackupSpec:
-                    description: which bakup spec field values to enforce
-                    properties:
-                      csiSnapshotTimeout:
-                        description: |-
-                          CSISnapshotTimeout specifies the time used to wait for CSI VolumeSnapshot status turns to
-                          ReadyToUse during creation, before returning error as timeout.
-                          The default value is 10 minute.
-                        type: string
-                      datamover:
-                        description: |-
-                          DataMover specifies the data mover to be used by the backup.
-                          If DataMover is "" or "velero", the built-in data mover will be used.
-                        type: string
-                      defaultVolumesToFsBackup:
-                        description: |-
-                          DefaultVolumesToFsBackup specifies whether pod volume file system backup should be used
-                          for all volumes by default.
-                        nullable: true
-                        type: boolean
-                      defaultVolumesToRestic:
-                        description: |-
-                          DefaultVolumesToRestic specifies whether restic should be used to take a
-                          backup of all pod volumes by default.
-
-
-                          Deprecated: this field is no longer used and will be removed entirely in future. Use DefaultVolumesToFsBackup instead.
-                        nullable: true
-                        type: boolean
-                      excludedClusterScopedResources:
-                        description: |-
-                          ExcludedClusterScopedResources is a slice of cluster-scoped
-                          resource type names to exclude from the backup.
-                          If set to "*", all cluster-scoped resource types are excluded.
-                          The default value is empty.
-                        items:
-                          type: string
-                        nullable: true
-                        type: array
-                      excludedNamespaceScopedResources:
-                        description: |-
-                          ExcludedNamespaceScopedResources is a slice of namespace-scoped
-                          resource type names to exclude from the backup.
-                          If set to "*", all namespace-scoped resource types are excluded.
-                          The default value is empty.
-                        items:
-                          type: string
-                        nullable: true
-                        type: array
-                      excludedNamespaces:
-                        description: |-
-                          ExcludedNamespaces contains a list of namespaces that are not
-                          included in the backup.
-                        items:
-                          type: string
-                        nullable: true
-                        type: array
-                      excludedResources:
-                        description: |-
-                          ExcludedResources is a slice of resource names that are not
-                          included in the backup.
-                        items:
-                          type: string
-                        nullable: true
-                        type: array
-                      hooks:
-                        description: Hooks represent custom behaviors that should
-                          be executed at different phases of the backup.
-                        properties:
-                          resources:
-                            description: Resources are hooks that should be executed
-                              when backing up individual instances of a resource.
-                            items:
-                              description: |-
-                                BackupResourceHookSpec defines one or more BackupResourceHooks that should be executed based on
-                                the rules defined for namespaces, resources, and label selector.
-                              properties:
-                                excludedNamespaces:
-                                  description: ExcludedNamespaces specifies the namespaces
-                                    to which this hook spec does not apply.
-                                  items:
-                                    type: string
-                                  nullable: true
-                                  type: array
-                                excludedResources:
-                                  description: ExcludedResources specifies the resources
-                                    to which this hook spec does not apply.
-                                  items:
-                                    type: string
-                                  nullable: true
-                                  type: array
-                                includedNamespaces:
-                                  description: |-
-                                    IncludedNamespaces specifies the namespaces to which this hook spec applies. If empty, it applies
-                                    to all namespaces.
-                                  items:
-                                    type: string
-                                  nullable: true
-                                  type: array
-                                includedResources:
-                                  description: |-
-                                    IncludedResources specifies the resources to which this hook spec applies. If empty, it applies
-                                    to all resources.
-                                  items:
-                                    type: string
-                                  nullable: true
-                                  type: array
-                                labelSelector:
-                                  description: LabelSelector, if specified, filters
-                                    the resources to which this hook spec applies.
-                                  nullable: true
-                                  properties:
-                                    matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
-                                      items:
-                                        description: |-
-                                          A label selector requirement is a selector that contains values, a key, and an operator that
-                                          relates the key and values.
-                                        properties:
-                                          key:
-                                            description: key is the label key that
-                                              the selector applies to.
-                                            type: string
-                                          operator:
-                                            description: |-
-                                              operator represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists and DoesNotExist.
-                                            type: string
-                                          values:
-                                            description: |-
-                                              values is an array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This array is replaced during a strategic
-                                              merge patch.
-                                            items:
-                                              type: string
-                                            type: array
-                                            x-kubernetes-list-type: atomic
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                      x-kubernetes-list-type: atomic
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      description: |-
-                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                      type: object
-                                  type: object
-                                  x-kubernetes-map-type: atomic
-                                name:
-                                  description: Name is the name of this hook.
-                                  type: string
-                                post:
-                                  description: |-
-                                    PostHooks is a list of BackupResourceHooks to execute after storing the item in the backup.
-                                    These are executed after all "additional items" from item actions are processed.
-                                  items:
-                                    description: BackupResourceHook defines a hook
-                                      for a resource.
-                                    properties:
-                                      exec:
-                                        description: Exec defines an exec hook.
-                                        properties:
-                                          command:
-                                            description: Command is the command and
-                                              arguments to execute.
-                                            items:
-                                              type: string
-                                            minItems: 1
-                                            type: array
-                                          container:
-                                            description: |-
-                                              Container is the container in the pod where the command should be executed. If not specified,
-                                              the pod's first container is used.
-                                            type: string
-                                          onError:
-                                            description: OnError specifies how Velero
-                                              should behave if it encounters an error
-                                              executing this hook.
-                                            enum:
-                                            - Continue
-                                            - Fail
-                                            type: string
-                                          timeout:
-                                            description: |-
-                                              Timeout defines the maximum amount of time Velero should wait for the hook to complete before
-                                              considering the execution a failure.
-                                            type: string
-                                        required:
-                                        - command
-                                        type: object
-                                    required:
-                                    - exec
-                                    type: object
-                                  type: array
-                                pre:
-                                  description: |-
-                                    PreHooks is a list of BackupResourceHooks to execute prior to storing the item in the backup.
-                                    These are executed before any "additional items" from item actions are processed.
-                                  items:
-                                    description: BackupResourceHook defines a hook
-                                      for a resource.
-                                    properties:
-                                      exec:
-                                        description: Exec defines an exec hook.
-                                        properties:
-                                          command:
-                                            description: Command is the command and
-                                              arguments to execute.
-                                            items:
-                                              type: string
-                                            minItems: 1
-                                            type: array
-                                          container:
-                                            description: |-
-                                              Container is the container in the pod where the command should be executed. If not specified,
-                                              the pod's first container is used.
-                                            type: string
-                                          onError:
-                                            description: OnError specifies how Velero
-                                              should behave if it encounters an error
-                                              executing this hook.
-                                            enum:
-                                            - Continue
-                                            - Fail
-                                            type: string
-                                          timeout:
-                                            description: |-
-                                              Timeout defines the maximum amount of time Velero should wait for the hook to complete before
-                                              considering the execution a failure.
-                                            type: string
-                                        required:
-                                        - command
-                                        type: object
-                                    required:
-                                    - exec
-                                    type: object
-                                  type: array
-                              required:
-                              - name
-                              type: object
-                            nullable: true
-                            type: array
-                        type: object
-                      includeClusterResources:
-                        description: |-
-                          IncludeClusterResources specifies whether cluster-scoped resources
-                          should be included for consideration in the backup.
-                        nullable: true
-                        type: boolean
-                      includedClusterScopedResources:
-                        description: |-
-                          IncludedClusterScopedResources is a slice of cluster-scoped
-                          resource type names to include in the backup.
-                          If set to "*", all cluster-scoped resource types are included.
-                          The default value is empty, which means only related
-                          cluster-scoped resources are included.
-                        items:
-                          type: string
-                        nullable: true
-                        type: array
-                      includedNamespaceScopedResources:
-                        description: |-
-                          IncludedNamespaceScopedResources is a slice of namespace-scoped
-                          resource type names to include in the backup.
-                          The default value is "*".
-                        items:
-                          type: string
-                        nullable: true
-                        type: array
-                      includedNamespaces:
-                        description: |-
-                          IncludedNamespaces is a slice of namespace names to include objects
-                          from. If empty, all namespaces are included.
-                        items:
-                          type: string
-                        nullable: true
-                        type: array
-                      includedResources:
-                        description: |-
-                          IncludedResources is a slice of resource names to include
-                          in the backup. If empty, all resources are included.
-                        items:
-                          type: string
-                        nullable: true
-                        type: array
-                      itemOperationTimeout:
-                        description: |-
-                          ItemOperationTimeout specifies the time used to wait for asynchronous BackupItemAction operations
-                          The default value is 4 hour.
-                        type: string
-                      labelSelector:
-                        description: |-
-                          LabelSelector is a metav1.LabelSelector to filter with
-                          when adding individual objects to the backup. If empty
-                          or nil, all objects are included. Optional.
-                        nullable: true
-                        properties:
-                          matchExpressions:
-                            description: matchExpressions is a list of label selector
-                              requirements. The requirements are ANDed.
-                            items:
-                              description: |-
-                                A label selector requirement is a selector that contains values, a key, and an operator that
-                                relates the key and values.
-                              properties:
-                                key:
-                                  description: key is the label key that the selector
-                                    applies to.
-                                  type: string
-                                operator:
-                                  description: |-
-                                    operator represents a key's relationship to a set of values.
-                                    Valid operators are In, NotIn, Exists and DoesNotExist.
-                                  type: string
-                                values:
-                                  description: |-
-                                    values is an array of string values. If the operator is In or NotIn,
-                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                    the values array must be empty. This array is replaced during a strategic
-                                    merge patch.
-                                  items:
-                                    type: string
-                                  type: array
-                                  x-kubernetes-list-type: atomic
-                              required:
-                              - key
-                              - operator
-                              type: object
-                            type: array
-                            x-kubernetes-list-type: atomic
-                          matchLabels:
-                            additionalProperties:
-                              type: string
-                            description: |-
-                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                              map is equivalent to an element of matchExpressions, whose key field is "key", the
-                              operator is "In", and the values array contains only "value". The requirements are ANDed.
-                            type: object
-                        type: object
-                        x-kubernetes-map-type: atomic
-                      metadata:
-                        properties:
-                          labels:
-                            additionalProperties:
-                              type: string
-                            type: object
-                        type: object
-                      orLabelSelectors:
-                        description: |-
-                          OrLabelSelectors is list of metav1.LabelSelector to filter with
-                          when adding individual objects to the backup. If multiple provided
-                          they will be joined by the OR operator. LabelSelector as well as
-                          OrLabelSelectors cannot co-exist in backup request, only one of them
-                          can be used.
-                        items:
+                    enforceBackupSpec:
+                      description: which bakup spec field values to enforce
+                      properties:
+                        csiSnapshotTimeout:
                           description: |-
-                            A label selector is a label query over a set of resources. The result of matchLabels and
-                            matchExpressions are ANDed. An empty label selector matches all objects. A null
-                            label selector matches no objects.
+                            CSISnapshotTimeout specifies the time used to wait for CSI VolumeSnapshot status turns to
+                            ReadyToUse during creation, before returning error as timeout.
+                            The default value is 10 minute.
+                          type: string
+                        datamover:
+                          description: |-
+                            DataMover specifies the data mover to be used by the backup.
+                            If DataMover is "" or "velero", the built-in data mover will be used.
+                          type: string
+                        defaultVolumesToFsBackup:
+                          description: |-
+                            DefaultVolumesToFsBackup specifies whether pod volume file system backup should be used
+                            for all volumes by default.
+                          nullable: true
+                          type: boolean
+                        defaultVolumesToRestic:
+                          description: |-
+                            DefaultVolumesToRestic specifies whether restic should be used to take a
+                            backup of all pod volumes by default.
+
+
+                            Deprecated: this field is no longer used and will be removed entirely in future. Use DefaultVolumesToFsBackup instead.
+                          nullable: true
+                          type: boolean
+                        excludedClusterScopedResources:
+                          description: |-
+                            ExcludedClusterScopedResources is a slice of cluster-scoped
+                            resource type names to exclude from the backup.
+                            If set to "*", all cluster-scoped resource types are excluded.
+                            The default value is empty.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        excludedNamespaceScopedResources:
+                          description: |-
+                            ExcludedNamespaceScopedResources is a slice of namespace-scoped
+                            resource type names to exclude from the backup.
+                            If set to "*", all namespace-scoped resource types are excluded.
+                            The default value is empty.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        excludedNamespaces:
+                          description: |-
+                            ExcludedNamespaces contains a list of namespaces that are not
+                            included in the backup.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        excludedResources:
+                          description: |-
+                            ExcludedResources is a slice of resource names that are not
+                            included in the backup.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        hooks:
+                          description: Hooks represent custom behaviors that should be executed at different phases of the backup.
+                          properties:
+                            resources:
+                              description: Resources are hooks that should be executed when backing up individual instances of a resource.
+                              items:
+                                description: |-
+                                  BackupResourceHookSpec defines one or more BackupResourceHooks that should be executed based on
+                                  the rules defined for namespaces, resources, and label selector.
+                                properties:
+                                  excludedNamespaces:
+                                    description: ExcludedNamespaces specifies the namespaces to which this hook spec does not apply.
+                                    items:
+                                      type: string
+                                    nullable: true
+                                    type: array
+                                  excludedResources:
+                                    description: ExcludedResources specifies the resources to which this hook spec does not apply.
+                                    items:
+                                      type: string
+                                    nullable: true
+                                    type: array
+                                  includedNamespaces:
+                                    description: |-
+                                      IncludedNamespaces specifies the namespaces to which this hook spec applies. If empty, it applies
+                                      to all namespaces.
+                                    items:
+                                      type: string
+                                    nullable: true
+                                    type: array
+                                  includedResources:
+                                    description: |-
+                                      IncludedResources specifies the resources to which this hook spec applies. If empty, it applies
+                                      to all resources.
+                                    items:
+                                      type: string
+                                    nullable: true
+                                    type: array
+                                  labelSelector:
+                                    description: LabelSelector, if specified, filters the resources to which this hook spec applies.
+                                    nullable: true
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  name:
+                                    description: Name is the name of this hook.
+                                    type: string
+                                  post:
+                                    description: |-
+                                      PostHooks is a list of BackupResourceHooks to execute after storing the item in the backup.
+                                      These are executed after all "additional items" from item actions are processed.
+                                    items:
+                                      description: BackupResourceHook defines a hook for a resource.
+                                      properties:
+                                        exec:
+                                          description: Exec defines an exec hook.
+                                          properties:
+                                            command:
+                                              description: Command is the command and arguments to execute.
+                                              items:
+                                                type: string
+                                              minItems: 1
+                                              type: array
+                                            container:
+                                              description: |-
+                                                Container is the container in the pod where the command should be executed. If not specified,
+                                                the pod's first container is used.
+                                              type: string
+                                            onError:
+                                              description: OnError specifies how Velero should behave if it encounters an error executing this hook.
+                                              enum:
+                                                - Continue
+                                                - Fail
+                                              type: string
+                                            timeout:
+                                              description: |-
+                                                Timeout defines the maximum amount of time Velero should wait for the hook to complete before
+                                                considering the execution a failure.
+                                              type: string
+                                          required:
+                                            - command
+                                          type: object
+                                      required:
+                                        - exec
+                                      type: object
+                                    type: array
+                                  pre:
+                                    description: |-
+                                      PreHooks is a list of BackupResourceHooks to execute prior to storing the item in the backup.
+                                      These are executed before any "additional items" from item actions are processed.
+                                    items:
+                                      description: BackupResourceHook defines a hook for a resource.
+                                      properties:
+                                        exec:
+                                          description: Exec defines an exec hook.
+                                          properties:
+                                            command:
+                                              description: Command is the command and arguments to execute.
+                                              items:
+                                                type: string
+                                              minItems: 1
+                                              type: array
+                                            container:
+                                              description: |-
+                                                Container is the container in the pod where the command should be executed. If not specified,
+                                                the pod's first container is used.
+                                              type: string
+                                            onError:
+                                              description: OnError specifies how Velero should behave if it encounters an error executing this hook.
+                                              enum:
+                                                - Continue
+                                                - Fail
+                                              type: string
+                                            timeout:
+                                              description: |-
+                                                Timeout defines the maximum amount of time Velero should wait for the hook to complete before
+                                                considering the execution a failure.
+                                              type: string
+                                          required:
+                                            - command
+                                          type: object
+                                      required:
+                                        - exec
+                                      type: object
+                                    type: array
+                                required:
+                                  - name
+                                type: object
+                              nullable: true
+                              type: array
+                          type: object
+                        includeClusterResources:
+                          description: |-
+                            IncludeClusterResources specifies whether cluster-scoped resources
+                            should be included for consideration in the backup.
+                          nullable: true
+                          type: boolean
+                        includedClusterScopedResources:
+                          description: |-
+                            IncludedClusterScopedResources is a slice of cluster-scoped
+                            resource type names to include in the backup.
+                            If set to "*", all cluster-scoped resource types are included.
+                            The default value is empty, which means only related
+                            cluster-scoped resources are included.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        includedNamespaceScopedResources:
+                          description: |-
+                            IncludedNamespaceScopedResources is a slice of namespace-scoped
+                            resource type names to include in the backup.
+                            The default value is "*".
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        includedNamespaces:
+                          description: |-
+                            IncludedNamespaces is a slice of namespace names to include objects
+                            from. If empty, all namespaces are included.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        includedResources:
+                          description: |-
+                            IncludedResources is a slice of resource names to include
+                            in the backup. If empty, all resources are included.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        itemOperationTimeout:
+                          description: |-
+                            ItemOperationTimeout specifies the time used to wait for asynchronous BackupItemAction operations
+                            The default value is 4 hour.
+                          type: string
+                        labelSelector:
+                          description: |-
+                            LabelSelector is a metav1.LabelSelector to filter with
+                            when adding individual objects to the backup. If empty
+                            or nil, all objects are included. Optional.
+                          nullable: true
                           properties:
                             matchExpressions:
-                              description: matchExpressions is a list of label selector
-                                requirements. The requirements are ANDed.
+                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                               items:
                                 description: |-
                                   A label selector requirement is a selector that contains values, a key, and an operator that
                                   relates the key and values.
                                 properties:
                                   key:
-                                    description: key is the label key that the selector
-                                      applies to.
+                                    description: key is the label key that the selector applies to.
                                     type: string
                                   operator:
                                     description: |-
@@ -1927,8 +1666,8 @@ spec:
                                     type: array
                                     x-kubernetes-list-type: atomic
                                 required:
-                                - key
-                                - operator
+                                  - key
+                                  - operator
                                 type: object
                               type: array
                               x-kubernetes-list-type: atomic
@@ -1942,721 +1681,725 @@ spec:
                               type: object
                           type: object
                           x-kubernetes-map-type: atomic
-                        nullable: true
-                        type: array
-                      orderedResources:
-                        additionalProperties:
-                          type: string
-                        description: |-
-                          OrderedResources specifies the backup order of resources of specific Kind.
-                          The map key is the resource name and value is a list of object names separated by commas.
-                          Each resource name has format "namespace/objectname".  For cluster resources, simply use "objectname".
-                        nullable: true
-                        type: object
-                      resourcePolicy:
-                        description: ResourcePolicy specifies the referenced resource
-                          policies that backup should follow
-                        properties:
-                          apiGroup:
+                        metadata:
+                          properties:
+                            labels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                        orLabelSelectors:
+                          description: |-
+                            OrLabelSelectors is list of metav1.LabelSelector to filter with
+                            when adding individual objects to the backup. If multiple provided
+                            they will be joined by the OR operator. LabelSelector as well as
+                            OrLabelSelectors cannot co-exist in backup request, only one of them
+                            can be used.
+                          items:
                             description: |-
-                              APIGroup is the group for the resource being referenced.
-                              If APIGroup is not specified, the specified Kind must be in the core API group.
-                              For any other third-party types, APIGroup is required.
-                            type: string
-                          kind:
-                            description: Kind is the type of resource being referenced
-                            type: string
-                          name:
-                            description: Name is the name of resource being referenced
-                            type: string
-                        required:
-                        - kind
-                        - name
-                        type: object
-                        x-kubernetes-map-type: atomic
-                      snapshotMoveData:
-                        description: SnapshotMoveData specifies whether snapshot data
-                          should be moved
-                        nullable: true
-                        type: boolean
-                      snapshotVolumes:
-                        description: |-
-                          SnapshotVolumes specifies whether to take snapshots
-                          of any PV's referenced in the set of objects included
-                          in the Backup.
-                        nullable: true
-                        type: boolean
-                      storageLocation:
-                        description: StorageLocation is a string containing the name
-                          of a BackupStorageLocation where the backup should be stored.
-                        type: string
-                      ttl:
-                        description: |-
-                          TTL is a time.Duration-parseable string describing how long
-                          the Backup should be retained for.
-                        type: string
-                      uploaderConfig:
-                        description: UploaderConfig specifies the configuration for
-                          the uploader.
-                        nullable: true
-                        properties:
-                          parallelFilesUpload:
-                            description: ParallelFilesUpload is the number of files
-                              parallel uploads to perform when using the uploader.
-                            type: integer
-                        type: object
-                      volumeSnapshotLocations:
-                        description: VolumeSnapshotLocations is a list containing
-                          names of VolumeSnapshotLocations associated with this backup.
-                        items:
-                          type: string
-                        type: array
-                    type: object
-                  enforceRestoreSpec:
-                    description: which restore spec field values to enforce
-                    properties:
-                      backupName:
-                        description: |-
-                          BackupName is the unique name of the Velero backup to restore
-                          from.
-                        type: string
-                      excludedNamespaces:
-                        description: |-
-                          ExcludedNamespaces contains a list of namespaces that are not
-                          included in the restore.
-                        items:
-                          type: string
-                        nullable: true
-                        type: array
-                      excludedResources:
-                        description: |-
-                          ExcludedResources is a slice of resource names that are not
-                          included in the restore.
-                        items:
-                          type: string
-                        nullable: true
-                        type: array
-                      existingResourcePolicy:
-                        description: ExistingResourcePolicy specifies the restore
-                          behavior for the Kubernetes resource to be restored
-                        nullable: true
-                        type: string
-                      hooks:
-                        description: Hooks represent custom behaviors that should
-                          be executed during or post restore.
-                        properties:
-                          resources:
-                            items:
-                              description: |-
-                                RestoreResourceHookSpec defines one or more RestoreResrouceHooks that should be executed based on
-                                the rules defined for namespaces, resources, and label selector.
-                              properties:
-                                excludedNamespaces:
-                                  description: ExcludedNamespaces specifies the namespaces
-                                    to which this hook spec does not apply.
-                                  items:
-                                    type: string
-                                  nullable: true
-                                  type: array
-                                excludedResources:
-                                  description: ExcludedResources specifies the resources
-                                    to which this hook spec does not apply.
-                                  items:
-                                    type: string
-                                  nullable: true
-                                  type: array
-                                includedNamespaces:
+                              A label selector is a label query over a set of resources. The result of matchLabels and
+                              matchExpressions are ANDed. An empty label selector matches all objects. A null
+                              label selector matches no objects.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                items:
                                   description: |-
-                                    IncludedNamespaces specifies the namespaces to which this hook spec applies. If empty, it applies
-                                    to all namespaces.
-                                  items:
-                                    type: string
-                                  nullable: true
-                                  type: array
-                                includedResources:
-                                  description: |-
-                                    IncludedResources specifies the resources to which this hook spec applies. If empty, it applies
-                                    to all resources.
-                                  items:
-                                    type: string
-                                  nullable: true
-                                  type: array
-                                labelSelector:
-                                  description: LabelSelector, if specified, filters
-                                    the resources to which this hook spec applies.
-                                  nullable: true
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
                                   properties:
-                                    matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
+                                    key:
+                                      description: key is the label key that the selector applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
                                       items:
-                                        description: |-
-                                          A label selector requirement is a selector that contains values, a key, and an operator that
-                                          relates the key and values.
-                                        properties:
-                                          key:
-                                            description: key is the label key that
-                                              the selector applies to.
-                                            type: string
-                                          operator:
-                                            description: |-
-                                              operator represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists and DoesNotExist.
-                                            type: string
-                                          values:
-                                            description: |-
-                                              values is an array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This array is replaced during a strategic
-                                              merge patch.
-                                            items:
-                                              type: string
-                                            type: array
-                                            x-kubernetes-list-type: atomic
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
+                                        type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      description: |-
-                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                      type: object
+                                  required:
+                                    - key
+                                    - operator
                                   type: object
-                                  x-kubernetes-map-type: atomic
-                                name:
-                                  description: Name is the name of this hook.
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
                                   type: string
-                                postHooks:
-                                  description: PostHooks is a list of RestoreResourceHooks
-                                    to execute during and after restoring a resource.
-                                  items:
-                                    description: RestoreResourceHook defines a restore
-                                      hook for a resource.
-                                    properties:
-                                      exec:
-                                        description: Exec defines an exec restore
-                                          hook.
-                                        properties:
-                                          command:
-                                            description: Command is the command and
-                                              arguments to execute from within a container
-                                              after a pod has been restored.
-                                            items:
-                                              type: string
-                                            minItems: 1
-                                            type: array
-                                          container:
-                                            description: |-
-                                              Container is the container in the pod where the command should be executed. If not specified,
-                                              the pod's first container is used.
-                                            type: string
-                                          execTimeout:
-                                            description: |-
-                                              ExecTimeout defines the maximum amount of time Velero should wait for the hook to complete before
-                                              considering the execution a failure.
-                                            type: string
-                                          onError:
-                                            description: OnError specifies how Velero
-                                              should behave if it encounters an error
-                                              executing this hook.
-                                            enum:
-                                            - Continue
-                                            - Fail
-                                            type: string
-                                          waitForReady:
-                                            description: WaitForReady ensures command
-                                              will be launched when container is Ready
-                                              instead of Running.
-                                            nullable: true
-                                            type: boolean
-                                          waitTimeout:
-                                            description: |-
-                                              WaitTimeout defines the maximum amount of time Velero should wait for the container to be Ready
-                                              before attempting to run the command.
-                                            type: string
-                                        required:
-                                        - command
-                                        type: object
-                                      init:
-                                        description: Init defines an init restore
-                                          hook.
-                                        properties:
-                                          initContainers:
-                                            description: InitContainers is list of
-                                              init containers to be added to a pod
-                                              during its restore.
-                                            items:
-                                              type: object
-                                              x-kubernetes-preserve-unknown-fields: true
-                                            type: array
-                                            x-kubernetes-preserve-unknown-fields: true
-                                          timeout:
-                                            description: Timeout defines the maximum
-                                              amount of time Velero should wait for
-                                              the initContainers to complete.
-                                            type: string
-                                        type: object
-                                    type: object
-                                  type: array
-                              required:
-                              - name
-                              type: object
-                            type: array
-                        type: object
-                      includeClusterResources:
-                        description: |-
-                          IncludeClusterResources specifies whether cluster-scoped resources
-                          should be included for consideration in the restore. If null, defaults
-                          to true.
-                        nullable: true
-                        type: boolean
-                      includedNamespaces:
-                        description: |-
-                          IncludedNamespaces is a slice of namespace names to include objects
-                          from. If empty, all namespaces are included.
-                        items:
-                          type: string
-                        nullable: true
-                        type: array
-                      includedResources:
-                        description: |-
-                          IncludedResources is a slice of resource names to include
-                          in the restore. If empty, all resources in the backup are included.
-                        items:
-                          type: string
-                        nullable: true
-                        type: array
-                      itemOperationTimeout:
-                        description: |-
-                          ItemOperationTimeout specifies the time used to wait for RestoreItemAction operations
-                          The default value is 4 hour.
-                        type: string
-                      labelSelector:
-                        description: |-
-                          LabelSelector is a metav1.LabelSelector to filter with
-                          when restoring individual objects from the backup. If empty
-                          or nil, all objects are included. Optional.
-                        nullable: true
-                        properties:
-                          matchExpressions:
-                            description: matchExpressions is a list of label selector
-                              requirements. The requirements are ANDed.
-                            items:
-                              description: |-
-                                A label selector requirement is a selector that contains values, a key, and an operator that
-                                relates the key and values.
-                              properties:
-                                key:
-                                  description: key is the label key that the selector
-                                    applies to.
-                                  type: string
-                                operator:
-                                  description: |-
-                                    operator represents a key's relationship to a set of values.
-                                    Valid operators are In, NotIn, Exists and DoesNotExist.
-                                  type: string
-                                values:
-                                  description: |-
-                                    values is an array of string values. If the operator is In or NotIn,
-                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                    the values array must be empty. This array is replaced during a strategic
-                                    merge patch.
-                                  items:
-                                    type: string
-                                  type: array
-                                  x-kubernetes-list-type: atomic
-                              required:
-                              - key
-                              - operator
-                              type: object
-                            type: array
-                            x-kubernetes-list-type: atomic
-                          matchLabels:
-                            additionalProperties:
-                              type: string
-                            description: |-
-                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                              map is equivalent to an element of matchExpressions, whose key field is "key", the
-                              operator is "In", and the values array contains only "value". The requirements are ANDed.
-                            type: object
-                        type: object
-                        x-kubernetes-map-type: atomic
-                      namespaceMapping:
-                        additionalProperties:
-                          type: string
-                        description: |-
-                          NamespaceMapping is a map of source namespace names
-                          to target namespace names to restore into. Any source
-                          namespaces not included in the map will be restored into
-                          namespaces of the same name.
-                        type: object
-                      orLabelSelectors:
-                        description: |-
-                          OrLabelSelectors is list of metav1.LabelSelector to filter with
-                          when restoring individual objects from the backup. If multiple provided
-                          they will be joined by the OR operator. LabelSelector as well as
-                          OrLabelSelectors cannot co-exist in restore request, only one of them
-                          can be used
-                        items:
-                          description: |-
-                            A label selector is a label query over a set of resources. The result of matchLabels and
-                            matchExpressions are ANDed. An empty label selector matches all objects. A null
-                            label selector matches no objects.
-                          properties:
-                            matchExpressions:
-                              description: matchExpressions is a list of label selector
-                                requirements. The requirements are ANDed.
-                              items:
                                 description: |-
-                                  A label selector requirement is a selector that contains values, a key, and an operator that
-                                  relates the key and values.
-                                properties:
-                                  key:
-                                    description: key is the label key that the selector
-                                      applies to.
-                                    type: string
-                                  operator:
-                                    description: |-
-                                      operator represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists and DoesNotExist.
-                                    type: string
-                                  values:
-                                    description: |-
-                                      values is an array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. This array is replaced during a strategic
-                                      merge patch.
-                                    items:
-                                      type: string
-                                    type: array
-                                    x-kubernetes-list-type: atomic
-                                required:
-                                - key
-                                - operator
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                 type: object
-                              type: array
-                              x-kubernetes-list-type: atomic
-                            matchLabels:
-                              additionalProperties:
-                                type: string
-                              description: |-
-                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                operator is "In", and the values array contains only "value". The requirements are ANDed.
-                              type: object
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        nullable: true
-                        type: array
-                      preserveNodePorts:
-                        description: PreserveNodePorts specifies whether to restore
-                          old nodePorts from backup.
-                        nullable: true
-                        type: boolean
-                      resourceModifier:
-                        description: ResourceModifier specifies the reference to JSON
-                          resource patches that should be applied to resources before
-                          restoration.
-                        nullable: true
-                        properties:
-                          apiGroup:
-                            description: |-
-                              APIGroup is the group for the resource being referenced.
-                              If APIGroup is not specified, the specified Kind must be in the core API group.
-                              For any other third-party types, APIGroup is required.
-                            type: string
-                          kind:
-                            description: Kind is the type of resource being referenced
-                            type: string
-                          name:
-                            description: Name is the name of resource being referenced
-                            type: string
-                        required:
-                        - kind
-                        - name
-                        type: object
-                        x-kubernetes-map-type: atomic
-                      restorePVs:
-                        description: |-
-                          RestorePVs specifies whether to restore all included
-                          PVs from snapshot
-                        nullable: true
-                        type: boolean
-                      restoreStatus:
-                        description: |-
-                          RestoreStatus specifies which resources we should restore the status
-                          field. If nil, no objects are included. Optional.
-                        nullable: true
-                        properties:
-                          excludedResources:
-                            description: ExcludedResources specifies the resources
-                              to which will not restore the status.
-                            items:
-                              type: string
-                            nullable: true
-                            type: array
-                          includedResources:
-                            description: |-
-                              IncludedResources specifies the resources to which will restore the status.
-                              If empty, it applies to all resources.
-                            items:
-                              type: string
-                            nullable: true
-                            type: array
-                        type: object
-                      scheduleName:
-                        description: |-
-                          ScheduleName is the unique name of the Velero schedule to restore
-                          from. If specified, and BackupName is empty, Velero will restore
-                          from the most recent successful backup created from this schedule.
-                        type: string
-                      uploaderConfig:
-                        description: UploaderConfig specifies the configuration for
-                          the restore.
-                        nullable: true
-                        properties:
-                          parallelFilesDownload:
-                            description: ParallelFilesDownload is the concurrency
-                              number setting for restore.
-                            type: integer
-                          writeSparseFiles:
-                            description: WriteSparseFiles is a flag to indicate whether
-                              write files sparsely or not.
-                            nullable: true
-                            type: boolean
-                        type: object
-                    type: object
-                  garbageCollectionPeriod:
-                    description: |-
-                      GarbageCollectionPeriod defines how frequently to look for possible leftover non admin related objects in OADP namespace.
-                      A value of 0 disables garbage collection.
-                      By default 24h
-                    type: string
-                  requireApprovalForBSL:
-                    description: |-
-                      RequireApprovalForBSL specifies whether cluster administrator approval is required
-                      for creating Velero BackupStorageLocation (BSL) resources.
-                      - If set to false, all NonAdminBackupStorageLocationApproval CRDs will be automatically approved,
-                        including those that were previously pending or rejected.
-                      - If set to true, any existing BackupStorageLocation CRDs that lack the necessary approvals may be deleted,
-                        leaving the associated NonAdminBackup objects non-restorable until approval is granted.
-                      Defaults to false
-                    type: boolean
-                type: object
-              podAnnotations:
-                additionalProperties:
-                  type: string
-                description: add annotations to pods deployed by operator
-                type: object
-              podDnsConfig:
-                description: |-
-                  podDnsConfig defines the DNS parameters of a pod in addition to
-                  those generated from DNSPolicy.
-                  https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config
-                properties:
-                  nameservers:
-                    description: |-
-                      A list of DNS name server IP addresses.
-                      This will be appended to the base nameservers generated from DNSPolicy.
-                      Duplicated nameservers will be removed.
-                    items:
-                      type: string
-                    type: array
-                    x-kubernetes-list-type: atomic
-                  options:
-                    description: |-
-                      A list of DNS resolver options.
-                      This will be merged with the base options generated from DNSPolicy.
-                      Duplicated entries will be removed. Resolution options given in Options
-                      will override those that appear in the base DNSPolicy.
-                    items:
-                      description: PodDNSConfigOption defines DNS resolver options
-                        of a pod.
-                      properties:
-                        name:
-                          description: Required.
-                          type: string
-                        value:
-                          type: string
-                      type: object
-                    type: array
-                    x-kubernetes-list-type: atomic
-                  searches:
-                    description: |-
-                      A list of DNS search domains for host-name lookup.
-                      This will be appended to the base search paths generated from DNSPolicy.
-                      Duplicated search paths will be removed.
-                    items:
-                      type: string
-                    type: array
-                    x-kubernetes-list-type: atomic
-                type: object
-              podDnsPolicy:
-                description: |-
-                  podDnsPolicy defines how a pod's DNS will be configured.
-                  https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
-                type: string
-              snapshotLocations:
-                description: snapshotLocations defines the list of desired configuration
-                  to use for VolumeSnapshotLocations
-                items:
-                  description: SnapshotLocation defines the configuration for the
-                    DPA snapshot store
-                  properties:
-                    name:
-                      type: string
-                    velero:
-                      description: VolumeSnapshotLocationSpec defines the specification
-                        for a Velero VolumeSnapshotLocation.
-                      properties:
-                        config:
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          nullable: true
+                          type: array
+                        orderedResources:
                           additionalProperties:
                             type: string
-                          description: Config is for provider-specific configuration
-                            fields.
+                          description: |-
+                            OrderedResources specifies the backup order of resources of specific Kind.
+                            The map key is the resource name and value is a list of object names separated by commas.
+                            Each resource name has format "namespace/objectname".  For cluster resources, simply use "objectname".
+                          nullable: true
                           type: object
-                        credential:
-                          description: Credential contains the credential information
-                            intended to be used with this location
+                        resourcePolicy:
+                          description: ResourcePolicy specifies the referenced resource policies that backup should follow
                           properties:
-                            key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
+                            apiGroup:
+                              description: |-
+                                APIGroup is the group for the resource being referenced.
+                                If APIGroup is not specified, the specified Kind must be in the core API group.
+                                For any other third-party types, APIGroup is required.
+                              type: string
+                            kind:
+                              description: Kind is the type of resource being referenced
                               type: string
                             name:
-                              default: ""
-                              description: |-
-                                Name of the referent.
-                                This field is effectively required, but due to backwards compatibility is
-                                allowed to be empty. Instances of this type with an empty value here are
-                                almost certainly wrong.
-                                TODO: Add other useful fields. apiVersion, kind, uid?
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                              description: Name is the name of resource being referenced
                               type: string
-                            optional:
-                              description: Specify whether the Secret or its key must
-                                be defined
-                              type: boolean
                           required:
-                          - key
+                            - kind
+                            - name
                           type: object
                           x-kubernetes-map-type: atomic
-                        provider:
-                          description: Provider is the provider of the volume storage.
+                        snapshotMoveData:
+                          description: SnapshotMoveData specifies whether snapshot data should be moved
+                          nullable: true
+                          type: boolean
+                        snapshotVolumes:
+                          description: |-
+                            SnapshotVolumes specifies whether to take snapshots
+                            of any PV's referenced in the set of objects included
+                            in the Backup.
+                          nullable: true
+                          type: boolean
+                        storageLocation:
+                          description: StorageLocation is a string containing the name of a BackupStorageLocation where the backup should be stored.
                           type: string
-                      required:
-                      - provider
+                        ttl:
+                          description: |-
+                            TTL is a time.Duration-parseable string describing how long
+                            the Backup should be retained for.
+                          type: string
+                        uploaderConfig:
+                          description: UploaderConfig specifies the configuration for the uploader.
+                          nullable: true
+                          properties:
+                            parallelFilesUpload:
+                              description: ParallelFilesUpload is the number of files parallel uploads to perform when using the uploader.
+                              type: integer
+                          type: object
+                        volumeSnapshotLocations:
+                          description: VolumeSnapshotLocations is a list containing names of VolumeSnapshotLocations associated with this backup.
+                          items:
+                            type: string
+                          type: array
                       type: object
-                  required:
-                  - velero
+                    enforceRestoreSpec:
+                      description: which restore spec field values to enforce
+                      properties:
+                        backupName:
+                          description: |-
+                            BackupName is the unique name of the Velero backup to restore
+                            from.
+                          type: string
+                        excludedNamespaces:
+                          description: |-
+                            ExcludedNamespaces contains a list of namespaces that are not
+                            included in the restore.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        excludedResources:
+                          description: |-
+                            ExcludedResources is a slice of resource names that are not
+                            included in the restore.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        existingResourcePolicy:
+                          description: ExistingResourcePolicy specifies the restore behavior for the Kubernetes resource to be restored
+                          nullable: true
+                          type: string
+                        hooks:
+                          description: Hooks represent custom behaviors that should be executed during or post restore.
+                          properties:
+                            resources:
+                              items:
+                                description: |-
+                                  RestoreResourceHookSpec defines one or more RestoreResrouceHooks that should be executed based on
+                                  the rules defined for namespaces, resources, and label selector.
+                                properties:
+                                  excludedNamespaces:
+                                    description: ExcludedNamespaces specifies the namespaces to which this hook spec does not apply.
+                                    items:
+                                      type: string
+                                    nullable: true
+                                    type: array
+                                  excludedResources:
+                                    description: ExcludedResources specifies the resources to which this hook spec does not apply.
+                                    items:
+                                      type: string
+                                    nullable: true
+                                    type: array
+                                  includedNamespaces:
+                                    description: |-
+                                      IncludedNamespaces specifies the namespaces to which this hook spec applies. If empty, it applies
+                                      to all namespaces.
+                                    items:
+                                      type: string
+                                    nullable: true
+                                    type: array
+                                  includedResources:
+                                    description: |-
+                                      IncludedResources specifies the resources to which this hook spec applies. If empty, it applies
+                                      to all resources.
+                                    items:
+                                      type: string
+                                    nullable: true
+                                    type: array
+                                  labelSelector:
+                                    description: LabelSelector, if specified, filters the resources to which this hook spec applies.
+                                    nullable: true
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  name:
+                                    description: Name is the name of this hook.
+                                    type: string
+                                  postHooks:
+                                    description: PostHooks is a list of RestoreResourceHooks to execute during and after restoring a resource.
+                                    items:
+                                      description: RestoreResourceHook defines a restore hook for a resource.
+                                      properties:
+                                        exec:
+                                          description: Exec defines an exec restore hook.
+                                          properties:
+                                            command:
+                                              description: Command is the command and arguments to execute from within a container after a pod has been restored.
+                                              items:
+                                                type: string
+                                              minItems: 1
+                                              type: array
+                                            container:
+                                              description: |-
+                                                Container is the container in the pod where the command should be executed. If not specified,
+                                                the pod's first container is used.
+                                              type: string
+                                            execTimeout:
+                                              description: |-
+                                                ExecTimeout defines the maximum amount of time Velero should wait for the hook to complete before
+                                                considering the execution a failure.
+                                              type: string
+                                            onError:
+                                              description: OnError specifies how Velero should behave if it encounters an error executing this hook.
+                                              enum:
+                                                - Continue
+                                                - Fail
+                                              type: string
+                                            waitForReady:
+                                              description: WaitForReady ensures command will be launched when container is Ready instead of Running.
+                                              nullable: true
+                                              type: boolean
+                                            waitTimeout:
+                                              description: |-
+                                                WaitTimeout defines the maximum amount of time Velero should wait for the container to be Ready
+                                                before attempting to run the command.
+                                              type: string
+                                          required:
+                                            - command
+                                          type: object
+                                        init:
+                                          description: Init defines an init restore hook.
+                                          properties:
+                                            initContainers:
+                                              description: InitContainers is list of init containers to be added to a pod during its restore.
+                                              items:
+                                                type: object
+                                                x-kubernetes-preserve-unknown-fields: true
+                                              type: array
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            timeout:
+                                              description: Timeout defines the maximum amount of time Velero should wait for the initContainers to complete.
+                                              type: string
+                                          type: object
+                                      type: object
+                                    type: array
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                          type: object
+                        includeClusterResources:
+                          description: |-
+                            IncludeClusterResources specifies whether cluster-scoped resources
+                            should be included for consideration in the restore. If null, defaults
+                            to true.
+                          nullable: true
+                          type: boolean
+                        includedNamespaces:
+                          description: |-
+                            IncludedNamespaces is a slice of namespace names to include objects
+                            from. If empty, all namespaces are included.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        includedResources:
+                          description: |-
+                            IncludedResources is a slice of resource names to include
+                            in the restore. If empty, all resources in the backup are included.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        itemOperationTimeout:
+                          description: |-
+                            ItemOperationTimeout specifies the time used to wait for RestoreItemAction operations
+                            The default value is 4 hour.
+                          type: string
+                        labelSelector:
+                          description: |-
+                            LabelSelector is a metav1.LabelSelector to filter with
+                            when restoring individual objects from the backup. If empty
+                            or nil, all objects are included. Optional.
+                          nullable: true
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                  - key
+                                  - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        namespaceMapping:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            NamespaceMapping is a map of source namespace names
+                            to target namespace names to restore into. Any source
+                            namespaces not included in the map will be restored into
+                            namespaces of the same name.
+                          type: object
+                        orLabelSelectors:
+                          description: |-
+                            OrLabelSelectors is list of metav1.LabelSelector to filter with
+                            when restoring individual objects from the backup. If multiple provided
+                            they will be joined by the OR operator. LabelSelector as well as
+                            OrLabelSelectors cannot co-exist in restore request, only one of them
+                            can be used
+                          items:
+                            description: |-
+                              A label selector is a label query over a set of resources. The result of matchLabels and
+                              matchExpressions are ANDed. An empty label selector matches all objects. A null
+                              label selector matches no objects.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          nullable: true
+                          type: array
+                        preserveNodePorts:
+                          description: PreserveNodePorts specifies whether to restore old nodePorts from backup.
+                          nullable: true
+                          type: boolean
+                        resourceModifier:
+                          description: ResourceModifier specifies the reference to JSON resource patches that should be applied to resources before restoration.
+                          nullable: true
+                          properties:
+                            apiGroup:
+                              description: |-
+                                APIGroup is the group for the resource being referenced.
+                                If APIGroup is not specified, the specified Kind must be in the core API group.
+                                For any other third-party types, APIGroup is required.
+                              type: string
+                            kind:
+                              description: Kind is the type of resource being referenced
+                              type: string
+                            name:
+                              description: Name is the name of resource being referenced
+                              type: string
+                          required:
+                            - kind
+                            - name
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        restorePVs:
+                          description: |-
+                            RestorePVs specifies whether to restore all included
+                            PVs from snapshot
+                          nullable: true
+                          type: boolean
+                        restoreStatus:
+                          description: |-
+                            RestoreStatus specifies which resources we should restore the status
+                            field. If nil, no objects are included. Optional.
+                          nullable: true
+                          properties:
+                            excludedResources:
+                              description: ExcludedResources specifies the resources to which will not restore the status.
+                              items:
+                                type: string
+                              nullable: true
+                              type: array
+                            includedResources:
+                              description: |-
+                                IncludedResources specifies the resources to which will restore the status.
+                                If empty, it applies to all resources.
+                              items:
+                                type: string
+                              nullable: true
+                              type: array
+                          type: object
+                        scheduleName:
+                          description: |-
+                            ScheduleName is the unique name of the Velero schedule to restore
+                            from. If specified, and BackupName is empty, Velero will restore
+                            from the most recent successful backup created from this schedule.
+                          type: string
+                        uploaderConfig:
+                          description: UploaderConfig specifies the configuration for the restore.
+                          nullable: true
+                          properties:
+                            parallelFilesDownload:
+                              description: ParallelFilesDownload is the concurrency number setting for restore.
+                              type: integer
+                            writeSparseFiles:
+                              description: WriteSparseFiles is a flag to indicate whether write files sparsely or not.
+                              nullable: true
+                              type: boolean
+                          type: object
+                      type: object
+                    garbageCollectionPeriod:
+                      description: |-
+                        GarbageCollectionPeriod defines how frequently to look for possible leftover non admin related objects in OADP namespace.
+                        A value of 0 disables garbage collection.
+                        By default 24h
+                      type: string
+                    requireApprovalForBSL:
+                      description: |-
+                        RequireApprovalForBSL specifies whether cluster administrator approval is required
+                        for creating Velero BackupStorageLocation (BSL) resources.
+                        - If set to false, all NonAdminBackupStorageLocationApproval CRDs will be automatically approved,
+                          including those that were previously pending or rejected.
+                        - If set to true, any existing BackupStorageLocation CRDs that lack the necessary approvals may be deleted,
+                          leaving the associated NonAdminBackup objects non-restorable until approval is granted.
+                        Defaults to false
+                      type: boolean
                   type: object
-                type: array
-              unsupportedOverrides:
-                additionalProperties:
-                  type: string
-                description: |-
-                  unsupportedOverrides can be used to override images used in deployments.
-                  Available keys are:
-                    - veleroImageFqin
-                    - awsPluginImageFqin
-                    - legacyAWSPluginImageFqin
-                    - openshiftPluginImageFqin
-                    - azurePluginImageFqin
-                    - gcpPluginImageFqin
-                    - resticRestoreImageFqin
-                    - kubevirtPluginImageFqin
-                    - nonAdminControllerImageFqin
-                    - operator-type
-                    - tech-preview-ack
-                type: object
-            required:
-            - configuration
-            type: object
-          status:
-            description: DataProtectionApplicationStatus defines the observed state
-              of DataProtectionApplication
-            properties:
-              conditions:
-                description: Conditions defines the observed state of DataProtectionApplication
-                items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                podAnnotations:
+                  additionalProperties:
+                    type: string
+                  description: add annotations to pods deployed by operator
+                  type: object
+                podDnsConfig:
+                  description: |-
+                    podDnsConfig defines the DNS parameters of a pod in addition to
+                    those generated from DNSPolicy.
+                    https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config
                   properties:
-                    lastTransitionTime:
+                    nameservers:
                       description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
+                        A list of DNS name server IP addresses.
+                        This will be appended to the base nameservers generated from DNSPolicy.
+                        Duplicated nameservers will be removed.
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    options:
                       description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
+                        A list of DNS resolver options.
+                        This will be merged with the base options generated from DNSPolicy.
+                        Duplicated entries will be removed. Resolution options given in Options
+                        will override those that appear in the base DNSPolicy.
+                      items:
+                        description: PodDNSConfigOption defines DNS resolver options of a pod.
+                        properties:
+                          name:
+                            description: Required.
+                            type: string
+                          value:
+                            type: string
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    searches:
                       description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                      type: string
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
+                        A list of DNS search domains for host-name lookup.
+                        This will be appended to the base search paths generated from DNSPolicy.
+                        Duplicated search paths will be removed.
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
                   type: object
-                type: array
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                podDnsPolicy:
+                  description: |-
+                    podDnsPolicy defines how a pod's DNS will be configured.
+                    https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
+                  type: string
+                snapshotLocations:
+                  description: snapshotLocations defines the list of desired configuration to use for VolumeSnapshotLocations
+                  items:
+                    description: SnapshotLocation defines the configuration for the DPA snapshot store
+                    properties:
+                      name:
+                        type: string
+                      velero:
+                        description: VolumeSnapshotLocationSpec defines the specification for a Velero VolumeSnapshotLocation.
+                        properties:
+                          config:
+                            additionalProperties:
+                              type: string
+                            description: Config is for provider-specific configuration fields.
+                            type: object
+                          credential:
+                            description: Credential contains the credential information intended to be used with this location
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must be a valid secret key.
+                                type: string
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  TODO: Add other useful fields. apiVersion, kind, uid?
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key must be defined
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          provider:
+                            description: Provider is the provider of the volume storage.
+                            type: string
+                        required:
+                          - provider
+                        type: object
+                    required:
+                      - velero
+                    type: object
+                  type: array
+                unsupportedOverrides:
+                  additionalProperties:
+                    type: string
+                  description: |-
+                    unsupportedOverrides can be used to override images used in deployments.
+                    Available keys are:
+                      - veleroImageFqin
+                      - awsPluginImageFqin
+                      - legacyAWSPluginImageFqin
+                      - openshiftPluginImageFqin
+                      - azurePluginImageFqin
+                      - gcpPluginImageFqin
+                      - resticRestoreImageFqin
+                      - kubevirtPluginImageFqin
+                      - nonAdminControllerImageFqin
+                      - operator-type
+                      - tech-preview-ack
+                  type: object
+              required:
+                - configuration
+              type: object
+            status:
+              description: DataProtectionApplicationStatus defines the observed state of DataProtectionApplication
+              properties:
+                conditions:
+                  description: Conditions defines the observed state of DataProtectionApplication
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource.\n---\nThis struct is intended for direct use as an array at the field path .status.conditions.  For example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the observations of a foo's current state.\n\t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    // +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t    // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t    // other fields\n\t}"
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: |-
+                          type of condition in CamelCase or in foo.example.com/CamelCase.
+                          ---
+                          Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                          useful (see .node.status.conditions), the ability to deconflict is important.
+                          The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}


### PR DESCRIPTION
We need to fix the `config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml` manifest.

How it happened we require to have this commit?
1. Firstly the non-admin PR https://github.com/migtools/oadp-non-admin/pull/236 was requiring oadp-operator manifest updates. This was achieved by running:
```shell
$ export NON_ADMIN_CONTROLLER_PATH=/oadp-non-admin-with-code-for-236
$ make update-non-admin-manifests 
# As part of the check prior to prepare PR I used as well
$ make bundle
$ make build
```
2. The above PR was merged as part of the: 
https://github.com/openshift/oadp-operator/pull/1644/files#diff-36cdb0b489ca7364adf5a3ab5b29796ddd3fc0e0adeed600e0e5e309cbe164ed

Those steps were enough to break the manifest, because `make build` and `make bundle` generates different manifests. The proper order should be first ran make build and then make bundle.

Ran $ make update-non-admin-manifests
to fix manifest.

## Why the changes were made
CRD manifest is broken, wired behavior of the:

```shell
$ export NON_ADMIN_CONTROLLER_PATH=/NON-ADMIN-GIT-CLONE/oadp-non-admin
$ make update-non-admin-manifests 
```
The manifests are updated, however different manifests are generated when running later:

```shell
$ make build
```

Running `$ make bundle` fixes it.

## How to test the changes made

Just ran the:
```shell
$ export NON_ADMIN_CONTROLLER_PATH=/NON-ADMIN-GIT-CLONE/oadp-non-admin
$ make update-non-admin-manifests 
```

Without later running `$ make build`
