### PR TITLE
add backup tests w/ labelselector vs by namespace

### DIFF
--- a/tests/e2e/backup_restore_suite_test.go
+++ b/tests/e2e/backup_restore_suite_test.go
@@ -167,22 +167,24 @@ func runBackup(brCase BackupRestoreCase, backupName string) bool {
 	var nsRequiresResticDCWorkaround bool
 	var err error
 
-	if brCase.Namespace != "" {
-		nsRequiresResticDCWorkaround, err = lib.NamespaceRequiresResticDCWorkaround(dpaCR.Client, brCase.Namespace)
-		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	nsRequiresResticDCWorkaround, err = lib.NamespaceRequiresResticDCWorkaround(dpaCR.Client, brCase.Namespace)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-		if strings.Contains(brCase.Name, "twovol") {
-			volumeSyncDelay := 30 * time.Second
-			log.Printf("Sleeping for %v to allow volume to be in sync with /tmp/log/ for case %s", volumeSyncDelay, brCase.Name)
-			// TODO this should be a function, not an arbitrary sleep
-			time.Sleep(volumeSyncDelay)
-		}
+	if strings.Contains(brCase.Name, "twovol") {
+		volumeSyncDelay := 30 * time.Second
+		log.Printf("Sleeping for %v to allow volume to be in sync with /tmp/log/ for case %s", volumeSyncDelay, brCase.Name)
+		// TODO this should be a function, not an arbitrary sleep
+		time.Sleep(volumeSyncDelay)
+	}
 
-		// create backup
-		log.Printf("Creating backup %s for case %s", backupName, brCase.Name)
+	// create backup
+	log.Printf("Creating backup %s for case %s", backupName, brCase.Name)
+	if brCase.BackupRestoreType != lib.CSILabel {
 		err = lib.CreateBackupForNamespaces(dpaCR.Client, namespace, backupName, []string{brCase.Namespace}, brCase.BackupRestoreType == lib.RESTIC || brCase.BackupRestoreType == lib.KOPIA, brCase.BackupRestoreType == lib.CSIDataMover)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
-	} else {
+	}
+
+	if brCase.BackupRestoreType == lib.CSILabel {
 		// Extract the first key-value pair from LabelSelector
 		var labelKey, labelValue string
 		for k, v := range brCase.LabelSelector {
@@ -337,13 +339,13 @@ var _ = ginkgo.Describe("Backup and restore tests", ginkgo.Ordered, func() {
 			}
 			runApplicationBackupAndRestore(brCase, updateLastBRcase, updateLastInstallTime)
 		},
-		ginkgo.Entry("MySQL application label CSI", ginkgo.FlakeAttempts(flakeAttempts), ApplicationBackupRestoreCase{
+		ginkgo.Entry("MySQL-label application CSI", ginkgo.FlakeAttempts(flakeAttempts), ApplicationBackupRestoreCase{
 			ApplicationTemplate: "./sample-applications/mysql-persistent/mysql-persistent-csi.yaml",
 			BackupRestoreCase: BackupRestoreCase{
-				Namespace:         "",
+				Namespace:         "mysql-persistent",
 				LabelSelector:     map[string]string{"app": "mysql"},
 				Name:              "mysql-csi-label-e2e",
-				BackupRestoreType: lib.CSI,
+				BackupRestoreType: lib.CSILabel,
 				PreBackupVerify:   todoListReady(true, false, "mysql"),
 				PostRestoreVerify: todoListReady(false, false, "mysql"),
 				BackupTimeout:     20 * time.Minute,

--- a/tests/e2e/backup_restore_suite_test.go
+++ b/tests/e2e/backup_restore_suite_test.go
@@ -25,6 +25,7 @@ type BackupRestoreCase struct {
 	PostRestoreVerify VerificationFunction
 	SkipVerifyLogs    bool // TODO remove
 	BackupTimeout     time.Duration
+	LabelSelector     map[string]string
 }
 
 type ApplicationBackupRestoreCase struct {
@@ -163,20 +164,35 @@ func runApplicationBackupAndRestore(brCase ApplicationBackupRestoreCase, updateL
 }
 
 func runBackup(brCase BackupRestoreCase, backupName string) bool {
-	nsRequiresResticDCWorkaround, err := lib.NamespaceRequiresResticDCWorkaround(dpaCR.Client, brCase.Namespace)
-	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	var nsRequiresResticDCWorkaround bool
+	var err error
 
-	if strings.Contains(brCase.Name, "twovol") {
-		volumeSyncDelay := 30 * time.Second
-		log.Printf("Sleeping for %v to allow volume to be in sync with /tmp/log/ for case %s", volumeSyncDelay, brCase.Name)
-		// TODO this should be a function, not an arbitrary sleep
-		time.Sleep(volumeSyncDelay)
+	if brCase.Namespace != "" {
+		nsRequiresResticDCWorkaround, err = lib.NamespaceRequiresResticDCWorkaround(dpaCR.Client, brCase.Namespace)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+		if strings.Contains(brCase.Name, "twovol") {
+			volumeSyncDelay := 30 * time.Second
+			log.Printf("Sleeping for %v to allow volume to be in sync with /tmp/log/ for case %s", volumeSyncDelay, brCase.Name)
+			// TODO this should be a function, not an arbitrary sleep
+			time.Sleep(volumeSyncDelay)
+		}
+
+		// create backup
+		log.Printf("Creating backup %s for case %s", backupName, brCase.Name)
+		err = lib.CreateBackupForNamespaces(dpaCR.Client, namespace, backupName, []string{brCase.Namespace}, brCase.BackupRestoreType == lib.RESTIC || brCase.BackupRestoreType == lib.KOPIA, brCase.BackupRestoreType == lib.CSIDataMover)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	} else {
+		// Extract the first key-value pair from LabelSelector
+		var labelKey, labelValue string
+		for k, v := range brCase.LabelSelector {
+			labelKey = k
+			labelValue = v
+			break // Take the first key-value pair
+		}
+		err = lib.CreateBackupForLabels(dpaCR.Client, namespace, backupName, []string{}, labelKey, labelValue, brCase.BackupRestoreType == lib.RESTIC || brCase.BackupRestoreType == lib.KOPIA, brCase.BackupRestoreType == lib.CSIDataMover)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 	}
-
-	// create backup
-	log.Printf("Creating backup %s for case %s", backupName, brCase.Name)
-	err = lib.CreateBackupForNamespaces(dpaCR.Client, namespace, backupName, []string{brCase.Namespace}, brCase.BackupRestoreType == lib.RESTIC || brCase.BackupRestoreType == lib.KOPIA, brCase.BackupRestoreType == lib.CSIDataMover)
-	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 	// wait for backup to not be running
 	gomega.Eventually(lib.IsBackupDone(dpaCR.Client, namespace, backupName), brCase.BackupTimeout, time.Second*10).Should(gomega.BeTrue())

--- a/tests/e2e/backup_restore_suite_test.go
+++ b/tests/e2e/backup_restore_suite_test.go
@@ -337,6 +337,18 @@ var _ = ginkgo.Describe("Backup and restore tests", ginkgo.Ordered, func() {
 			}
 			runApplicationBackupAndRestore(brCase, updateLastBRcase, updateLastInstallTime)
 		},
+		ginkgo.Entry("MySQL application label CSI", ginkgo.FlakeAttempts(flakeAttempts), ApplicationBackupRestoreCase{
+			ApplicationTemplate: "./sample-applications/mysql-persistent/mysql-persistent-csi.yaml",
+			BackupRestoreCase: BackupRestoreCase{
+				Namespace:         "",
+				LabelSelector:     map[string]string{"app": "mysql"},
+				Name:              "mysql-csi-label-e2e",
+				BackupRestoreType: lib.CSI,
+				PreBackupVerify:   todoListReady(true, false, "mysql"),
+				PostRestoreVerify: todoListReady(false, false, "mysql"),
+				BackupTimeout:     20 * time.Minute,
+			},
+		}, nil),
 		ginkgo.Entry("MySQL application CSI", ginkgo.FlakeAttempts(flakeAttempts), ApplicationBackupRestoreCase{
 			ApplicationTemplate: "./sample-applications/mysql-persistent/mysql-persistent-csi.yaml",
 			BackupRestoreCase: BackupRestoreCase{

--- a/tests/e2e/lib/backup.go
+++ b/tests/e2e/lib/backup.go
@@ -50,6 +50,26 @@ func CreateCustomBackupForNamespaces(ocClient client.Client, veleroNamespace, ba
 	return ocClient.Create(context.Background(), &backup)
 }
 
+func CreateBackupForLabels(ocClient client.Client, veleroNamespace, backupName string, namespaces []string, labelKey, labelValue string, defaultVolumesToFsBackup bool, snapshotMoveData bool) error {
+	backup := velero.Backup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      backupName,
+			Namespace: veleroNamespace,
+		},
+		Spec: velero.BackupSpec{
+			IncludedNamespaces: []string{},
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					labelKey: labelValue,
+				},
+			},
+			DefaultVolumesToFsBackup: &defaultVolumesToFsBackup,
+			SnapshotMoveData:         &snapshotMoveData,
+		},
+	}
+	return ocClient.Create(context.Background(), &backup)
+}
+
 func GetBackup(c client.Client, namespace string, name string) (*velero.Backup, error) {
 	backup := velero.Backup{}
 	err := c.Get(context.Background(), client.ObjectKey{

--- a/tests/e2e/lib/dpa_helpers.go
+++ b/tests/e2e/lib/dpa_helpers.go
@@ -29,6 +29,7 @@ const (
 	RESTIC          BackupRestoreType = "restic"
 	KOPIA           BackupRestoreType = "kopia"
 	NativeSnapshots BackupRestoreType = "native-snapshots"
+	CSILabel        BackupRestoreType = "csi-label"
 )
 
 type DpaCustomResource struct {

--- a/tests/e2e/sample-applications/mysql-persistent/mysql-backup-labels.yaml
+++ b/tests/e2e/sample-applications/mysql-persistent/mysql-backup-labels.yaml
@@ -1,0 +1,11 @@
+apiVersion: velero.io/v1
+kind: Backup
+metadata:
+  name: mysql-persistent-labels
+  namespace: openshift-adp
+spec:
+  labelSelector:
+    matchLabels:
+      app: mysql
+  storageLocation: dpa-sample-1
+  ttl: 720h0m0s

--- a/tests/e2e/sample-applications/mysql-persistent/mysql-backup-labels.yaml
+++ b/tests/e2e/sample-applications/mysql-persistent/mysql-backup-labels.yaml
@@ -6,6 +6,6 @@ metadata:
 spec:
   labelSelector:
     matchLabels:
-      app: mysql
+      app: todolist
   storageLocation: dpa-sample-1
   ttl: 720h0m0s

--- a/tests/e2e/sample-applications/mysql-persistent/mysql-persistent-csi.yaml
+++ b/tests/e2e/sample-applications/mysql-persistent/mysql-persistent-csi.yaml
@@ -6,7 +6,7 @@ items:
     metadata:
       name: mysql-persistent
       labels:
-        app: mysql
+        app: todolist
   - apiVersion: v1
     kind: ServiceAccount
     metadata:
@@ -14,6 +14,7 @@ items:
       namespace: mysql-persistent
       labels:
         component: mysql-persistent
+        app: todolist
   - kind: SecurityContextConstraints
     apiVersion: security.openshift.io/v1
     metadata:
@@ -41,7 +42,7 @@ items:
       name: mysql
       namespace: mysql-persistent
       labels:
-        app: mysql
+        app: todolist
         service: mysql
     spec:
       ports:
@@ -49,7 +50,7 @@ items:
         name: mysql
         port: 3306
       selector:
-        app: mysql
+        app: todolist
   - apiVersion: apps/v1
     kind: Deployment
     metadata:
@@ -62,14 +63,14 @@ items:
     spec:
       selector:
         matchLabels:
-          app: mysql
+          app: todolist
       strategy:
         type: Recreate
       template:
         metadata:
           labels:
             e2e-app: "true"
-            app: mysql
+            app: todolist
             curl-tool: "true"
         spec:
           securityContext:
@@ -192,6 +193,10 @@ items:
     metadata:
       name: todolist-route
       namespace: mysql-persistent
+      labels:
+        app: todolist
+        service: todolist
+        e2e-app: "true"
     spec:
       path: "/"
       to:

--- a/tests/e2e/sample-applications/mysql-persistent/mysql-restore-labels.yaml
+++ b/tests/e2e/sample-applications/mysql-persistent/mysql-restore-labels.yaml
@@ -1,0 +1,8 @@
+apiVersion: velero.io/v1
+kind: Restore
+metadata:
+  name: mysql-persistent-labels
+  namespace: openshift-adp
+spec:
+  backupName: mysql-persistent-labels
+  restorePVs: true


### PR DESCRIPTION
## Why the changes were made

Test use and changes for https://issues.redhat.com/browse/OADP-6248

## How to test the changes made

 make test-e2e GINKGO_ARGS="--ginkgo.focus='MySQL-label application CSI'"

recreates hypershift plugin bug where restores fail w/
""Namespace mysql, resource restore error: error preparing secrets/mysql/mysql: rpc error: code = Unknown desc = backup or included namespaces is nil" "