### PR TITLE
OADP CLI check - do not attempt to connect to server

### DIFF
--- a/tests/e2e/backup_restore_cli_suite_test.go
+++ b/tests/e2e/backup_restore_cli_suite_test.go
@@ -198,7 +198,7 @@ var _ = ginkgo.Describe("Backup and restore tests via OADP CLI", ginkgo.Label("c
 	ginkgo.BeforeAll(func() {
 		// Verify OADP CLI is available (should be installed in Docker image)
 		log.Print("Verifying OADP CLI is available...")
-		cmd := exec.Command("kubectl", "oadp", "version")
+		cmd := exec.Command("kubectl", "oadp", "version", "--client-only")
 		output, err := cmd.CombinedOutput()
 		if err != nil {
 			ginkgo.Fail(fmt.Sprintf("OADP CLI not available: %v, output: %s", err, string(output)))


### PR DESCRIPTION
Use `--client` with `kubectl oadp version` in the CLI availability check to ensure it only reports the client version without attempting to connect to the cluster. This prevents errors when the `velero` namespace is not yet present during test setup.

The example error:
 https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_oadp-operator/1897/pull-ci-openshift-oadp-operator-oadp-dev-4.19-e2e-test-cli-aws/1955901235508809728/artifacts/e2e-test-cli-aws/e2e/build-log.txt