### PR TITLE
Ensure root fs in the controller manager is readonly

### DIFF
--- a/bundle/manifests/oadp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/oadp-operator.clusterserviceversion.yaml
@@ -1106,6 +1106,10 @@ spec:
                     memory: 128Mi
                 securityContext:
                   allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+                  readOnlyRootFilesystem: true
                 startupProbe:
                   failureThreshold: 12
                   httpGet:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -87,7 +87,11 @@ spec:
           name: manager
           terminationMessagePolicy: FallbackToLogsOnError
           securityContext:
+            capabilities:
+              drop:
+              - ALL
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
           startupProbe:
             httpGet:
               path: /healthz


### PR DESCRIPTION
Fixes [OADP-5275](https://issues.redhat.com//browse/OADP-5275) which ensures the controller manager has readOnlyRootFilesystem set to true.

## Why the changes were made

Fix [OADP-5275](https://issues.redhat.com//browse/OADP-5275)

## How to test the changes made

1. Deploy from the source
2. Ensure root fs in the `openshift-adp-controller-manager-*` pod is read only:
```shell
sh-5.1$ touch /testreadonly
touch: cannot touch '/testreadonly': Read-only file system

sh-5.1$ whoami
1000650000
```