### PR TITLE
OADP-6500: allow nonadmin.enabled.false

### DIFF
--- a/internal/controller/validator_test.go
+++ b/internal/controller/validator_test.go
@@ -1508,7 +1508,7 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 			messageErr: "only a single instance of Non-Admin Controller can be installed across the entire cluster. Non-Admin controller is already configured and installed in test-another-ns namespace",
 		},
 		{
-			name: "[valid] DPA CR: NonAdmin.Enable is false with existing NAC deployment",
+			name: "[valid] DPA CR: NonAdmin.Enable is true with another DPA having NonAdmin.Enable false",
 			dpa: &oadpv1alpha1.DataProtectionApplication{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-DPA-CR",

--- a/internal/controller/validator_test.go
+++ b/internal/controller/validator_test.go
@@ -1508,6 +1508,49 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 			messageErr: "only a single instance of Non-Admin Controller can be installed across the entire cluster. Non-Admin controller is already configured and installed in test-another-ns namespace",
 		},
 		{
+			name: "[valid] DPA CR: NonAdmin.Enable is false with existing NAC deployment",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-DPA-CR",
+					Namespace: "test-ns",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					NonAdmin: &oadpv1alpha1.NonAdmin{
+						Enable: pointer.Bool(true),
+					},
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{
+							DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
+								oadpv1alpha1.DefaultPluginAWS,
+							},
+							NoDefaultBackupLocation: true,
+						},
+					},
+					BackupImages: pointer.Bool(false),
+				},
+			},
+			objects: []client.Object{
+				&oadpv1alpha1.DataProtectionApplication{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "another-DPA-CR",
+						Namespace: "test-another-ns",
+					},
+					Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+						NonAdmin: &oadpv1alpha1.NonAdmin{
+							Enable: pointer.Bool(false),
+						},
+					},
+				},
+				&appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "non-admin-controller",
+						Namespace: "test-another-ns",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "given invalid DPA CR aws and legacy-aws plugins both specified",
 			dpa: &oadpv1alpha1.DataProtectionApplication{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## Why the changes were made

Only one dpa w/ nonadmin.enabled true is allowed.  Other DPA's should be allowed to have nonadmin.enabled.false w/o error

## How to test the changes made

* install 2 oadp's in different namespaces
* set the first to nonadmin.enabled: true
* Create the second dpa w/ nonadmin.enabled.false
  * you should not see an error.