### PR TITLE
OADP-6300: Fix DPT Azure Authentication with Velero BSL Secret Format

### DIFF
--- a/pkg/cloudprovider/azure_test.go
+++ b/pkg/cloudprovider/azure_test.go
@@ -1,0 +1,163 @@
+package cloudprovider
+
+import (
+	"testing"
+)
+
+func TestParseAzureCredentials_CloudKeyFormat(t *testing.T) {
+	// Test Velero BSL secret format (single 'cloud' key with env vars)
+	cloudContent := `AZURE_SUBSCRIPTION_ID=test-subscription-id
+AZURE_TENANT_ID=test-tenant-id
+AZURE_CLIENT_ID=test-client-id
+AZURE_CLIENT_SECRET=test-client-secret
+AZURE_RESOURCE_GROUP=test-rg
+AZURE_STORAGE_ACCOUNT_ID=teststorageaccount`
+
+	data := map[string][]byte{
+		"cloud": []byte(cloudContent),
+	}
+
+	creds := ParseAzureCredentials(data)
+
+	if creds.SubscriptionID != "test-subscription-id" {
+		t.Errorf("Expected SubscriptionID to be 'test-subscription-id', got '%s'", creds.SubscriptionID)
+	}
+	if creds.TenantID != "test-tenant-id" {
+		t.Errorf("Expected TenantID to be 'test-tenant-id', got '%s'", creds.TenantID)
+	}
+	if creds.ClientID != "test-client-id" {
+		t.Errorf("Expected ClientID to be 'test-client-id', got '%s'", creds.ClientID)
+	}
+	if creds.ClientSecret != "test-client-secret" {
+		t.Errorf("Expected ClientSecret to be 'test-client-secret', got '%s'", creds.ClientSecret)
+	}
+	if creds.ResourceGroupName != "test-rg" {
+		t.Errorf("Expected ResourceGroupName to be 'test-rg', got '%s'", creds.ResourceGroupName)
+	}
+	if creds.StorageAccountName != "teststorageaccount" {
+		t.Errorf("Expected StorageAccountName to be 'teststorageaccount', got '%s'", creds.StorageAccountName)
+	}
+}
+
+func TestParseAzureCredentials_IndividualKeysFormat(t *testing.T) {
+	// Test individual keys format (existing DPT format)
+	data := map[string][]byte{
+		"AZURE_SUBSCRIPTION_ID":    []byte("test-subscription-id"),
+		"AZURE_TENANT_ID":          []byte("test-tenant-id"),
+		"AZURE_CLIENT_ID":          []byte("test-client-id"),
+		"AZURE_CLIENT_SECRET":      []byte("test-client-secret"),
+		"AZURE_RESOURCE_GROUP":     []byte("test-rg"),
+		"AZURE_STORAGE_ACCOUNT_ID": []byte("teststorageaccount"),
+	}
+
+	creds := ParseAzureCredentials(data)
+
+	if creds.SubscriptionID != "test-subscription-id" {
+		t.Errorf("Expected SubscriptionID to be 'test-subscription-id', got '%s'", creds.SubscriptionID)
+	}
+	if creds.TenantID != "test-tenant-id" {
+		t.Errorf("Expected TenantID to be 'test-tenant-id', got '%s'", creds.TenantID)
+	}
+	if creds.ClientID != "test-client-id" {
+		t.Errorf("Expected ClientID to be 'test-client-id', got '%s'", creds.ClientID)
+	}
+	if creds.ClientSecret != "test-client-secret" {
+		t.Errorf("Expected ClientSecret to be 'test-client-secret', got '%s'", creds.ClientSecret)
+	}
+	if creds.ResourceGroupName != "test-rg" {
+		t.Errorf("Expected ResourceGroupName to be 'test-rg', got '%s'", creds.ResourceGroupName)
+	}
+	if creds.StorageAccountName != "teststorageaccount" {
+		t.Errorf("Expected StorageAccountName to be 'teststorageaccount', got '%s'", creds.StorageAccountName)
+	}
+}
+
+func TestParseAzureCredentials_EmptyCloudKey(t *testing.T) {
+	// Test with empty cloud key should fall back to individual keys
+	data := map[string][]byte{
+		"cloud":                 []byte(""),
+		"AZURE_SUBSCRIPTION_ID": []byte("test-subscription"),
+		"AZURE_TENANT_ID":       []byte("test-tenant"),
+	}
+
+	creds := ParseAzureCredentials(data)
+
+	if creds.SubscriptionID != "test-subscription" {
+		t.Errorf("Expected SubscriptionID to be 'test-subscription', got '%s'", creds.SubscriptionID)
+	}
+	if creds.TenantID != "test-tenant" {
+		t.Errorf("Expected TenantID to be 'test-tenant', got '%s'", creds.TenantID)
+	}
+}
+
+func TestParseAzureCredentials_StorageAccountKeyFormat(t *testing.T) {
+	// Test Velero BSL secret format with storage account key authentication
+	cloudContent := `AZURE_SUBSCRIPTION_ID=test-subscription-id
+AZURE_TENANT_ID=test-tenant-id
+AZURE_CLIENT_ID=test-client-id
+AZURE_CLIENT_SECRET=test-client-secret
+AZURE_RESOURCE_GROUP=test-rg
+AZURE_STORAGE_ACCOUNT_ID=teststorageaccount
+AZURE_STORAGE_ACCOUNT_ACCESS_KEY=test-storage-key`
+
+	data := map[string][]byte{
+		"cloud": []byte(cloudContent),
+	}
+
+	creds := ParseAzureCredentials(data)
+
+	// Verify all fields are parsed correctly for storage account key auth
+	if creds.SubscriptionID != "test-subscription-id" {
+		t.Errorf("Expected SubscriptionID to be 'test-subscription-id', got '%s'", creds.SubscriptionID)
+	}
+	if creds.TenantID != "test-tenant-id" {
+		t.Errorf("Expected TenantID to be 'test-tenant-id', got '%s'", creds.TenantID)
+	}
+	if creds.ClientID != "test-client-id" {
+		t.Errorf("Expected ClientID to be 'test-client-id', got '%s'", creds.ClientID)
+	}
+	if creds.ClientSecret != "test-client-secret" {
+		t.Errorf("Expected ClientSecret to be 'test-client-secret', got '%s'", creds.ClientSecret)
+	}
+	if creds.ResourceGroupName != "test-rg" {
+		t.Errorf("Expected ResourceGroupName to be 'test-rg', got '%s'", creds.ResourceGroupName)
+	}
+	if creds.StorageAccountName != "teststorageaccount" {
+		t.Errorf("Expected StorageAccountName to be 'teststorageaccount', got '%s'", creds.StorageAccountName)
+	}
+	if creds.StorageAccountKey != "test-storage-key" {
+		t.Errorf("Expected StorageAccountKey to be 'test-storage-key', got '%s'", creds.StorageAccountKey)
+	}
+}
+
+func TestParseCloudCredentials(t *testing.T) {
+	cloudData := `AZURE_SUBSCRIPTION_ID=test-sub
+AZURE_TENANT_ID=test-tenant
+
+# This is a comment
+AZURE_CLIENT_ID=test-client
+INVALID_LINE_WITHOUT_EQUALS
+AZURE_CLIENT_SECRET=test-secret`
+
+	envVars := parseCloudCredentials(cloudData)
+
+	expected := map[string]string{
+		"AZURE_SUBSCRIPTION_ID": "test-sub",
+		"AZURE_TENANT_ID":       "test-tenant",
+		"AZURE_CLIENT_ID":       "test-client",
+		"AZURE_CLIENT_SECRET":   "test-secret",
+	}
+
+	for key, expectedValue := range expected {
+		if value, exists := envVars[key]; !exists {
+			t.Errorf("Expected key '%s' to exist", key)
+		} else if value != expectedValue {
+			t.Errorf("Expected %s to be '%s', got '%s'", key, expectedValue, value)
+		}
+	}
+
+	// Should not include invalid lines
+	if _, exists := envVars["INVALID_LINE_WITHOUT_EQUALS"]; exists {
+		t.Error("Should not include invalid lines without equals sign")
+	}
+}


### PR DESCRIPTION
## Why the changes were made

<!-- Explain why this PR is important, what problems it fixes, link related issues -->

DataProtectionTest (DPT) fails with Azure BSL when using service principal authentication due to credential parsing incompatibility:

  ERROR: upload failed: DefaultAzureCredential: failed to acquire a token.
  ERROR: failed to get blob service properties: parameter resourceGroupName cannot be empty

Root Cause: DPT expects Azure credentials as individual secret keys (AZURE_TENANT_ID, AZURE_CLIENT_ID, etc.), but Velero BSL stores them in a single cloud key with
  environment variable format:
  AZURE_SUBSCRIPTION_ID=xxx
  AZURE_TENANT_ID=xxx
  AZURE_CLIENT_ID=xxx

Modified ParseAzureCredentials() in pkg/cloudprovider/azure.go to support both credential formats:

  1. Primary: Parse Velero BSL format (single cloud key)
  2. Fallback: Parse individual keys format (existing DPT format)

 Added parseCloudCredentials() helper function to parse environment variable format from the cloud key.

## How to test the changes made

<!-- Explain how the changes introduced by this PR can be tested and verified, with commands and pictures -->

 1. Create BSL secret using Velero format (This is for service principal with secret auth type):
```
  oc create secret generic azure-credentials-bsl \
    --from-file=cloud=azure-credentials-velero \
    -n openshift-adp
  Where azure-credentials-velero contains:
  AZURE_SUBSCRIPTION_ID=<subscription-id>
  AZURE_TENANT_ID=<tenant-id>
  AZURE_CLIENT_ID=<client-id>
  AZURE_CLIENT_SECRET=<client-secret>
  AZURE_RESOURCE_GROUP=<resource-group>
  AZURE_STORAGE_ACCOUNT_ID=<storage-account>
```

2. Create DPA
```
  spec:
    backupLocations:
    - name: azure-bsl
      velero:
        provider: azure
        credential:
          name: azure-credentials-bsl
          key: cloud
        config:
          resourceGroup: <resource-group>
          storageAccount: <storage-account>
          subscriptionId: <subscription-id>
```
3. Check if Azure BSL is available 
4. Create DPT referring the azure BSL
```
spec:
  backupLocationName: azure-bsl
  forceRun: true
  uploadSpeedTestConfig:
    fileSize: "10MB"
    timeout: "90s"
```
5. Check the DPT status, some examples are below
```
spampatt@spampatt-mac oadp-operator [fix-az-dpt-creds-parse]$ oc get dpt
NAME               PHASE      LASTTESTED   UPLOADSPEED(MBPS)   ENCRYPTION          VERSIONING   SNAPSHOTS   AGE
dpt-azure-test-2   Complete   13m          51                  Microsoft.Storage   Disabled                 13m
dpt-bsl-test       Complete   4s           80                  Microsoft.Storage   Disabled                 4s
```
🤖 Generated with https://claude.ai/code

Co-Authored-By: Claude [noreply@anthropic.com](mailto:noreply@anthropic.com)