### PR TITLE
OADP-5799: Pass log format to NAC controller

### DIFF
--- a/internal/controller/nonadmin_controller.go
+++ b/internal/controller/nonadmin_controller.go
@@ -170,6 +170,14 @@ func ensureRequiredSpecs(deploymentObject *appsv1.Deployment, dpa *oadpv1alpha1.
 			}(),
 		})
 	}
+
+	if len(dpa.Spec.LogFormat) > 0 {
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  common.LogFormatEnvVar,
+			Value: string(dpa.Spec.LogFormat),
+		})
+	}
+
 	if len(dpaResourceVersion) == 0 ||
 		!reflect.DeepEqual(dpa.Spec.NonAdmin, previousNonAdminConfiguration) ||
 		(dpa.Spec.Configuration.Velero.Args != nil &&

--- a/internal/controller/nonadmin_controller_test.go
+++ b/internal/controller/nonadmin_controller_test.go
@@ -308,6 +308,7 @@ func TestEnsureRequiredSpecs(t *testing.T) {
 			NonAdmin: &oadpv1alpha1.NonAdmin{
 				Enable: ptr.To(true),
 			},
+			LogFormat: oadpv1alpha1.LogFormatJSON,
 		},
 	}
 	err := ensureRequiredSpecs(deployment, dpa, defaultNonAdminImage, corev1.PullAlways)
@@ -335,6 +336,11 @@ func TestEnsureRequiredSpecs(t *testing.T) {
 				if env.Value != strconv.FormatUint(uint64(expectedLevel), 10) {
 					t.Errorf("log level unexpected")
 				}
+			}
+		}
+		if env.Name == common.LogFormatEnvVar {
+			if env.Value != string(oadpv1alpha1.LogFormatJSON) && env.Value != string(oadpv1alpha1.LogFormatText) {
+				t.Errorf("log format unexpected")
 			}
 		}
 	}

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -99,6 +99,7 @@ const (
 	HTTPSProxyEnvVar               = "HTTPS_PROXY"
 	NoProxyEnvVar                  = "NO_PROXY"
 	LogLevelEnvVar                 = "LOG_LEVEL"
+	LogFormatEnvVar                = "LOG_FORMAT"
 )
 
 // Unsupported Server Args annotation keys


### PR DESCRIPTION
## Why the changes were made

<!-- Explain why this PR is important, what problems it fixes, link related issues -->

Fixes https://issues.redhat.com/browse/OADP-5799
Depends on https://github.com/migtools/oadp-non-admin/pull/260
Fixes https://github.com/migtools/oadp-non-admin/issues/254

## How to test the changes made

<!-- Explain how the changes introduced by this PR can be tested and verified, with commands and pictures -->

- Try passing `logFormat` via DPA as `json` or `text`
- Check the NAC deployment/Pod for the value of `LOG_FORMAT` env var
- Finally, check the format of logs in NAC controller pod