### PR TITLE
Fix velero container to have explicit ReadOnlyRootFilesystem

### DIFF
--- a/internal/controller/velero_test.go
+++ b/internal/controller/velero_test.go
@@ -94,10 +94,12 @@ var (
 	}
 
 	baseVolumeMounts = []corev1.VolumeMount{
-		{Name: "plugins", MountPath: "/plugins"},
+		{Name: "plugins", MountPath: "/plugins", ReadOnly: true},
 		{Name: "scratch", MountPath: "/scratch"},
 		{Name: "certs", MountPath: "/etc/ssl/certs"},
 		{Name: "bound-sa-token", MountPath: "/var/run/secrets/openshift/serviceaccount", ReadOnly: true},
+		{Name: "tmp", MountPath: "/tmp"},
+		{Name: "home", MountPath: "/home/velero"},
 	}
 
 	baseVolumes = []corev1.Volume{
@@ -111,6 +113,14 @@ var (
 		},
 		{
 			Name:         "certs",
+			VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+		},
+		{
+			Name:         "tmp",
+			VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+		},
+		{
+			Name:         "home",
 			VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
 		},
 		{
@@ -417,6 +427,11 @@ func createTestBuiltVeleroDeployment(options TestBuiltVeleroDeploymentOptions) *
 							ImagePullPolicy:          corev1.PullAlways,
 							TerminationMessagePath:   "/dev/termination-log",
 							TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+							SecurityContext: &corev1.SecurityContext{
+								ReadOnlyRootFilesystem:   ptr.To(true),
+								Privileged:               ptr.To(false),
+								AllowPrivilegeEscalation: ptr.To(false),
+							},
 							Ports: []corev1.ContainerPort{{
 								Name:          "metrics",
 								ContainerPort: 8085,


### PR DESCRIPTION
Depends-on #1752 

## Why the changes were made

<!-- Explain why this PR is important, what problems it fixes, link related issues -->

Similar to https://github.com/openshift/oadp-operator/pull/1752

This PR is for the Velero container.

## How to test the changes made

Deploy, check YML of the velero container as well sh to the running velero container and see:
```shell
sh-5.1$ touch /testme
touch: cannot touch '/testme': Read-only file system
sh-5.1$ touch /plugins/testme
touch: cannot touch '/plugins/testme': Read-only file system
sh-5.1$ ls /plugins
velero-plugin-for-aws  velero-plugins
sh-5.1$ touch ~/testme
sh-5.1$ ls -lah ~/testme
-rw-r--r--. 1 1000660000 1000660000 0 May 13 08:08 /home/velero/testme
```
