### PR TITLE
OADP-6019: Add emptyDir volume for tmp files to avoid readonly root filesystem issues.

### DIFF
--- a/bundle/manifests/oadp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/oadp-operator.clusterserviceversion.yaml
@@ -1164,6 +1164,8 @@ spec:
                 - mountPath: /var/run/secrets/openshift/serviceaccount
                   name: bound-sa-token
                   readOnly: true
+                - mountPath: /tmp
+                  name: tmp-dir
               securityContext:
                 runAsNonRoot: true
               serviceAccountName: openshift-adp-controller-manager
@@ -1176,6 +1178,8 @@ spec:
                       audience: openshift
                       expirationSeconds: 3600
                       path: token
+              - emptyDir: {}
+                name: tmp-dir
       permissions:
       - rules:
         - apiGroups:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -51,6 +51,8 @@ spec:
             - mountPath: /var/run/secrets/openshift/serviceaccount
               name: bound-sa-token
               readOnly: true
+            - mountPath: /tmp
+              name: tmp-dir
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -126,4 +128,6 @@ spec:
                   path: token
                   expirationSeconds: 3600
                   audience: openshift
+        - name: tmp-dir
+          emptyDir: {}
       terminationGracePeriodSeconds: 10

--- a/pkg/bucket/client.go
+++ b/pkg/bucket/client.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -91,7 +90,7 @@ func SharedCredentialsFileFromSecret(secret *corev1.Secret) (string, error) {
 		return "", errors.New("invalid secret for aws credentials")
 	}
 
-	f, err := ioutil.TempFile("", "aws-shared-credentials")
+	f, err := os.CreateTemp("", "aws-shared-credentials")
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
# [OADP-6019](https://issues.redhat.com//browse/OADP-6019): Add emptyDir volume for tmp files created by CCO flow for AWS STS
Regression from https://github.com/openshift/oadp-operator/pull/1679
## Why the changes were made

When using AWS STS authentication with the Cloud Credential Operator (CCO) flow, OADP fails to create temporary files needed for AWS credential handling. This occurs because the container is configured with `readOnlyRootFilesystem: true` for security, but the code attempts to create temporary files in `/tmp` using `os.CreateTemp()`.

The error seen in logs is:
```
ERROR unable to determine if bucket exists. {"error": "open /tmp/aws-shared-credentials1211864681: read-only file system"}
```


The changes address this issue by:
1. Adding a new emptyDir volume named `tmp-dir` to the controller pod specification
2. Adding a volume mount to the container that mounts this volume to `/tmp`
3. Maintaining `readOnlyRootFilesystem: true` for security best practices

Additionally, the PR includes code improvements:
- Replaced the deprecated `ioutil.TempFile()` function with the recommended `os.CreateTemp()` function
- Removed the unnecessary `io/ioutil` import since it's no longer needed

## How to test the changes made

1. Use an AWS STS Cluster
2. Install OADP using this branch (via `make deploy-olm` or DS build equivalent)
3. Install OADP from UI (remove existing installed CSV if any)
4. Verify that the UI prompts for ARN, proceed with installation
5. Create CloudStorage using secret from OADP created CredentialRequest and ensure error mentioned in JIRA is not found.
6. Create a backup to verify functionality