### PR TITLE
OADP-6454: Add deprecation warning for PodAnnotations field

### DIFF
--- a/internal/controller/validator.go
+++ b/internal/controller/validator.go
@@ -40,6 +40,16 @@ func (r *DataProtectionApplicationReconciler) ValidateDataProtectionCR(log logr.
 		return false, errors.New("DPA CR Velero configuration cannot be nil")
 	}
 
+	// Check for deprecated PodAnnotations field and log warning
+	if len(r.dpa.Spec.PodAnnotations) > 0 {
+		deprecationWarning := "(Deprecation Warning) The 'podAnnotations' field is deprecated. " +
+			"Please migrate to 'configuration.velero.podConfig.annotations' for Velero pods " +
+			"and 'configuration.nodeAgent.podConfig.annotations' for NodeAgent pods."
+		// V(-1) corresponds to the warn level
+		log.V(-1).Info(deprecationWarning)
+		r.EventRecorder.Event(r.dpa, corev1.EventTypeWarning, "DeprecationPodAnnotations", deprecationWarning)
+	}
+
 	if r.dpa.Spec.Configuration.Velero.NoDefaultBackupLocation {
 		if len(r.dpa.Spec.BackupLocations) != 0 {
 			return false, errors.New("DPA CR Velero configuration cannot have backup locations if noDefaultBackupLocation is set")


### PR DESCRIPTION
- Added deprecation warning in ValidateDataProtectionCR when PodAnnotations is used
- Warning guides users to migrate to configuration.velero.podConfig.annotations
  for Velero pods and configuration.nodeAgent.podConfig.annotations for NodeAgent pods
- Added comprehensive tests for deprecation warning functionality
- Validation continues to pass when deprecated field is used (non-blocking)
- No automatic migration - users must manually update their configurations

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

## Why the changes were made

<!-- Explain why this PR is important, what problems it fixes, link related issues -->

## How to test the changes made

<!-- Explain how the changes introduced by this PR can be tested and verified, with commands and pictures -->
