### PR TITLE
OADP-5960: Don't mount default creds if no BSLs or VSLs for provider

### DIFF
--- a/internal/controller/nodeagent.go
+++ b/internal/controller/nodeagent.go
@@ -592,12 +592,12 @@ func (r *DataProtectionApplicationReconciler) customizeNodeAgentDaemonset(ds *ap
 		ds.Spec.Template.Spec.DNSConfig = &dpa.Spec.PodDnsConfig
 	}
 
-	providerNeedsDefaultCreds, hasCloudStorage, err := r.noDefaultCredentials()
+	providerNeedsDefaultCreds, err := r.noDefaultCredentials()
 	if err != nil {
 		return nil, err
 	}
 
-	credentials.AppendCloudProviderVolumes(dpa, ds, providerNeedsDefaultCreds, hasCloudStorage)
+	credentials.AppendCloudProviderVolumes(dpa, ds, providerNeedsDefaultCreds)
 
 	setPodTemplateSpecDefaults(&ds.Spec.Template)
 	if ds.Spec.UpdateStrategy.Type == appsv1.RollingUpdateDaemonSetStrategyType {

--- a/internal/controller/nodeagent_test.go
+++ b/internal/controller/nodeagent_test.go
@@ -1173,17 +1173,9 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 					},
 				},
 			),
-			clientObjects:      []client.Object{testGenericInfrastructure},
-			nodeAgentDaemonSet: testNodeAgentDaemonSet.DeepCopy(),
-			wantNodeAgentDaemonSet: createTestBuiltNodeAgentDaemonSet(TestBuiltNodeAgentDaemonSetOptions{
-				volumes: []corev1.Volume{deploymentVolumeSecret("cloud-credentials")},
-				volumeMounts: []corev1.VolumeMount{
-					{Name: "cloud-credentials", MountPath: "/credentials"},
-				},
-				env: []corev1.EnvVar{
-					{Name: common.AWSSharedCredentialsFileEnvKey, Value: "/credentials/cloud"},
-				},
-			}),
+			clientObjects:          []client.Object{testGenericInfrastructure},
+			nodeAgentDaemonSet:     testNodeAgentDaemonSet.DeepCopy(),
+			wantNodeAgentDaemonSet: createTestBuiltNodeAgentDaemonSet(TestBuiltNodeAgentDaemonSetOptions{}),
 		},
 		{
 			name: "valid DPA CR with aws and kubevirt plugin, NodeAgent DaemonSet is built",
@@ -1204,17 +1196,9 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 					},
 				},
 			),
-			clientObjects:      []client.Object{testGenericInfrastructure},
-			nodeAgentDaemonSet: testNodeAgentDaemonSet.DeepCopy(),
-			wantNodeAgentDaemonSet: createTestBuiltNodeAgentDaemonSet(TestBuiltNodeAgentDaemonSetOptions{
-				volumes: []corev1.Volume{deploymentVolumeSecret("cloud-credentials")},
-				volumeMounts: []corev1.VolumeMount{
-					{Name: "cloud-credentials", MountPath: "/credentials"},
-				},
-				env: []corev1.EnvVar{
-					{Name: common.AWSSharedCredentialsFileEnvKey, Value: "/credentials/cloud"},
-				},
-			}),
+			clientObjects:          []client.Object{testGenericInfrastructure},
+			nodeAgentDaemonSet:     testNodeAgentDaemonSet.DeepCopy(),
+			wantNodeAgentDaemonSet: createTestBuiltNodeAgentDaemonSet(TestBuiltNodeAgentDaemonSetOptions{}),
 		},
 		{
 			name: "valid DPA CR with disabled FS backup, NodeAgent DaemonSet is built",
@@ -1239,13 +1223,6 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 			nodeAgentDaemonSet: testNodeAgentDaemonSet.DeepCopy(),
 			wantNodeAgentDaemonSet: createTestBuiltNodeAgentDaemonSet(TestBuiltNodeAgentDaemonSetOptions{
 				disableFsBackup: ptr.To(true),
-				volumes:         []corev1.Volume{deploymentVolumeSecret("cloud-credentials")},
-				volumeMounts: []corev1.VolumeMount{
-					{Name: "cloud-credentials", MountPath: "/credentials"},
-				},
-				env: []corev1.EnvVar{
-					{Name: common.AWSSharedCredentialsFileEnvKey, Value: "/credentials/cloud"},
-				},
 			}),
 		},
 		{

--- a/internal/controller/velero_test.go
+++ b/internal/controller/velero_test.go
@@ -1639,13 +1639,6 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 			veleroDeployment: testVeleroDeployment.DeepCopy(),
 			wantVeleroDeployment: createTestBuiltVeleroDeployment(TestBuiltVeleroDeploymentOptions{
 				initContainers: []corev1.Container{pluginContainer(common.VeleroPluginForAWS, common.AWSPluginImage)},
-				volumes:        []corev1.Volume{deploymentVolumeSecret("cloud-credentials")},
-				volumeMounts: []corev1.VolumeMount{
-					{Name: "cloud-credentials", MountPath: "/credentials"},
-				},
-				env: append(baseEnvVars, []corev1.EnvVar{
-					{Name: common.AWSSharedCredentialsFileEnvKey, Value: "/credentials/cloud"},
-				}...),
 				args: []string{
 					defaultFileSystemBackupTimeout,
 					defaultRestoreResourcePriorities,
@@ -1670,13 +1663,6 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 			veleroDeployment: testVeleroDeployment.DeepCopy(),
 			wantVeleroDeployment: createTestBuiltVeleroDeployment(TestBuiltVeleroDeploymentOptions{
 				initContainers: []corev1.Container{pluginContainer(common.VeleroPluginForLegacyAWS, common.LegacyAWSPluginImage)},
-				volumes:        []corev1.Volume{deploymentVolumeSecret("cloud-credentials")},
-				volumeMounts: []corev1.VolumeMount{
-					{Name: "cloud-credentials", MountPath: "/credentials"},
-				},
-				env: append(baseEnvVars, []corev1.EnvVar{
-					{Name: common.AWSSharedCredentialsFileEnvKey, Value: "/credentials/cloud"},
-				}...),
 				args: []string{
 					defaultFileSystemBackupTimeout,
 					defaultRestoreResourcePriorities,
@@ -1705,13 +1691,6 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 					pluginContainer(common.VeleroPluginForAWS, common.AWSPluginImage),
 					pluginContainer(common.KubeVirtPlugin, common.KubeVirtPluginImage),
 				},
-				volumes: []corev1.Volume{deploymentVolumeSecret("cloud-credentials")},
-				volumeMounts: []corev1.VolumeMount{
-					{Name: "cloud-credentials", MountPath: "/credentials"},
-				},
-				env: append(baseEnvVars, []corev1.EnvVar{
-					{Name: common.AWSSharedCredentialsFileEnvKey, Value: "/credentials/cloud"},
-				}...),
 				args: []string{
 					defaultFileSystemBackupTimeout,
 					defaultRestoreResourcePriorities,
@@ -1740,13 +1719,6 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 					pluginContainer(common.VeleroPluginForAWS, common.AWSPluginImage),
 					pluginContainer(common.HypershiftPlugin, common.HypershiftPluginImage),
 				},
-				volumes: []corev1.Volume{deploymentVolumeSecret("cloud-credentials")},
-				volumeMounts: []corev1.VolumeMount{
-					{Name: "cloud-credentials", MountPath: "/credentials"},
-				},
-				env: append(baseEnvVars, []corev1.EnvVar{
-					{Name: common.AWSSharedCredentialsFileEnvKey, Value: "/credentials/cloud"},
-				}...),
 				args: []string{
 					defaultFileSystemBackupTimeout,
 					defaultRestoreResourcePriorities,
@@ -2311,11 +2283,10 @@ func TestDPAReconciler_noDefaultCredentials(t *testing.T) {
 		dpa oadpv1alpha1.DataProtectionApplication
 	}
 	tests := []struct {
-		name                string
-		args                args
-		want                map[string]bool
-		wantHasCloudStorage bool
-		wantErr             bool
+		name    string
+		args    args
+		want    map[string]bool
+		wantErr bool
 	}{
 		{
 			name: "dpa with all plugins but with noDefaultBackupLocation should not require default credentials",
@@ -2340,8 +2311,7 @@ func TestDPAReconciler_noDefaultCredentials(t *testing.T) {
 				"gcp":   false,
 				"azure": false,
 			},
-			wantHasCloudStorage: false,
-			wantErr:             false,
+			wantErr: false,
 		},
 		{
 			name: "dpa no default cloudprovider plugins should not require default credentials",
@@ -2361,9 +2331,8 @@ func TestDPAReconciler_noDefaultCredentials(t *testing.T) {
 					},
 				},
 			},
-			want:                map[string]bool{},
-			wantHasCloudStorage: false,
-			wantErr:             false,
+			want:    map[string]bool{},
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {
@@ -2376,16 +2345,13 @@ func TestDPAReconciler_noDefaultCredentials(t *testing.T) {
 				Client: fakeClient,
 				dpa:    &tt.args.dpa,
 			}
-			got, got1, err := r.noDefaultCredentials()
+			got, err := r.noDefaultCredentials()
 			if (err != nil) != tt.wantErr {
 				t.Errorf("DataProtectionApplicationReconciler.noDefaultCredentials() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("DataProtectionApplicationReconciler.noDefaultCredentials() got = \n%v, \nwant \n%v", got, tt.want)
-			}
-			if got1 != tt.wantHasCloudStorage {
-				t.Errorf("DataProtectionApplicationReconciler.noDefaultCredentials() got1 = %v, want %v", got1, tt.wantHasCloudStorage)
 			}
 		})
 	}

--- a/pkg/credentials/credentials.go
+++ b/pkg/credentials/credentials.go
@@ -200,7 +200,7 @@ func GetPluginImage(defaultPlugin oadpv1alpha1.DefaultPlugin, dpa *oadpv1alpha1.
 	return ""
 }
 
-func AppendCloudProviderVolumes(dpa *oadpv1alpha1.DataProtectionApplication, ds *appsv1.DaemonSet, providerNeedsDefaultCreds map[string]bool, hasCloudStorage bool) {
+func AppendCloudProviderVolumes(dpa *oadpv1alpha1.DataProtectionApplication, ds *appsv1.DaemonSet, providerNeedsDefaultCreds map[string]bool) {
 	var nodeAgentContainer *corev1.Container
 	for i, container := range ds.Spec.Template.Spec.Containers {
 		if container.Name == common.NodeAgent {
@@ -217,11 +217,7 @@ func AppendCloudProviderVolumes(dpa *oadpv1alpha1.DataProtectionApplication, ds 
 			(!dpa.Spec.Configuration.Velero.NoDefaultBackupLocation || // it has a backup location in OADP/velero context OR
 				dpa.Spec.UnsupportedOverrides[oadpv1alpha1.OperatorTypeKey] == oadpv1alpha1.OperatorTypeMTC) { // OADP is installed via MTC
 
-			pluginNeedsCheck, foundProviderPlugin := providerNeedsDefaultCreds[cloudProviderMap.ProviderName]
-			// duplication with controllers/validator.go
-			if !foundProviderPlugin && !hasCloudStorage {
-				pluginNeedsCheck = true
-			}
+			pluginNeedsCheck := providerNeedsDefaultCreds[cloudProviderMap.ProviderName]
 
 			if !cloudProviderMap.IsCloudProvider || !pluginNeedsCheck {
 				continue


### PR DESCRIPTION
## Why the changes were made

OADP should only mount the default creds if they're needed for a BSL or VSL. Current logic is mounting default creds if either the provider has no BSLs/VSLs or there's at least one BSL/VSL whihc needs it. This PR drops the mount if there are no BSLs or VSLs at all.

Fixes [OADP-5960](https://issues.redhat.com//browse/OADP-5960)
<!-- Explain why this PR is important, what problems it fixes, link related issues -->

## How to test the changes made
Create a DPA with a single AWS backupLocation that uses named credentials. Add both aws and azure under defaultPlugins. Without this fix, /cloud-credentials-azure is mounted as a volume. With the fix, we won't get the mount.
To confirm that the fix doesn't break the "needs default creds" case, add an aws BSL with no credentials specified, and then you should see /cloud-credentials mounted.
(make sure cloud-credentials and cloud-credentials-azure secrets exist in order to test whether or not they mount properly)

<!-- Explain how the changes introduced by this PR can be tested and verified, with commands and pictures -->
