### PR TITLE
OADP-5973, OADP-3340, OADP-6212: AWS, GCP, Azure Standardized Flow Implementation (oadp-1.5 backport)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,5 +14,4 @@ cache
 ./*.yaml
 OWNERS
 PROJECT
-LICENSE
 Dockerfile

--- a/Makefile
+++ b/Makefile
@@ -447,7 +447,162 @@ deploy-olm: undeploy-olm ## Build current branch operator image, bundle image, p
 undeploy-olm: login-required operator-sdk ## Uninstall current branch operator via OLM
 	$(OC_CLI) whoami # Check if logged in
 	$(OC_CLI) create namespace $(OADP_TEST_NAMESPACE) || true
-	$(OPERATOR_SDK) cleanup oadp-operator --namespace $(OADP_TEST_NAMESPACE)
+	-$(OPERATOR_SDK) cleanup oadp-operator --namespace $(OADP_TEST_NAMESPACE) || true
+	# Also try to clean up any leftover resources
+	-$(OC_CLI) delete subscription oadp-operator -n $(OADP_TEST_NAMESPACE) --ignore-not-found=true
+	-$(OC_CLI) get subscription -n $(OADP_TEST_NAMESPACE) -o name | xargs -I {} $(OC_CLI) get {} -n $(OADP_TEST_NAMESPACE) -o jsonpath='{.metadata.name}{"\t"}{.spec.source}{"\n"}' | grep "oadp-operator-catalog" | cut -f1 | xargs -I {} $(OC_CLI) delete subscription {} -n $(OADP_TEST_NAMESPACE) --ignore-not-found=true
+	-$(OC_CLI) delete csv -l operators.coreos.com/oadp-operator.$(OADP_TEST_NAMESPACE) -n $(OADP_TEST_NAMESPACE) --ignore-not-found=true
+	-$(OC_CLI) delete catalogsource oadp-operator-catalog -n $(OADP_TEST_NAMESPACE) --ignore-not-found=true
+
+# Create subscription YAML helper function
+# Parameters:
+#   $(1) - Path to the subscription YAML file to create (e.g., /tmp/oadp-gcp-subscription.yaml)
+create-sts-subscription = \
+	echo "apiVersion: operators.coreos.com/v1alpha1" > $(1) && \
+	echo "kind: Subscription" >> $(1) && \
+	echo "metadata:" >> $(1) && \
+	echo "  name: oadp-operator" >> $(1) && \
+	echo "  namespace: $(OADP_TEST_NAMESPACE)" >> $(1) && \
+	echo "spec:" >> $(1) && \
+	echo "  channel: operator-sdk-run-bundle" >> $(1) && \
+	echo "  name: oadp-operator" >> $(1) && \
+	echo "  source: oadp-operator-catalog" >> $(1) && \
+	echo "  sourceNamespace: $(OADP_TEST_NAMESPACE)" >> $(1) && \
+	echo "  installPlanApproval: Automatic" >> $(1) && \
+	echo "  config:" >> $(1) && \
+	echo "    env:" >> $(1)
+
+# Apply subscription and wait for ready helper function
+# Parameters:
+#   $(1) - Path to the subscription YAML file to apply (e.g., /tmp/oadp-gcp-subscription.yaml)
+#   $(2) - Cloud provider descriptive name for status messages (e.g., "GCP WIF", "AWS STS", "Azure Workload Identity")
+apply-sts-subscription = \
+	$(OC_CLI) apply -f $(1) && \
+	rm -f $(1) && \
+	echo "" && \
+	echo "Subscription created with $(2) environment variables." && \
+	echo "Waiting for operator to be ready..." && \
+	echo "Waiting for InstallPlan to be created..." && \
+	timeout=60; \
+	while [ $$timeout -gt 0 ]; do \
+		INSTALL_PLAN=$$($(OC_CLI) get subscription oadp-operator -n $(OADP_TEST_NAMESPACE) -o jsonpath='{.status.installPlanRef.name}' 2>/dev/null); \
+		if [ -n "$$INSTALL_PLAN" ]; then \
+			echo "InstallPlan $$INSTALL_PLAN found"; \
+			break; \
+		fi; \
+		echo -n "."; \
+		sleep 2; \
+		timeout=$$((timeout-2)); \
+	done; \
+	if [ $$timeout -le 0 ]; then \
+		echo "Timeout waiting for InstallPlan"; \
+		exit 1; \
+	fi; \
+	echo "Waiting for CSV to exist..."; \
+	timeout=120; \
+	while [ $$timeout -gt 0 ]; do \
+		CSV_NAME=$$($(OC_CLI) get subscription oadp-operator -n $(OADP_TEST_NAMESPACE) -o jsonpath='{.status.currentCSV}' 2>/dev/null); \
+		if [ -n "$$CSV_NAME" ]; then \
+			if $(OC_CLI) get csv/$$CSV_NAME -n $(OADP_TEST_NAMESPACE) >/dev/null 2>&1; then \
+				echo "CSV $$CSV_NAME found"; \
+				break; \
+			fi; \
+		fi; \
+		echo -n "."; \
+		sleep 2; \
+		timeout=$$((timeout-2)); \
+	done; \
+	if [ $$timeout -le 0 ]; then \
+		echo "Timeout waiting for CSV to exist"; \
+		exit 1; \
+	fi; \
+	echo "Waiting for CSV to be ready..."; \
+	if [ -n "$$CSV_NAME" ]; then \
+		$(OC_CLI) wait --for=jsonpath='{.status.phase}'=Succeeded csv/$$CSV_NAME -n $(OADP_TEST_NAMESPACE) --timeout=300s; \
+	fi; \
+	echo "Operator is ready!"; \
+	$(OC_CLI) get subscription oadp-operator -n $(OADP_TEST_NAMESPACE); \
+	$(OC_CLI) get csv -n $(OADP_TEST_NAMESPACE)
+
+.PHONY: deploy-olm-stsflow
+deploy-olm-stsflow: deploy-olm ## Deploy via OLM then uninstall CSV/Subscription and provide console URL for standardized flow
+	@echo "Uninstalling CSV and Subscription to trigger standardized flow UI..."
+	-$(OC_CLI) get subscription -n $(OADP_TEST_NAMESPACE) -o name | xargs -I {} $(OC_CLI) get {} -n $(OADP_TEST_NAMESPACE) -o jsonpath='{.metadata.name}{"\t"}{.spec.source}{"\n"}' | grep "oadp-operator-catalog" | cut -f1 | xargs -I {} $(OC_CLI) delete subscription {} -n $(OADP_TEST_NAMESPACE) --ignore-not-found=true
+	-$(OC_CLI) delete csv oadp-operator.v$(VERSION) -n $(OADP_TEST_NAMESPACE) --ignore-not-found=true
+	@echo ""
+	@echo "==========================================================================="
+	@echo "Open the following URL in your browser to trigger the standardized flow UI:"
+	@echo ""
+	@CONSOLE_URL=$$($(OC_CLI) get route console -n openshift-console -o jsonpath='{.spec.host}'); \
+	echo "https://$$CONSOLE_URL/operatorhub/ns/$(OADP_TEST_NAMESPACE)?keyword=oadp-operator&details-item=oadp-operator-oadp-operator-catalog-$(OADP_TEST_NAMESPACE)&channel=operator-sdk-run-bundle&version=$(VERSION)"
+	@echo ""
+	@echo "==========================================================================="
+
+.PHONY: deploy-olm-stsflow-gcp
+deploy-olm-stsflow-gcp: deploy-olm-stsflow ## Deploy via OLM with GCP WIF standardized flow and create subscription with GCP env vars
+	@if [ -n "$(GCP_PROJECT_NUM)" ] && [ -n "$(GCP_POOL_ID)" ] && [ -n "$(GCP_PROVIDER_ID)" ] && [ -n "$(GCP_SA_EMAIL)" ]; then \
+		echo "Creating subscription with GCP WIF environment variables..."; \
+		$(call create-sts-subscription,/tmp/oadp-gcp-subscription.yaml); \
+		echo "    - name: PROJECT_NUMBER" >> /tmp/oadp-gcp-subscription.yaml; \
+		echo "      value: \"$(GCP_PROJECT_NUM)\"" >> /tmp/oadp-gcp-subscription.yaml; \
+		echo "    - name: POOL_ID" >> /tmp/oadp-gcp-subscription.yaml; \
+		echo "      value: \"$(GCP_POOL_ID)\"" >> /tmp/oadp-gcp-subscription.yaml; \
+		echo "    - name: PROVIDER_ID" >> /tmp/oadp-gcp-subscription.yaml; \
+		echo "      value: \"$(GCP_PROVIDER_ID)\"" >> /tmp/oadp-gcp-subscription.yaml; \
+		echo "    - name: SERVICE_ACCOUNT_EMAIL" >> /tmp/oadp-gcp-subscription.yaml; \
+		echo "      value: \"$(GCP_SA_EMAIL)\"" >> /tmp/oadp-gcp-subscription.yaml; \
+		$(call apply-sts-subscription,/tmp/oadp-gcp-subscription.yaml,GCP WIF); \
+	else \
+		echo ""; \
+		echo "GCP WIF environment variables not set. Please set all of the following:"; \
+		echo "  GCP_PROJECT_NUM"; \
+		echo "  GCP_POOL_ID"; \
+		echo "  GCP_PROVIDER_ID"; \
+		echo "  GCP_SA_EMAIL"; \
+		echo ""; \
+		echo "Example:"; \
+		echo "  make deploy-olm-stsflow-gcp GCP_PROJECT_NUM=123456789 GCP_POOL_ID=my-pool GCP_PROVIDER_ID=my-provider GCP_SA_EMAIL=my-sa@my-project.iam.gserviceaccount.com"; \
+	fi
+
+.PHONY: deploy-olm-stsflow-aws
+deploy-olm-stsflow-aws: deploy-olm-stsflow ## Deploy via OLM with AWS STS standardized flow and create subscription with AWS env vars
+	@if [ -n "$(AWS_ROLE_ARN)" ]; then \
+		echo "Creating subscription with AWS STS environment variables..."; \
+		$(call create-sts-subscription,/tmp/oadp-aws-subscription.yaml); \
+		echo "    - name: ROLEARN" >> /tmp/oadp-aws-subscription.yaml; \
+		echo "      value: \"$(AWS_ROLE_ARN)\"" >> /tmp/oadp-aws-subscription.yaml; \
+		$(call apply-sts-subscription,/tmp/oadp-aws-subscription.yaml,AWS STS); \
+	else \
+		echo ""; \
+		echo "AWS STS environment variable not set. Please set:"; \
+		echo "  AWS_ROLE_ARN"; \
+		echo ""; \
+		echo "Example:"; \
+		echo "  make deploy-olm-stsflow-aws AWS_ROLE_ARN=arn:aws:iam::123456789012:role/my-oadp-role"; \
+	fi
+
+.PHONY: deploy-olm-stsflow-azure
+deploy-olm-stsflow-azure: deploy-olm-stsflow ## Deploy via OLM with Azure Workload Identity standardized flow and create subscription with Azure env vars
+	@if [ -n "$(AZURE_CLIENT_ID)" ] && [ -n "$(AZURE_TENANT_ID)" ] && [ -n "$(AZURE_SUBSCRIPTION_ID)" ]; then \
+		echo "Creating subscription with Azure Workload Identity environment variables..."; \
+		$(call create-sts-subscription,/tmp/oadp-azure-subscription.yaml); \
+		echo "    - name: CLIENTID" >> /tmp/oadp-azure-subscription.yaml; \
+		echo "      value: \"$(AZURE_CLIENT_ID)\"" >> /tmp/oadp-azure-subscription.yaml; \
+		echo "    - name: TENANTID" >> /tmp/oadp-azure-subscription.yaml; \
+		echo "      value: \"$(AZURE_TENANT_ID)\"" >> /tmp/oadp-azure-subscription.yaml; \
+		echo "    - name: SUBSCRIPTIONID" >> /tmp/oadp-azure-subscription.yaml; \
+		echo "      value: \"$(AZURE_SUBSCRIPTION_ID)\"" >> /tmp/oadp-azure-subscription.yaml; \
+		$(call apply-sts-subscription,/tmp/oadp-azure-subscription.yaml,Azure Workload Identity); \
+	else \
+		echo ""; \
+		echo "Azure Workload Identity environment variables not set. Please set all of the following:"; \
+		echo "  AZURE_CLIENT_ID"; \
+		echo "  AZURE_TENANT_ID"; \
+		echo "  AZURE_SUBSCRIPTION_ID"; \
+		echo ""; \
+		echo "Example:"; \
+		echo "  make deploy-olm-stsflow-azure AZURE_CLIENT_ID=12345678-1234-1234-1234-123456789012 AZURE_TENANT_ID=87654321-4321-4321-4321-210987654321 AZURE_SUBSCRIPTION_ID=abcdef12-3456-7890-abcd-ef1234567890"; \
+	fi
 
 # A valid Git branch from https://github.com/openshift/oadp-operator
 PREVIOUS_CHANNEL ?= oadp-1.4

--- a/bundle/manifests/oadp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/oadp-operator.clusterserviceversion.yaml
@@ -279,8 +279,8 @@ metadata:
     features.operators.openshift.io/proxy-aware: "true"
     features.operators.openshift.io/tls-profiles: "false"
     features.operators.openshift.io/token-auth-aws: "true"
-    features.operators.openshift.io/token-auth-azure: "false"
-    features.operators.openshift.io/token-auth-gcp: "false"
+    features.operators.openshift.io/token-auth-azure: "true"
+    features.operators.openshift.io/token-auth-gcp: "true"
     olm.skipRange: '>=0.0.0 <1.5.0'
     operatorframework.io/suggested-namespace: openshift-adp
     operators.openshift.io/infrastructure-features: '["Disconnected"]'

--- a/config/manifests/bases/oadp-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/oadp-operator.clusterserviceversion.yaml
@@ -18,8 +18,8 @@ metadata:
     features.operators.openshift.io/proxy-aware: "true"
     features.operators.openshift.io/tls-profiles: "false"
     features.operators.openshift.io/token-auth-aws: "true"
-    features.operators.openshift.io/token-auth-azure: "false"
-    features.operators.openshift.io/token-auth-gcp: "false"
+    features.operators.openshift.io/token-auth-azure: "true"
+    features.operators.openshift.io/token-auth-gcp: "true"
     olm.skipRange: '>=0.0.0 <1.5.0'
     operatorframework.io/suggested-namespace: openshift-adp
     operators.openshift.io/infrastructure-features: '["Disconnected"]'

--- a/docs/standardized-flow-implementation.md
+++ b/docs/standardized-flow-implementation.md
@@ -1,0 +1,739 @@
+# Standardized Flow Implementation for OADP Operator
+
+This document outlines the implementation of the standardized authentication workflow for OADP Operator, supporting AWS STS, Azure Workload Identity, and GCP Workload Identity Federation (WIF).
+
+## Overview
+
+The OADP Operator implements a standardized authentication flow that provides secure authentication mechanisms across multiple cloud providers by leveraging short-lived tokens instead of long-lived credentials. This implementation follows the standardized authentication workflow defined in OpenShift Enhancement Proposal #1800 and supports:
+
+- **AWS**: Security Token Service (STS) with IAM roles
+- **Azure**: Workload Identity with managed identities
+- **GCP**: Workload Identity Federation (WIF) with service account impersonation
+
+## Implementation Details
+
+The OADP Operator implements a standardized workflow for short-lived token authentication across AWS, Azure, and GCP cloud providers. This standardized approach conforms to [OpenShift Enhancement Proposal #1800](https://github.com/openshift/enhancements/pull/1800) and is triggered during operator startup to create the necessary secrets for authentication.
+
+The key benefits of this approach include:
+
+- **Enhanced Security**: Uses short-lived tokens instead of long-lived credentials
+- **Simplified Management**: Direct secret creation without external dependencies
+- **Consistent Experience**: Same workflow pattern across all supported cloud providers
+- **OpenShift Integration**: Leverages OpenShift service account tokens for authentication
+
+### 1. Environment Variables and Configuration
+
+The operator detects cloud provider configuration through environment variables provided during OLM installation. Each cloud provider has specific environment variables that must be provided for the standardized flow to be triggered:
+
+- **Cloud Provider Detection**: The operator automatically detects which cloud provider configuration is present based on the provided environment variables
+- **OLM Integration**: Environment variables are set during operator installation through the OpenShift Console
+- **Single Provider**: Only one cloud provider's credentials should be configured at a time
+
+Specific environment variables for each cloud provider are detailed in the cloud-specific sections below.
+
+### 2. Standardized Credential Flow
+
+The `STSStandardizedFlow()` function in the `stsflow` package handles credential creation for all supported cloud providers:
+
+
+```go
+func STSStandardizedFlow() (string, error) {
+    // AWS STS environment variables
+    roleARN := os.Getenv(RoleARNEnvKey)
+
+    // GCP WIF environment variables
+    serviceAccountEmail := os.Getenv(ServiceAccountEmailEnvKey)
+    projectNumber := os.Getenv(ProjectNumberEnvKey)
+    poolId := os.Getenv(PoolIDEnvKey)
+    providerId := os.Getenv(ProviderId)
+
+    // Azure environment variables
+    clientID := os.Getenv(ClientIDEnvKey)
+    tenantID := os.Getenv(TenantIDEnvKey)
+    subscriptionID := os.Getenv(SubscriptionIDEnvKey)
+
+    // Check if any cloud provider credentials are provided
+    hasAWSCreds := len(roleARN) > 0
+    hasGCPCreds := len(serviceAccountEmail) > 0 &&
+        len(projectNumber) > 0 && len(poolId) > 0 && len(providerId) > 0
+    hasAzureCreds := len(clientID) > 0 && len(tenantID) > 0 && len(subscriptionID) > 0
+
+    // If no credentials are provided, return nil
+    if !hasAWSCreds && !hasGCPCreds && !hasAzureCreds {
+        return "", nil
+    }
+
+    // Create appropriate secret based on cloud provider
+    if hasAWSCreds {
+        if err := CreateOrUpdateSTSAWSSecret(logger, roleARN, installNS, kcfg); err != nil {
+            return "", err
+        }
+        return VeleroAWSSecretName, nil
+    } else if hasGCPCreds {
+        if err := CreateOrUpdateSTSGCPSecret(logger, serviceAccountEmail, projectNumber,
+                                             poolId, providerId, installNS, kcfg); err != nil {
+            return "", err
+        }
+        return VeleroGCPSecretName, nil
+    } else if hasAzureCreds {
+        if err := CreateOrUpdateSTSAzureSecret(logger, clientID, tenantID,
+                                               subscriptionID, installNS, kcfg); err != nil {
+            return "", err
+        }
+        return VeleroAzureSecretName, nil
+    }
+
+    return "", nil
+}
+```
+
+### 3. Cloud Provider Secret Creation
+
+The operator creates cloud-specific secrets using a common `CreateOrUpdateSTSSecret` function, but with different credential formats for each provider:
+
+- **Unified Interface**: All cloud providers use the same secret creation function with provider-specific credential data
+- **Secret Naming**: Each provider uses a distinct secret name pattern for easy identification
+- **Token Integration**: All providers leverage the OpenShift service account token at `/var/run/secrets/openshift/serviceaccount/token`
+- **Atomic Operations**: Secrets are created or updated atomically to ensure consistency
+
+The specific secret formats and implementations for each cloud provider are detailed in the cloud-specific sections below.
+
+### 4. Secret Creation and Management
+
+The `CreateOrUpdateSTSSecret` function handles Secret creation and updates for all cloud providers:
+
+
+```go
+func CreateOrUpdateSTSSecret(setupLog logr.Logger, credStringData map[string]string,
+                            secretNS string, kubeconf *rest.Config) error {
+    // Determine secret name based on the cloud provider
+    secretName := getSecretNameFromCredentials(credStringData)
+
+    secret := corev1.Secret{
+        ObjectMeta: metav1.ObjectMeta{
+            Name:      secretName,  // e.g., "cloud-credentials", "cloud-credentials-gcp", "cloud-credentials-azure"
+            Namespace: secretNS,
+        },
+        StringData: credStringData,
+    }
+
+    // Create the secret, or update if it already exists
+    if err := clientInstance.Create(context.Background(), &secret); err != nil {
+        if errors.IsAlreadyExists(err) {
+            // Update existing secret
+            // ... patch logic ...
+        }
+    }
+
+    // Secret is now available for use by Velero
+}
+```
+
+The function automatically determines the appropriate secret name based on the cloud provider:
+
+- AWS: `cloud-credentials`
+- Azure: `cloud-credentials-azure`
+- GCP: `cloud-credentials-gcp`
+
+### 5. Integration with the Operator
+
+The standardized flow is integrated at multiple points:
+
+#### a. Operator Startup (main.go)
+
+
+```go
+// Create Secret and wait for STS cred to exists
+if _, err := stsflow.STSStandardizedFlow(); err != nil {
+    setupLog.Error(err, "error setting up STS Standardized Flow")
+    os.Exit(1)
+}
+```
+
+#### b. CloudStorage Controller
+
+The CloudStorage controller also calls `STSStandardizedFlow()` to ensure secrets exist before creating cloud storage:
+
+
+```go
+// check if STSStandardizedFlow was successful
+if secretName, err = stsflow.STSStandardizedFlow(); err != nil {
+    r.Log.Error(err, "unable to check for STS creds secret")
+    return ctrl.Result{}, err
+}
+```
+
+### 6. Secret Names and Content
+
+The implementation uses consistent secret naming and content patterns:
+
+| Cloud Provider | Secret Name | Secret Keys | Content Type |
+|----------------|-------------|-------------|---------------|
+| AWS | `cloud-credentials` | `credentials` | AWS credentials file format |
+| Azure | `cloud-credentials-azure` | `cloud`, `subscriptionId`, `tenantId`, `clientId` | Individual key-value pairs |
+| GCP | `cloud-credentials-gcp` | `service_account.json` | GCP external account JSON |
+
+These secrets are created directly by the operator without dependency on external operators like the Cloud Credentials Operator (CCO).
+
+## Usage Instructions
+
+### Prerequisites
+
+#### AWS STS Prerequisites
+
+1. **OpenShift cluster with AWS STS enabled**
+   - Cluster must be installed with manual credentials mode
+   - Reference: [Installing a cluster on AWS with short-term credentials](https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html-single/installing_on_aws/index#installing-aws-with-short-term-creds_installing-aws-customizations)
+
+2. **AWS IAM Role with required permissions**
+
+   - Create an IAM role with trust policy for the OpenShift service account
+   - Attach policies with S3 and EC2 permissions for backup operations
+   - Note the Role ARN for installation
+
+#### Azure Workload Identity Prerequisites
+
+1. **OpenShift cluster with Azure Workload Identity enabled**
+   - Cluster must be installed with manual credentials mode
+   - Reference: [Installing a cluster on Azure with short-term credentials](https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html-single/installing_on_azure/#installing-azure-with-short-term-creds_installing-azure-customizations)
+
+2. **Azure Managed Identity with required permissions**
+
+   - Create a managed identity with Storage Blob Data Contributor role
+   - Note the Client ID, Tenant ID, and Subscription ID
+
+#### GCP WIF Prerequisites
+
+1. **OpenShift cluster with GCP Workload Identity Federation enabled**
+   - Cluster must be installed with manual credentials mode
+   - Workload Identity Pool and Provider must be configured
+   - Reference: [Installing a cluster on GCP with short-term credentials](https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html-single/installing_on_gcp/#installing-gcp-with-short-term-creds_installing-gcp-customizations)
+   - Prepare the following information from your cluster:
+     - GCP Project Number
+     - Workload Identity Pool
+     - Workload Identity Provider
+
+2. **GCP Service Account with required permissions**
+
+   - Create a service account in your GCP project with the following roles:
+
+     ```text
+     compute.disks.create
+     compute.disks.createSnapshot
+     compute.disks.get
+     compute.snapshots.create
+     compute.snapshots.delete
+     compute.snapshots.get
+     compute.snapshots.useReadOnly
+     compute.zones.get
+     iam.serviceAccounts.signBlob
+     storage.objects.create
+     storage.objects.delete
+     storage.objects.get
+     storage.objects.list
+     ```
+
+   - Note the Service Account email for the next steps
+
+3. **Grant necessary permissions for GCP**
+
+   Grant the `system:serviceaccount:openshift-adp:velero` service account the `roles/iam.serviceAccountTokenCreator` role:
+   ```bash
+   gcloud iam service-accounts add-iam-policy-binding <SERVICE_ACCOUNT_EMAIL> \
+     --project=<YOUR_PROJECT> \
+     --role=roles/iam.serviceAccountTokenCreator \
+     --member="principal://iam.googleapis.com/projects/<PROJECT_NUMBER>/locations/global/workloadIdentityPools/<POOL_ID>/subject/system:serviceaccount:openshift-adp:velero"
+   ```
+
+   Also bind the service account to the workload identity for the controller manager:
+   ```bash
+   gcloud iam service-accounts add-iam-policy-binding \
+     <SERVICE_ACCOUNT_EMAIL> \
+     --role roles/iam.workloadIdentityUser \
+     --member "principal://iam.googleapis.com/projects/<PROJECT_NUMBER>/locations/global/workloadIdentityPools/<POOL_ID>/subject/system:serviceaccount:openshift-adp:openshift-adp-controller-manager"
+   ```
+
+### Installation Steps
+
+The installation process is similar for all cloud providers, with cloud-specific configuration provided through the OpenShift Console.
+
+1. **Install OADP Operator via OLM**
+
+   For testing the operator from source:
+   ```bash
+   make deploy-olm && oc delete csv -n openshift-adp oadp-operator.v99.0.0
+   ```
+
+   Then install via the console with the appropriate cloud provider parameter:
+
+   **For AWS:**
+   ```bash
+   $(BROWSER) $(oc whoami --show-console)/operatorhub/subscribe?pkg=oadp-operator&catalog=oadp-operator-catalog&catalogNamespace=openshift-adp&targetNamespace=openshift-adp&channel=operator-sdk-run-bundle&version=99.0.0&tokenizedAuth=AWS
+   ```
+
+   **For Azure:**
+   ```bash
+   $(BROWSER) $(oc whoami --show-console)/operatorhub/subscribe?pkg=oadp-operator&catalog=oadp-operator-catalog&catalogNamespace=openshift-adp&targetNamespace=openshift-adp&channel=operator-sdk-run-bundle&version=99.0.0&tokenizedAuth=Azure
+   ```
+
+   **For GCP:**
+   ```bash
+   $(BROWSER) $(oc whoami --show-console)/operatorhub/subscribe?pkg=oadp-operator&catalog=oadp-operator-catalog&catalogNamespace=openshift-adp&targetNamespace=openshift-adp&channel=operator-sdk-run-bundle&version=99.0.0&tokenizedAuth=GCP
+   ```
+
+   > **Tip:** The URL contains `&tokenizedAuth=<CLOUD>` which allows you to test the secret creation functionality even on a cluster without the specific cloud provider configuration. You can input dummy data and see the secret created for testing purposes.
+
+   When installing through the OpenShift Console, you'll be prompted to provide cloud-specific configuration:
+
+   **AWS Configuration:**
+   - **Role ARN**: The AWS IAM role ARN to assume
+
+   **Azure Configuration:**
+   - **Client ID**: Azure managed identity client ID
+   - **Tenant ID**: Azure tenant ID
+   - **Subscription ID**: Azure subscription ID
+
+   **GCP Configuration:**
+   - **GCP Project Number**: Your GCP project number
+   - **Pool ID**: The workload identity pool ID
+   - **Provider ID**: The workload identity provider ID
+   - **Service Account Email**: The email of the GCP service account to impersonate
+
+   These values will be set as environment variables on the operator deployment.
+
+2. **Verify Secret Creation**
+
+   After installation, verify that the secret was created by the operator:
+
+   **For AWS:**
+   ```bash
+   oc get secret cloud-credentials -n openshift-adp
+   oc extract secret/cloud-credentials -n openshift-adp --to=-
+   ```
+
+   **For Azure:**
+   ```bash
+   oc get secret cloud-credentials-azure -n openshift-adp
+   oc describe secret cloud-credentials-azure -n openshift-adp
+   ```
+
+   **For GCP:**
+   ```bash
+   oc get secret cloud-credentials-gcp -n openshift-adp
+   oc extract secret/cloud-credentials-gcp -n openshift-adp --to=-
+   ```
+
+   The secrets should contain the appropriate configuration for each cloud provider's authentication mechanism.
+
+3. **Create Data Protection Application (DPA)**
+
+   **AWS DPA Example:**
+   ```yaml
+   apiVersion: oadp.openshift.io/v1alpha1
+   kind: DataProtectionApplication
+   metadata:
+     name: dpa-aws
+     namespace: openshift-adp
+   spec:
+     configuration:
+       velero:
+         defaultPlugins:
+         - openshift
+         - aws
+     backupLocations:
+       - velero:
+           provider: aws
+           default: true
+           credential:
+             key: credentials
+             name: cloud-credentials
+           config:
+             region: us-east-1  # REQUIRED: Must specify region here
+           objectStorage:
+             bucket: <bucket_name>
+             prefix: <prefix>
+   ```
+
+   **Azure DPA Example:**
+   ```yaml
+   apiVersion: oadp.openshift.io/v1alpha1
+   kind: DataProtectionApplication
+   metadata:
+     name: dpa-azure
+     namespace: openshift-adp
+   spec:
+     configuration:
+       velero:
+         defaultPlugins:
+         - openshift
+         - azure
+     backupLocations:
+       - velero:
+           provider: azure
+           default: true
+           credential:
+             key: cloud
+             name: cloud-credentials-azure
+           config:
+             resourceGroup: <resource_group>
+             storageAccount: <storage_account>
+           objectStorage:
+             bucket: <container_name>
+             prefix: <prefix>
+   ```
+
+   **GCP DPA Example:**
+   ```yaml
+   apiVersion: oadp.openshift.io/v1alpha1
+   kind: DataProtectionApplication
+   metadata:
+     name: dpa-gcp
+     namespace: openshift-adp
+   spec:
+     configuration:
+       velero:
+         defaultPlugins:
+         - openshift
+         - gcp
+     backupLocations:
+       - velero:
+           provider: gcp
+           default: true
+           credential:
+             key: service_account.json
+             name: cloud-credentials-gcp
+           objectStorage:
+             bucket: <bucket_name>
+             prefix: <prefix>
+   ```
+
+### Testing the Installation
+
+1. Create a test backup:
+   ```bash
+   velero backup create test-backup --include-namespaces=<namespace>
+   ```
+
+2. Verify the backup completed:
+   ```bash
+   velero backup describe test-backup
+   ```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Secret not created**
+   - Check operator logs: `oc logs -n openshift-adp deployment/openshift-adp-controller-manager`
+   - Verify all environment variables are set correctly on the operator deployment
+   - Ensure the cloud provider credentials/identities have the correct permissions
+   - The operator creates the secret directly without relying on external operators
+
+2. **Authentication failures**
+
+   **AWS:**
+   - Verify the IAM role trust policy includes the OpenShift service account
+   - Check that the role ARN is correctly formatted
+   - Ensure the token file exists at `/var/run/secrets/openshift/serviceaccount/token`
+
+   **Azure:**
+   - Verify the managed identity is correctly assigned
+   - Check that all Azure IDs (client, tenant, subscription) are valid
+   - Ensure the federated identity credential is configured
+
+   **GCP:**
+   - Verify the workload identity binding is correct
+   - Check that the audience URL is properly formatted
+   - Ensure the token file exists at `/var/run/secrets/openshift/serviceaccount/token`
+
+3. **Backup failures**
+   - Verify the storage bucket/container exists and is accessible
+   - Check that the cloud identity has appropriate storage permissions
+   - Review Velero pod logs for detailed error messages
+   - Ensure the DPA configuration matches your cloud provider setup
+
+## Key Differences from CCO-based Approach
+
+This implementation follows the standardized authentication workflow (OEP #1800) and differs from CCO-based approaches:
+
+1. **Direct Secret Creation**: The operator creates credentials secrets directly without requiring CredentialsRequest resources
+2. **Environment Variable Configuration**: Authentication parameters are provided via environment variables during operator installation
+3. **No External Dependencies**: The operator handles all credential management internally without relying on the Cloud Credentials Operator
+4. **Standardized Workflow**: Uses the same pattern across AWS STS, GCP WIF, and Azure for consistency
+
+## Cloud-Specific Implementation Details
+
+### AWS STS Implementation
+
+#### AWS Environment Variables
+```go
+RoleARNEnvKey = "ROLE_ARN"  // AWS IAM role ARN to assume
+```
+
+#### AWS Prerequisites
+1. **OpenShift cluster with AWS STS enabled**
+   - Cluster must be installed with manual credentials mode
+   - Reference: [Installing a cluster on AWS with short-term credentials](https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html-single/installing_on_aws/index#installing-aws-with-short-term-creds_installing-aws-customizations)
+
+2. **AWS IAM Role with required permissions**
+   - Create an IAM role with trust policy for the OpenShift service account
+   - Attach policies with S3 and EC2 permissions for backup operations
+   - Note the Role ARN for installation
+
+#### AWS Secret Creation
+The `CreateOrUpdateSTSAWSSecret` function creates a Secret with AWS STS configuration:
+
+```go
+func CreateOrUpdateSTSAWSSecret(setupLog logr.Logger, roleARN, secretNS string,
+                               kubeconf *rest.Config) error {
+    return CreateOrUpdateSTSSecret(setupLog, map[string]string{
+        AWSSecretCredentialsFileKey: fmt.Sprintf(`[default]
+role_arn = %s
+web_identity_token_file = %s`, roleARN, WebIdentityTokenPath),
+    }, secretNS, kubeconf)
+}
+```
+
+#### AWS Secret Format
+- **Secret Name**: `cloud-credentials`
+- **Secret Key**: `credentials` (AWS credentials file format)
+- **Content**: Standard AWS credentials file with role_arn and web_identity_token_file
+
+#### AWS DPA Configuration
+```yaml
+apiVersion: oadp.openshift.io/v1alpha1
+kind: DataProtectionApplication
+metadata:
+  name: dpa-aws
+  namespace: openshift-adp
+spec:
+  configuration:
+    velero:
+      defaultPlugins:
+      - openshift
+      - aws
+  backupLocations:
+    - velero:
+        provider: aws
+        default: true
+        credential:
+          key: credentials
+          name: cloud-credentials
+        config:
+          region: us-east-1  # REQUIRED: Must specify region here
+        objectStorage:
+          bucket: <bucket_name>
+          prefix: <prefix>
+```
+
+#### Dynamic Region Configuration
+
+The OADP operator automatically patches the AWS credentials secret with the region information from the first BackupStorageLocation. The region is obtained from:
+1. The BSL `config.region` if specified
+2. Automatic discovery using the `aws.GetBucketRegion()` function if the bucket is discoverable
+
+This enhancement eliminates the need to manually configure the region in the secret.
+
+**Important**: The standardized flow only supports the first BSL configuration. Additional BSLs in different regions require separate credentials and should not use the standardized flow secret.
+
+### Azure Workload Identity Implementation
+
+#### Azure Environment Variables
+
+```go
+ClientIDEnvKey      = "AZURE_CLIENT_ID"       // Azure managed identity client ID
+TenantIDEnvKey      = "AZURE_TENANT_ID"       // Azure tenant ID
+SubscriptionIDEnvKey = "AZURE_SUBSCRIPTION_ID" // Azure subscription ID
+```
+
+#### Azure Prerequisites
+
+1. **OpenShift cluster with Azure Workload Identity enabled**
+   - Cluster must be installed with manual credentials mode
+   - Reference: [Installing a cluster on Azure with short-term credentials](https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html-single/installing_on_azure/#installing-azure-with-short-term-creds_installing-azure-customizations)
+
+2. **Azure Managed Identity with required permissions**
+   - Create a managed identity with Storage Blob Data Contributor role
+   - Note the Client ID, Tenant ID, and Subscription ID
+
+#### Azure Secret Creation
+
+The `CreateOrUpdateSTSAzureSecret` function creates a Secret with Azure configuration:
+
+```go
+func CreateOrUpdateSTSAzureSecret(setupLog logr.Logger, azureClientId, azureTenantId, 
+                                 azureSubscriptionId, secretNS string, kubeconf *rest.Config) error {
+    // Azure federated identity credentials format
+    return CreateOrUpdateSTSSecret(setupLog, VeleroAzureSecretName, map[string]string{
+        "azurekey": fmt.Sprintf(`
+AZURE_SUBSCRIPTION_ID=%s
+AZURE_TENANT_ID=%s
+AZURE_CLIENT_ID=%s
+AZURE_CLOUD_NAME=AzurePublicCloud
+`, azureSubscriptionId, azureTenantId, azureClientId)}, secretNS, kubeconf)
+}
+```
+
+#### Azure Secret Format
+
+- **Secret Name**: `cloud-credentials-azure`
+- **Secret Key**: `azurekey`
+- **Content**: Azure environment variables format following [Velero Azure Plugin Option 3: Use Azure AD Workload Identity](https://github.com/vmware-tanzu/velero-plugin-for-microsoft-azure/tree/main#option-3-use-azure-ad-workload-identity)
+
+#### Azure Dynamic Resource Group Configuration
+
+The OADP operator automatically patches the Azure credentials secret with the `AZURE_RESOURCE_GROUP` environment variable from the first BackupStorageLocation that includes the `resourceGroup` in its configuration. This enhancement eliminates the need to manually configure the resource group in the secret.
+
+**Important**: The standardized flow only supports the first BSL configuration. Additional BSLs with different resource groups require separate credentials and should not use the standardized flow secret.
+
+#### Azure DPA Configuration
+
+```yaml
+apiVersion: oadp.openshift.io/v1alpha1
+kind: DataProtectionApplication
+metadata:
+  name: dpa-azure
+  namespace: openshift-adp
+spec:
+  configuration:
+    velero:
+      defaultPlugins:
+      - openshift
+      - azure
+  backupLocations:
+    - velero:
+        provider: azure
+        default: true
+        credential:
+          key: azurekey
+          name: cloud-credentials-azure
+        config:
+          resourceGroup: <resource_group>
+          storageAccount: <storage_account>
+        objectStorage:
+          bucket: <container_name>
+          prefix: <prefix>
+```
+
+### GCP Workload Identity Federation Implementation
+
+#### GCP Environment Variables
+
+```go
+ProjectNumberEnvKey       = "PROJECT_NUMBER"        // GCP project number
+PoolIDEnvKey              = "POOL_ID"               // Workload identity pool ID
+ProviderId                = "PROVIDER_ID"           // Workload identity provider ID
+ServiceAccountEmailEnvKey = "SERVICE_ACCOUNT_EMAIL" // Service account email to impersonate
+```
+
+#### GCP Prerequisites
+
+1. **OpenShift cluster with GCP Workload Identity Federation enabled**
+   - Cluster must be installed with manual credentials mode
+   - Workload Identity Pool and Provider must be configured
+   - Reference: [Installing a cluster on GCP with short-term credentials](https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html-single/installing_on_gcp/#installing-gcp-with-short-term-creds_installing-gcp-customizations)
+   - Prepare the following information from your cluster:
+     - GCP Project Number
+     - Workload Identity Pool
+     - Workload Identity Provider
+
+2. **GCP Service Account with required permissions**
+   - Create a service account in your GCP project with the following roles:
+
+     ```text
+     compute.disks.create
+     compute.disks.createSnapshot
+     compute.disks.get
+     compute.snapshots.create
+     compute.snapshots.delete
+     compute.snapshots.get
+     compute.snapshots.useReadOnly
+     compute.zones.get
+     iam.serviceAccounts.signBlob
+     storage.objects.create
+     storage.objects.delete
+     storage.objects.get
+     storage.objects.list
+     ```
+
+   - Note the Service Account email for the next steps
+
+3. **Grant necessary permissions for GCP**
+
+   Grant the `system:serviceaccount:openshift-adp:velero` service account the `roles/iam.serviceAccountTokenCreator` role:
+
+   ```bash
+   gcloud iam service-accounts add-iam-policy-binding <SERVICE_ACCOUNT_EMAIL> \
+     --project=<YOUR_PROJECT> \
+     --role=roles/iam.serviceAccountTokenCreator \
+     --member="principal://iam.googleapis.com/projects/<PROJECT_NUMBER>/locations/global/workloadIdentityPools/<POOL_ID>/subject/system:serviceaccount:openshift-adp:velero"
+   ```
+
+   Also bind the service account to the workload identity for the controller manager:
+
+   ```bash
+   gcloud iam service-accounts add-iam-policy-binding \
+     <SERVICE_ACCOUNT_EMAIL> \
+     --role roles/iam.workloadIdentityUser \
+     --member "principal://iam.googleapis.com/projects/<PROJECT_NUMBER>/locations/global/workloadIdentityPools/<POOL_ID>/subject/system:serviceaccount:openshift-adp:openshift-adp-controller-manager"
+   ```
+
+#### GCP Secret Creation
+
+The `CreateOrUpdateSTSGCPSecret` function creates a Secret with the required GCP WIF configuration:
+
+```go
+func CreateOrUpdateSTSGCPSecret(setupLog logr.Logger, serviceAccountEmail, projectNumber,
+                               poolId, providerId, secretNS string, kubeconf *rest.Config) error {
+    audience := fmt.Sprintf("//iam.googleapis.com/projects/%s/locations/global/workloadIdentityPools/%s/providers/%s",
+                           projectNumber, poolId, providerId)
+
+    return CreateOrUpdateSTSSecret(setupLog, map[string]string{
+        GcpSecretJSONKey: fmt.Sprintf(`{
+    "type": "external_account",
+    "audience": "%s",
+    "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+    "token_url": "https://sts.googleapis.com/v1/token",
+    "service_account_impersonation_url": "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/%s:generateAccessToken",
+    "credential_source": {
+        "file": "%s",
+        "format": {
+            "type": "text"
+        }
+    }
+}`, audience, serviceAccountEmail, WebIdentityTokenPath),
+    }, secretNS, kubeconf)
+}
+```
+
+#### GCP Secret Format
+
+- **Secret Name**: `cloud-credentials-gcp`
+- **Secret Key**: `service_account.json`
+- **Content**: GCP external account JSON following Google's external account format
+
+#### GCP DPA Configuration
+
+```yaml
+apiVersion: oadp.openshift.io/v1alpha1
+kind: DataProtectionApplication
+metadata:
+  name: dpa-gcp
+  namespace: openshift-adp
+spec:
+  configuration:
+    velero:
+      defaultPlugins:
+      - openshift
+      - gcp
+  backupLocations:
+    - velero:
+        provider: gcp
+        default: true
+        credential:
+          key: service_account.json
+          name: cloud-credentials-gcp
+        objectStorage:
+          bucket: <bucket_name>
+          prefix: <prefix>
+```

--- a/internal/controller/dataprotectionapplication_controller.go
+++ b/internal/controller/dataprotectionapplication_controller.go
@@ -103,6 +103,7 @@ func (r *DataProtectionApplicationReconciler) Reconcile(ctx context.Context, req
 		r.ReconcileRegistryRouteConfigs,
 		r.LabelVSLSecrets,
 		r.ReconcileVolumeSnapshotLocations,
+		r.ReconcileAzureWorkloadIdentitySecret,
 		r.ReconcileVeleroDeployment,
 		r.ReconcileNodeAgentConfigMap,
 		r.ReconcileBackupRepositoryConfigMap,

--- a/internal/controller/stsflow.go
+++ b/internal/controller/stsflow.go
@@ -1,0 +1,72 @@
+package controller
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"github.com/openshift/oadp-operator/pkg/credentials/stsflow"
+)
+
+// ReconcileAzureWorkloadIdentitySecret ensures the Azure workload identity secret exists.
+// These environment variables are required to trigger Velero's workload identity credential flow:
+// https://github.com/vmware-tanzu/velero/blob/5c0cb58f6a4f95eb93c18e7e8f8d3d14b94d6805/pkg/util/azure/credential.go#L48-L54
+// The azidentity.NewWorkloadIdentityCredential relies on these three environment variables:
+// - AZURE_CLIENT_ID
+// - AZURE_TENANT_ID
+// - AZURE_FEDERATED_TOKEN_FILE
+func (r *DataProtectionApplicationReconciler) ReconcileAzureWorkloadIdentitySecret(log logr.Logger) (bool, error) {
+	dpa := r.dpa
+	azureClientID := os.Getenv(stsflow.ClientIDEnvKey)
+
+	// Only create secret if Azure workload identity environment variables are present
+	azureTenantID := os.Getenv(stsflow.TenantIDEnvKey)
+	if azureClientID == "" || azureTenantID == "" || os.Getenv(stsflow.SubscriptionIDEnvKey) == "" {
+		// No Azure workload identity configured, nothing to do
+		return true, nil
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      stsflow.AzureWorkloadIdentitySecretName,
+			Namespace: dpa.Namespace,
+		},
+	}
+
+	op, err := controllerutil.CreateOrUpdate(r.Context, r.Client, secret, func() error {
+		// Add labels
+		secret.Labels = getDpaAppLabels(dpa)
+
+		// Set the data
+		if secret.Data == nil {
+			secret.Data = make(map[string][]byte)
+		}
+		// This secret is used via envFrom in both velero.go and nodeagent.go
+		// to inject these environment variables into the Velero deployment and NodeAgent daemonset containers
+		secret.Data["AZURE_CLIENT_ID"] = []byte(azureClientID)
+		secret.Data["AZURE_TENANT_ID"] = []byte(azureTenantID)
+		secret.Data["AZURE_FEDERATED_TOKEN_FILE"] = []byte(stsflow.WebIdentityTokenPath)
+
+		// Set controller reference
+		return controllerutil.SetControllerReference(dpa, secret, r.Scheme)
+	})
+
+	if err != nil {
+		log.Error(err, "Error reconciling Azure workload identity secret")
+		return false, err
+	}
+
+	if op == controllerutil.OperationResultCreated || op == controllerutil.OperationResultUpdated {
+		r.EventRecorder.Event(secret,
+			corev1.EventTypeNormal,
+			"AzureWorkloadIdentitySecretReconciled",
+			fmt.Sprintf("performed %s on azure workload identity secret %s/%s", op, secret.Namespace, secret.Name),
+		)
+	}
+
+	return true, nil
+}

--- a/internal/controller/stsflow_test.go
+++ b/internal/controller/stsflow_test.go
@@ -1,0 +1,188 @@
+package controller
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
+	"github.com/openshift/oadp-operator/pkg/credentials/stsflow"
+)
+
+func newEventRecorder() record.EventRecorder {
+	return record.NewFakeRecorder(10)
+}
+
+func TestDPAReconciler_ReconcileAzureWorkloadIdentitySecret(t *testing.T) {
+	tests := []struct {
+		name           string
+		dpa            *oadpv1alpha1.DataProtectionApplication
+		envVars        map[string]string
+		wantSecret     bool
+		wantSecretData map[string]string
+		wantError      bool
+	}{
+		{
+			name: "Azure STS credentials present - should create secret",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-dpa",
+					Namespace: "test-ns",
+				},
+			},
+			envVars: map[string]string{
+				stsflow.ClientIDEnvKey:       "test-client-id",
+				stsflow.TenantIDEnvKey:       "test-tenant-id",
+				stsflow.SubscriptionIDEnvKey: "test-subscription-id",
+			},
+			wantSecret: true,
+			wantSecretData: map[string]string{
+				"AZURE_CLIENT_ID":            "test-client-id",
+				"AZURE_TENANT_ID":            "test-tenant-id",
+				"AZURE_FEDERATED_TOKEN_FILE": stsflow.WebIdentityTokenPath,
+			},
+			wantError: false,
+		},
+		{
+			name: "No Azure credentials - should not create secret",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-dpa",
+					Namespace: "test-ns",
+				},
+			},
+			envVars:    map[string]string{},
+			wantSecret: false,
+			wantError:  false,
+		},
+		{
+			name: "Partial Azure credentials (missing tenant) - should not create secret",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-dpa",
+					Namespace: "test-ns",
+				},
+			},
+			envVars: map[string]string{
+				stsflow.ClientIDEnvKey:       "test-client-id",
+				stsflow.SubscriptionIDEnvKey: "test-subscription-id",
+			},
+			wantSecret: false,
+			wantError:  false,
+		},
+		{
+			name: "Partial Azure credentials (missing subscription) - should not create secret",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-dpa",
+					Namespace: "test-ns",
+				},
+			},
+			envVars: map[string]string{
+				stsflow.ClientIDEnvKey: "test-client-id",
+				stsflow.TenantIDEnvKey: "test-tenant-id",
+			},
+			wantSecret: false,
+			wantError:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set environment variables for test
+			for key, value := range tt.envVars {
+				os.Setenv(key, value)
+				defer os.Unsetenv(key)
+			}
+
+			// Create scheme with required types
+			scheme := runtime.NewScheme()
+			oadpv1alpha1.AddToScheme(scheme)
+			corev1.AddToScheme(scheme)
+
+			// Create fake client
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(tt.dpa).
+				Build()
+
+			// Create reconciler
+			r := &DataProtectionApplicationReconciler{
+				Client:        fakeClient,
+				Scheme:        scheme,
+				dpa:           tt.dpa,
+				Log:           logr.Discard(),
+				Context:       context.Background(),
+				EventRecorder: newEventRecorder(),
+			}
+
+			// Call the function
+			result, err := r.ReconcileAzureWorkloadIdentitySecret(logr.Discard())
+
+			// Check error
+			if (err != nil) != tt.wantError {
+				t.Errorf("ReconcileAzureWorkloadIdentitySecret() error = %v, wantError %v", err, tt.wantError)
+				return
+			}
+
+			// Should always return true unless there's an error
+			if !tt.wantError && !result {
+				t.Errorf("ReconcileAzureWorkloadIdentitySecret() result = %v, want true", result)
+			}
+
+			// Check if secret was created
+			secret := &corev1.Secret{}
+			err = fakeClient.Get(context.Background(), types.NamespacedName{
+				Name:      stsflow.AzureWorkloadIdentitySecretName,
+				Namespace: tt.dpa.Namespace,
+			}, secret)
+
+			if tt.wantSecret {
+				if err != nil {
+					t.Errorf("Expected secret to be created, but got error: %v", err)
+					return
+				}
+
+				// Check secret data
+				for key, expectedValue := range tt.wantSecretData {
+					actualValue, exists := secret.Data[key]
+					if !exists {
+						t.Errorf("Expected secret data key %s to exist", key)
+						continue
+					}
+					if string(actualValue) != expectedValue {
+						t.Errorf("Secret data[%s] = %s, want %s", key, string(actualValue), expectedValue)
+					}
+				}
+
+				// Check labels
+				labels := secret.GetLabels()
+				if labels[oadpv1alpha1.OadpOperatorLabel] != "True" {
+					t.Errorf("Expected OADP operator label to be set")
+				}
+
+				// Check owner reference
+				if len(secret.GetOwnerReferences()) != 1 {
+					t.Errorf("Expected exactly one owner reference, got %d", len(secret.GetOwnerReferences()))
+				} else {
+					ownerRef := secret.GetOwnerReferences()[0]
+					if ownerRef.Name != tt.dpa.Name {
+						t.Errorf("Expected owner reference name to be %s, got %s", tt.dpa.Name, ownerRef.Name)
+					}
+				}
+			} else {
+				if err == nil {
+					t.Errorf("Expected secret to not be created, but it was")
+				}
+			}
+		})
+	}
+}

--- a/internal/controller/velero.go
+++ b/internal/controller/velero.go
@@ -29,17 +29,15 @@ import (
 	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
 	"github.com/openshift/oadp-operator/pkg/common"
 	"github.com/openshift/oadp-operator/pkg/credentials"
+	"github.com/openshift/oadp-operator/pkg/credentials/stsflow"
 	veleroserver "github.com/openshift/oadp-operator/pkg/velero/server"
 )
 
 const (
 	Server = "server"
 	//TODO: Check for default secret names
-	VeleroAWSSecretName   = "cloud-credentials"
-	VeleroAzureSecretName = "cloud-credentials-azure"
-	VeleroGCPSecretName   = "cloud-credentials-gcp"
-	enableCSIFeatureFlag  = "EnableCSI"
-	veleroIOPrefix        = "velero.io/"
+	enableCSIFeatureFlag = "EnableCSI"
+	veleroIOPrefix       = "velero.io/"
 
 	VeleroReplicaOverride = "VELERO_DEBUG_REPLICAS_OVERRIDE"
 
@@ -216,6 +214,7 @@ func (r *DataProtectionApplicationReconciler) customizeVeleroDeployment(veleroDe
 	if err != nil {
 		return fmt.Errorf("velero deployment label: %v", err)
 	}
+
 	if veleroDeployment.Spec.Selector == nil {
 		veleroDeployment.Spec.Selector = &metav1.LabelSelector{
 			MatchLabels: make(map[string]string),
@@ -575,6 +574,23 @@ func (r *DataProtectionApplicationReconciler) customizeVeleroContainer(veleroCon
 			Name:  "OPENSHIFT_IMAGESTREAM_BACKUP",
 			Value: "true",
 		}})
+	}
+
+	// Add Azure workload identity environment variables if using Azure STS
+	azureClientID := os.Getenv(stsflow.ClientIDEnvKey)
+	if azureClientID != "" && os.Getenv(stsflow.TenantIDEnvKey) != "" && os.Getenv(stsflow.SubscriptionIDEnvKey) != "" {
+		// Use envFrom to reference the secret containing Azure workload identity env vars
+		if veleroContainer.EnvFrom == nil {
+			veleroContainer.EnvFrom = []corev1.EnvFromSource{}
+		}
+		veleroContainer.EnvFrom = append(veleroContainer.EnvFrom, corev1.EnvFromSource{
+			SecretRef: &corev1.SecretEnvSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: stsflow.AzureWorkloadIdentitySecretName,
+				},
+			},
+		})
+		r.Log.Info("Added Azure workload identity secret reference to Velero container")
 	}
 
 	// Enable user to specify --fs-backup-timeout (defaults to 4h)

--- a/internal/controller/velero_test.go
+++ b/internal/controller/velero_test.go
@@ -31,6 +31,7 @@ import (
 	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
 	oadpclient "github.com/openshift/oadp-operator/pkg/client"
 	"github.com/openshift/oadp-operator/pkg/common"
+	"github.com/openshift/oadp-operator/pkg/credentials/stsflow"
 )
 
 const (
@@ -2482,6 +2483,111 @@ func TestDPAReconciler_VeleroDebugEnvironment(t *testing.T) {
 					t.Error("debug replica override did not apply")
 					return
 				}
+			}
+		})
+	}
+}
+
+func TestDPAReconciler_buildVeleroDeploymentWithAzureWorkloadIdentity(t *testing.T) {
+	tests := []struct {
+		name             string
+		dpa              *oadpv1alpha1.DataProtectionApplication
+		envVars          map[string]string
+		wantAzureLabel   bool
+		veleroDeployment *appsv1.Deployment
+	}{
+		{
+			name: "Azure STS credentials present - should add workload identity label",
+			dpa: createTestDpaWith(
+				nil,
+				oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{},
+					},
+				},
+			),
+			envVars: map[string]string{
+				"CLIENTID":       "test-client-id",
+				"TENANTID":       "test-tenant-id",
+				"SUBSCRIPTIONID": "test-subscription-id",
+			},
+			wantAzureLabel:   true,
+			veleroDeployment: testVeleroDeployment.DeepCopy(),
+		},
+		{
+			name: "No Azure credentials - should not add workload identity label",
+			dpa: createTestDpaWith(
+				nil,
+				oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{},
+					},
+				},
+			),
+			envVars:          map[string]string{},
+			wantAzureLabel:   false,
+			veleroDeployment: testVeleroDeployment.DeepCopy(),
+		},
+		{
+			name: "Partial Azure credentials - should not add workload identity label",
+			dpa: createTestDpaWith(
+				nil,
+				oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{},
+					},
+				},
+			),
+			envVars: map[string]string{
+				"CLIENTID": "test-client-id",
+				"TENANTID": "test-tenant-id",
+				// Missing SUBSCRIPTIONID
+			},
+			wantAzureLabel:   false,
+			veleroDeployment: testVeleroDeployment.DeepCopy(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set environment variables for test
+			for key, value := range tt.envVars {
+				os.Setenv(key, value)
+				defer os.Unsetenv(key)
+			}
+
+			// Create reconciler
+			r := &DataProtectionApplicationReconciler{
+				dpa: tt.dpa,
+				Log: logr.Discard(),
+			}
+
+			// Build the deployment
+			err := r.buildVeleroDeployment(tt.veleroDeployment)
+			if err != nil {
+				t.Errorf("buildVeleroDeployment() error = %v", err)
+				return
+			}
+
+			// Check if Azure workload identity label is present
+			if tt.wantAzureLabel {
+				// Check that Azure workload identity secret reference is added via envFrom
+				foundAzureSecretRef := false
+				for _, container := range tt.veleroDeployment.Spec.Template.Spec.Containers {
+					if container.Name == common.Velero {
+						for _, envFrom := range container.EnvFrom {
+							if envFrom.SecretRef != nil && envFrom.SecretRef.Name == stsflow.AzureWorkloadIdentitySecretName {
+								foundAzureSecretRef = true
+								break
+							}
+						}
+						break
+					}
+				}
+				if !foundAzureSecretRef {
+					t.Errorf("Expected %s secret reference in envFrom", stsflow.AzureWorkloadIdentitySecretName)
+				}
+			} else {
 			}
 		})
 	}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -10,7 +10,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var commonClient client.Client
+var (
+	commonClient client.Client
+	kubeconf     *rest.Config
+)
 
 func SetClient(c client.Client) {
 	commonClient = c
@@ -23,6 +26,14 @@ func NewClientFromConfig(cfg *rest.Config) (c client.Client, err error) {
 
 func GetClient() client.Client {
 	return commonClient
+}
+
+func SetKubeconf(kcfg *rest.Config) {
+	kubeconf = kcfg
+}
+
+func GetKubeconf() *rest.Config {
+	return kubeconf
 }
 
 func CreateOrUpdate(ctx context.Context, obj client.Object) error {

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"fmt"
-	"os"
 	"regexp"
 	"sort"
 	"strings"
@@ -205,17 +204,6 @@ func AppendTTMapAsCopy[T comparable](add ...map[T]T) map[T]T {
 		}
 	}
 	return base
-}
-
-// CCOWorkflow checks if the AWS STS secret is to be obtained from Cloud Credentials Operator (CCO)
-// if the user provides role ARN during installation then the ARN gets set as env var on operator deployment
-// during installation via OLM
-func CCOWorkflow() bool {
-	roleARN := os.Getenv("ROLEARN")
-	if len(roleARN) > 0 {
-		return true
-	}
-	return false
 }
 
 // GetImagePullPolicy get imagePullPolicy for a container, based on its image, if an override is not provided.

--- a/pkg/credentials/stsflow/stsflow.go
+++ b/pkg/credentials/stsflow/stsflow.go
@@ -1,0 +1,384 @@
+package stsflow
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
+	// to ensure that exec-entrypoint and run can make use of them.
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	pkgclient "github.com/openshift/oadp-operator/pkg/client"
+)
+
+const (
+	// STS Flow Environment Vars
+	RoleARNEnvKey = "ROLEARN" // AWS STS role ARN
+
+	ProjectNumberEnvKey       = "PROJECT_NUMBER"        // GCP WIF project number
+	PoolIDEnvKey              = "POOL_ID"               // GCP WIF pool ID
+	ProviderId                = "PROVIDER_ID"           // GCP WIF provider ID
+	ServiceAccountEmailEnvKey = "SERVICE_ACCOUNT_EMAIL" // GCP WIF service account email
+
+	ClientIDEnvKey       = "CLIENTID"       // Azure client ID
+	TenantIDEnvKey       = "TENANTID"       // Azure tenant ID
+	SubscriptionIDEnvKey = "SUBSCRIPTIONID" // Azure subscription ID
+
+	// WebIdentityTokenPath mount present on operator CSV
+	WebIdentityTokenPath = "/var/run/secrets/openshift/serviceaccount/token"
+
+	// Azure workload identity secret name
+	AzureWorkloadIdentitySecretName = "azure-workload-identity-env"
+
+	// Cloud Provider Secret Keys - standard key names for cloud credentials
+	AzureClientID           = "azure_client_id"
+	AzureClientSecret       = "azure_client_secret"
+	AzureRegion             = "azure_region"
+	AzureResourceGroup      = "azure_resourcegroup"
+	AzureResourcePrefix     = "azure_resource_prefix"
+	AzureSubscriptionID     = "azure_subscription_id"
+	AzureTenantID           = "azure_tenant_id"
+	AzureFederatedTokenFile = "azure_federated_token_file"
+
+	// GCP Secret key name
+	GcpSecretJSONKey = "service_account.json"
+
+	VeleroAWSSecretName   = "cloud-credentials"
+	VeleroAzureSecretName = "cloud-credentials-azure"
+	VeleroGCPSecretName   = "cloud-credentials-gcp"
+)
+
+// STSStandardizedFlow creates secrets for Short Term Service Account Tokens from environment variables for
+// AWS STS, GCP WIF, and Azure following the standardized authentication workflow (https://github.com/openshift/enhancements/pull/1800).
+// Users provide these values during web console installation, and they are set as environment
+// variables on the operator deployment during installation via OLM.
+// Returns "", error if secret creation fails.
+// Returns <secretName>, nil if secret creation succeeds.
+// Returns "", nil if no STS environment variables are provided.
+func STSStandardizedFlow() (string, error) {
+	// Reference of provided envs from web console.
+	// https://github.com/openshift/console/blob/f11a6158ae722200d342519971af337f8ff61d3a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx#L502-L555
+
+	// AWS STS environment variables
+	roleARN := os.Getenv(RoleARNEnvKey)
+
+	// GCP WIF environment variables
+	serviceAccountEmail := os.Getenv(ServiceAccountEmailEnvKey)
+	projectNumber := os.Getenv(ProjectNumberEnvKey)
+	poolId := os.Getenv(PoolIDEnvKey)
+	providerId := os.Getenv(ProviderId)
+
+	// Azure environment variables
+	clientID := os.Getenv(ClientIDEnvKey)
+	tenantID := os.Getenv(TenantIDEnvKey)
+	subscriptionID := os.Getenv(SubscriptionIDEnvKey)
+
+	// Check if any cloud provider credentials are provided
+	hasAWSCreds := len(roleARN) > 0
+	hasGCPCreds := len(serviceAccountEmail) > 0 &&
+		len(projectNumber) > 0 && len(poolId) > 0 && len(providerId) > 0
+	hasAzureCreds := len(clientID) > 0 && len(tenantID) > 0 && len(subscriptionID) > 0
+
+	// If no credentials are provided, return nil
+	if !hasAWSCreds && !hasGCPCreds && !hasAzureCreds {
+		return "", nil
+	}
+	// Logger set from cmd/main.go by ctrl.SetLogger
+	logger := log.Log
+	installNS := os.Getenv("WATCH_NAMESPACE")
+	kcfg := pkgclient.GetKubeconf()
+	if hasAWSCreds {
+		if err := CreateOrUpdateSTSAWSSecret(logger, roleARN, installNS, kcfg); err != nil {
+			return "", err
+		}
+		return VeleroAWSSecretName, nil
+	} else if hasGCPCreds {
+		if err := CreateOrUpdateSTSGCPSecret(logger, serviceAccountEmail, projectNumber, poolId, providerId, installNS, kcfg); err != nil {
+			return "", err
+		}
+		return VeleroGCPSecretName, nil
+	} else if hasAzureCreds {
+		if err := CreateOrUpdateSTSAzureSecret(logger, clientID, tenantID, subscriptionID, installNS, kcfg); err != nil {
+			return "", err
+		}
+		return VeleroAzureSecretName, nil
+	}
+
+	return "", nil
+}
+
+func CreateOrUpdateSTSAWSSecret(setupLog logr.Logger, roleARN string, secretNS string, kubeconf *rest.Config) error {
+	// AWS STS credentials format
+	return CreateOrUpdateSTSSecret(setupLog, VeleroAWSSecretName, map[string]string{
+		"credentials": fmt.Sprintf(`[default]
+sts_regional_endpoints = regional
+role_arn = %s
+web_identity_token_file = %s`, roleARN, WebIdentityTokenPath),
+	}, secretNS, kubeconf)
+}
+
+func CreateOrUpdateSTSGCPSecret(setupLog logr.Logger, serviceAccountEmail, projectNumber, poolId, providerId, secretNS string, kubeconf *rest.Config) error {
+	audience := fmt.Sprintf("//iam.googleapis.com/projects/%s/locations/global/workloadIdentityPools/%s/providers/%s", projectNumber, poolId, providerId)
+	// GCP external account credentials format for Workload Identity Federation
+	return CreateOrUpdateSTSSecret(setupLog, VeleroGCPSecretName, map[string]string{
+		GcpSecretJSONKey: fmt.Sprintf(`{
+	"type": "external_account",
+	"audience": "%s",
+	"subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+	"token_url": "https://sts.googleapis.com/v1/token",
+	"service_account_impersonation_url": "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/%s:generateAccessToken",
+	"credential_source": {
+		"file": "%s",
+		"format": {
+			"type": "text"
+		}
+	}
+}`, audience, serviceAccountEmail, WebIdentityTokenPath),
+	}, secretNS, kubeconf)
+}
+
+func CreateOrUpdateSTSAzureSecret(setupLog logr.Logger, azureClientId, azureTenantId, azureSubscriptionId, secretNS string, kubeconf *rest.Config) error {
+	clientInstance, err := client.New(kubeconf, client.Options{})
+	if err != nil {
+		setupLog.Error(err, "unable to create client")
+		return err
+	}
+
+	// Create a clientset to use for waiting on the secret
+	clientset, err := kubernetes.NewForConfig(kubeconf)
+	if err != nil {
+		setupLog.Error(err, "unable to create clientset")
+		return err
+	}
+
+	return CreateOrUpdateSTSAzureSecretWithClients(setupLog, azureClientId, azureTenantId, azureSubscriptionId, secretNS, clientInstance, clientset)
+}
+
+// CreateOrUpdateSTSAzureSecretWithClients is a testable version that accepts injected clients
+func CreateOrUpdateSTSAzureSecretWithClients(setupLog logr.Logger, azureClientId, azureTenantId, azureSubscriptionId, secretNS string, clientInstance client.Client, clientset kubernetes.Interface) error {
+	// Azure federated identity credentials format
+	err := CreateOrUpdateSTSSecretWithClients(setupLog, VeleroAzureSecretName, map[string]string{
+		"azurekey": fmt.Sprintf(`
+AZURE_SUBSCRIPTION_ID=%s
+AZURE_TENANT_ID=%s
+AZURE_CLIENT_ID=%s
+AZURE_CLOUD_NAME=AzurePublicCloud
+`, azureSubscriptionId, azureTenantId, azureClientId)}, secretNS, clientInstance, clientset)
+
+	if err != nil {
+		return err
+	}
+
+	// Annotate the Velero service account for Azure workload identity
+	if err := AnnotateVeleroServiceAccountForAzureWithClient(setupLog, azureClientId, secretNS, clientInstance); err != nil {
+		// Log the error but don't fail the secret creation
+		setupLog.Error(err, "Failed to annotate Velero service account for Azure workload identity")
+	}
+
+	return nil
+}
+
+func CreateOrUpdateSTSSecret(setupLog logr.Logger, secretName string, credStringData map[string]string, secretNS string, kubeconf *rest.Config) error {
+	clientInstance, err := client.New(kubeconf, client.Options{})
+	if err != nil {
+		setupLog.Error(err, "unable to create client")
+		return err
+	}
+
+	// Create a clientset to use for waiting on the secret
+	clientset, err := kubernetes.NewForConfig(kubeconf)
+	if err != nil {
+		setupLog.Error(err, "unable to create clientset")
+		return err
+	}
+
+	return CreateOrUpdateSTSSecretWithClients(setupLog, secretName, credStringData, secretNS, clientInstance, clientset)
+}
+
+// CreateOrUpdateSTSSecretWithClients is a testable version that accepts injected clients
+func CreateOrUpdateSTSSecretWithClients(setupLog logr.Logger, secretName string, credStringData map[string]string, secretNS string, clientInstance client.Client, clientset kubernetes.Interface) error {
+	return CreateOrUpdateSTSSecretWithClientsAndWait(setupLog, secretName, credStringData, secretNS, clientInstance, clientset, true)
+}
+
+// CreateOrUpdateSTSSecretWithClientsAndWait is a testable version that accepts injected clients and optional wait
+func CreateOrUpdateSTSSecretWithClientsAndWait(setupLog logr.Logger, secretName string, credStringData map[string]string, secretNS string, clientInstance client.Client, clientset kubernetes.Interface, waitForSecret bool) error {
+	// Create a secret with the appropriate credentials format for STS/WIF authentication
+	// Secret format follows standard patterns used by cloud providers
+	secret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: secretNS,
+			Labels: map[string]string{
+				"oadp.openshift.io/secret-type": "sts-credentials",
+			},
+		},
+		StringData: credStringData,
+	}
+	verb := "created"
+	if err := clientInstance.Create(context.Background(), &secret); err != nil {
+		if errors.IsAlreadyExists(err) {
+			verb = "updated"
+			setupLog.Info("Secret already exists, updating")
+			fromCluster := corev1.Secret{}
+			err = clientInstance.Get(context.Background(), types.NamespacedName{Name: secret.Name, Namespace: secret.Namespace}, &fromCluster)
+			if err != nil {
+				setupLog.Error(err, "unable to get existing secret resource")
+				return err
+			}
+			// update StringData - preserve existing Data that's not being replaced
+			// This is safe because STS credentials are only updated during install/reconfiguration,
+			// and any BSL-specific patches (like region) should be preserved
+			updatedFromCluster := fromCluster.DeepCopy()
+			// Initialize StringData if not present
+			if updatedFromCluster.StringData == nil {
+				updatedFromCluster.StringData = make(map[string]string)
+			}
+			// Update only the new StringData fields, preserving existing Data
+			for key, value := range secret.StringData {
+				updatedFromCluster.StringData[key] = value
+			}
+			// Ensure labels are set
+			if updatedFromCluster.Labels == nil {
+				updatedFromCluster.Labels = make(map[string]string)
+			}
+			updatedFromCluster.Labels["oadp.openshift.io/secret-type"] = "sts-credentials"
+			if err := clientInstance.Patch(context.Background(), updatedFromCluster, client.MergeFrom(&fromCluster)); err != nil {
+				setupLog.Error(err, fmt.Sprintf("unable to update secret resource: %v", err))
+				return err
+			}
+		} else {
+			setupLog.Error(err, "unable to create secret resource")
+			return err
+		}
+	}
+	setupLog.Info("Secret " + secret.Name + " " + verb + " successfully")
+
+	if waitForSecret {
+		// Wait for the Secret to be available
+		setupLog.Info(fmt.Sprintf("Waiting for %s Secret to be available", secret.Name))
+		_, err := WaitForSecret(clientset, secretNS, secretName)
+		if err != nil {
+			setupLog.Error(err, "error waiting for credentials Secret")
+			return err
+		}
+		setupLog.Info("credentials Secret is now available")
+	}
+
+	return nil
+}
+
+// AnnotateVeleroServiceAccountForAzure annotates the Velero service account with Azure workload identity client ID
+func AnnotateVeleroServiceAccountForAzure(setupLog logr.Logger, clientID string, namespace string, kubeconf *rest.Config) error {
+	if clientID == "" {
+		return fmt.Errorf("clientID cannot be empty")
+	}
+
+	clientInstance, err := client.New(kubeconf, client.Options{})
+	if err != nil {
+		setupLog.Error(err, "unable to create client")
+		return err
+	}
+
+	return AnnotateVeleroServiceAccountForAzureWithClient(setupLog, clientID, namespace, clientInstance)
+}
+
+// AnnotateVeleroServiceAccountForAzureWithClient is a testable version that accepts an injected client
+func AnnotateVeleroServiceAccountForAzureWithClient(setupLog logr.Logger, clientID string, namespace string, clientInstance client.Client) error {
+	if clientID == "" {
+		return fmt.Errorf("clientID cannot be empty")
+	}
+
+	// Get the velero service account
+	sa := &corev1.ServiceAccount{}
+	err := clientInstance.Get(context.Background(), types.NamespacedName{
+		Name:      "velero",
+		Namespace: namespace,
+	}, sa)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			setupLog.Info("Velero service account not found yet, skipping annotation")
+			return nil
+		}
+		return err
+	}
+
+	// Prepare the patch
+	originalSA := sa.DeepCopy()
+	if sa.Annotations == nil {
+		sa.Annotations = make(map[string]string)
+	}
+
+	// Apply the patch
+	if err := clientInstance.Patch(context.Background(), sa, client.MergeFrom(originalSA)); err != nil {
+		setupLog.Error(err, "unable to patch service account with Azure workload identity annotation")
+		return err
+	}
+
+	setupLog.Info("Successfully annotated Velero service account for Azure workload identity", "clientID", clientID)
+	return nil
+}
+
+// CreateCredRequest WITP : WebIdentityTokenPath
+// WaitForSecret is a function that takes a Kubernetes client, a namespace, and a v1 "k8s.io/api/core/v1" name as arguments
+// It waits until the secret object with the given name exists in the given namespace
+// It returns the secret object or an error if the timeout is exceeded
+func WaitForSecret(k8sClient kubernetes.Interface, namespace, name string) (*corev1.Secret, error) {
+	// set a timeout of 10 minutes
+	timeout := time.After(10 * time.Minute)
+
+	// set a polling interval of 10 seconds
+	ticker := time.NewTicker(10 * time.Second)
+
+	// loop until the timeout or the secret is found
+	for {
+		select {
+		case <-timeout:
+			// timeout is exceeded, return an error
+			return nil, fmt.Errorf("timed out waiting for secret %s in namespace %s. Please follow the manual path to create a Secret", name, namespace)
+		case <-ticker.C:
+			// polling interval is reached, try to get the secret
+			secret, err := k8sClient.CoreV1().Secrets(namespace).Get(context.Background(), name, metav1.GetOptions{})
+			if err != nil {
+				if errors.IsNotFound(err) {
+					// secret does not exist yet, continue waiting
+					continue
+				} else {
+					// some other error occurred, return it
+					return nil, err
+				}
+			} else {
+				// secret is found, return it
+				return secret, nil
+			}
+		}
+	}
+}
+
+// GetGCPCredentialsFromSecret waits for the cloud-credentials Secret
+// and reads the service_account.json field
+func GetGCPCredentialsFromSecret(clientset kubernetes.Interface, namespace string) (string, error) {
+	// Wait for the Secret to be available
+	secret, err := WaitForSecret(clientset, namespace, VeleroGCPSecretName)
+	if err != nil {
+		return "", fmt.Errorf("error waiting for GCP credentials Secret: %v", err)
+	}
+
+	// Read the service_account.json field from the Secret
+	serviceAccountJSON, ok := secret.Data[GcpSecretJSONKey]
+	if !ok {
+		return "", fmt.Errorf("cloud-credentials Secret does not contain %s field", GcpSecretJSONKey)
+	}
+
+	return string(serviceAccountJSON), nil
+}

--- a/pkg/credentials/stsflow/stsflow_test.go
+++ b/pkg/credentials/stsflow/stsflow_test.go
@@ -1,0 +1,661 @@
+package stsflow
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+func TestCreateOrUpdateSTSSecret(t *testing.T) {
+	// Setup
+	testNamespace := "test-namespace"
+	testSecretName := "test-secret"
+	testLogger := zap.New(zap.UseDevMode(true))
+	testCases := []struct {
+		name           string
+		existingSecret *corev1.Secret
+		credStringData map[string]string
+		expectError    bool
+		errorMessage   string
+	}{
+		{
+			name:           "Create new secret successfully",
+			existingSecret: nil,
+			credStringData: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+			expectError: false,
+		},
+		{
+			name: "Update existing secret with same data",
+			existingSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testSecretName,
+					Namespace: testNamespace,
+				},
+				Data: map[string][]byte{
+					"key1": []byte("value1"),
+					"key2": []byte("value2"),
+				},
+			},
+			credStringData: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+			expectError: false,
+		},
+		{
+			name: "Update existing secret with different data",
+			existingSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testSecretName,
+					Namespace: testNamespace,
+				},
+				Data: map[string][]byte{
+					"key1": []byte("old-value1"),
+					"key2": []byte("old-value2"),
+				},
+			},
+			credStringData: map[string]string{
+				"key1": "new-value1",
+				"key2": "new-value2",
+				"key3": "new-value3",
+			},
+			expectError: false,
+		},
+		{
+			name: "Update existing secret with partial data change",
+			existingSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testSecretName,
+					Namespace: testNamespace,
+				},
+				Data: map[string][]byte{
+					"key1": []byte("value1"),
+					"key2": []byte("old-value2"),
+					"key3": []byte("value3"),
+				},
+			},
+			credStringData: map[string]string{
+				"key1": "value1",
+				"key2": "new-value2",
+			},
+			expectError: false,
+		},
+		{
+			name: "Update existing secret preserves patched Data field",
+			existingSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testSecretName,
+					Namespace: testNamespace,
+				},
+				Data: map[string][]byte{
+					"credentials": []byte("[default]\nrole_arn = arn:aws:iam::123456789012:role/test\nweb_identity_token_file = /var/run/secrets/openshift/serviceaccount/token\nregion = us-west-2"),
+				},
+			},
+			credStringData: map[string]string{
+				"credentials": "[default]\nrole_arn = arn:aws:iam::123456789012:role/test\nweb_identity_token_file = /var/run/secrets/openshift/serviceaccount/token",
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create fake client with or without existing secret
+			var objs []runtime.Object
+			if tc.existingSecret != nil {
+				objs = append(objs, tc.existingSecret)
+			}
+
+			fakeClient := fake.NewClientBuilder().
+				WithRuntimeObjects(objs...).
+				Build()
+
+			// Mock the WaitForSecret function by creating a fake clientset
+			fakeClientset := k8sfake.NewSimpleClientset(objs...)
+
+			// Use the refactored function directly
+			err := CreateOrUpdateSTSSecretWithClientsAndWait(testLogger, testSecretName, tc.credStringData, testNamespace, fakeClient, fakeClientset, false)
+
+			if tc.expectError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tc.errorMessage)
+			} else {
+				assert.NoError(t, err)
+
+				// Verify the secret was created/updated correctly
+				secret := &corev1.Secret{}
+				err = fakeClient.Get(context.Background(), client.ObjectKey{
+					Name:      testSecretName,
+					Namespace: testNamespace,
+				}, secret)
+				assert.NoError(t, err)
+
+				// Verify the StringData (fake client doesn't convert to Data)
+				assert.Equal(t, tc.credStringData, secret.StringData)
+
+				// Special case: For the test that verifies Data preservation
+				if tc.name == "Update existing secret preserves patched Data field" {
+					// Verify that existing Data is preserved when not being overwritten by StringData
+					// In a real Kubernetes cluster, Data with region would be preserved
+					// but we can't test this with fake client as it doesn't handle Data/StringData conversion
+					assert.NotNil(t, secret.Data, "Data should be preserved")
+				}
+
+				// Verify the label is set
+				assert.NotNil(t, secret.Labels)
+				assert.Equal(t, "sts-credentials", secret.Labels["oadp.openshift.io/secret-type"])
+			}
+		})
+	}
+}
+
+func TestCreateOrUpdateSTSAWSSecret(t *testing.T) {
+
+	testNamespace := "test-namespace"
+	testLogger := zap.New(zap.UseDevMode(true))
+	roleARN := "arn:aws:iam::123456789012:role/test-role"
+
+	fakeClient := fake.NewClientBuilder().
+		Build()
+	fakeClientset := k8sfake.NewSimpleClientset()
+
+	// Use the refactored function directly
+	expectedCredentials := `[default]
+sts_regional_endpoints = regional
+role_arn = ` + roleARN + `
+web_identity_token_file = ` + WebIdentityTokenPath
+	err := CreateOrUpdateSTSSecretWithClientsAndWait(testLogger, VeleroAWSSecretName, map[string]string{
+		"credentials": expectedCredentials,
+	}, testNamespace, fakeClient, fakeClientset, false)
+
+	assert.NoError(t, err)
+
+	// Verify the secret was created correctly
+	secretResult := &corev1.Secret{}
+	err = fakeClient.Get(context.Background(), client.ObjectKey{
+		Name:      VeleroAWSSecretName,
+		Namespace: testNamespace,
+	}, secretResult)
+	assert.NoError(t, err)
+	assert.Contains(t, secretResult.StringData["credentials"], roleARN)
+	assert.Contains(t, secretResult.StringData["credentials"], WebIdentityTokenPath)
+}
+
+func TestCreateOrUpdateSTSGCPSecret(t *testing.T) {
+	testNamespace := "test-namespace"
+	testLogger := zap.New(zap.UseDevMode(true))
+	serviceAccountEmail := "test@example.iam.gserviceaccount.com"
+	projectNumber := "123456789012"
+	poolId := "test-pool"
+	providerId := "test-provider"
+
+	fakeClient := fake.NewClientBuilder().
+		Build()
+	fakeClientset := k8sfake.NewSimpleClientset()
+
+	audience := "//iam.googleapis.com/projects/" + projectNumber + "/locations/global/workloadIdentityPools/" + poolId + "/providers/" + providerId
+
+	// Use the refactored function directly
+	expectedJSON := `{
+	"type": "external_account",
+	"audience": "` + audience + `",
+	"subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+	"token_url": "https://sts.googleapis.com/v1/token",
+	"service_account_impersonation_url": "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/` + serviceAccountEmail + `:generateAccessToken",
+	"credential_source": {
+		"file": "` + WebIdentityTokenPath + `",
+		"format": {
+			"type": "text"
+		}
+	}
+}`
+	err := CreateOrUpdateSTSSecretWithClientsAndWait(testLogger, VeleroGCPSecretName, map[string]string{
+		GcpSecretJSONKey: expectedJSON,
+	}, testNamespace, fakeClient, fakeClientset, false)
+
+	assert.NoError(t, err)
+
+	// Verify the secret was created correctly
+	secretResult := &corev1.Secret{}
+	err = fakeClient.Get(context.Background(), client.ObjectKey{
+		Name:      VeleroGCPSecretName,
+		Namespace: testNamespace,
+	}, secretResult)
+	assert.NoError(t, err)
+	assert.Contains(t, secretResult.StringData[GcpSecretJSONKey], serviceAccountEmail)
+	assert.Contains(t, secretResult.StringData[GcpSecretJSONKey], audience)
+	assert.Contains(t, secretResult.StringData[GcpSecretJSONKey], WebIdentityTokenPath)
+}
+
+func TestCreateOrUpdateSTSAzureSecret(t *testing.T) {
+	testNamespace := "test-namespace"
+	testLogger := zap.New(zap.UseDevMode(true))
+	clientID := "test-client-id"
+	tenantID := "test-tenant-id"
+	subscriptionID := "test-subscription-id"
+
+	fakeClient := fake.NewClientBuilder().
+		Build()
+	fakeClientset := k8sfake.NewSimpleClientset()
+
+	// Use the refactored function directly with new environment variable format
+	expectedCredentials := `
+AZURE_SUBSCRIPTION_ID=` + subscriptionID + `
+AZURE_TENANT_ID=` + tenantID + `
+AZURE_CLIENT_ID=` + clientID + `
+AZURE_CLOUD_NAME=AzurePublicCloud
+`
+	err := CreateOrUpdateSTSSecretWithClientsAndWait(testLogger, VeleroAzureSecretName, map[string]string{
+		"azurekey": expectedCredentials,
+	}, testNamespace, fakeClient, fakeClientset, false)
+
+	assert.NoError(t, err)
+
+	// Verify the secret was created correctly
+	secretResult := &corev1.Secret{}
+	err = fakeClient.Get(context.Background(), client.ObjectKey{
+		Name:      VeleroAzureSecretName,
+		Namespace: testNamespace,
+	}, secretResult)
+	assert.NoError(t, err)
+	assert.Contains(t, secretResult.StringData["azurekey"], "AZURE_SUBSCRIPTION_ID="+subscriptionID)
+	assert.Contains(t, secretResult.StringData["azurekey"], "AZURE_TENANT_ID="+tenantID)
+	assert.Contains(t, secretResult.StringData["azurekey"], "AZURE_CLIENT_ID="+clientID)
+	assert.Contains(t, secretResult.StringData["azurekey"], "AZURE_CLOUD_NAME=AzurePublicCloud")
+}
+
+func TestCreateOrUpdateSTSSecret_ErrorScenarios(t *testing.T) {
+	testNamespace := "test-namespace"
+	testSecretName := "test-secret"
+	testLogger := zap.New(zap.UseDevMode(true))
+
+	t.Run("Get error during update", func(t *testing.T) {
+		// Create a client that returns an error on Get
+		fakeClient := &mockErrorClient{
+			Client: fake.NewClientBuilder().
+				WithRuntimeObjects(&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testSecretName,
+						Namespace: testNamespace,
+					},
+				}).
+				Build(),
+			getError: true,
+		}
+		fakeClientset := k8sfake.NewSimpleClientset()
+
+		err := CreateOrUpdateSTSSecretWithClientsAndWait(testLogger, testSecretName, map[string]string{
+			"key": "value",
+		}, testNamespace, fakeClient, fakeClientset, false)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("Patch error during update", func(t *testing.T) {
+		// Create a client that returns an error on Patch
+		fakeClient := &mockErrorClient{
+			Client: fake.NewClientBuilder().
+				WithRuntimeObjects(&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testSecretName,
+						Namespace: testNamespace,
+					},
+				}).
+				Build(),
+			patchError: true,
+		}
+		fakeClientset := k8sfake.NewSimpleClientset()
+
+		err := CreateOrUpdateSTSSecretWithClientsAndWait(testLogger, testSecretName, map[string]string{
+			"key": "value",
+		}, testNamespace, fakeClient, fakeClientset, false)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "patch error")
+	})
+}
+
+// Mock client that can simulate errors
+type mockErrorClient struct {
+	client.Client
+	getError   bool
+	patchError bool
+}
+
+func (m *mockErrorClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	// Always return AlreadyExists to trigger the update path
+	return errors.NewAlreadyExists(schema.GroupResource{}, "test")
+}
+
+func (m *mockErrorClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	if m.getError {
+		return errors.NewNotFound(schema.GroupResource{}, "test")
+	}
+	return m.Client.Get(ctx, key, obj, opts...)
+}
+
+func (m *mockErrorClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	if m.patchError {
+		return errors.NewBadRequest("patch error")
+	}
+	return m.Client.Patch(ctx, obj, patch, opts...)
+}
+
+func TestSTSStandardizedFlow(t *testing.T) {
+	// Save original env values
+	originalWatchNS := os.Getenv("WATCH_NAMESPACE")
+	originalRoleARN := os.Getenv(RoleARNEnvKey)
+	originalServiceAccountEmail := os.Getenv(ServiceAccountEmailEnvKey)
+	originalProjectNumber := os.Getenv(ProjectNumberEnvKey)
+	originalPoolID := os.Getenv(PoolIDEnvKey)
+	originalProviderID := os.Getenv(ProviderId)
+	originalClientID := os.Getenv(ClientIDEnvKey)
+	originalTenantID := os.Getenv(TenantIDEnvKey)
+	originalSubscriptionID := os.Getenv(SubscriptionIDEnvKey)
+
+	// Restore env values after test
+	defer func() {
+		os.Setenv("WATCH_NAMESPACE", originalWatchNS)
+		os.Setenv(RoleARNEnvKey, originalRoleARN)
+		os.Setenv(ServiceAccountEmailEnvKey, originalServiceAccountEmail)
+		os.Setenv(ProjectNumberEnvKey, originalProjectNumber)
+		os.Setenv(PoolIDEnvKey, originalPoolID)
+		os.Setenv(ProviderId, originalProviderID)
+		os.Setenv(ClientIDEnvKey, originalClientID)
+		os.Setenv(TenantIDEnvKey, originalTenantID)
+		os.Setenv(SubscriptionIDEnvKey, originalSubscriptionID)
+	}()
+
+	testCases := []struct {
+		name           string
+		envVars        map[string]string
+		expectedSecret string
+		expectError    bool
+	}{
+		{
+			name:           "No credentials provided",
+			envVars:        map[string]string{},
+			expectedSecret: "",
+			expectError:    false,
+		},
+		{
+			name: "AWS credentials provided",
+			envVars: map[string]string{
+				"WATCH_NAMESPACE": "test-namespace",
+				RoleARNEnvKey:     "arn:aws:iam::123456789012:role/test-role",
+			},
+			expectedSecret: VeleroAWSSecretName,
+			expectError:    false,
+		},
+		{
+			name: "GCP credentials provided",
+			envVars: map[string]string{
+				"WATCH_NAMESPACE":         "test-namespace",
+				ServiceAccountEmailEnvKey: "test@example.iam.gserviceaccount.com",
+				ProjectNumberEnvKey:       "123456789012",
+				PoolIDEnvKey:              "test-pool",
+				ProviderId:                "test-provider",
+			},
+			expectedSecret: VeleroGCPSecretName,
+			expectError:    false,
+		},
+		{
+			name: "Azure credentials provided",
+			envVars: map[string]string{
+				"WATCH_NAMESPACE":    "test-namespace",
+				ClientIDEnvKey:       "test-client-id",
+				TenantIDEnvKey:       "test-tenant-id",
+				SubscriptionIDEnvKey: "test-subscription-id",
+			},
+			expectedSecret: VeleroAzureSecretName,
+			expectError:    false,
+		},
+		{
+			name: "Partial GCP credentials - should return empty",
+			envVars: map[string]string{
+				"WATCH_NAMESPACE":         "test-namespace",
+				ServiceAccountEmailEnvKey: "test@example.iam.gserviceaccount.com",
+				ProjectNumberEnvKey:       "123456789012",
+				// Missing PoolIDEnvKey and ProviderId
+			},
+			expectedSecret: "",
+			expectError:    false,
+		},
+		{
+			name: "Partial Azure credentials - should return empty",
+			envVars: map[string]string{
+				"WATCH_NAMESPACE": "test-namespace",
+				ClientIDEnvKey:    "test-client-id",
+				TenantIDEnvKey:    "test-tenant-id",
+				// Missing SubscriptionIDEnvKey
+			},
+			expectedSecret: "",
+			expectError:    false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Clear all env vars first
+			os.Clearenv()
+
+			// Set test env vars
+			for k, v := range tc.envVars {
+				os.Setenv(k, v)
+			}
+
+			// Since STSStandardizedFlow uses pkgclient.GetKubeconf() which we can't easily mock,
+			// we'll skip these tests for now in CI environment
+			// In a real scenario, you would refactor STSStandardizedFlow to accept a kubeconfig parameter
+			t.Skip("Skipping test that requires real kubeconfig")
+		})
+	}
+}
+
+func TestAnnotateVeleroServiceAccountForAzure(t *testing.T) {
+	testNamespace := "test-namespace"
+	testClientID := "test-client-id"
+	testLogger := zap.New(zap.UseDevMode(true))
+
+	testCases := []struct {
+		name                   string
+		clientID               string
+		existingServiceAccount *corev1.ServiceAccount
+		expectError            bool
+		expectedAnnotations    map[string]string
+		skipAnnotation         bool
+	}{
+		{
+			name:     "Successfully annotate service account",
+			clientID: testClientID,
+			existingServiceAccount: &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "velero",
+					Namespace: testNamespace,
+				},
+			},
+			expectError:         false,
+			expectedAnnotations: map[string]string{
+				// Annotation is commented out in implementation
+			},
+		},
+		{
+			name:     "Successfully annotate service account with existing annotations",
+			clientID: testClientID,
+			existingServiceAccount: &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "velero",
+					Namespace: testNamespace,
+					Annotations: map[string]string{
+						"existing-annotation": "existing-value",
+					},
+				},
+			},
+			expectError: false,
+			expectedAnnotations: map[string]string{
+				// Annotation is commented out in implementation, only existing annotations should remain
+				"existing-annotation": "existing-value",
+			},
+		},
+		{
+			name:     "Empty client ID returns error",
+			clientID: "",
+			existingServiceAccount: &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "velero",
+					Namespace: testNamespace,
+				},
+			},
+			expectError: true,
+		},
+		{
+			name:                   "Service account not found - skip annotation",
+			clientID:               testClientID,
+			existingServiceAccount: nil,
+			expectError:            false,
+			skipAnnotation:         true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Setup fake client
+			var fakeClient client.Client
+			if tc.existingServiceAccount != nil {
+				fakeClient = fake.NewClientBuilder().
+					WithObjects(tc.existingServiceAccount).
+					Build()
+			} else {
+				fakeClient = fake.NewClientBuilder().Build()
+			}
+
+			// Call the function
+			err := AnnotateVeleroServiceAccountForAzureWithClient(testLogger, tc.clientID, testNamespace, fakeClient)
+
+			// Check error
+			if tc.expectError {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+
+			// Skip verification if annotation was skipped
+			if tc.skipAnnotation {
+				return
+			}
+
+			// Verify the service account was annotated correctly
+			sa := &corev1.ServiceAccount{}
+			err = fakeClient.Get(context.Background(), client.ObjectKey{
+				Name:      "velero",
+				Namespace: testNamespace,
+			}, sa)
+			assert.NoError(t, err)
+
+			// Check all expected annotations
+			for key, value := range tc.expectedAnnotations {
+				assert.Equal(t, value, sa.Annotations[key])
+			}
+		})
+	}
+}
+
+func TestCreateOrUpdateSTSAzureSecretWithServiceAccountAnnotation(t *testing.T) {
+	testNamespace := "test-namespace"
+	testLogger := zap.New(zap.UseDevMode(true))
+	clientID := "test-client-id"
+	tenantID := "test-tenant-id"
+	subscriptionID := "test-subscription-id"
+
+	t.Run("Azure secret creation with service account annotation", func(t *testing.T) {
+		// Create a velero service account
+		veleroSA := &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "velero",
+				Namespace: testNamespace,
+			},
+		}
+
+		fakeClient := fake.NewClientBuilder().
+			WithObjects(veleroSA).
+			Build()
+		fakeClientset := k8sfake.NewSimpleClientset()
+
+		// Call CreateOrUpdateSTSAzureSecret which should also annotate the service account
+		// Use the function without waiting to avoid timeout in tests
+		err := CreateOrUpdateSTSSecretWithClientsAndWait(testLogger, VeleroAzureSecretName, map[string]string{
+			"azurekey": fmt.Sprintf(`
+AZURE_SUBSCRIPTION_ID=%s
+AZURE_TENANT_ID=%s
+AZURE_CLIENT_ID=%s
+AZURE_CLOUD_NAME=AzurePublicCloud
+`, subscriptionID, tenantID, clientID),
+		}, testNamespace, fakeClient, fakeClientset, false) // Don't wait for secret
+		assert.NoError(t, err)
+
+		// Now annotate the service account
+		err = AnnotateVeleroServiceAccountForAzureWithClient(testLogger, clientID, testNamespace, fakeClient)
+		assert.NoError(t, err)
+
+		// Verify the secret was created
+		secretResult := &corev1.Secret{}
+		err = fakeClient.Get(context.Background(), client.ObjectKey{
+			Name:      VeleroAzureSecretName,
+			Namespace: testNamespace,
+		}, secretResult)
+		assert.NoError(t, err)
+		assert.Contains(t, secretResult.StringData["azurekey"], "AZURE_CLIENT_ID="+clientID)
+
+		// Verify the service account was annotated
+		saResult := &corev1.ServiceAccount{}
+		err = fakeClient.Get(context.Background(), client.ObjectKey{
+			Name:      "velero",
+			Namespace: testNamespace,
+		}, saResult)
+		assert.NoError(t, err)
+	})
+
+	t.Run("Azure secret creation continues even if service account annotation fails", func(t *testing.T) {
+		// Don't create the service account, so annotation will fail
+		fakeClient := fake.NewClientBuilder().Build()
+		fakeClientset := k8sfake.NewSimpleClientset()
+
+		// Call CreateOrUpdateSTSAzureSecret
+		// Use the function without waiting to avoid timeout in tests
+		err := CreateOrUpdateSTSSecretWithClientsAndWait(testLogger, VeleroAzureSecretName, map[string]string{
+			"azurekey": fmt.Sprintf(`
+AZURE_SUBSCRIPTION_ID=%s
+AZURE_TENANT_ID=%s
+AZURE_CLIENT_ID=%s
+AZURE_CLOUD_NAME=AzurePublicCloud
+`, subscriptionID, tenantID, clientID),
+		}, testNamespace, fakeClient, fakeClientset, false) // Don't wait for secret
+
+		// Should not error even though service account doesn't exist
+		assert.NoError(t, err)
+
+		// Verify the secret was still created
+		secretResult := &corev1.Secret{}
+		err = fakeClient.Get(context.Background(), client.ObjectKey{
+			Name:      VeleroAzureSecretName,
+			Namespace: testNamespace,
+		}, secretResult)
+		assert.NoError(t, err)
+	})
+}


### PR DESCRIPTION
## Summary
Backport of #1712 to oadp-1.5 branch

This PR backports the AWS, GCP, and Azure Standardized Flow Implementation to the oadp-1.5 branch.

## Original PR Description
- AWS, GCP, Azure Standardized Flow Secret Creation
- Add BSL-specific patching for STS secrets
- Implement automatic region patching for AWS STS secrets from BSL configuration
- Implement automatic resource group patching for Azure STS secrets from BSL configuration
- Add Azure workload identity support for Velero deployment and service account annotation
- Enhance Azure workload identity secret management in DataProtectionApplication reconciler

## Changes
- Cherry-picked commit 045988cf9f7e9106e2b520cb28b6bd43cc2b1da0
- Resolved conflicts in ClusterServiceVersion files by enabling token-auth features for Azure and GCP

## Test plan
- [ ] Verify AWS STS flow works correctly
- [ ] Verify GCP STS flow works correctly  
- [ ] Verify Azure workload identity flow works correctly
- [ ] Run existing unit tests
- [ ] Run e2e tests for credential flows

🤖 Generated with [Claude Code](https://claude.ai/code)