### PR TITLE
Konflux branch protection PR

### DIFF
--- a/.tekton/oadp-must-gather-oadp-1-5-pull-request.yaml
+++ b/.tekton/oadp-must-gather-oadp-1-5-pull-request.yaml
@@ -246,20 +246,20 @@ spec:
       - name: LABELS
         value:
         - $(tasks.generate-labels.results.labels[*])
+        - License=ASL 2.0
+        - com.redhat.component=oadp-mustgather-container
         - description=OpenShift API for Data Protection data gathering image
+        - io.k8s.description=Migration Toolkit for Containers Hook Runner
+        - io.k8s.display-name=OpenShift API for Data Protection - mustgather
+        - io.openshift.build.source-location=https://github.com/openshift/oadp-operator
+        - io.openshift.expose-services=
+        - io.openshift.tags=data,images
+        - maintainer=OpenShift API for Data Protection Team <oadp-team@redhat.com>
         - name=oadp/oadp-mustgather-rhel9
+        - summary=OpenShift API for Data Protection data gathering image
         - url=https://github.com/openshift/oadp-operator
         - vendor=Red Hat, Inc.
-        - summary=OpenShift API for Data Protection data gathering image
-        - maintainer=OpenShift API for Data Protection Team <oadp-team@redhat.com>
-        - com.redhat.component=oadp-mustgather-container
         - version=1.5.1
-        - License=ASL 2.0
-        - io.openshift.expose-services=''
-        - io.k8s.display-name=OpenShift API for Data Protection - mustgather
-        - io.openshift.tags=data,images
-        - io.k8s.description=Migration Toolkit for Containers Hook Runner
-        - io.openshift.build.source-location=https://github.com/openshift/oadp-operator
       runAfter:
       - prefetch-dependencies
       taskRef:

--- a/.tekton/oadp-must-gather-oadp-1-5-push.yaml
+++ b/.tekton/oadp-must-gather-oadp-1-5-push.yaml
@@ -243,20 +243,20 @@ spec:
       - name: LABELS
         value:
         - $(tasks.generate-labels.results.labels[*])
+        - License=ASL 2.0
+        - com.redhat.component=oadp-mustgather-container
         - description=OpenShift API for Data Protection data gathering image
+        - io.k8s.description=Migration Toolkit for Containers Hook Runner
+        - io.k8s.display-name=OpenShift API for Data Protection - mustgather
+        - io.openshift.build.source-location=https://github.com/openshift/oadp-operator
+        - io.openshift.expose-services=
+        - io.openshift.tags=data,images
+        - maintainer=OpenShift API for Data Protection Team <oadp-team@redhat.com>
         - name=oadp/oadp-mustgather-rhel9
+        - summary=OpenShift API for Data Protection data gathering image
         - url=https://github.com/openshift/oadp-operator
         - vendor=Red Hat, Inc.
-        - summary=OpenShift API for Data Protection data gathering image
-        - maintainer=OpenShift API for Data Protection Team <oadp-team@redhat.com>
-        - com.redhat.component=oadp-mustgather-container
         - version=1.5.1
-        - License=ASL 2.0
-        - io.openshift.expose-services=''
-        - io.k8s.display-name=OpenShift API for Data Protection - mustgather
-        - io.openshift.tags=data,images
-        - io.k8s.description=Migration Toolkit for Containers Hook Runner
-        - io.openshift.build.source-location=https://github.com/openshift/oadp-operator
       runAfter:
       - prefetch-dependencies
       taskRef:

--- a/.tekton/oadp-operator-oadp-1-5-pull-request.yaml
+++ b/.tekton/oadp-operator-oadp-1-5-pull-request.yaml
@@ -32,6 +32,10 @@ spec:
     - linux/x86_64
   - name: dockerfile
     value: Dockerfile.oadp
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '[{"type": "gomod", "path": "."}, {"type": "rpm", "path": "."}]'
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.
@@ -182,6 +186,8 @@ spec:
         workspace: git-auth
     - name: prefetch-dependencies
       params:
+      - name: dev-package-managers
+        value: "true"
       - name: input
         value: $(params.prefetch-input)
       - name: SOURCE_ARTIFACT

--- a/.tekton/oadp-operator-oadp-1-5-pull-request.yaml
+++ b/.tekton/oadp-operator-oadp-1-5-pull-request.yaml
@@ -28,6 +28,9 @@ spec:
     value: 5d
   - name: build-platforms
     value:
+    - linux/arm64
+    - linux/ppc64le
+    - linux/s390x
     - linux/x86_64
   - name: dockerfile
     value: Dockerfile.oadp

--- a/.tekton/oadp-operator-oadp-1-5-pull-request.yaml
+++ b/.tekton/oadp-operator-oadp-1-5-pull-request.yaml
@@ -243,6 +243,20 @@ spec:
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       - name: IMAGE_APPEND_PLATFORM
         value: "true"
+      - name: LABELS
+        value:
+        - $(tasks.generate-labels.results.labels[*])
+        - License=Apache License 2.0
+        - com.redhat.component=oadp-operator-container
+        - io.k8s.description=OpenShift API for Data Protection - Operator
+        - io.k8s.display-name=OADP Operator
+        - io.openshift.build.source-location=https://github.com/openshift/oadp-operator
+        - io.openshift.tags=migration
+        - maintainer=OpenShift API for Data Protection Team <oadp-team@redhat.com>
+        - name=oadp/oadp-rhel9-operator
+        - summary=OpenShift API for Data Protection - Operator
+        - vendor=Red Hat, Inc.
+        - version=1.5.1
       runAfter:
       - prefetch-dependencies
       taskRef:
@@ -618,7 +632,7 @@ spec:
         - build-date=$SOURCE_DATE
         - short-commit=$(tasks.clone-repository.results.short-commit)
         - io.openshift.build.commit.id=$(tasks.clone-repository.results.commit)
-        - io.openshift.build.commit.url=https://github.com/UPDATE_ORG/UPDATE_REPO/commit/$(tasks.clone-repository.results.commit)
+        - io.openshift.build.commit.url=https://github.com/openshift/oadp-operator/commit/$(tasks.clone-repository.results.commit)
         - release=$ACTUAL_DATE_EPOCH
       - name: source-date-epoch
         value: $(tasks.clone-repository.results.commit-timestamp)

--- a/.tekton/oadp-operator-oadp-1-5-pull-request.yaml
+++ b/.tekton/oadp-operator-oadp-1-5-pull-request.yaml
@@ -8,9 +8,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "oadp-1.5"
-  creationTimestamp: null
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "oadp-1.5"
+  creationTimestamp:
   labels:
     appstudio.openshift.io/application: oadp-operator
     appstudio.openshift.io/component: oadp-operator-oadp-1-5
@@ -68,13 +67,11 @@ spec:
       name: output-image
       type: string
     - default: .
-      description: Path to the source code of an application's component from where
-        to build image.
+      description: Path to the source code of an application's component from where to build image.
       name: path-context
       type: string
     - default: Dockerfile
-      description: Path to the Dockerfile inside the context specified by parameter
-        path-context
+      description: Path to the Dockerfile inside the context specified by parameter path-context
       name: dockerfile
       type: string
     - default: "false"
@@ -94,8 +91,7 @@ spec:
       name: prefetch-input
       type: string
     - default: ""
-      description: Image tag expiration time, time values could be something like
-        1h, 2d, 3w for hours, days, and weeks, respectively.
+      description: Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
     - default: "false"
       description: Build a source image.
@@ -114,14 +110,12 @@ spec:
       name: build-args-file
       type: string
     - default: "false"
-      description: Whether to enable privileged mode, should be used only with remote
-        VMs
+      description: Whether to enable privileged mode, should be used only with remote VMs
       name: privileged-nested
       type: string
     - default:
       - linux/x86_64
-      description: List of platforms to build the container images on. The available
-        set of values is determined by the configuration of the multi-platform-controller.
+      description: List of platforms to build the container images on. The available set of values is determined by the configuration of the multi-platform-controller.
       name: build-platforms
       type: array
     results:
@@ -555,6 +549,9 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: IMAGE_DIGEST
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: ADDITIONAL_TAGS
+        value:
+        - 'pull-request-{{pull_request_number}}'
       runAfter:
       - build-image-index
       taskRef:
@@ -611,6 +608,28 @@ spec:
         operator: in
         values:
         - "false"
+    - name: generate-labels
+      params:
+      - name: label-templates
+        value:
+        - build-date=$SOURCE_DATE
+        - short-commit=$(tasks.clone-repository.results.short-commit)
+        - io.openshift.build.commit.id=$(tasks.clone-repository.results.commit)
+        - io.openshift.build.commit.url=https://github.com/UPDATE_ORG/UPDATE_REPO/commit/$(tasks.clone-repository.results.commit)
+        - release=$ACTUAL_DATE_EPOCH
+      - name: source-date-epoch
+        value: $(tasks.clone-repository.results.commit-timestamp)
+      runAfter:
+      - clone-repository
+      taskRef:
+        params:
+        - name: name
+          value: generate-labels
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-generate-labels:0.1@sha256:e1f4746dc33206a17867ead8f5c82a569cd925d352a19d108f205f54efc5589d
+        - name: kind
+          value: task
+        resolver: bundles
     workspaces:
     - name: git-auth
       optional: true

--- a/.tekton/oadp-operator-oadp-1-5-push.yaml
+++ b/.tekton/oadp-operator-oadp-1-5-push.yaml
@@ -29,6 +29,10 @@ spec:
     - linux/x86_64
   - name: dockerfile
     value: Dockerfile.oadp
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '[{"type": "gomod", "path": "."}, {"type": "rpm", "path": "."}]'
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.
@@ -179,6 +183,8 @@ spec:
         workspace: git-auth
     - name: prefetch-dependencies
       params:
+      - name: dev-package-managers
+        value: "true"
       - name: input
         value: $(params.prefetch-input)
       - name: SOURCE_ARTIFACT

--- a/.tekton/oadp-operator-oadp-1-5-push.yaml
+++ b/.tekton/oadp-operator-oadp-1-5-push.yaml
@@ -7,9 +7,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "oadp-1.5"
-  creationTimestamp: null
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "oadp-1.5"
+  creationTimestamp:
   labels:
     appstudio.openshift.io/application: oadp-operator
     appstudio.openshift.io/component: oadp-operator-oadp-1-5
@@ -65,13 +64,11 @@ spec:
       name: output-image
       type: string
     - default: .
-      description: Path to the source code of an application's component from where
-        to build image.
+      description: Path to the source code of an application's component from where to build image.
       name: path-context
       type: string
     - default: Dockerfile
-      description: Path to the Dockerfile inside the context specified by parameter
-        path-context
+      description: Path to the Dockerfile inside the context specified by parameter path-context
       name: dockerfile
       type: string
     - default: "false"
@@ -91,8 +88,7 @@ spec:
       name: prefetch-input
       type: string
     - default: ""
-      description: Image tag expiration time, time values could be something like
-        1h, 2d, 3w for hours, days, and weeks, respectively.
+      description: Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
     - default: "false"
       description: Build a source image.
@@ -111,14 +107,12 @@ spec:
       name: build-args-file
       type: string
     - default: "false"
-      description: Whether to enable privileged mode, should be used only with remote
-        VMs
+      description: Whether to enable privileged mode, should be used only with remote VMs
       name: privileged-nested
       type: string
     - default:
       - linux/x86_64
-      description: List of platforms to build the container images on. The available
-        set of values is determined by the configuration of the multi-platform-controller.
+      description: List of platforms to build the container images on. The available set of values is determined by the configuration of the multi-platform-controller.
       name: build-platforms
       type: array
     results:
@@ -552,6 +546,11 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: IMAGE_DIGEST
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: ADDITIONAL_TAGS
+        value:
+        - '1.5'
+        - '1.5.1'
+        - 'latest'
       runAfter:
       - build-image-index
       taskRef:
@@ -608,6 +607,28 @@ spec:
         operator: in
         values:
         - "false"
+    - name: generate-labels
+      params:
+      - name: label-templates
+        value:
+        - build-date=$SOURCE_DATE
+        - short-commit=$(tasks.clone-repository.results.short-commit)
+        - io.openshift.build.commit.id=$(tasks.clone-repository.results.commit)
+        - io.openshift.build.commit.url=https://github.com/UPDATE_ORG/UPDATE_REPO/commit/$(tasks.clone-repository.results.commit)
+        - release=$ACTUAL_DATE_EPOCH
+      - name: source-date-epoch
+        value: $(tasks.clone-repository.results.commit-timestamp)
+      runAfter:
+      - clone-repository
+      taskRef:
+        params:
+        - name: name
+          value: generate-labels
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-generate-labels:0.1@sha256:e1f4746dc33206a17867ead8f5c82a569cd925d352a19d108f205f54efc5589d
+        - name: kind
+          value: task
+        resolver: bundles
     workspaces:
     - name: git-auth
       optional: true

--- a/.tekton/oadp-operator-oadp-1-5-push.yaml
+++ b/.tekton/oadp-operator-oadp-1-5-push.yaml
@@ -25,6 +25,9 @@ spec:
     value: quay.io/redhat-user-workloads/ocp-art-tenant/oadp-operator-oadp-1-5:{{revision}}
   - name: build-platforms
     value:
+    - linux/arm64
+    - linux/ppc64le
+    - linux/s390x
     - linux/x86_64
   - name: dockerfile
     value: Dockerfile.oadp

--- a/.tekton/oadp-operator-oadp-1-5-push.yaml
+++ b/.tekton/oadp-operator-oadp-1-5-push.yaml
@@ -240,6 +240,20 @@ spec:
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       - name: IMAGE_APPEND_PLATFORM
         value: "true"
+      - name: LABELS
+        value:
+        - $(tasks.generate-labels.results.labels[*])
+        - License=Apache License 2.0
+        - com.redhat.component=oadp-operator-container
+        - io.k8s.description=OpenShift API for Data Protection - Operator
+        - io.k8s.display-name=OADP Operator
+        - io.openshift.build.source-location=https://github.com/openshift/oadp-operator
+        - io.openshift.tags=migration
+        - maintainer=OpenShift API for Data Protection Team <oadp-team@redhat.com>
+        - name=oadp/oadp-rhel9-operator
+        - summary=OpenShift API for Data Protection - Operator
+        - vendor=Red Hat, Inc.
+        - version=1.5.1
       runAfter:
       - prefetch-dependencies
       taskRef:
@@ -617,7 +631,7 @@ spec:
         - build-date=$SOURCE_DATE
         - short-commit=$(tasks.clone-repository.results.short-commit)
         - io.openshift.build.commit.id=$(tasks.clone-repository.results.commit)
-        - io.openshift.build.commit.url=https://github.com/UPDATE_ORG/UPDATE_REPO/commit/$(tasks.clone-repository.results.commit)
+        - io.openshift.build.commit.url=https://github.com/openshift/oadp-operator/commit/$(tasks.clone-repository.results.commit)
         - release=$ACTUAL_DATE_EPOCH
       - name: source-date-epoch
         value: $(tasks.clone-repository.results.commit-timestamp)

--- a/Dockerfile.oadp
+++ b/Dockerfile.oadp
@@ -12,17 +12,3 @@ WORKDIR /
 COPY --from=builder /workspace/bin/manager .
 USER 65532:65532
 ENTRYPOINT ["/manager"]
-
-LABEL \
-        com.redhat.component="oadp-operator-container" \
-        version="1.5.1" \
-        name="oadp/oadp-rhel9-operator" \
-        License="Apache License 2.0" \
-        io.k8s.display-name="OADP Operator" \
-        io.openshift.tags="migration" \
-        io.k8s.description="OpenShift API for Data Protection - Operator" \
-        io.openshift.build.commit.id="06f6e887bdb5700980a89d10518acc67b92b5837" \
-        io.openshift.build.source-location="https://github.com/openshift/oadp-operator" \
-        io.openshift.build.commit.url="https://github.com/openshift/oadp-operator/commit/06f6e887bdb5700980a89d10518acc67b92b5837" \
-        summary="OpenShift API for Data Protection - Operator" \
-        maintainer="OpenShift API for Data Protection Team <oadp-team@redhat.com>"


### PR DESCRIPTION
Unlike every instance prior to this one, branch protection rules are preventing me from pushing directly to this branch. :smirk: 

```
Total 23 (delta 19), reused 0 (delta 0), pack-reused 0 (from 0)
remote: Resolving deltas: 100% (19/19), completed with 5 local objects.
remote: error: GH006: Protected branch update failed for refs/heads/konflux-oadp-operator-oadp-1-5.
remote: 
remote: - Changes must be made through a pull request.
To github.com:openshift/oadp-operator.git
 ! [remote rejected]   konflux-oadp-operator-oadp-1-5 -> konflux-oadp-operator-oadp-1-5 (protected branch hook declined)
error: failed to push some refs to 'github.com:openshift/oadp-operator.git'
```