### PR TITLE
OADP-5275 init plugin containers to have read only fs

### DIFF
--- a/internal/controller/velero.go
+++ b/internal/controller/velero.go
@@ -464,6 +464,11 @@ func (r *DataProtectionApplicationReconciler) appendPluginSpecificSpecs(veleroDe
 							Name:      "plugins",
 						},
 					},
+					SecurityContext: &corev1.SecurityContext{
+						ReadOnlyRootFilesystem:   ptr.To(true),
+						Privileged:               ptr.To(false),
+						AllowPrivilegeEscalation: ptr.To(false),
+					},
 				})
 
 			pluginNeedsCheck := providerNeedsDefaultCreds[pluginSpecificMap.ProviderName]
@@ -528,6 +533,11 @@ func (r *DataProtectionApplicationReconciler) appendPluginSpecificSpecs(veleroDe
 							MountPath: "/target",
 							Name:      "plugins",
 						},
+					},
+					SecurityContext: &corev1.SecurityContext{
+						ReadOnlyRootFilesystem:   ptr.To(true),
+						Privileged:               ptr.To(false),
+						AllowPrivilegeEscalation: ptr.To(false),
 					},
 				})
 		}

--- a/internal/controller/velero_test.go
+++ b/internal/controller/velero_test.go
@@ -323,6 +323,11 @@ var _ = ginkgo.Describe("Test ReconcileVeleroDeployment function", func() {
 
 func pluginContainer(name, image string) corev1.Container {
 	container := baseContainer
+	container.SecurityContext = &corev1.SecurityContext{
+		ReadOnlyRootFilesystem:   ptr.To(true),
+		Privileged:               ptr.To(false),
+		AllowPrivilegeEscalation: ptr.To(false),
+	}
 	container.Name = name
 	container.Image = image
 	return container


### PR DESCRIPTION
This adds ReadOnlyRootFilesystem to the init containers (plugins)

Also additional security context flags are applied to ensure the init containers are using:
 - ReadOnlyRootFilesystem: true
 - Privileged: false
 - AllowPrivilegeEscalation: false

## Why the changes were made

Fix [OADP-5275](https://issues.redhat.com//browse/OADP-5275)

## How to test the changes made

Deploy operator, run DPA with plugins, check the yaml of the init containers to set the above flags.