### PR TITLE
Fix HCP test suite BeforeAll failures and nil pointer panics

### DIFF
--- a/tests/e2e/lib/hcp/mce.go
+++ b/tests/e2e/lib/hcp/mce.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"time"
 
 	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
@@ -11,6 +12,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -149,4 +151,104 @@ func (h *HCHandler) IsMCEDeployed() bool {
 	}
 
 	return true
+}
+
+// WaitForCatalogSourceReady waits for a CatalogSource to be ready
+func WaitForCatalogSourceReady(ctx context.Context, c client.Client, catalogSourceName, namespace string, timeout time.Duration) error {
+	log.Printf("Waiting for CatalogSource %s/%s to be ready...", namespace, catalogSourceName)
+
+	catalogSource := &unstructured.Unstructured{}
+	catalogSource.SetGroupVersionKind(schema.GroupVersionResource{
+		Group:    "operators.coreos.com",
+		Version:  "v1alpha1",
+		Resource: "catalogsources",
+	}.GroupVersion().WithKind("CatalogSource"))
+
+	err := wait.PollUntilContextTimeout(ctx, time.Second*10, timeout, true, func(ctx context.Context) (bool, error) {
+		err := c.Get(ctx, types.NamespacedName{
+			Name:      catalogSourceName,
+			Namespace: namespace,
+		}, catalogSource)
+
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				log.Printf("CatalogSource %s/%s not found, waiting...", namespace, catalogSourceName)
+				return false, nil
+			}
+			log.Printf("Error getting CatalogSource: %v", err)
+			return false, nil
+		}
+
+		// Check connection state
+		state, found, err := unstructured.NestedString(catalogSource.Object, "status", "connectionState", "lastObservedState")
+		if err != nil {
+			log.Printf("Error getting connection state: %v", err)
+			return false, nil
+		}
+
+		if !found {
+			log.Printf("Connection state not found yet, waiting...")
+			return false, nil
+		}
+
+		log.Printf("CatalogSource %s/%s state: %s", namespace, catalogSourceName, state)
+		return state == "READY", nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("timeout waiting for CatalogSource %s/%s to be ready: %v", namespace, catalogSourceName, err)
+	}
+
+	log.Printf("CatalogSource %s/%s is ready", namespace, catalogSourceName)
+	return nil
+}
+
+// WaitForPackageManifest waits for a PackageManifest to be available
+func WaitForPackageManifest(ctx context.Context, c client.Client, packageName, namespace string, timeout time.Duration) error {
+	log.Printf("Waiting for PackageManifest %s/%s to be available...", namespace, packageName)
+
+	pkg := &unstructured.Unstructured{}
+	pkg.SetGroupVersionKind(schema.GroupVersionResource{
+		Group:    "packages.operators.coreos.com",
+		Version:  "v1",
+		Resource: "packagemanifests",
+	}.GroupVersion().WithKind("PackageManifest"))
+
+	err := wait.PollUntilContextTimeout(ctx, time.Second*10, timeout, true, func(ctx context.Context) (bool, error) {
+		err := c.Get(ctx, types.NamespacedName{
+			Name:      packageName,
+			Namespace: namespace,
+		}, pkg)
+
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				log.Printf("PackageManifest %s/%s not found, waiting...", namespace, packageName)
+				return false, nil
+			}
+			log.Printf("Error getting PackageManifest: %v", err)
+			return false, nil
+		}
+
+		// Check if it has channels
+		channels, found, err := unstructured.NestedSlice(pkg.Object, "status", "channels")
+		if err != nil {
+			log.Printf("Error getting channels: %v", err)
+			return false, nil
+		}
+
+		if !found || len(channels) == 0 {
+			log.Printf("PackageManifest %s/%s found but no channels available yet", namespace, packageName)
+			return false, nil
+		}
+
+		log.Printf("PackageManifest %s/%s is available with %d channels", namespace, packageName, len(channels))
+		return true, nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("timeout waiting for PackageManifest %s/%s: %v", namespace, packageName, err)
+	}
+
+	log.Printf("PackageManifest %s/%s is ready", namespace, packageName)
+	return nil
 }


### PR DESCRIPTION
Fix HCP test suite BeforeAll failures and nil pointer panics

This commit addresses the HCP backup and restore test suite failing with:
1. "multicluster-engine PackageManifest not found" errors
2. Nil pointer dereference panics in cleanup functions

Changes made:
- Add WaitForCatalogSourceReady() function to wait for CatalogSource to be READY
- Add WaitForPackageManifest() function to wait for PackageManifest availability
- Update BeforeAll to wait for prerequisites before operator installation
- Use libhcp constants (RHOperatorsNamespace, OCPMarketplaceNamespace) instead of hardcoded strings
- Use ginkgo.Fail() instead of ginkgo.Skip() for prerequisite failures
- Add nil checks in AfterAll and AfterEach to prevent cleanup panics
- Remove unused error variable to fix linting issues

The test suite now properly handles timing issues with operator catalog
synchronization and reports prerequisite failures as test failures rather
than skipped tests.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

## Why the changes were made

<!-- Explain why this PR is important, what problems it fixes, link related issues -->

## How to test the changes made

<!-- Explain how the changes introduced by this PR can be tested and verified, with commands and pictures -->
