### PR TITLE
OADP-5782: Add hypershift-oadp-plugin as a default one in oadp-operator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ junit_report.xml
 cache/
 # debug files
 debug.test*
+
+# Others
+.envrc

--- a/api/v1alpha1/dataprotectionapplication_types.go
+++ b/api/v1alpha1/dataprotectionapplication_types.go
@@ -36,7 +36,7 @@ const ReconcileCompleteMessage = "Reconcile complete"
 
 const OadpOperatorLabel = "openshift.io/oadp"
 
-// +kubebuilder:validation:Enum=aws;legacy-aws;gcp;azure;csi;vsm;openshift;kubevirt
+// +kubebuilder:validation:Enum=aws;legacy-aws;gcp;azure;csi;vsm;openshift;kubevirt;hypershift
 type DefaultPlugin string
 
 const DefaultPluginAWS DefaultPlugin = "aws"
@@ -47,6 +47,7 @@ const DefaultPluginCSI DefaultPlugin = "csi"
 const DefaultPluginVSM DefaultPlugin = "vsm"
 const DefaultPluginOpenShift DefaultPlugin = "openshift"
 const DefaultPluginKubeVirt DefaultPlugin = "kubevirt"
+const DefaultPluginHypershift DefaultPlugin = "hypershift"
 
 type CustomPlugin struct {
 	Name  string `json:"name"`
@@ -71,6 +72,7 @@ const AzurePluginImageKey UnsupportedImageKey = "azurePluginImageFqin"
 const GCPPluginImageKey UnsupportedImageKey = "gcpPluginImageFqin"
 const ResticRestoreImageKey UnsupportedImageKey = "resticRestoreImageFqin"
 const KubeVirtPluginImageKey UnsupportedImageKey = "kubevirtPluginImageFqin"
+const HypershiftPluginImageKey UnsupportedImageKey = "hypershiftPluginImageFqin"
 const NonAdminControllerImageKey UnsupportedImageKey = "nonAdminControllerImageFqin"
 const OperatorTypeKey UnsupportedImageKey = "operator-type"
 
@@ -713,6 +715,7 @@ type DataProtectionApplicationSpec struct {
 	//   - gcpPluginImageFqin
 	//   - resticRestoreImageFqin
 	//   - kubevirtPluginImageFqin
+	//   - hypershiftPluginImageFqin
 	//   - nonAdminControllerImageFqin
 	//   - operator-type
 	//   - tech-preview-ack

--- a/bundle/manifests/oadp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/oadp-operator.clusterserviceversion.yaml
@@ -1078,6 +1078,8 @@ spec:
                   value: quay.io/konveyor/velero-plugin-for-gcp:latest
                 - name: RELATED_IMAGE_KUBEVIRT_VELERO_PLUGIN
                   value: quay.io/konveyor/kubevirt-velero-plugin:v0.7.0
+                - name: RELATED_IMAGE_HYPERSHIFT_VELERO_PLUGIN
+                  value: quay.io/hypershift/hypershift-oadp-plugin:latest
                 - name: RELATED_IMAGE_MUSTGATHER
                   value: registry.redhat.io/oadp/oadp-mustgather-rhel8:v1.2
                 - name: RELATED_IMAGE_NON_ADMIN_CONTROLLER
@@ -1236,6 +1238,8 @@ spec:
     name: velero-plugin-for-gcp
   - image: quay.io/konveyor/kubevirt-velero-plugin:v0.7.0
     name: kubevirt-velero-plugin
+  - image: quay.io/hypershift/hypershift-oadp-plugin:latest
+    name: hypershift-velero-plugin
   - image: registry.redhat.io/oadp/oadp-mustgather-rhel8:v1.2
     name: mustgather
   - image: quay.io/konveyor/oadp-non-admin:latest

--- a/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
@@ -976,6 +976,7 @@ spec:
                               - vsm
                               - openshift
                               - kubevirt
+                              - hypershift
                             type: string
                           type: array
                         defaultSnapshotMoveData:
@@ -2439,6 +2440,7 @@ spec:
                       - gcpPluginImageFqin
                       - resticRestoreImageFqin
                       - kubevirtPluginImageFqin
+                      - hypershiftPluginImageFqin
                       - nonAdminControllerImageFqin
                       - operator-type
                       - tech-preview-ack

--- a/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
@@ -976,6 +976,7 @@ spec:
                               - vsm
                               - openshift
                               - kubevirt
+                              - hypershift
                             type: string
                           type: array
                         defaultSnapshotMoveData:
@@ -2439,6 +2440,7 @@ spec:
                       - gcpPluginImageFqin
                       - resticRestoreImageFqin
                       - kubevirtPluginImageFqin
+                      - hypershiftPluginImageFqin
                       - nonAdminControllerImageFqin
                       - operator-type
                       - tech-preview-ack

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -76,6 +76,8 @@ spec:
               value: quay.io/konveyor/velero-plugin-for-gcp:latest
             - name: RELATED_IMAGE_KUBEVIRT_VELERO_PLUGIN
               value: quay.io/konveyor/kubevirt-velero-plugin:v0.7.0
+            - name: RELATED_IMAGE_HYPERSHIFT_VELERO_PLUGIN
+              value: quay.io/hypershift/hypershift-oadp-plugin:latest
             - name: RELATED_IMAGE_MUSTGATHER
               value: registry.redhat.io/oadp/oadp-mustgather-rhel8:v1.2
             - name: RELATED_IMAGE_NON_ADMIN_CONTROLLER

--- a/docs/developer/testing/TESTING.md
+++ b/docs/developer/testing/TESTING.md
@@ -106,6 +106,7 @@ export GCP_PLUGIN_IMAGE=<gcp_plugin_image>
 export CSI_PLUGIN_IMAGE=<csi_plugin_image>
 export RESTORE_IMAGE=<restore_image>
 export KUBEVIRT_PLUGIN_IMAGE=<kubevirt_plugin_image>
+export HYPERSHIFT_PLUGIN_IMAGE=<hypershift_plugin_image>
 export NON_ADMIN_IMAGE=<non_admin_image>
 ```
 For further details, see [tests/e2e/scripts/](../../../tests/e2e/scripts/)

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/kubernetes-csi/external-snapshotter/client/v4 v4.2.0
 	github.com/onsi/ginkgo/v2 v2.19.0
 	github.com/onsi/gomega v1.33.1
-	github.com/openshift/api v0.0.0-20230213134911-7ba313770556 // release-4.12
+	github.com/openshift/api v0.0.0-20240524162738-d899f8877d22 // release-4.12
 	github.com/operator-framework/api v0.10.7
 	github.com/operator-framework/operator-lib v0.9.0
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.51.2
@@ -72,7 +72,7 @@ require (
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
-	github.com/google/pprof v0.0.0-20240525223248-4bfdf5a9a2af // indirect
+	github.com/google/pprof v0.0.0-20241210010833-40e02aabc2ad // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/hashicorp/go-hclog v1.2.0 // indirect
 	github.com/hashicorp/go-plugin v1.6.0 // indirect
@@ -102,7 +102,7 @@ require (
 	github.com/prometheus/common v0.62.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/spf13/cobra v1.8.1 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/spf13/pflag v1.0.6-0.20210604193023-d5e0c0615ace // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -404,8 +404,8 @@ github.com/google/pprof v0.0.0-20201023163331-3e6fc7fc9c4c/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20201203190320-1bf35d6f28c2/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210122040257-d980be63207e/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210226084205-cbba55b83ad5/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
-github.com/google/pprof v0.0.0-20240525223248-4bfdf5a9a2af h1:kmjWCqn2qkEml422C2Rrd27c3VGxi6a/6HNq8QmHRKM=
-github.com/google/pprof v0.0.0-20240525223248-4bfdf5a9a2af/go.mod h1:K1liHPHnj73Fdn/EKuT8nrFqBihUSKXoLYU0BuatOYo=
+github.com/google/pprof v0.0.0-20241210010833-40e02aabc2ad h1:a6HEuzUHeKH6hwfN/ZoQgRgVIWFJljSWa/zetS2WTvg=
+github.com/google/pprof v0.0.0-20241210010833-40e02aabc2ad/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -613,8 +613,8 @@ github.com/onsi/gomega v1.14.0/go.mod h1:cIuvLEne0aoVhAgh/O6ac0Op8WWw9H6eYCriF+t
 github.com/onsi/gomega v1.15.0/go.mod h1:cIuvLEne0aoVhAgh/O6ac0Op8WWw9H6eYCriF+tEHG0=
 github.com/onsi/gomega v1.33.1 h1:dsYjIxxSR755MDmKVsaFQTE22ChNBcuuTWgkUDSubOk=
 github.com/onsi/gomega v1.33.1/go.mod h1:U4R44UsT+9eLIaYRB2a5qajjtQYn0hauxvRm16AVYg0=
-github.com/openshift/api v0.0.0-20230213134911-7ba313770556 h1:7W2fOhJicyEff24VaF7ASNzPtYvr+iSCVft4SIBAzaE=
-github.com/openshift/api v0.0.0-20230213134911-7ba313770556/go.mod h1:aQ6LDasvHMvHZXqLHnX2GRmnfTWCF/iIwz8EMTTIE9A=
+github.com/openshift/api v0.0.0-20240524162738-d899f8877d22 h1:AW8KUN4k7qR2egrCCe3x95URHQ3N188+a/b0qpRyAHg=
+github.com/openshift/api v0.0.0-20240524162738-d899f8877d22/go.mod h1:7Hm1kLJGxWT6eysOpD2zUztdn+w91eiERn6KtI5o9aw=
 github.com/openshift/velero v0.10.2-0.20250313160323-584cf1148a74 h1:ZHO0O6g1Enel2O4rAk7VfWLHlQKYkOcdWGAmoiZ3fQw=
 github.com/openshift/velero v0.10.2-0.20250313160323-584cf1148a74/go.mod h1:sASoDB9pLWqvIi1nD1ZFOpmj5JB+p10lHVm+f+Hp1oU=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
@@ -713,8 +713,9 @@ github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.1/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
-github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spf13/pflag v1.0.6-0.20210604193023-d5e0c0615ace h1:9PNP1jnUjRhfmGMlkXHjYPishpcw4jpSt/V/xYY3FMA=
+github.com/spf13/pflag v1.0.6-0.20210604193023-d5e0c0615ace/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -65,14 +65,15 @@ var DefaultRestoreResourcePriorities = types.Priorities{
 
 // Images
 const (
-	VeleroImage          = "quay.io/konveyor/velero:latest"
-	OpenshiftPluginImage = "quay.io/konveyor/openshift-velero-plugin:latest"
-	AWSPluginImage       = "quay.io/konveyor/velero-plugin-for-aws:latest"
-	LegacyAWSPluginImage = "quay.io/konveyor/velero-plugin-for-legacy-aws:latest"
-	AzurePluginImage     = "quay.io/konveyor/velero-plugin-for-microsoft-azure:latest"
-	GCPPluginImage       = "quay.io/konveyor/velero-plugin-for-gcp:latest"
-	RegistryImage        = "quay.io/konveyor/registry:latest"
-	KubeVirtPluginImage  = "quay.io/konveyor/kubevirt-velero-plugin:v0.7.0"
+	VeleroImage           = "quay.io/konveyor/velero:latest"
+	OpenshiftPluginImage  = "quay.io/konveyor/openshift-velero-plugin:latest"
+	AWSPluginImage        = "quay.io/konveyor/velero-plugin-for-aws:latest"
+	LegacyAWSPluginImage  = "quay.io/konveyor/velero-plugin-for-legacy-aws:latest"
+	AzurePluginImage      = "quay.io/konveyor/velero-plugin-for-microsoft-azure:latest"
+	GCPPluginImage        = "quay.io/konveyor/velero-plugin-for-gcp:latest"
+	RegistryImage         = "quay.io/konveyor/registry:latest"
+	KubeVirtPluginImage   = "quay.io/konveyor/kubevirt-velero-plugin:v0.7.0"
+	HypershiftPluginImage = "quay.io/hypershift/hypershift-oadp-plugin:latest"
 )
 
 // Plugin names
@@ -83,6 +84,7 @@ const (
 	VeleroPluginForGCP       = "velero-plugin-for-gcp"
 	VeleroPluginForOpenshift = "openshift-velero-plugin"
 	KubeVirtPlugin           = "kubevirt-velero-plugin"
+	HypershiftPlugin         = "hypershift-oadp-plugin"
 )
 
 // Environment Vars keys

--- a/pkg/credentials/credentials.go
+++ b/pkg/credentials/credentials.go
@@ -78,6 +78,10 @@ var (
 			IsCloudProvider: false,
 			PluginName:      common.KubeVirtPlugin,
 		},
+		oadpv1alpha1.DefaultPluginHypershift: {
+			IsCloudProvider: false,
+			PluginName:      common.HypershiftPlugin,
+		},
 	}
 )
 
@@ -159,6 +163,16 @@ func getKubeVirtPluginImage(dpa *oadpv1alpha1.DataProtectionApplication) string 
 	return os.Getenv("RELATED_IMAGE_KUBEVIRT_VELERO_PLUGIN")
 }
 
+func getHypershiftPluginImage(dpa *oadpv1alpha1.DataProtectionApplication) string {
+	if dpa.Spec.UnsupportedOverrides[oadpv1alpha1.HypershiftPluginImageKey] != "" {
+		return dpa.Spec.UnsupportedOverrides[oadpv1alpha1.HypershiftPluginImageKey]
+	}
+	if os.Getenv("RELATED_IMAGE_HYPERSHIFT_VELERO_PLUGIN") == "" {
+		return common.HypershiftPluginImage
+	}
+	return os.Getenv("RELATED_IMAGE_HYPERSHIFT_VELERO_PLUGIN")
+}
+
 func GetPluginImage(defaultPlugin oadpv1alpha1.DefaultPlugin, dpa *oadpv1alpha1.DataProtectionApplication) string {
 	switch defaultPlugin {
 
@@ -179,6 +193,9 @@ func GetPluginImage(defaultPlugin oadpv1alpha1.DefaultPlugin, dpa *oadpv1alpha1.
 
 	case oadpv1alpha1.DefaultPluginKubeVirt:
 		return getKubeVirtPluginImage(dpa)
+
+	case oadpv1alpha1.DefaultPluginHypershift:
+		return getHypershiftPluginImage(dpa)
 	}
 	return ""
 }

--- a/pkg/credentials/credentials_test.go
+++ b/pkg/credentials/credentials_test.go
@@ -425,6 +425,50 @@ func TestCredentials_getPluginImage(t *testing.T) {
 				"RELATED_IMAGE_KUBEVIRT_VELERO_PLUGIN": "quay.io/kubevirt/kubevirt-velero-plugin:latest",
 			},
 		},
+		// Hypershift tests
+		{
+			name: "given default Velero CR with no env var, default hypershift image should be returned",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-Velero-CR",
+					Namespace: "test-ns",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{
+							DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
+								oadpv1alpha1.DefaultPluginHypershift,
+							},
+						},
+					},
+				},
+			},
+			pluginName: oadpv1alpha1.DefaultPluginHypershift,
+			wantImage:  common.HypershiftPluginImage,
+		},
+		{
+			name: "given hypershift plugin override, custom hypershift image should be returned",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-Velero-CR",
+					Namespace: "test-ns",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{
+							DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
+								oadpv1alpha1.DefaultPluginHypershift,
+							},
+						},
+					},
+				},
+			},
+			pluginName: oadpv1alpha1.DefaultPluginHypershift,
+			wantImage:  "quay.io/hypershift/hypershift-oadp-plugin:latest",
+			setEnvVars: map[string]string{
+				"RELATED_IMAGE_HYPERSHIFT_VELERO_PLUGIN": "quay.io/hypershift/hypershift-oadp-plugin:latest",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/tests/e2e/scripts/aws_settings.sh
+++ b/tests/e2e/scripts/aws_settings.sh
@@ -11,6 +11,7 @@ cat > $TMP_DIR/oadpcreds <<EOF
         "gcpPluginImageFqin": "$GCP_PLUGIN_IMAGE",
         "resticRestoreImageFqin": "$RESTORE_IMAGE",
         "kubevirtPluginImageFqin": "$KUBEVIRT_PLUGIN_IMAGE",
+        "hypershiftPluginImageFqin": "$HYPERSHIFT_PLUGIN_IMAGE",
         "nonAdminControllerImageFqin": "$NON_ADMIN_IMAGE"
       },
       "configuration":{
@@ -38,7 +39,7 @@ cat > $TMP_DIR/oadpcreds <<EOF
        {
          "velero": {
            "provider": "$PROVIDER",
-           "config": { 
+           "config": {
              "profile": "default",
              "region": "$VSL_REGION"
            }

--- a/tests/e2e/scripts/azure_settings.sh
+++ b/tests/e2e/scripts/azure_settings.sh
@@ -33,7 +33,7 @@ AZURE_TENANT_ID=${AZURE_TENANT_ID}
 AZURE_CLIENT_ID=${AZURE_CLIENT_ID}
 AZURE_CLIENT_SECRET=${AZURE_CLIENT_SECRET}
 AZURE_RESOURCE_GROUP=${AZURE_RESOURCE_GROUP}
-AZURE_STORAGE_ACCOUNT_ACCESS_KEY=${AZURE_STORAGE_ACCOUNT_ACCESS_KEY} 
+AZURE_STORAGE_ACCOUNT_ACCESS_KEY=${AZURE_STORAGE_ACCOUNT_ACCESS_KEY}
 AZURE_CLOUD_NAME=AzurePublicCloud
 EOF
 
@@ -48,6 +48,7 @@ cat > $TMP_DIR/oadpcreds <<EOF
         "gcpPluginImageFqin": "$GCP_PLUGIN_IMAGE",
         "resticRestoreImageFqin": "$RESTORE_IMAGE",
         "kubevirtPluginImageFqin": "$KUBEVIRT_PLUGIN_IMAGE",
+        "hypershiftPluginImageFqin": "$HYPERSHIFT_PLUGIN_IMAGE",
         "nonAdminControllerImageFqin": "$NON_ADMIN_IMAGE"
       },
       "configuration":{
@@ -77,7 +78,7 @@ cat > $TMP_DIR/oadpcreds <<EOF
        {
          "velero": {
            "provider": "$PROVIDER",
-           "config": { 
+           "config": {
               "subscriptionId": "$CI_AZURE_SUBSCRIPTION_ID",
               "resourceGroup": "$CI_AZURE_RESOURCE_GROUP"
            }

--- a/tests/e2e/scripts/gcp_settings.sh
+++ b/tests/e2e/scripts/gcp_settings.sh
@@ -11,6 +11,7 @@ cat > $TMP_DIR/oadpcreds <<EOF
         "gcpPluginImageFqin": "$GCP_PLUGIN_IMAGE",
         "resticRestoreImageFqin": "$RESTORE_IMAGE",
         "kubevirtPluginImageFqin": "$KUBEVIRT_PLUGIN_IMAGE",
+        "hypershiftPluginImageFqin": "$HYPERSHIFT_PLUGIN_IMAGE",
         "nonAdminControllerImageFqin": "$NON_ADMIN_IMAGE"
       },
       "configuration":{
@@ -36,7 +37,7 @@ cat > $TMP_DIR/oadpcreds <<EOF
        {
          "velero": {
            "provider": "$PROVIDER",
-           "config": { 
+           "config": {
              "snapshotLocation": "$VSL_REGION"
            }
          }

--- a/tests/e2e/scripts/ibmcloud_settings.sh
+++ b/tests/e2e/scripts/ibmcloud_settings.sh
@@ -11,7 +11,8 @@ cat > $TMP_DIR/oadpcreds <<EOF
         "gcpPluginImageFqin": "$GCP_PLUGIN_IMAGE",
         "resticRestoreImageFqin": "$RESTORE_IMAGE",
         "kubevirtPluginImageFqin": "$KUBEVIRT_PLUGIN_IMAGE",
-        "nonAdminControllerImageFqin": "$NON_ADMIN_IMAGE"  
+        "hypershiftPluginImageFqin": "$HYPERSHIFT_PLUGIN_IMAGE",
+        "nonAdminControllerImageFqin": "$NON_ADMIN_IMAGE"
       },
       "configuration":{
         "velero":{

--- a/tests/e2e/scripts/openstack_settings.sh
+++ b/tests/e2e/scripts/openstack_settings.sh
@@ -11,6 +11,7 @@ cat > $TMP_DIR/oadpcreds <<EOF
         "gcpPluginImageFqin": "$GCP_PLUGIN_IMAGE",
         "resticRestoreImageFqin": "$RESTORE_IMAGE",
         "kubevirtPluginImageFqin": "$KUBEVIRT_PLUGIN_IMAGE",
+        "hypershiftPluginImageFqin": "$HYPERSHIFT_PLUGIN_IMAGE",
         "nonAdminControllerImageFqin": "$NON_ADMIN_IMAGE"
       },
       "configuration":{
@@ -42,7 +43,7 @@ cat > $TMP_DIR/oadpcreds <<EOF
        {
          "velero": {
            "provider": "aws",
-           "config": { 
+           "config": {
              "profile": "default",
              "region": "$VSL_REGION"
            }

--- a/tests/e2e/templates/default_settings.json
+++ b/tests/e2e/templates/default_settings.json
@@ -5,7 +5,8 @@
           "defaultPlugins": [
             "openshift",
             "aws",
-            "kubevirt"
+            "kubevirt",
+            "hypershift"
           ]
         }
       },
@@ -27,7 +28,7 @@
         {
           "velero": {
             "provider": "aws",
-            "config": { 
+            "config": {
               "profile": "default",
               "region": "us-east-1"
             }


### PR DESCRIPTION
## Why the changes were made

This allows the [hypershift-oadp-plugin](https://github.com/openshift/hypershift-oadp-plugin) to be part of the default ones delivered into oadp-operator. This also give supportability to the DR scenarios to HCP using OADP as a provider.

Bumping some dependencies too:
- github.com/openshift/api v0.0.0-20240524162738-d899f8877d22
- github.com/google/pprof v0.0.0-20241210010833-40e02aabc2ad // indirect
- github.com/spf13/pflag v1.0.6-0.20210604193023-d5e0c0615ace // indirect

## How to test the changes made

1. Modify the DPA adding the `hypershift` default plugin
2. Perform a backup/restore using the samples from the [hypershift-oadp-plugin](https://github.com/openshift/hypershift-oadp-plugin/tree/main/examples) repository

