### PR TITLE
Small fix for the manifest to allow 233 Non Admin passing

### DIFF
--- a/bundle/manifests/oadp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/oadp-operator.clusterserviceversion.yaml
@@ -254,7 +254,7 @@ metadata:
       Cloud Provider,Developer Tools,Modernization & Migration,OpenShift Optional,Storage
     certified: "false"
     containerImage: quay.io/konveyor/oadp-operator:latest
-    createdAt: "2025-02-28T20:03:54Z"
+    createdAt: "2025-03-05T14:59:35Z"
     description: OADP (OpenShift API for Data Protection) operator sets up and installs
       Data Protection Applications on the OpenShift platform.
     features.operators.openshift.io/cnf: "false"


### PR DESCRIPTION
Small update to the manifest to allow Non Admin job passing.

## Why the changes were made

To allow https://github.com/migtools/oadp-non-admin/pull/233 passing

## How to test the changes made

run `make update-non-admin-manifests` on the oadp-operator gate.