### PR TITLE
Add logFormat to the DPA's velero config

### DIFF
--- a/api/v1alpha1/dataprotectionapplication_types.go
+++ b/api/v1alpha1/dataprotectionapplication_types.go
@@ -51,6 +51,13 @@ type CustomPlugin struct {
 	Image string `json:"image"`
 }
 
+type LogFormat string
+
+const (
+	LogFormatText LogFormat = "text"
+	LogFormatJSON LogFormat = "json"
+)
+
 // Field does not have enum validation for development flexibility
 type UnsupportedImageKey string
 
@@ -286,6 +293,11 @@ type VeleroConfig struct {
 	// +optional
 	// +kubebuilder:validation:Enum=trace;debug;info;warning;error;fatal;panic
 	LogLevel string `json:"logLevel,omitempty"`
+	// The format for log output. Valid values are text, json. (default text)
+	// +kubebuilder:validation:Enum=text;json
+	// +kubebuilder:default=text
+	// +optional
+	LogFormat LogFormat `json:"logFormat,omitempty"`
 	// How often to check status on async backup/restore operations after backup processing. Default value is 2m.
 	// +optional
 	ItemOperationSyncFrequency string `json:"itemOperationSyncFrequency,omitempty"`

--- a/api/v1alpha1/dataprotectionapplication_types.go
+++ b/api/v1alpha1/dataprotectionapplication_types.go
@@ -293,11 +293,6 @@ type VeleroConfig struct {
 	// +optional
 	// +kubebuilder:validation:Enum=trace;debug;info;warning;error;fatal;panic
 	LogLevel string `json:"logLevel,omitempty"`
-	// The format for log output. Valid values are text, json. (default text)
-	// +kubebuilder:validation:Enum=text;json
-	// +kubebuilder:default=text
-	// +optional
-	LogFormat LogFormat `json:"logFormat,omitempty"`
 	// How often to check status on async backup/restore operations after backup processing. Default value is 2m.
 	// +optional
 	ItemOperationSyncFrequency string `json:"itemOperationSyncFrequency,omitempty"`
@@ -701,6 +696,11 @@ type DataProtectionApplicationSpec struct {
 	// nonAdmin defines the configuration for the DPA to enable backup and restore operations for non-admin users
 	// +optional
 	NonAdmin *NonAdmin `json:"nonAdmin,omitempty"`
+	// The format for log output. Valid values are text, json. (default text)
+	// +kubebuilder:validation:Enum=text;json
+	// +kubebuilder:default=text
+	// +optional
+	LogFormat LogFormat `json:"logFormat,omitempty"`
 }
 
 // DataProtectionApplicationStatus defines the observed state of DataProtectionApplication

--- a/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
@@ -902,6 +902,13 @@ spec:
                         itemOperationSyncFrequency:
                           description: How often to check status on async backup/restore operations after backup processing. Default value is 2m.
                           type: string
+                        logFormat:
+                          default: text
+                          description: The format for log output. Valid values are text, json. (default text)
+                          enum:
+                            - text
+                            - json
+                          type: string
                         logLevel:
                           description: Velero server's log level (use debug for the most logging, leave unset for velero default)
                           enum:

--- a/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
@@ -902,13 +902,6 @@ spec:
                         itemOperationSyncFrequency:
                           description: How often to check status on async backup/restore operations after backup processing. Default value is 2m.
                           type: string
-                        logFormat:
-                          default: text
-                          description: The format for log output. Valid values are text, json. (default text)
-                          enum:
-                            - text
-                            - json
-                          type: string
                         logLevel:
                           description: Velero server's log level (use debug for the most logging, leave unset for velero default)
                           enum:
@@ -1285,6 +1278,13 @@ spec:
                     - Always
                     - IfNotPresent
                     - Never
+                  type: string
+                logFormat:
+                  default: text
+                  description: The format for log output. Valid values are text, json. (default text)
+                  enum:
+                    - text
+                    - json
                   type: string
                 nonAdmin:
                   description: nonAdmin defines the configuration for the DPA to enable backup and restore operations for non-admin users

--- a/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
@@ -902,6 +902,13 @@ spec:
                         itemOperationSyncFrequency:
                           description: How often to check status on async backup/restore operations after backup processing. Default value is 2m.
                           type: string
+                        logFormat:
+                          default: text
+                          description: The format for log output. Valid values are text, json. (default text)
+                          enum:
+                            - text
+                            - json
+                          type: string
                         logLevel:
                           description: Velero server's log level (use debug for the most logging, leave unset for velero default)
                           enum:

--- a/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
@@ -902,13 +902,6 @@ spec:
                         itemOperationSyncFrequency:
                           description: How often to check status on async backup/restore operations after backup processing. Default value is 2m.
                           type: string
-                        logFormat:
-                          default: text
-                          description: The format for log output. Valid values are text, json. (default text)
-                          enum:
-                            - text
-                            - json
-                          type: string
                         logLevel:
                           description: Velero server's log level (use debug for the most logging, leave unset for velero default)
                           enum:
@@ -1285,6 +1278,13 @@ spec:
                     - Always
                     - IfNotPresent
                     - Never
+                  type: string
+                logFormat:
+                  default: text
+                  description: The format for log output. Valid values are text, json. (default text)
+                  enum:
+                    - text
+                    - json
                   type: string
                 nonAdmin:
                   description: nonAdmin defines the configuration for the DPA to enable backup and restore operations for non-admin users

--- a/internal/controller/velero.go
+++ b/internal/controller/velero.go
@@ -330,8 +330,8 @@ func (r *DataProtectionApplicationReconciler) customizeVeleroDeployment(veleroDe
 		veleroContainer.Args = append(veleroContainer.Args, "--log-level", logLevel.String())
 	}
 
-	if dpa.Spec.Configuration.Velero.LogFormat != "" {
-		veleroContainer.Args = append(veleroContainer.Args, fmt.Sprintf("--log-format=%s", dpa.Spec.Configuration.Velero.LogFormat))
+	if dpa.Spec.LogFormat != "" {
+		veleroContainer.Args = append(veleroContainer.Args, fmt.Sprintf("--log-format=%s", dpa.Spec.LogFormat))
 	}
 
 	// Setting async operations server parameter ItemOperationSyncFrequency

--- a/internal/controller/velero.go
+++ b/internal/controller/velero.go
@@ -330,6 +330,10 @@ func (r *DataProtectionApplicationReconciler) customizeVeleroDeployment(veleroDe
 		veleroContainer.Args = append(veleroContainer.Args, "--log-level", logLevel.String())
 	}
 
+	if dpa.Spec.Configuration.Velero.LogFormat != "" {
+		veleroContainer.Args = append(veleroContainer.Args, fmt.Sprintf("--log-format=%s", dpa.Spec.Configuration.Velero.LogFormat))
+	}
+
 	// Setting async operations server parameter ItemOperationSyncFrequency
 	if dpa.Spec.Configuration.Velero.ItemOperationSyncFrequency != "" {
 		ItemOperationSyncFrequencyString := dpa.Spec.Configuration.Velero.ItemOperationSyncFrequency

--- a/internal/controller/velero_test.go
+++ b/internal/controller/velero_test.go
@@ -852,6 +852,7 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 					Configuration: &oadpv1alpha1.ApplicationConfig{
 						Velero: &oadpv1alpha1.VeleroConfig{
 							LogLevel:                    logrus.InfoLevel.String(),
+							LogFormat:                   oadpv1alpha1.LogFormatJSON,
 							ItemOperationSyncFrequency:  "5m",
 							DefaultItemOperationTimeout: "2h",
 							DefaultSnapshotMoveData:     ptr.To(false),
@@ -870,6 +871,7 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 					defaultRestoreResourcePriorities,
 					"--log-level",
 					logrus.InfoLevel.String(),
+					"--log-format=json",
 					"--item-operation-sync-frequency=5m",
 					"--default-item-operation-timeout=2h",
 					"--default-snapshot-move-data=false",

--- a/internal/controller/velero_test.go
+++ b/internal/controller/velero_test.go
@@ -849,10 +849,10 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 			dpa: createTestDpaWith(
 				nil,
 				oadpv1alpha1.DataProtectionApplicationSpec{
+					LogFormat: oadpv1alpha1.LogFormatJSON,
 					Configuration: &oadpv1alpha1.ApplicationConfig{
 						Velero: &oadpv1alpha1.VeleroConfig{
 							LogLevel:                    logrus.InfoLevel.String(),
-							LogFormat:                   oadpv1alpha1.LogFormatJSON,
 							ItemOperationSyncFrequency:  "5m",
 							DefaultItemOperationTimeout: "2h",
 							DefaultSnapshotMoveData:     ptr.To(false),

--- a/pkg/common/common_test.go
+++ b/pkg/common/common_test.go
@@ -252,6 +252,7 @@ func TestGenerateCliArgsFromConfigMap(t *testing.T) {
 				Data: map[string]string{
 					"--default-volume-snapshot-locations": "aws:backups-primary,azure:backups-secondary",
 					"--log-level":                         "debug",
+					"--log-format":                        "json",
 					"--default-snapshot-move-data":        "True",
 					"-v":                                  "3",
 					"a":                                   "somearg",
@@ -262,6 +263,7 @@ func TestGenerateCliArgsFromConfigMap(t *testing.T) {
 				"--a=somearg",
 				"--default-snapshot-move-data=true",
 				"--default-volume-snapshot-locations=aws:backups-primary,azure:backups-secondary",
+				"--log-format=json",
 				"--log-level=debug",
 				"-v=3",
 			},


### PR DESCRIPTION
Fixes [OADP-3391](https://issues.redhat.com//browse/OADP-3391)

## Why the changes were made

To fix [OADP-3391](https://issues.redhat.com//browse/OADP-3391)

## How to test the changes made

1. Run tests, the log format was added to the test cases
2. Deploy this PR and check that the log format field is now an option in the OCP UI as well the proper description is in the  text window (screenshot attached)
3. Try to insert incorrect value `jsonabc` or other, the object won't be allowed
4. Deploy DPA's velero with json field and confirm the server arg is passed correctly

![image](https://github.com/user-attachments/assets/655e9c1c-dc8b-4ac1-b661-1a6099f56c8f)

![image](https://github.com/user-attachments/assets/efbfc89f-2132-473b-8968-ff1603aee54d)
 