### PR TITLE
bump to latest v1 linter prep for v2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,12 +140,21 @@ test: vet envtest ## Run unit tests; run Go linters checks; check if api and bun
 	@make bundle-isupdated
 	@make check-go-dependencies
 
+# Extract the toolchain directive from go.mod
+GO_TOOLCHAIN_VERSION := $(shell grep -E "^toolchain" go.mod | awk '{print $$2}')
+
+# Lint CLI needs to be built from the same toolchain version
 GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
-GOLANGCI_LINT_VERSION ?= v1.55.2
-.PHONY: golangci-lint
+GOLANGCI_LINT_VERSION ?= v1.64.8
+.PHONY: golangci-lint $(GOLANGCI_LINT)
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
-	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION))
+	@if [ -f $(GOLANGCI_LINT) ] && $(GOLANGCI_LINT) --version | grep -q $(GOLANGCI_LINT_VERSION); then \
+		echo "golangci-lint $(GOLANGCI_LINT_VERSION) is already installed"; \
+	else \
+		echo "Installing golangci-lint $(GOLANGCI_LINT_VERSION)"; \
+		$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)); \
+	fi
 
 .PHONY: lint
 lint: golangci-lint ## Run Go linters checks against all project's Go files.


### PR DESCRIPTION
Fixes #1719 upgrade to latest v1 linter which support go1.23

Signed-off-by: Tiger Kaovilai <tkaovila@redhat.com>

## Why the changes were made

<!-- Explain why this PR is important, what problems it fixes, link related issues -->

## How to test the changes made

<!-- Explain how the changes introduced by this PR can be tested and verified, with commands and pictures -->
