### PR TITLE
Doc fix for the OADP-5265

### DIFF
--- a/docs/examples/manifests/user_monitoring/3_create_oadp_service_monitor.yaml
+++ b/docs/examples/manifests/user_monitoring/3_create_oadp_service_monitor.yaml
@@ -14,3 +14,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: "velero"
+      app.kubernetes.io/instance: "velero-sample" # <---- This is the name of the DPA CR

--- a/docs/oadp_monitoring.md
+++ b/docs/oadp_monitoring.md
@@ -88,7 +88,7 @@ This paragraph will provide a short set of instructions how to enable user workl
 
 OADP provides an `openshift-adp-velero-metrics-svc` service which is being created when DPA is configured. The ServiceMonitor that is used by the user workload monitoring will need to point to that SVC service.
 
-1. Ensure the `openshift-adp-velero-metrics-svc` exists. It should contain `app.kubernetes.io/name=velero` label which will be used as selector for our ServiceMonitor
+1. Ensure the `openshift-adp-velero-metrics-svc` exists. It should contain `app.kubernetes.io/name=velero` label which will be used as selector for our ServiceMonitor and the `app.kubernetes.io/instance` label which will be used to identify the Velero instance, The instance name is the name of the DPA CR.
 
     ```shell
     $ oc get svc -n openshift-adp -l app.kubernetes.io/name=velero
@@ -115,6 +115,7 @@ OADP provides an `openshift-adp-velero-metrics-svc` service which is being creat
       selector:
         matchLabels:
           app.kubernetes.io/name: "velero"
+          app.kubernetes.io/instance: "velero-sample" # <---- This is the name of the DPA CR
     ```
 
 3. Apply the `3_create_oadp_service_monitor.yaml`


### PR DESCRIPTION
DNM: Maybe there is a better way to match the labels for all the velero pods, possibly upstream work...

## Why the changes were made

Fix [OADP-5265](https://issues.redhat.com//browse/OADP-5265)

Notes:
```
OADP-5265

######## 1. Velero pod labels:
$ oc describe pod -l 'app.kubernetes.io/instance=velero-sample' -n openshift-adp
Name:             velero-69445f858c-6dbxh
Namespace:        openshift-adp
Priority:         0
Service Account:  velero
Node:             10.243.64.5/10.243.64.5
Start Time:       Thu, 13 Mar 2025 13:17:00 +0100
Labels:           app.kubernetes.io/component=server
                  app.kubernetes.io/instance=velero-sample
                  app.kubernetes.io/managed-by=oadp-operator
                  app.kubernetes.io/name=velero
                  component=velero
                  deploy=velero
                  openshift.io/oadp=True
                  pod-template-hash=69445f858c
Annotations:      cni.projectcalico.org/containerID: 6422e64c572b42af762b5188daeff688532cce0b94aa9339a464e22045775e58
                  cni.projectcalico.org/podIP: 172.17.57.6/32
                  cni.projectcalico.org/podIPs: 172.17.57.6/32
                  openshift.io/scc: restricted-v2
                  prometheus.io/path: /metrics
                  prometheus.io/port: 8085
                  prometheus.io/scrape: true
                  seccomp.security.alpha.kubernetes.io/pod: runtime/default
Status:           Running

######## 2. DPA
$ oc describe dpa velero-sample -n openshift-adp
Name:         velero-sample
Namespace:    openshift-adp
Labels:       <none>
Annotations:  <none>
API Version:  oadp.openshift.io/v1alpha1

######## 3. labels on the node-agent
$ oc describe pod -l 'name=node-agent' -n openshift-adp
Name:             node-agent-mnvg4
Namespace:        openshift-adp
Priority:         0
Service Account:  velero
Node:             10.243.64.4/10.243.64.4
Start Time:       Thu, 13 Mar 2025 13:17:00 +0100
Labels:           component=velero
                  controller-revision-hash=c4f9fd9f9
                  name=node-agent
                  pod-template-generation=1
Annotations:      cni.projectcalico.org/containerID: e4b3a201a89a909e099240fc0a7ce3d202d3d507938a12410427f8f23b795a0c
                  cni.projectcalico.org/podIP: 172.17.34.2/32
                  cni.projectcalico.org/podIPs: 172.17.34.2/32
                  openshift.io/scc: privileged

######## 4. Labels on the service
$ oc describe svc -n openshift-adp -l app.kubernetes.io/name=velero
Name:              openshift-adp-velero-metrics-svc
Namespace:         openshift-adp
Labels:            app.kubernetes.io/component=server
                   app.kubernetes.io/instance=velero-sample
                   app.kubernetes.io/managed-by=oadp-operator
                   app.kubernetes.io/name=velero
                   openshift.io/oadp=True
Annotations:       <none>
Selector:          app.kubernetes.io/component=server,app.kubernetes.io/instance=velero-sample,app.kubernetes.io/managed-by=oadp-operator,app.kubernetes.io/name=velero,openshift.io/oadp=True
Type:              ClusterIP
IP Family Policy:  SingleStack
IP Families:       IPv4
IP:                172.21.75.70
IPs:               172.21.75.70
Port:              monitoring  8085/TCP
TargetPort:        8085/TCP
Endpoints:         172.17.57.6:8085
Session Affinity:  None
Events:
  Type    Reason                          Age   From            Message
  ----    ------                          ----  ----            -------
  Normal  VeleroMetricsServiceReconciled  21m   DPA-controller  performed created on dpa metrics service openshift-adp/openshift-adp-velero-metrics-svc


######## 5. BSL labels
  labels:
    app.kubernetes.io/component: bsl
    app.kubernetes.io/instance: default
    app.kubernetes.io/managed-by: oadp-operator
    app.kubernetes.io/name: oadp-operator-velero
    openshift.io/oadp: 'True'
    openshift.io/oadp-registry: 'True'
```