### PR TITLE
OADP-5635: dpa support for parallel item backup

### DIFF
--- a/api/v1alpha1/dataprotectionapplication_types.go
+++ b/api/v1alpha1/dataprotectionapplication_types.go
@@ -301,6 +301,11 @@ type VeleroConfig struct {
 	// Disable informer cache for Get calls on restore. With this enabled, it will speed up restore in cases where there are backup resources which already exist in the cluster, but for very large clusters this will increase velero memory usage. Default is false.
 	// +optional
 	DisableInformerCache *bool `json:"disableInformerCache,omitempty"`
+	// Number of workers in worker pool for processing item backup. This will allow multiple items within
+	// a Velero backup to be backed up at the same time which may improve performance for backups with
+	// a large number of items. Default is 1.
+	// +optional
+	ItemBlockWorkerCount int `json:"itemBlockWorkerCount,omitempty"`
 	// resourceTimeout defines how long to wait for several Velero resources before timeout occurs,
 	// such as Velero CRD availability, volumeSnapshot deletion, and repo availability.
 	// Default is 10m

--- a/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
@@ -893,6 +893,12 @@ spec:
                           items:
                             type: string
                           type: array
+                        itemBlockWorkerCount:
+                          description: |-
+                            Number of workers in worker pool for processing item backup. This will allow multiple items within
+                            a Velero backup to be backed up at the same time which may improve performance for backups with
+                            a large number of items. Default is 1.
+                          type: integer
                         itemOperationSyncFrequency:
                           description: How often to check status on async backup/restore operations after backup processing. Default value is 2m.
                           type: string

--- a/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
@@ -893,6 +893,12 @@ spec:
                           items:
                             type: string
                           type: array
+                        itemBlockWorkerCount:
+                          description: |-
+                            Number of workers in worker pool for processing item backup. This will allow multiple items within
+                            a Velero backup to be backed up at the same time which may improve performance for backups with
+                            a large number of items. Default is 1.
+                          type: integer
                         itemOperationSyncFrequency:
                           description: How often to check status on async backup/restore operations after backup processing. Default value is 2m.
                           type: string

--- a/internal/controller/velero.go
+++ b/internal/controller/velero.go
@@ -364,6 +364,10 @@ func (r *DataProtectionApplicationReconciler) customizeVeleroDeployment(veleroDe
 	disableInformerCache := disableInformerCacheValue(dpa)
 	veleroContainer.Args = append(veleroContainer.Args, fmt.Sprintf("--disable-informer-cache=%s", disableInformerCache))
 
+	if dpa.Spec.Configuration.Velero.ItemBlockWorkerCount > 0 {
+		veleroContainer.Args = append(veleroContainer.Args, fmt.Sprintf("--item-block-worker-count=%v", dpa.Spec.Configuration.Velero.ItemBlockWorkerCount))
+	}
+
 	// Set defaults to avoid update events
 	if veleroDeployment.Spec.Strategy.Type == "" {
 		veleroDeployment.Spec.Strategy.Type = appsv1.RollingUpdateDeploymentStrategyType

--- a/internal/controller/velero_test.go
+++ b/internal/controller/velero_test.go
@@ -981,6 +981,28 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 			}),
 		},
 		{
+			name: "valid DPA CR with ItemBlockWorkerCount set to 2, Velero Deployment is built with ItemBlockWorkerCount set to 2",
+			dpa: createTestDpaWith(
+				nil,
+				oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{
+							ItemBlockWorkerCount: 2,
+						},
+					},
+				},
+			),
+			veleroDeployment: testVeleroDeployment.DeepCopy(),
+			wantVeleroDeployment: createTestBuiltVeleroDeployment(TestBuiltVeleroDeploymentOptions{
+				args: []string{
+					defaultFileSystemBackupTimeout,
+					defaultRestoreResourcePriorities,
+					defaultDisableInformerCache,
+					"--item-block-worker-count=2",
+				},
+			}),
+		},
+		{
 			name: "valid DPA CR with DefaultItemOperationTimeout, Velero Deployment is built with DefaultItemOperationTimeout arg",
 			dpa: createTestDpaWith(
 				nil,


### PR DESCRIPTION
## Why the changes were made
Velero 1.16 introduces parallel item backup, allowing multiple items within a backup to be processed in parallel. By default, only one worker thread processes item blocks, so even though item processing is in a separate goroutine, only one item at a time gets backed up. The optional velero server parameter `--item-block-worker-count` allows velero to run additional worker threads to process items in parallel.

To enable this in OADP, set `dpa.Spec.Configuration.Velero.ItemBlockWorkerCount` to an integer value greater than zero.
<!-- Explain why this PR is important, what problems it fixes, link related issues -->

## How to test the changes made
Set `dpa.Spec.Configuration.Velero.ItemBlockWorkerCount` to an integer value -- velero should be redeployed with a server arg added: `--item-block-worker-count=<dpa-value>`

<!-- Explain how the changes introduced by this PR can be tested and verified, with commands and pictures -->
