### PR TITLE
Propagate errors from HCP deletion checks

### DIFF
--- a/tests/e2e/lib/hcp/hcp.go
+++ b/tests/e2e/lib/hcp/hcp.go
@@ -66,9 +66,13 @@ func (h *HCHandler) RemoveHCP(timeout time.Duration) error {
 	log.Printf("\tWaiting for the HC to be deleted")
 	err := wait.PollUntilContextTimeout(h.Ctx, time.Second*5, timeout, true, func(ctx context.Context) (bool, error) {
 		log.Printf("\tAttempting to verify HC deletion...")
-		result := IsHCDeleted(h)
-		log.Printf("\tHC deletion check result: %v", result)
-		return result, nil
+		deleted, err := IsHCDeleted(h)
+		if err != nil {
+			log.Printf("\tHC deletion check error: %v", err)
+			return false, err
+		}
+		log.Printf("\tHC deletion check result: %v", deleted)
+		return deleted, nil
 	})
 
 	if err != nil {
@@ -222,14 +226,24 @@ func (h *HCHandler) DeleteHCSecrets() error {
 // WaitForHCDeletion waits for the HostedCluster to be deleted
 func (h *HCHandler) WaitForHCDeletion() error {
 	return wait.PollUntilContextTimeout(h.Ctx, WaitForNextCheckTimeout, Wait10Min, true, func(ctx context.Context) (bool, error) {
-		return IsHCDeleted(h), nil
+		deleted, err := IsHCDeleted(h)
+		if err != nil {
+			// Return the error to stop polling and propagate the error details
+			return false, err
+		}
+		return deleted, nil
 	})
 }
 
 // WaitForHCPDeletion waits for the HostedControlPlane to be deleted
 func (h *HCHandler) WaitForHCPDeletion(hcp *hypershiftv1.HostedControlPlane) error {
 	return wait.PollUntilContextTimeout(h.Ctx, WaitForNextCheckTimeout, Wait10Min, true, func(ctx context.Context) (bool, error) {
-		return IsHCPDeleted(h, hcp), nil
+		deleted, err := IsHCPDeleted(h, hcp)
+		if err != nil {
+			// Return the error to stop polling and propagate the error details
+			return false, err
+		}
+		return deleted, nil
 	})
 }
 
@@ -513,10 +527,10 @@ func handleDeploymentValidationFailure(ctx context.Context, ocClient client.Clie
 }
 
 // IsHCPDeleted checks if a HostedControlPlane has been deleted
-func IsHCPDeleted(h *HCHandler, hcp *hypershiftv1.HostedControlPlane) bool {
+func IsHCPDeleted(h *HCHandler, hcp *hypershiftv1.HostedControlPlane) (bool, error) {
 	if hcp == nil {
 		log.Printf("\tNo HCP provided, assuming deleted")
-		return true
+		return true, nil
 	}
 	log.Printf("\tChecking if HCP %s is deleted...", hcp.Name)
 	newHCP := &hypershiftv1.HostedControlPlane{}
@@ -526,20 +540,20 @@ func IsHCPDeleted(h *HCHandler, hcp *hypershiftv1.HostedControlPlane) bool {
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			log.Printf("\tHCP %s is confirmed deleted", hcp.Name)
-			return true
+			return true, nil
 		}
 		log.Printf("\tHCP %s deletion check failed with error: %v", hcp.Name, err)
-		return false
+		return false, fmt.Errorf("failed to check HCP deletion: %w", err)
 	}
 	log.Printf("\tHCP %s still exists", hcp.Name)
-	return false
+	return false, nil
 }
 
 // IsHCDeleted checks if a HostedCluster has been deleted
-func IsHCDeleted(h *HCHandler) bool {
+func IsHCDeleted(h *HCHandler) (bool, error) {
 	if h.HostedCluster == nil {
 		log.Printf("\tNo HostedCluster provided, assuming deleted")
-		return true
+		return true, nil
 	}
 	log.Printf("\tChecking if HC %s is deleted...", h.HostedCluster.Name)
 	newHC := &hypershiftv1.HostedCluster{}
@@ -549,13 +563,13 @@ func IsHCDeleted(h *HCHandler) bool {
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			log.Printf("\tHC %s is confirmed deleted", h.HostedCluster.Name)
-			return true
+			return true, nil
 		}
 		log.Printf("\tHC %s deletion check failed with error: %v", h.HostedCluster.Name, err)
-		return false
+		return false, fmt.Errorf("failed to check HC deletion: %w", err)
 	}
 	log.Printf("\tHC %s still exists", h.HostedCluster.Name)
-	return false
+	return false, nil
 }
 
 // GetHCPNamespace returns the namespace for a HostedControlPlane

--- a/tests/e2e/lib/hcp/hcp_test.go
+++ b/tests/e2e/lib/hcp/hcp_test.go
@@ -218,7 +218,8 @@ func TestIsHCPDeleted(t *testing.T) {
 			}
 
 			// Call IsHCPDeleted
-			result := IsHCPDeleted(h, tt.hcp)
+			result, err := IsHCPDeleted(h, tt.hcp)
+			g.Expect(err).ToNot(gomega.HaveOccurred())
 			g.Expect(result).To(gomega.Equal(tt.expectedResult))
 		})
 	}
@@ -277,7 +278,8 @@ func TestIsHCDeleted(t *testing.T) {
 			}
 
 			// Call IsHCDeleted
-			result := IsHCDeleted(h)
+			result, err := IsHCDeleted(h)
+			g.Expect(err).ToNot(gomega.HaveOccurred())
 			g.Expect(result).To(gomega.Equal(tt.expectedResult))
 		})
 	}


### PR DESCRIPTION
## Why the changes were made

Previously, IsHCDeleted and IsHCPDeleted only returned a boolean value, causing actual API errors to be lost and reported as generic "context deadline exceeded" errors. This made debugging difficult when deletion checks failed due to API errors (network issues, permission problems, etc.) rather than the resource still existing.

This change improves error visibility by propagating the actual error from the Kubernetes API calls, helping operators troubleshoot HCP deletion timeouts more effectively.

## How to test the changes made

1. Run the unit tests:
   ```bash
   go test ./tests/e2e/lib/hcp/... -v
   ```

2. To see the improved error reporting in action, you can simulate an API error scenario where the deletion check fails. The error will now show the actual API error instead of just "context deadline exceeded".

3. E2E tests should continue to pass as before, but with better error messages when deletion checks fail.

🤖 Generated with [Claude Code](https://claude.ai/code)