### PR TITLE
Add node-agent log format settings

### DIFF
--- a/internal/controller/nodeagent.go
+++ b/internal/controller/nodeagent.go
@@ -445,6 +445,10 @@ func (r *DataProtectionApplicationReconciler) customizeNodeAgentDaemonset(ds *ap
 				nodeAgentContainer.Args = append(nodeAgentContainer.Args, fmt.Sprintf("--resource-timeout=%s", dpa.Spec.Configuration.NodeAgent.ResourceTimeout.Duration))
 			}
 
+			if dpa.Spec.LogFormat != "" {
+				nodeAgentContainer.Args = append(nodeAgentContainer.Args, fmt.Sprintf("--log-format=%s", dpa.Spec.LogFormat))
+			}
+
 			// Apply unsupported server args from the specified ConfigMap.
 			// This will completely override any previously set args for the node-agent server.
 			// If the ConfigMap exists and is not empty, its key-value pairs will be used as the new CLI arguments.


### PR DESCRIPTION
Uses fix from: OADP-3391
Fixes: OADP-4408

## Why the changes were made

To ensure node-agent logs are in the format requested by the user.

## How to test the changes made
1. Deploy this PR and create DPA with top level `logFormat` setting

```yaml
apiVersion: oadp.openshift.io/v1alpha1
kind: DataProtectionApplication
metadata:
[...]
spec:
  [...]
  logFormat: json

```

2. Confirm that the node-agent args has `--log-format` passed properly:
```yaml
kind: Pod
apiVersion: v1
metadata:
[...]
spec:
[...]
  containers:
  [...]
      args:
        - node-agent
        - server
        - '--log-format=json'
 ```

3. Perform the same using `text` 
4. Try to include improper value to the `logFormat` e.g. `myvalue` - result: validation webhook won't allow to use it
5. Try removing this value: because default is text, after reconcile the value should appear.