### PR TITLE
CRD updates for the oc CLI fields for the NAR, NAB and NABSL objects

### DIFF
--- a/bundle/manifests/oadp.openshift.io_nonadminbackups.yaml
+++ b/bundle/manifests/oadp.openshift.io_nonadminbackups.yaml
@@ -16,7 +16,17 @@ spec:
     singular: nonadminbackup
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Request-Phase
+      type: string
+    - jsonPath: .status.veleroBackup.status.phase
+      name: Velero-Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: NonAdminBackup is the Schema for the nonadminbackups API

--- a/bundle/manifests/oadp.openshift.io_nonadminbackupstoragelocationrequests.yaml
+++ b/bundle/manifests/oadp.openshift.io_nonadminbackupstoragelocationrequests.yaml
@@ -16,7 +16,20 @@ spec:
     singular: nonadminbackupstoragelocationrequest
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Request-Phase
+      type: string
+    - jsonPath: .status.nonAdminBackupStorageLocation.namespace
+      name: Request-Namespace
+      type: string
+    - jsonPath: .status.nonAdminBackupStorageLocation.name
+      name: Request-Name
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: NonAdminBackupStorageLocationRequest is the Schema for the nonadminbackupstoragelocationrequests

--- a/bundle/manifests/oadp.openshift.io_nonadminbackupstoragelocations.yaml
+++ b/bundle/manifests/oadp.openshift.io_nonadminbackupstoragelocations.yaml
@@ -16,7 +16,20 @@ spec:
     singular: nonadminbackupstoragelocation
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=='ClusterAdminApproved')].status
+      name: Request-Approved
+      type: string
+    - jsonPath: .status.phase
+      name: Request-Phase
+      type: string
+    - jsonPath: .status.veleroBackupStorageLocation.status.phase
+      name: Velero-Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: NonAdminBackupStorageLocation is the Schema for the nonadminbackupstoragelocations

--- a/bundle/manifests/oadp.openshift.io_nonadmindownloadrequests.yaml
+++ b/bundle/manifests/oadp.openshift.io_nonadmindownloadrequests.yaml
@@ -18,8 +18,11 @@ spec:
   versions:
   - additionalPrinterColumns:
     - jsonPath: .status.phase
-      name: Status
+      name: Request-Phase
       type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/bundle/manifests/oadp.openshift.io_nonadminrestores.yaml
+++ b/bundle/manifests/oadp.openshift.io_nonadminrestores.yaml
@@ -16,7 +16,17 @@ spec:
     singular: nonadminrestore
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Request-Phase
+      type: string
+    - jsonPath: .status.veleroRestore.status.phase
+      name: Velero-Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: NonAdminRestore is the Schema for the nonadminrestores API

--- a/config/crd/bases/oadp.openshift.io_nonadminbackups.yaml
+++ b/config/crd/bases/oadp.openshift.io_nonadminbackups.yaml
@@ -16,7 +16,17 @@ spec:
     singular: nonadminbackup
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Request-Phase
+      type: string
+    - jsonPath: .status.veleroBackup.status.phase
+      name: Velero-Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: NonAdminBackup is the Schema for the nonadminbackups API

--- a/config/crd/bases/oadp.openshift.io_nonadminbackupstoragelocationrequests.yaml
+++ b/config/crd/bases/oadp.openshift.io_nonadminbackupstoragelocationrequests.yaml
@@ -16,7 +16,20 @@ spec:
     singular: nonadminbackupstoragelocationrequest
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Request-Phase
+      type: string
+    - jsonPath: .status.nonAdminBackupStorageLocation.namespace
+      name: Request-Namespace
+      type: string
+    - jsonPath: .status.nonAdminBackupStorageLocation.name
+      name: Request-Name
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: NonAdminBackupStorageLocationRequest is the Schema for the nonadminbackupstoragelocationrequests

--- a/config/crd/bases/oadp.openshift.io_nonadminbackupstoragelocations.yaml
+++ b/config/crd/bases/oadp.openshift.io_nonadminbackupstoragelocations.yaml
@@ -16,7 +16,20 @@ spec:
     singular: nonadminbackupstoragelocation
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=='ClusterAdminApproved')].status
+      name: Request-Approved
+      type: string
+    - jsonPath: .status.phase
+      name: Request-Phase
+      type: string
+    - jsonPath: .status.veleroBackupStorageLocation.status.phase
+      name: Velero-Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: NonAdminBackupStorageLocation is the Schema for the nonadminbackupstoragelocations

--- a/config/crd/bases/oadp.openshift.io_nonadmindownloadrequests.yaml
+++ b/config/crd/bases/oadp.openshift.io_nonadmindownloadrequests.yaml
@@ -18,8 +18,11 @@ spec:
   versions:
   - additionalPrinterColumns:
     - jsonPath: .status.phase
-      name: Status
+      name: Request-Phase
       type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/oadp.openshift.io_nonadminrestores.yaml
+++ b/config/crd/bases/oadp.openshift.io_nonadminrestores.yaml
@@ -16,7 +16,17 @@ spec:
     singular: nonadminrestore
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Request-Phase
+      type: string
+    - jsonPath: .status.veleroRestore.status.phase
+      name: Velero-Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: NonAdminRestore is the Schema for the nonadminrestores API


### PR DESCRIPTION
Needed-by: https://github.com/migtools/oadp-non-admin/pull/245

Implements https://github.com/migtools/oadp-non-admin/issues/232  with additional fields for:

 - NonAdminBackup
 - NonAdminRestore
 - NonAdminBackupStorageLocation

## Why the changes were made

https://github.com/migtools/oadp-non-admin/issues/232 and add similar fields for the NAB and NAR objects.

## How to test the changes made

1. Deployed with local oadp-operator deployment
2. Tested various objects and it's states:

# Prior admin approval or rejections
## Created couple of BSLs - names reflect the idea behind each of them

- suspicious-nabsl (reject)
- nonexistingsecretinns-nabsl (do nothing - no nabslrequest)
- waitingapproval-nabsl (do nothing)
- incorrect-bucket-nabsl (approve)
- perfect-nabsl (approve)

### Before any admin action:
```console
$ oc get nabsl -n non-admin-bsl-test
NAME                          REQUEST-APPROVED   REQUEST-PHASE  VELERO-PHASE       AGE
incorrect-bucket-nabsl        False              New                               2m11s
nonexistingsecretinns-nabsl                      BackingOff                        39s
perfect-nabsl                 False              New                               2m40s
suspicious-sample             False              New                               10s
waitingapproval-nabsl         False              New                               94s
```

Note the `nonexistingsecretinns-nabsl` have not created request - the user must create secret to get to that state

```console
$ oc get nabslrequest
NAME                                                              REQUEST-PHASE   REQUEST-NAMESPACE     REQUEST-NAME
non-admin-bsl-test-incorre-9aa22872-f39d-427c-b352-6924ff9c2175   Pending         non-admin-bsl-test    incorrect-bucket-nabsl
non-admin-bsl-test-perfect-4413c67d-8eb8-42bc-8274-279a91895196   Pending         non-admin-bsl-test    perfect-nabsl
non-admin-bsl-test-suspici-4fbdcebf-2277-4f44-890e-35d765815e1a   Pending         non-admin-bsl-test    suspicious-sample
non-admin-bsl-test-waiting-fcae28c2-d8ea-48e2-a35c-8882bfd865e0   Pending         non-admin-bsl-test    waitingapproval-nabsl
```

Approving or rejecting some:

```console
$ oc get nabslrequest
NAME                                                              REQUEST-PHASE   REQUEST-NAMESPACE     REQUEST-NAME               AGE
non-admin-bsl-test-incorre-9aa22872-f39d-427c-b352-6924ff9c2175   Approved        non-admin-bsl-test    incorrect-bucket-nabsl    4m57s
non-admin-bsl-test-perfect-4413c67d-8eb8-42bc-8274-279a91895196   Approved        non-admin-bsl-test    perfect-nabsl             5m26s
non-admin-bsl-test-suspici-4fbdcebf-2277-4f44-890e-35d765815e1a   Rejected        non-admin-bsl-test    suspicious-sample         2m56s
non-admin-bsl-test-waiting-fcae28c2-d8ea-48e2-a35c-8882bfd865e0   Pending         non-admin-bsl-test    waitingapproval-nabsl     4m20s
```


Now the  NABSL objects
```console
$ oc get nabsl -n non-admin-bsl-test
NAME                          REQUEST-APPROVED   REQUEST-PHASE   VELERO-PHASE   AGE
incorrect-bucket-nabsl        True               Created         Unavailable    8m25s
nonexistingsecretinns-nabsl                      BackingOff                     6m53s
perfect-nabsl                 True               Created         Available      8m54s
suspicious-sample             False              BackingOff                     6m24s
waitingapproval-nabsl         False              New                            7m48s
```

##### Backup

Couple of backup objects were created

```console
$ oc get nab -n non-admin-bsl-test
NAME                       REQUEST-PHASE   VELERO-PHASE       AGE
backup-failed-sample       Created         PartiallyFailed    6s
incorrect-bsl-backup       BackingOff                         3m39s
some-backup                Created         Completed          13s
```

#### Restore

Nice InProgress and Completed status:

```console
$ oc get nar -n non-admin-bsl-test
NAME               REQUEST-PHASE   VELERO-PHASE   AGE
non-existing-nab   BackingOff                     46s

$ oc get nar -n non-admin-bsl-test
NAME               REQUEST-PHASE   VELERO-PHASE   AGE
existing-nab       Created         InProgress     1s
non-existing-nab   BackingOff                     51s

$ oc get nar -n non-admin-bsl-test
NAME               REQUEST-PHASE   VELERO-PHASE   AGE
existing-nab       Created         Completed      3s
non-existing-nab   BackingOff                     53s
```