### PR TITLE
[master] OADP-6005: Set pinned version for hypershift-oadp-plugin on master

### DIFF
--- a/bundle/manifests/oadp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/oadp-operator.clusterserviceversion.yaml
@@ -1120,7 +1120,7 @@ spec:
                 - name: RELATED_IMAGE_KUBEVIRT_VELERO_PLUGIN
                   value: quay.io/konveyor/kubevirt-velero-plugin:v0.7.0
                 - name: RELATED_IMAGE_HYPERSHIFT_VELERO_PLUGIN
-                  value: quay.io/hypershift/hypershift-oadp-plugin:latest
+                  value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-oadp-plugin-main:latest
                 - name: RELATED_IMAGE_MUSTGATHER
                   value: registry.redhat.io/oadp/oadp-mustgather-rhel8:v1.2
                 - name: RELATED_IMAGE_NON_ADMIN_CONTROLLER
@@ -1281,7 +1281,7 @@ spec:
     name: velero-plugin-for-gcp
   - image: quay.io/konveyor/kubevirt-velero-plugin:v0.7.0
     name: kubevirt-velero-plugin
-  - image: quay.io/hypershift/hypershift-oadp-plugin:latest
+  - image: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-oadp-plugin-main:latest
     name: hypershift-velero-plugin
   - image: registry.redhat.io/oadp/oadp-mustgather-rhel8:v1.2
     name: mustgather

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -77,7 +77,7 @@ spec:
             - name: RELATED_IMAGE_KUBEVIRT_VELERO_PLUGIN
               value: quay.io/konveyor/kubevirt-velero-plugin:v0.7.0
             - name: RELATED_IMAGE_HYPERSHIFT_VELERO_PLUGIN
-              value: quay.io/hypershift/hypershift-oadp-plugin:latest
+              value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-oadp-plugin-main:latest
             - name: RELATED_IMAGE_MUSTGATHER
               value: registry.redhat.io/oadp/oadp-mustgather-rhel8:v1.2
             - name: RELATED_IMAGE_NON_ADMIN_CONTROLLER

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -75,7 +75,7 @@ const (
 	GCPPluginImage        = "quay.io/konveyor/velero-plugin-for-gcp:latest"
 	RegistryImage         = "quay.io/konveyor/registry:latest"
 	KubeVirtPluginImage   = "quay.io/konveyor/kubevirt-velero-plugin:v0.7.0"
-	HypershiftPluginImage = "quay.io/hypershift/hypershift-oadp-plugin:latest"
+	HypershiftPluginImage = "quay.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-oadp-plugin-main:latest"
 )
 
 // Plugin names

--- a/pkg/credentials/credentials_test.go
+++ b/pkg/credentials/credentials_test.go
@@ -464,9 +464,9 @@ func TestCredentials_getPluginImage(t *testing.T) {
 				},
 			},
 			pluginName: oadpv1alpha1.DefaultPluginHypershift,
-			wantImage:  "quay.io/hypershift/hypershift-oadp-plugin:latest",
+			wantImage:  "quay.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-oadp-plugin-main:latest",
 			setEnvVars: map[string]string{
-				"RELATED_IMAGE_HYPERSHIFT_VELERO_PLUGIN": "quay.io/hypershift/hypershift-oadp-plugin:latest",
+				"RELATED_IMAGE_HYPERSHIFT_VELERO_PLUGIN": "quay.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-oadp-plugin-main:latest",
 			},
 		},
 	}

--- a/tests/e2e/lib/hcp/dpa.go
+++ b/tests/e2e/lib/hcp/dpa.go
@@ -41,7 +41,7 @@ func (h *HCHandler) AddHCPPluginToDPA(namespace, name string, overrides bool) er
 
 	if overrides {
 		dpa.Spec.UnsupportedOverrides = map[oadpv1alpha1.UnsupportedImageKey]string{
-			oadpv1alpha1.HypershiftPluginImageKey: "quay.io/hypershift/hypershift-oadp-plugin:latest",
+			oadpv1alpha1.HypershiftPluginImageKey: "quay.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-oadp-plugin-main:latest",
 		}
 	}
 

--- a/tests/e2e/lib/hcp/dpa_test.go
+++ b/tests/e2e/lib/hcp/dpa_test.go
@@ -146,7 +146,7 @@ func TestRemoveHCPPluginFromDPA(t *testing.T) {
 						},
 					},
 					UnsupportedOverrides: map[oadpv1alpha1.UnsupportedImageKey]string{
-						oadpv1alpha1.HypershiftPluginImageKey: "quay.io/hypershift/hypershift-oadp-plugin:latest",
+						oadpv1alpha1.HypershiftPluginImageKey: "quay.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-oadp-plugin-main:latest",
 					},
 				},
 			},


### PR DESCRIPTION
## Why the changes were made
- Moving from `hypershift-oadp-plugin:latest` tag to the multiarch imaeg built on Konflux just for upstream for master branch.
- Tag: `quay.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-oadp-plugin-main:latest`

## Agreements and Context
- The Multiarch image for downstream is being built via CPaaS for now until they move to Konflux definitively.
- The Multiarch image for upstream is being built via Konflux.
