### PR TITLE
use golang 1.23.x for 1.3

### DIFF
--- a/must-gather/go.mod
+++ b/must-gather/go.mod
@@ -1,8 +1,8 @@
 module github.com/openshift/oadp-operator/must-gather
 
-go 1.24.0
+go 1.23.1
 
-toolchain go1.24.2
+toolchain go1.23.4
 
 require (
 	github.com/kubernetes-csi/external-snapshotter/client/v4 v4.2.0


### PR DESCRIPTION
## Why the changes were made

We accidentally used golang 1.24 for the mustgather go mod and did a crappy job reviewing :)
Including myself in that.
