### PR TITLE
fix: backport compatibility must-gather

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,5 +41,6 @@ debug.test*
 .envrc
 
 # must-gather
+must-gather/oadp-must-gather
 must-gather/must-gather/
 must-gather/must-gather.local.*/

--- a/must-gather/Dockerfile
+++ b/must-gather/Dockerfile
@@ -14,6 +14,7 @@ RUN go mod download
 
 COPY cmd/main.go cmd/main.go
 COPY pkg/ pkg/
+COPY deprecated/ deprecated/
 
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -mod=mod -a -o gather cmd/main.go
 
@@ -33,6 +34,7 @@ FROM registry.access.redhat.com/ubi9-minimal:latest
 RUN microdnf -y install rsync tar
 
 COPY --from=builder /workspace/gather /usr/bin/gather
+COPY --from=builder /workspace/deprecated/* /usr/bin/
 COPY --from=builder /kopia /usr/bin/kopia
 COPY --from=builder /restic /usr/bin/restic
 

--- a/must-gather/README.md
+++ b/must-gather/README.md
@@ -8,12 +8,12 @@ go run cmd/main.go
 
 To test OADP Must-gather with `oc adm must-gather`, run
 ```sh
-podman build -t ttl.sh/oadp/must-gather-$(git rev-parse --short HEAD)-$(echo $RANDOM) -f Dockerfile . --platform=<cluster-architecture>
+podman build -t ttl.sh/oadp/must-gather-$(git rev-parse --short HEAD)-$(echo $RANDOM):1h -f Dockerfile . --platform=<cluster-architecture>
 podman push <this-image>
 oc adm must-gather --image=<this-image> -- /usr/bin/gather -h
 oc adm must-gather --image=<this-image>
 ```
-TODO mention e2e tests
+TODO mention e2e tests!
 
 To test omg tool, create `omg.Dockerfile` file
 ```Dockerfile
@@ -71,3 +71,7 @@ go mod verify
 ```
 
 > **Note:** If it is a minor release, `mustGatherImage` must also be updated.
+
+## Deprecated folder
+
+Scripts under `deprecated/` folder are for backwards compatibility with old OADP Must-gather shell script. Users should use new OADP Must-gather Go script, as highlighted in product documentation.

--- a/must-gather/deprecated/gather_1h
+++ b/must-gather/deprecated/gather_1h
@@ -1,0 +1,5 @@
+#!/bin/bash
+echo "This script is not supported anymore, use /usr/bin/gather instead"
+echo "/usr/bin/gather help"
+/usr/bin/gather -h
+exit 1

--- a/must-gather/deprecated/gather_1h_essential
+++ b/must-gather/deprecated/gather_1h_essential
@@ -1,0 +1,5 @@
+#!/bin/bash
+echo "This script is not supported anymore, use /usr/bin/gather instead"
+echo "/usr/bin/gather help"
+/usr/bin/gather -h
+exit 1

--- a/must-gather/deprecated/gather_24h
+++ b/must-gather/deprecated/gather_24h
@@ -1,0 +1,5 @@
+#!/bin/bash
+echo "This script is not supported anymore, use /usr/bin/gather instead"
+echo "/usr/bin/gather help"
+/usr/bin/gather -h
+exit 1

--- a/must-gather/deprecated/gather_24h_essential
+++ b/must-gather/deprecated/gather_24h_essential
@@ -1,0 +1,5 @@
+#!/bin/bash
+echo "This script is not supported anymore, use /usr/bin/gather instead"
+echo "/usr/bin/gather help"
+/usr/bin/gather -h
+exit 1

--- a/must-gather/deprecated/gather_6h
+++ b/must-gather/deprecated/gather_6h
@@ -1,0 +1,5 @@
+#!/bin/bash
+echo "This script is not supported anymore, use /usr/bin/gather instead"
+echo "/usr/bin/gather help"
+/usr/bin/gather -h
+exit 1

--- a/must-gather/deprecated/gather_6h_essential
+++ b/must-gather/deprecated/gather_6h_essential
@@ -1,0 +1,5 @@
+#!/bin/bash
+echo "This script is not supported anymore, use /usr/bin/gather instead"
+echo "/usr/bin/gather help"
+/usr/bin/gather -h
+exit 1

--- a/must-gather/deprecated/gather_72h
+++ b/must-gather/deprecated/gather_72h
@@ -1,0 +1,5 @@
+#!/bin/bash
+echo "This script is not supported anymore, use /usr/bin/gather instead"
+echo "/usr/bin/gather help"
+/usr/bin/gather -h
+exit 1

--- a/must-gather/deprecated/gather_72h_essential
+++ b/must-gather/deprecated/gather_72h_essential
@@ -1,0 +1,5 @@
+#!/bin/bash
+echo "This script is not supported anymore, use /usr/bin/gather instead"
+echo "/usr/bin/gather help"
+/usr/bin/gather -h
+exit 1

--- a/must-gather/deprecated/gather_all
+++ b/must-gather/deprecated/gather_all
@@ -1,0 +1,3 @@
+#!/bin/bash
+echo "This script is deprecated, use /usr/bin/gather instead"
+/usr/bin/gather

--- a/must-gather/deprecated/gather_all
+++ b/must-gather/deprecated/gather_all
@@ -1,3 +1,26 @@
 #!/bin/bash
 echo "This script is deprecated, use /usr/bin/gather instead"
+logs_since="${logs_since}"
+skip_tls="${skip_tls}"
+request_timeout="${request_timeout}"
+if [ ! -z "${logs_since}" ]; then
+    echo "logs_since variable is not supported anymore"
+    exit 1
+fi
+if [ ! -z "${skip_tls}" ] && [ ! -z "${request_timeout}" ]; then
+    echo "insecure-skip-tls-verify: ${skip_tls}"
+    echo "timeout: ${request_timeout}"
+    /usr/bin/gather --skip-tls=${skip_tls} --request-timeout=${request_timeout}
+    exit
+fi
+if [ ! -z "${skip_tls}" ]; then
+    echo "insecure-skip-tls-verify: ${skip_tls}"
+    /usr/bin/gather --skip-tls=${skip_tls}
+    exit
+fi
+if [ ! -z "${request_timeout}" ]; then
+    echo "timeout: ${request_timeout}"
+    /usr/bin/gather --request-timeout=${request_timeout}
+    exit
+fi
 /usr/bin/gather

--- a/must-gather/deprecated/gather_all_essential
+++ b/must-gather/deprecated/gather_all_essential
@@ -1,0 +1,5 @@
+#!/bin/bash
+echo "This script is not supported anymore, use /usr/bin/gather instead"
+echo "/usr/bin/gather help"
+/usr/bin/gather -h
+exit 1

--- a/must-gather/deprecated/gather_metrics_dump
+++ b/must-gather/deprecated/gather_metrics_dump
@@ -1,0 +1,5 @@
+#!/bin/bash
+echo "This script is not supported anymore, use /usr/bin/gather instead"
+echo "/usr/bin/gather help"
+/usr/bin/gather -h
+exit 1

--- a/must-gather/deprecated/gather_with_timeout
+++ b/must-gather/deprecated/gather_with_timeout
@@ -1,0 +1,4 @@
+#!/bin/bash
+echo "This script is deprecated, use /usr/bin/gather instead"
+echo "timeout: $1"
+/usr/bin/gather --request-timeout=$1

--- a/must-gather/deprecated/gather_with_timeout
+++ b/must-gather/deprecated/gather_with_timeout
@@ -1,4 +1,15 @@
 #!/bin/bash
 echo "This script is deprecated, use /usr/bin/gather instead"
+logs_since="${logs_since}"
+skip_tls="${skip_tls}"
 echo "timeout: $1"
+if [ ! -z "${logs_since}" ]; then
+    echo "logs_since variable is not supported anymore"
+    exit 1
+fi
+if [ ! -z "${skip_tls}" ]; then
+    echo "insecure-skip-tls-verify: ${skip_tls}"
+    /usr/bin/gather --request-timeout=$1 --skip-tls=${skip_tls}
+    exit
+fi
 /usr/bin/gather --request-timeout=$1

--- a/must-gather/deprecated/gather_without_tls
+++ b/must-gather/deprecated/gather_without_tls
@@ -1,4 +1,15 @@
 #!/bin/bash
 echo "This script is deprecated, use /usr/bin/gather instead"
 echo "insecure-skip-tls-verify: $1"
+logs_since="${logs_since}"
+request_timeout="${request_timeout}"
+if [ ! -z "${logs_since}" ]; then
+    echo "logs_since variable is not supported anymore"
+    exit 1
+fi
+if [ ! -z "${request_timeout}" ]; then
+    echo "timeout: ${request_timeout}"
+    /usr/bin/gather --skip-tls=$1 --request-timeout=${request_timeout}
+    exit
+fi
 /usr/bin/gather --skip-tls=$1

--- a/must-gather/deprecated/gather_without_tls
+++ b/must-gather/deprecated/gather_without_tls
@@ -1,0 +1,4 @@
+#!/bin/bash
+echo "This script is deprecated, use /usr/bin/gather instead"
+echo "insecure-skip-tls-verify: $1"
+/usr/bin/gather --skip-tls=$1

--- a/must-gather/pkg/cli.go
+++ b/must-gather/pkg/cli.go
@@ -44,7 +44,7 @@ var (
 		Use: fmt.Sprintf("oc adm must-gather --image=%[1]s -- /usr/bin/gather", mustGatherImage),
 		Long: `OADP Must-gather: a tool to collect information about OADP installation in a cluster, along with information about its custom resources and cluster storage.
 
-For more information, check OADP must-gather documentation: https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/backup_and_restore/oadp-application-backup-and-restore#migration-using-must-gather_oadp-troubleshooting`,
+For more information, check OADP must-gather documentation: https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/backup_and_restore/oadp-application-backup-and-restore#using-the-must-gather-tool`,
 		Args: cobra.NoArgs,
 		Example: fmt.Sprintf(`  # running OADP Must-gather with default configuration
   oc adm must-gather --image=%[1]s


### PR DESCRIPTION
## Why the changes were made

Allow users to use old style must-gather (with new must-gather). Also add error message to no longer supported scripts (instead of user just seeing file does not exist error).

## How to test the changes made

Follow https://github.com/openshift/oadp-operator/blob/master/must-gather/README.md to create a test image to use `oc adm must-gather` command

Read https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/backup_and_restore/oadp-application-backup-and-restore#using-the-must-gather-tool and see that you are able to run every command present in documentation

Also check https://github.com/openshift/oadp-operator/tree/oadp-1.4/must-gather code to see if other scripts must be added to deprecated folder
