### PR TITLE
Fix for the node-agent privs and volumes

### DIFF
--- a/api/v1alpha1/dataprotectionapplication_types.go
+++ b/api/v1alpha1/dataprotectionapplication_types.go
@@ -295,6 +295,12 @@ type VeleroConfig struct {
 	// Use pod volume file system backup by default for volumes
 	// +optional
 	DefaultVolumesToFSBackup *bool `json:"defaultVolumesToFSBackup,omitempty"`
+	// DisableFsBackup determines whether the NodeAgent should disable file system backup.
+	// When set to true, the NodeAgent runs in non-privileged mode.
+	// Defaults to false.
+	// +optional
+	// +kubebuilder:default=false
+	DisableFsBackup *bool `json:"disableFsBackup,omitempty"`
 	// Specify whether CSI snapshot data should be moved to backup storage by default
 	// +optional
 	DefaultSnapshotMoveData *bool `json:"defaultSnapshotMoveData,omitempty"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -947,6 +947,11 @@ func (in *VeleroConfig) DeepCopyInto(out *VeleroConfig) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.DisableFsBackup != nil {
+		in, out := &in.DisableFsBackup, &out.DisableFsBackup
+		*out = new(bool)
+		**out = **in
+	}
 	if in.DefaultSnapshotMoveData != nil {
 		in, out := &in.DefaultSnapshotMoveData, &out.DefaultSnapshotMoveData
 		*out = new(bool)

--- a/bundle/manifests/oadp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/oadp-operator.clusterserviceversion.yaml
@@ -41,7 +41,8 @@ metadata:
                   "openshift",
                   "aws",
                   "kubevirt"
-                ]
+                ],
+                "disableFsBackup": false
               }
             },
             "snapshotLocations": [

--- a/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
@@ -885,6 +885,13 @@ spec:
                         defaultVolumesToFSBackup:
                           description: Use pod volume file system backup by default for volumes
                           type: boolean
+                        disableFsBackup:
+                          default: false
+                          description: |-
+                            DisableFsBackup determines whether the NodeAgent should disable file system backup.
+                            When set to true, the NodeAgent runs in non-privileged mode.
+                            Defaults to false.
+                          type: boolean
                         disableInformerCache:
                           description: Disable informer cache for Get calls on restore. With this enabled, it will speed up restore in cases where there are backup resources which already exist in the cluster, but for very large clusters this will increase velero memory usage. Default is false.
                           type: boolean

--- a/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
@@ -885,6 +885,13 @@ spec:
                         defaultVolumesToFSBackup:
                           description: Use pod volume file system backup by default for volumes
                           type: boolean
+                        disableFsBackup:
+                          default: false
+                          description: |-
+                            DisableFsBackup determines whether the NodeAgent should disable file system backup.
+                            When set to true, the NodeAgent runs in non-privileged mode.
+                            Defaults to false.
+                          type: boolean
                         disableInformerCache:
                           description: Disable informer cache for Get calls on restore. With this enabled, it will speed up restore in cases where there are backup resources which already exist in the cluster, but for very large clusters this will increase velero memory usage. Default is false.
                           type: boolean

--- a/config/samples/oadp_v1alpha1_dataprotectionapplication.yaml
+++ b/config/samples/oadp_v1alpha1_dataprotectionapplication.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   configuration:
     velero:
+      disableFsBackup: false
       defaultPlugins:
       - openshift
       - aws

--- a/internal/controller/nodeagent.go
+++ b/internal/controller/nodeagent.go
@@ -260,6 +260,13 @@ func (r *DataProtectionApplicationReconciler) customizeNodeAgentDaemonset(ds *ap
 				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},
 		},
+		// append /tmp volume
+		corev1.Volume{
+			Name: "tmp",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
 		// used for short-lived credentials, inert if not used
 		corev1.Volume{
 			Name: "bound-sa-token",
@@ -404,6 +411,12 @@ func (r *DataProtectionApplicationReconciler) customizeNodeAgentDaemonset(ds *ap
 				corev1.VolumeMount{
 					Name:      "home-velero",
 					MountPath: "/home/velero",
+					ReadOnly:  false,
+				},
+				// Ensure /tmp is writable
+				corev1.VolumeMount{
+					Name:      "tmp",
+					MountPath: "/tmp",
 					ReadOnly:  false,
 				},
 			)

--- a/internal/controller/nodeagent_test.go
+++ b/internal/controller/nodeagent_test.go
@@ -331,6 +331,12 @@ func createTestBuiltNodeAgentDaemonSet(options TestBuiltNodeAgentDaemonSetOption
 			},
 		},
 		corev1.Volume{
+			Name: "tmp",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+		corev1.Volume{
 			Name: "bound-sa-token",
 			VolumeSource: corev1.VolumeSource{
 				Projected: &corev1.ProjectedVolumeSource{
@@ -369,6 +375,11 @@ func createTestBuiltNodeAgentDaemonSet(options TestBuiltNodeAgentDaemonSetOption
 		corev1.VolumeMount{
 			Name:      "home-velero",
 			MountPath: "/home/velero",
+			ReadOnly:  false,
+		},
+		corev1.VolumeMount{
+			Name:      "tmp",
+			MountPath: "/tmp",
 			ReadOnly:  false,
 		},
 	)


### PR DESCRIPTION
Depends-On: https://github.com/openshift/velero/pull/361 (this one will get into openshift/velero from upstream via rebase as the upstream got already merged)

Fixes:
-  [OADP-5033](https://issues.redhat.com//browse/OADP-5033)
-  [OADP-5104](https://issues.redhat.com//browse/OADP-5104)
   - With default to be permissive (FSBackup working)
-  [OADP-5105](https://issues.redhat.com//browse/OADP-5105)
   - With default to be permissive (FSBackup working)

Partial fix for:
- [OADP-5031](https://issues.redhat.com//browse/OADP-5031) - need to address doc and sample apps
-  [OADP-5141](https://issues.redhat.com//browse/OADP-5141) - need to address datamover ?
-  [OADP-5182](https://issues.redhat.com//browse/OADP-5182) - need to address datamover ?

# About the change
This changes adds:
 - New configuration option to the `velero` under DPA Spec
 - The `disableFsBackup`  default is **false** or **non-existing**, which is same as **false**
   ```yaml
    spec:
    [...]
      configuration:
        [...]
        velero:
          disableFsBackup: true <----- NEW OPTION
   ```
 - Modifies that the node-agent is `always` ran as non-root user !
 - Changes the root filesystem to be read only !
   - Makes two mountpoints writeable:
     - `/home/velero`
     - `/tmp/credentials`
 - Uses `SeccompProfileTypeRuntimeDefault` for the `SeccompProfile`

 - With the `disableFsBackup` set to **false** or **non-existing**, the following options are added to the `SecurityContext`:
     - `Privileged: true`
     - `AllowPrivilegeEscalation: true` 
  
 - With `disableFsBackup` flag to set to true:
   - Removes the following mounts from the node-agent:
     - `host-pods`
     - `host-plugins`
   
## Why the changes were made

To enhance node-agent security

## How to test the changes made

1. Deploy with this PR and velero built:
DPA:
```yaml
spec:
[...]
  configuration:
    [...]
    velero:
      disableFsBackup: true <----- NEW OPTION
    nodeAgent:
      enable: true
      uploaderType: kopia
  unsupportedOverrides:
    veleroImageFqin: 'quay.io/migi/velero:latest'
```