### PR TITLE
Makefile: ensure the various versions are very visible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -230,6 +230,7 @@ vet: ## Run go vet against code.
 # If bin/ contains binaries of different arch, you may remove them so the container can install their arch.
 .PHONY: test
 test: vet envtest ## Run unit tests; run Go linters checks; check if api and bundle folders are up to date; and check if go dependencies are valid
+	@make versions
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test -mod=mod $(shell go list -mod=mod ./... | grep -v /tests/e2e) -coverprofile cover.out
 	@make lint
 	@make api-isupdated

--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,26 @@ all: build
 # More info on the awk command:
 # http://linuxcommand.org/lc3_adv_awk.php
 
+# Function to check tool version
+# Parameters: $(1)=TOOL_NAME $(2)=TOOL_PATH $(3)=VERSION_CMD $(4)=EXPECTED_VERSION $(5)=MAKE_TARGET $(6)=DISPLAY_NAME $(7)=SPECIAL_HANDLING
+define CHECK_TOOL_VERSION
+	@printf "\n\033[1m$(1) Version Check:\033[0m\n"
+	@if [ -f "$(2)" ]; then \
+		INSTALLED_VERSION=$$($(3) || echo "unknown"); \
+		EXPECTED_VERSION="$(4)"; \
+		if [ "$$INSTALLED_VERSION" = "$$EXPECTED_VERSION" ]; then \
+			printf "\033[32m%-30s\033[0m %-20s %s\n" "$(6)" "$$INSTALLED_VERSION" "✓ matches Makefile"; \
+		$(if $(7),$(7)) \
+		else \
+			printf "\033[33m%-30s\033[0m %-20s %s\n" "$(6)" "$$INSTALLED_VERSION" "⚠ differs from Makefile ($$EXPECTED_VERSION)"; \
+			exit 1; \
+		fi; \
+	else \
+		printf "\033[31m%-30s\033[0m %-20s %s\n" "$(6)" "not found" "✗ not installed in $(LOCALBIN)"; \
+		$(MAKE) $(5); \
+	fi
+endef
+
 .PHONY: help
 help: ## Display this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
@@ -130,78 +150,11 @@ versions: ## Display all variables containing 'version' in their name.
 	@printf "\033[36m%-30s\033[0m %-20s %s\n" "PREVIOUS_CHANNEL" "$(PREVIOUS_CHANNEL)" "catalog-test-upgrade"
 	@printf "\033[36m%-30s\033[0m %-20s %s\n" "PREVIOUS_CHANNEL_GO_VERSION" "$(PREVIOUS_CHANNEL_GO_VERSION)" "catalog-test-upgrade"
 	@printf "\033[36m%-30s\033[0m %-20s %s\n" "GO_TOOLCHAIN_VERSION" "$(GO_TOOLCHAIN_VERSION)" "(informational only)"
-	@printf "\n\033[1mOperator-SDK Version Check:\033[0m\n"
-	@if [ -f "$(OPERATOR_SDK)" ]; then \
-		INSTALLED_VERSION=$$($(OPERATOR_SDK) version 2>/dev/null | grep 'operator-sdk version' | cut -d'"' -f2 || echo "unknown"); \
-		EXPECTED_VERSION="$(OPERATOR_SDK_VERSION)"; \
-		if [ "$$INSTALLED_VERSION" = "$$EXPECTED_VERSION" ]; then \
-			printf "\033[32m%-30s\033[0m %-20s %s\n" "OPERATOR_SDK_LOCAL" "$$INSTALLED_VERSION" "✓ matches Makefile"; \
-		else \
-			printf "\033[33m%-30s\033[0m %-20s %s\n" "OPERATOR_SDK_LOCAL" "$$INSTALLED_VERSION" "⚠ differs from Makefile ($$EXPECTED_VERSION)"; \
-			exit 1; \
-		fi; \
-	else \
-		printf "\033[31m%-30s\033[0m %-20s %s\n" "OPERATOR_SDK_LOCAL" "not found" "✗ not installed in $(LOCALBIN)"; \
-		$(MAKE) operator-sdk; \
-	fi
-	@printf "\n\033[1mController-Gen Version Check:\033[0m\n"
-	@if [ -f "$(CONTROLLER_GEN)" ]; then \
-		INSTALLED_VERSION=$$($(CONTROLLER_GEN) --version 2>/dev/null | grep 'Version:' | cut -d' ' -f2 || echo "unknown"); \
-		EXPECTED_VERSION="$(CONTROLLER_TOOLS_VERSION)"; \
-		if [ "$$INSTALLED_VERSION" = "$$EXPECTED_VERSION" ]; then \
-			printf "\033[32m%-30s\033[0m %-20s %s\n" "CONTROLLER_GEN_LOCAL" "$$INSTALLED_VERSION" "✓ matches Makefile"; \
-		else \
-			printf "\033[33m%-30s\033[0m %-20s %s\n" "CONTROLLER_GEN_LOCAL" "$$INSTALLED_VERSION" "⚠ differs from Makefile ($$EXPECTED_VERSION)"; \
-			exit 1; \
-		fi; \
-	else \
-		printf "\033[31m%-30s\033[0m %-20s %s\n" "CONTROLLER_GEN_LOCAL" "not found" "✗ not installed in $(LOCALBIN)"; \
-		$(MAKE) controller-gen; \
-	fi
-	@printf "\n\033[1mOPM Version Check:\033[0m\n"
-	@if [ -f "$(OPM)" ]; then \
-		INSTALLED_VERSION=$$($(OPM) version 2>/dev/null | cut -d'"' -f2 || echo "unknown"); \
-		EXPECTED_VERSION="$(OPM_VERSION)"; \
-		if [ "$$INSTALLED_VERSION" = "$$EXPECTED_VERSION" ]; then \
-			printf "\033[32m%-30s\033[0m %-20s %s\n" "OPM_LOCAL" "$$INSTALLED_VERSION" "✓ matches Makefile"; \
-		else \
-			printf "\033[33m%-30s\033[0m %-20s %s\n" "OPM_LOCAL" "$$INSTALLED_VERSION" "⚠ differs from Makefile ($$EXPECTED_VERSION)"; \
-			exit 1; \
-		fi; \
-	else \
-		printf "\033[31m%-30s\033[0m %-20s %s\n" "OPM_LOCAL" "not found" "✗ not installed in $(LOCALBIN)"; \
-		$(MAKE) opm; \
-	fi
-	@printf "\n\033[1mGolangci-Lint Version Check:\033[0m\n"
-	@if [ -f "$(GOLANGCI_LINT)" ]; then \
-		INSTALLED_VERSION=$$($(GOLANGCI_LINT) --version 2>/dev/null | grep 'golangci-lint has version' | sed 's/.*version \([^ ]*\).*/\1/' || echo "unknown"); \
-		EXPECTED_VERSION="$(GOLANGCI_LINT_VERSION)"; \
-		if [ "$$INSTALLED_VERSION" = "$$EXPECTED_VERSION" ]; then \
-			printf "\033[32m%-30s\033[0m %-20s %s\n" "GOLANGCI_LINT_LOCAL" "$$INSTALLED_VERSION" "✓ matches Makefile"; \
-		else \
-			printf "\033[33m%-30s\033[0m %-20s %s\n" "GOLANGCI_LINT_LOCAL" "$$INSTALLED_VERSION" "⚠ differs from Makefile ($$EXPECTED_VERSION)"; \
-			exit 1; \
-		fi; \
-	else \
-		printf "\033[31m%-30s\033[0m %-20s %s\n" "GOLANGCI_LINT_LOCAL" "not found" "✗ not installed in $(LOCALBIN)"; \
-		$(MAKE) golangci-lint; \
-	fi
-	@printf "\n\033[1mKustomize Version Check:\033[0m\n"
-	@if [ -f "$(KUSTOMIZE)" ]; then \
-		INSTALLED_VERSION=$$($(KUSTOMIZE) version --short 2>/dev/null | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' || echo "(devel)"); \
-		EXPECTED_VERSION="$(KUSTOMIZE_VERSION)"; \
-		if [ "$$INSTALLED_VERSION" = "$$EXPECTED_VERSION" ]; then \
-			printf "\033[32m%-30s\033[0m %-20s %s\n" "KUSTOMIZE_LOCAL" "$$INSTALLED_VERSION" "✓ matches Makefile"; \
-		elif [ "$$INSTALLED_VERSION" = "(devel)" ]; then \
-			printf "\033[36m%-30s\033[0m %-20s %s\n" "KUSTOMIZE_LOCAL" "$$INSTALLED_VERSION" "ⓘ dev build (expected $(EXPECTED_VERSION))"; \
-		else \
-			printf "\033[33m%-30s\033[0m %-20s %s\n" "KUSTOMIZE_LOCAL" "$$INSTALLED_VERSION" "⚠ differs from Makefile ($$EXPECTED_VERSION)"; \
-			exit 1; \
-		fi; \
-	else \
-		printf "\033[31m%-30s\033[0m %-20s %s\n" "KUSTOMIZE_LOCAL" "not found" "✗ not installed in $(LOCALBIN)"; \
-		$(MAKE) kustomize; \
-	fi
+	$(call CHECK_TOOL_VERSION,Operator-SDK,$(OPERATOR_SDK),$(OPERATOR_SDK) version 2>/dev/null | grep 'operator-sdk version' | cut -d'"' -f2,$(OPERATOR_SDK_VERSION),operator-sdk,OPERATOR_SDK_LOCAL)
+	$(call CHECK_TOOL_VERSION,Controller-Gen,$(CONTROLLER_GEN),$(CONTROLLER_GEN) --version 2>/dev/null | grep 'Version:' | cut -d' ' -f2,$(CONTROLLER_TOOLS_VERSION),controller-gen,CONTROLLER_GEN_LOCAL)
+	$(call CHECK_TOOL_VERSION,OPM,$(OPM),$(OPM) version 2>/dev/null | cut -d'"' -f2,$(OPM_VERSION),opm,OPM_LOCAL)
+	$(call CHECK_TOOL_VERSION,Golangci-Lint,$(GOLANGCI_LINT),$(GOLANGCI_LINT) --version 2>/dev/null | grep 'golangci-lint has version' | sed 's/.*version \([^ ]*\).*/\1/',$(GOLANGCI_LINT_VERSION),golangci-lint,GOLANGCI_LINT_LOCAL)
+	$(call CHECK_TOOL_VERSION,Kustomize,$(KUSTOMIZE),$(KUSTOMIZE) version --short 2>/dev/null | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' || echo "(devel)",$(KUSTOMIZE_VERSION),kustomize,KUSTOMIZE_LOCAL,elif [ "$$INSTALLED_VERSION" = "(devel)" ]; then printf "\033[36m%-30s\033[0m %-20s %s\n" "KUSTOMIZE_LOCAL" "$$INSTALLED_VERSION" "ⓘ dev build (expected $(KUSTOMIZE_VERSION))";)
 
 
 ##@ Development

--- a/Makefile
+++ b/Makefile
@@ -64,9 +64,6 @@ IMG ?= quay.io/konveyor/oadp-operator:latest
 # You can override this with environment variable (e.g., export TTL_DURATION=4h)
 TTL_DURATION ?= 1h
 
-# ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-# ENVTEST_K8S_VERSION is defined at the top of this file
-
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -630,10 +627,6 @@ deploy-olm-stsflow-azure: deploy-olm-stsflow ## Deploy via OLM with Azure Worklo
 		echo "Example:"; \
 		echo "  make deploy-olm-stsflow-azure AZURE_CLIENT_ID=12345678-1234-1234-1234-123456789012 AZURE_TENANT_ID=87654321-4321-4321-4321-210987654321 AZURE_SUBSCRIPTION_ID=abcdef12-3456-7890-abcd-ef1234567890"; \
 	fi
-
-# A valid Git branch from https://github.com/openshift/oadp-operator
-# PREVIOUS_CHANNEL is defined at the top of this file
-# Go version in go.mod in that branch - PREVIOUS_CHANNEL_GO_VERSION is defined at the top of this file
 
 .PHONY: catalog-test-upgrade
 catalog-test-upgrade: PREVIOUS_OPERATOR_IMAGE?=ttl.sh/oadp-operator-previous-$(GIT_REV):$(TTL_DURATION)

--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ define CHECK_TOOL_VERSION
 		else \
 			printf "\033[33m%-30s\033[0m %-20s %s\n" "$(6)" "$$INSTALLED_VERSION" "⚠ differs from Makefile ($$EXPECTED_VERSION)"; \
 			printf "\033[33m✗ Installing the version requested by the Makefile\033[0m\n"; \
-			exit 1; \
+			$(MAKE) $(5); \
 		fi; \
 	else \
 		printf "\033[31m%-30s\033[0m %-20s %s\n" "$(6)" "not found" "✗ not installed in $(LOCALBIN)"; \

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ GOLANGCI_LINT_VERSION ?= v2.1.2
 KUSTOMIZE_VERSION ?= v5.2.1
 CONTROLLER_TOOLS_VERSION ?= v0.16.5
 OPM_VERSION ?= v1.23.0
+BRANCH_VERSION = oadp-dev
 PREVIOUS_CHANNEL ?= oadp-1.5
 PREVIOUS_CHANNEL_GO_VERSION ?= 1.23
 # Extract the toolchain directive from go.mod
@@ -129,6 +130,79 @@ versions: ## Display all variables containing 'version' in their name.
 	@printf "\033[36m%-30s\033[0m %-20s %s\n" "PREVIOUS_CHANNEL" "$(PREVIOUS_CHANNEL)" "catalog-test-upgrade"
 	@printf "\033[36m%-30s\033[0m %-20s %s\n" "PREVIOUS_CHANNEL_GO_VERSION" "$(PREVIOUS_CHANNEL_GO_VERSION)" "catalog-test-upgrade"
 	@printf "\033[36m%-30s\033[0m %-20s %s\n" "GO_TOOLCHAIN_VERSION" "$(GO_TOOLCHAIN_VERSION)" "(informational only)"
+	@printf "\n\033[1mOperator-SDK Version Check:\033[0m\n"
+	@if [ -f "$(OPERATOR_SDK)" ]; then \
+		INSTALLED_VERSION=$$($(OPERATOR_SDK) version 2>/dev/null | grep 'operator-sdk version' | cut -d'"' -f2 || echo "unknown"); \
+		EXPECTED_VERSION="$(OPERATOR_SDK_VERSION)"; \
+		if [ "$$INSTALLED_VERSION" = "$$EXPECTED_VERSION" ]; then \
+			printf "\033[32m%-30s\033[0m %-20s %s\n" "OPERATOR_SDK_LOCAL" "$$INSTALLED_VERSION" "✓ matches Makefile"; \
+		else \
+			printf "\033[33m%-30s\033[0m %-20s %s\n" "OPERATOR_SDK_LOCAL" "$$INSTALLED_VERSION" "⚠ differs from Makefile ($$EXPECTED_VERSION)"; \
+			exit 1; \
+		fi; \
+	else \
+		printf "\033[31m%-30s\033[0m %-20s %s\n" "OPERATOR_SDK_LOCAL" "not found" "✗ not installed in $(LOCALBIN)"; \
+		$(MAKE) operator-sdk; \
+	fi
+	@printf "\n\033[1mController-Gen Version Check:\033[0m\n"
+	@if [ -f "$(CONTROLLER_GEN)" ]; then \
+		INSTALLED_VERSION=$$($(CONTROLLER_GEN) --version 2>/dev/null | grep 'Version:' | cut -d' ' -f2 || echo "unknown"); \
+		EXPECTED_VERSION="$(CONTROLLER_TOOLS_VERSION)"; \
+		if [ "$$INSTALLED_VERSION" = "$$EXPECTED_VERSION" ]; then \
+			printf "\033[32m%-30s\033[0m %-20s %s\n" "CONTROLLER_GEN_LOCAL" "$$INSTALLED_VERSION" "✓ matches Makefile"; \
+		else \
+			printf "\033[33m%-30s\033[0m %-20s %s\n" "CONTROLLER_GEN_LOCAL" "$$INSTALLED_VERSION" "⚠ differs from Makefile ($$EXPECTED_VERSION)"; \
+			exit 1; \
+		fi; \
+	else \
+		printf "\033[31m%-30s\033[0m %-20s %s\n" "CONTROLLER_GEN_LOCAL" "not found" "✗ not installed in $(LOCALBIN)"; \
+		$(MAKE) controller-gen; \
+	fi
+	@printf "\n\033[1mOPM Version Check:\033[0m\n"
+	@if [ -f "$(OPM)" ]; then \
+		INSTALLED_VERSION=$$($(OPM) version 2>/dev/null | cut -d'"' -f2 || echo "unknown"); \
+		EXPECTED_VERSION="$(OPM_VERSION)"; \
+		if [ "$$INSTALLED_VERSION" = "$$EXPECTED_VERSION" ]; then \
+			printf "\033[32m%-30s\033[0m %-20s %s\n" "OPM_LOCAL" "$$INSTALLED_VERSION" "✓ matches Makefile"; \
+		else \
+			printf "\033[33m%-30s\033[0m %-20s %s\n" "OPM_LOCAL" "$$INSTALLED_VERSION" "⚠ differs from Makefile ($$EXPECTED_VERSION)"; \
+			exit 1; \
+		fi; \
+	else \
+		printf "\033[31m%-30s\033[0m %-20s %s\n" "OPM_LOCAL" "not found" "✗ not installed in $(LOCALBIN)"; \
+		$(MAKE) opm; \
+	fi
+	@printf "\n\033[1mGolangci-Lint Version Check:\033[0m\n"
+	@if [ -f "$(GOLANGCI_LINT)" ]; then \
+		INSTALLED_VERSION=$$($(GOLANGCI_LINT) --version 2>/dev/null | grep 'golangci-lint has version' | sed 's/.*version \([^ ]*\).*/\1/' || echo "unknown"); \
+		EXPECTED_VERSION="$(GOLANGCI_LINT_VERSION)"; \
+		if [ "$$INSTALLED_VERSION" = "$$EXPECTED_VERSION" ]; then \
+			printf "\033[32m%-30s\033[0m %-20s %s\n" "GOLANGCI_LINT_LOCAL" "$$INSTALLED_VERSION" "✓ matches Makefile"; \
+		else \
+			printf "\033[33m%-30s\033[0m %-20s %s\n" "GOLANGCI_LINT_LOCAL" "$$INSTALLED_VERSION" "⚠ differs from Makefile ($$EXPECTED_VERSION)"; \
+			exit 1; \
+		fi; \
+	else \
+		printf "\033[31m%-30s\033[0m %-20s %s\n" "GOLANGCI_LINT_LOCAL" "not found" "✗ not installed in $(LOCALBIN)"; \
+		$(MAKE) golangci-lint; \
+	fi
+	@printf "\n\033[1mKustomize Version Check:\033[0m\n"
+	@if [ -f "$(KUSTOMIZE)" ]; then \
+		INSTALLED_VERSION=$$($(KUSTOMIZE) version --short 2>/dev/null | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' || echo "(devel)"); \
+		EXPECTED_VERSION="$(KUSTOMIZE_VERSION)"; \
+		if [ "$$INSTALLED_VERSION" = "$$EXPECTED_VERSION" ]; then \
+			printf "\033[32m%-30s\033[0m %-20s %s\n" "KUSTOMIZE_LOCAL" "$$INSTALLED_VERSION" "✓ matches Makefile"; \
+		elif [ "$$INSTALLED_VERSION" = "(devel)" ]; then \
+			printf "\033[36m%-30s\033[0m %-20s %s\n" "KUSTOMIZE_LOCAL" "$$INSTALLED_VERSION" "ⓘ dev build (expected $(EXPECTED_VERSION))"; \
+		else \
+			printf "\033[33m%-30s\033[0m %-20s %s\n" "KUSTOMIZE_LOCAL" "$$INSTALLED_VERSION" "⚠ differs from Makefile ($$EXPECTED_VERSION)"; \
+			exit 1; \
+		fi; \
+	else \
+		printf "\033[31m%-30s\033[0m %-20s %s\n" "KUSTOMIZE_LOCAL" "not found" "✗ not installed in $(LOCALBIN)"; \
+		$(MAKE) kustomize; \
+	fi
+
 
 ##@ Development
 
@@ -164,7 +238,7 @@ test: vet envtest ## Run unit tests; run Go linters checks; check if api and bun
 
 
 # Lint CLI needs to be built from the same toolchain version
-GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
+GOLANGCI_LINT = $(LOCALBIN)/$(BRANCH_VERSION)/golangci-lint
 .PHONY: golangci-lint $(GOLANGCI_LINT)
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
@@ -172,8 +246,12 @@ $(GOLANGCI_LINT): $(LOCALBIN)
 		echo "golangci-lint $(GOLANGCI_LINT_VERSION) is already installed"; \
 	else \
 		echo "Installing golangci-lint $(GOLANGCI_LINT_VERSION)"; \
-		$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)); \
+		$(call go-install-tool-branch,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)); \
 	fi
+	@if [ -L "$(LOCALBIN)/golangci-lint" ]; then \
+		unlink "$(LOCALBIN)/golangci-lint"; \
+	fi
+	@ln -sf "$(LOCALBIN)/$(BRANCH_VERSION)/golangci-lint" "$(LOCALBIN)/golangci-lint"
 
 .PHONY: lint
 lint: golangci-lint ## Run Go linters checks against all project's Go files.
@@ -249,19 +327,27 @@ $(LOCALBIN):
 
 ## Tool Binaries
 KUBECTL ?= kubectl
-KUSTOMIZE ?= $(LOCALBIN)/kustomize
-CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
+KUSTOMIZE ?= $(LOCALBIN)/$(BRANCH_VERSION)/kustomize
+CONTROLLER_GEN ?= $(LOCALBIN)/$(BRANCH_VERSION)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary. If wrong version is installed, it will be removed before downloading.
 $(KUSTOMIZE): $(LOCALBIN)
-	$(call go-install-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v5@$(KUSTOMIZE_VERSION))
+	$(call go-install-tool-branch,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v5@$(KUSTOMIZE_VERSION))
+	@if [ -L "$(LOCALBIN)/kustomize" ]; then \
+		unlink "$(LOCALBIN)/kustomize"; \
+	fi
+	@ln -sf "$(LOCALBIN)/$(BRANCH_VERSION)/kustomize" "$(LOCALBIN)/kustomize"
 
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary. If wrong version is installed, it will be overwritten.
 $(CONTROLLER_GEN): $(LOCALBIN)
-	$(call go-install-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION))
+	$(call go-install-tool-branch,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION))
+	@if [ -L "$(LOCALBIN)/controller-gen" ]; then \
+		unlink "$(LOCALBIN)/controller-gen"; \
+	fi
+	@ln -sf "$(LOCALBIN)/$(BRANCH_VERSION)/controller-gen" "$(LOCALBIN)/controller-gen"
 
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
@@ -269,7 +355,7 @@ $(ENVTEST): $(LOCALBIN)
 	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20250308055145-5fe7bb3edc86)
 
 .PHONY: operator-sdk
-OPERATOR_SDK ?= $(LOCALBIN)/operator-sdk
+OPERATOR_SDK ?= $(LOCALBIN)/$(BRANCH_VERSION)/operator-sdk
 operator-sdk: ## Download operator-sdk locally if necessary.
 ifneq ($(shell $(OPERATOR_SDK) version | cut -d'"' -f2),$(OPERATOR_SDK_VERSION))
 	set -e; \
@@ -278,6 +364,11 @@ ifneq ($(shell $(OPERATOR_SDK) version | cut -d'"' -f2),$(OPERATOR_SDK_VERSION))
 	curl -sSLo $(OPERATOR_SDK) https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk_$${OS}_$${ARCH} ;\
 	chmod +x $(OPERATOR_SDK);
 endif
+	@if [ -L "$(LOCALBIN)/operator-sdk" ]; then \
+		unlink "$(LOCALBIN)/operator-sdk"; \
+	fi
+	@ln -sf "$(LOCALBIN)/$(BRANCH_VERSION)/operator-sdk" "$(LOCALBIN)/operator-sdk"
+
 
 .PHONY: bundle
 bundle: manifests kustomize operator-sdk ## Generate bundle manifests and metadata, then validate generated files.
@@ -301,7 +392,7 @@ bundle-push: ## Push the bundle image.
 	$(MAKE) docker-push IMG=$(BUNDLE_IMG)
 
 .PHONY: opm
-OPM ?= $(LOCALBIN)/opm
+OPM ?= $(LOCALBIN)/$(BRANCH_VERSION)/opm
 opm: ## Download opm locally if necessary.
 ifneq ($(shell $(OPM) version | cut -d'"' -f2),$(OPM_VERSION))
 	set -e ;\
@@ -310,6 +401,10 @@ ifneq ($(shell $(OPM) version | cut -d'"' -f2),$(OPM_VERSION))
 	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/$(OPM_VERSION)/$${OS}-$${ARCH}-opm ;\
 	chmod +x $(OPM)
 endif
+	@if [ -L "$(LOCALBIN)/opm" ]; then \
+		unlink "$(LOCALBIN)/opm"; \
+	fi
+	@ln -sf "$(LOCALBIN)/$(BRANCH_VERSION)/opm" "$(LOCALBIN)/opm"
 
 # A comma-separated list of bundle images (e.g. make catalog-build BUNDLE_IMGS=example.com/operator-bundle:v0.1.0,example.com/operator-bundle:v0.2.0).
 # These images MUST exist in a registry and be pull-able.
@@ -383,13 +478,27 @@ submit-coverage:
 # go-install-tool will 'go install' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 define go-install-tool
-@[ -f $(1) ] || { \
+[ -f $(1) ] || { \
 set -e ;\
 TMP_DIR=$$(mktemp -d) ;\
 cd $$TMP_DIR ;\
 go mod init tmp ;\
 echo "Downloading $(2)" ;\
 GOBIN=$(PROJECT_DIR)/bin go install -mod=mod $(2) ;\
+rm -rf $$TMP_DIR ;\
+}
+endef
+
+# go-install-tool-branch will 'go install' any package $2 and install it to branch-specific directory $1.
+define go-install-tool-branch
+[ -f $(1) ] || { \
+set -e ;\
+mkdir -p $(dir $(1)) ;\
+TMP_DIR=$$(mktemp -d) ;\
+cd $$TMP_DIR ;\
+go mod init tmp ;\
+echo "Downloading $(2) to branch directory" ;\
+GOBIN=$(dir $(1)) go install -mod=mod $(2) ;\
 rm -rf $$TMP_DIR ;\
 }
 endef

--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,7 @@ define CHECK_TOOL_VERSION
 		$(if $(7),$(7)) \
 		else \
 			printf "\033[33m%-30s\033[0m %-20s %s\n" "$(6)" "$$INSTALLED_VERSION" "⚠ differs from Makefile ($$EXPECTED_VERSION)"; \
+			printf "\033[33m✗ Installing the version requested by the Makefile\033[0m\n"; \
 			exit 1; \
 		fi; \
 	else \
@@ -136,7 +137,7 @@ help: ## Display this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
 .PHONY: versions
-versions: ## Display all variables containing 'version' in their name.
+versions: check-go ## Display all variables containing 'version' in their name.
 	@printf "\033[36m%-30s\033[0m %s\n" "GO_VERSION" "$$(go version | awk '{print $$3}')"
 	@printf "\n\033[1m%-30s %-20s %s\033[0m\n" "Tool and Project Versions:" "Value" "Used by Targets"
 	@printf "\033[36m%-30s\033[0m %-20s %s\n" "DEFAULT_VERSION" "$(DEFAULT_VERSION)" "bundle-isupdated"
@@ -156,6 +157,14 @@ versions: ## Display all variables containing 'version' in their name.
 	$(call CHECK_TOOL_VERSION,Golangci-Lint,$(GOLANGCI_LINT),$(GOLANGCI_LINT) --version 2>/dev/null | grep 'golangci-lint has version' | sed 's/.*version \([^ ]*\).*/\1/',$(GOLANGCI_LINT_VERSION),golangci-lint,GOLANGCI_LINT_LOCAL)
 	$(call CHECK_TOOL_VERSION,Kustomize,$(KUSTOMIZE),$(KUSTOMIZE) version --short 2>/dev/null | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' || echo "(devel)",$(KUSTOMIZE_VERSION),kustomize,KUSTOMIZE_LOCAL,elif [ "$$INSTALLED_VERSION" = "(devel)" ]; then printf "\033[36m%-30s\033[0m %-20s %s\n" "KUSTOMIZE_LOCAL" "$$INSTALLED_VERSION" "ⓘ dev build (expected $(KUSTOMIZE_VERSION))";)
 
+.PHONY: check-go
+check-go: ## Check if go binary is available in PATH
+	@if ! command -v go >/dev/null 2>&1; then \
+		printf "\033[31m✗ Error: 'go' binary not found in PATH\033[0m\n"; \
+		printf "Please install Go from https://golang.org/dl/ and ensure it's in your PATH\n"; \
+		exit 1; \
+	fi
+	@printf "\033[32m✓ Go binary found in PATH\033[0m\n"
 
 ##@ Development
 
@@ -168,11 +177,11 @@ generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and
 	GOFLAGS="-mod=mod" $(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
 .PHONY: fmt
-fmt: ## Run go fmt against code.
+fmt: check-go ## Run go fmt against code.
 	go fmt -mod=mod ./...
 
 .PHONY: vet
-vet: ## Run go vet against code.
+vet: check-go ## Run go vet against code.
 	go vet -mod=mod ./...
 
 # If test results in prow are different, it is because the environment used.
@@ -182,7 +191,7 @@ vet: ## Run go vet against code.
 # to login to registry cluster follow https://docs.ci.openshift.org/docs/how-tos/use-registries-in-build-farm/#how-do-i-log-in-to-pull-images-that-require-authentication
 # If bin/ contains binaries of different arch, you may remove them so the container can install their arch.
 .PHONY: test
-test: vet envtest ## Run unit tests; run Go linters checks; check if api and bundle folders are up to date; and check if go dependencies are valid
+test: check-go vet envtest ## Run unit tests; run Go linters checks; check if api and bundle folders are up to date; and check if go dependencies are valid
 	@make versions
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test -mod=mod $(shell go list -mod=mod ./... | grep -v /tests/e2e) -coverprofile cover.out
 	@make lint
@@ -218,11 +227,11 @@ lint-fix: golangci-lint ## Fix Go linters issues.
 ##@ Build
 
 .PHONY: build
-build: manifests generate fmt vet ## Build manager binary.
+build: check-go manifests generate fmt vet ## Build manager binary.
 	go build -o bin/manager cmd/main.go
 
 .PHONY: run
-run: manifests generate fmt vet ## Run a controller from your host.
+run: check-go manifests generate fmt vet ## Run a controller from your host.
 	go run ./cmd/main.go
 
 OC_CLI ?= $(shell which oc)
@@ -401,7 +410,7 @@ bundle-isupdated:
 
 .PHONY: check-go-dependencies
 check-go-dependencies: TEMP:= $(shell mktemp -d)
-check-go-dependencies:
+check-go-dependencies: check-go
 	@cp -r ./ $(TEMP) && cd $(TEMP) && go mod tidy && cd - && diff -ruN ./ $(TEMP)/ && echo "go dependencies checked" || (echo "go dependencies are out of date, run 'go mod tidy' to update" && exit 1)
 	@chmod -R 777 $(TEMP) && rm -rf $(TEMP)
 	go mod verify
@@ -716,7 +725,7 @@ catalog-test-upgrade: opm login-required ## Prepare a catalog image with two cha
 	chmod -R 777 test-upgrade && rm -rf test-upgrade && $(CONTAINER_TOOL) image rm catalog-test-upgrade
 
 .PHONY: install-ginkgo
-install-ginkgo: ## Make sure ginkgo is in $GOPATH/bin
+install-ginkgo: check-go ## Make sure ginkgo is in $GOPATH/bin
 	go install -v -mod=mod github.com/onsi/ginkgo/v2/ginkgo
 
 # CONFIGS FOR CLOUD
@@ -882,5 +891,5 @@ endif
 	@make bundle
 
 .PHONY: build-must-gather
-build-must-gather: ## Build OADP Must-gather binary must-gather/oadp-must-gather
+build-must-gather: check-go ## Build OADP Must-gather binary must-gather/oadp-must-gather
 	cd must-gather && go build -mod=mod -a -o oadp-must-gather cmd/main.go

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,17 @@
-# VERSION defines the project version for the bundle.
-# Update this value when you upgrade the version of your project.
-# To re-generate a bundle for another specific version without changing the standard setup, you can:
-# - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
-# - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
+# TOOL VERSIONS
+# All version-related variables are defined here for easy maintenance
 DEFAULT_VERSION := 99.0.0
-VERSION ?= $(DEFAULT_VERSION)
+VERSION ?= $(DEFAULT_VERSION) # the version of the operator
+OPERATOR_SDK_VERSION ?= v1.35.0
+ENVTEST_K8S_VERSION = 1.32 #refers to the version of kubebuilder assets to be downloaded by envtest binary # Kubernetes version from OpenShift 4.19.x
+GOLANGCI_LINT_VERSION ?= v2.1.2
+KUSTOMIZE_VERSION ?= v5.2.1
+CONTROLLER_TOOLS_VERSION ?= v0.16.5
+OPM_VERSION ?= v1.23.0
+PREVIOUS_CHANNEL ?= oadp-1.5
+PREVIOUS_CHANNEL_GO_VERSION ?= 1.23
+# Extract the toolchain directive from go.mod
+GO_TOOLCHAIN_VERSION := $(shell grep -E "^toolchain" go.mod | awk '{print $$2}')
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")
@@ -49,10 +56,6 @@ ifeq ($(USE_IMAGE_DIGESTS), true)
 	BUNDLE_GEN_FLAGS += --use-image-digests
 endif
 
-# Set the Operator SDK version to use. By default, what is installed on the system is used.
-# This is useful for CI or a project to utilize a specific version of the operator-sdk toolkit.
-OPERATOR_SDK_VERSION ?= v1.35.0
-
 # Image URL to use all building/pushing image targets
 IMG ?= quay.io/konveyor/oadp-operator:latest
 
@@ -62,7 +65,7 @@ IMG ?= quay.io/konveyor/oadp-operator:latest
 TTL_DURATION ?= 1h
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.32 # Kubernetes version from OpenShift 4.19.x https://openshift-release.apps.ci.l2s4.p1.openshiftapps.com/#4-stable
+# ENVTEST_K8S_VERSION is defined at the top of this file
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -114,6 +117,22 @@ all: build
 help: ## Display this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
+.PHONY: versions
+versions: ## Display all variables containing 'version' in their name.
+	@printf "\033[36m%-30s\033[0m %s\n" "GO_VERSION" "$$(go version | awk '{print $$3}')"
+	@printf "\n\033[1m%-30s %-20s %s\033[0m\n" "Tool and Project Versions:" "Value" "Used by Targets"
+	@printf "\033[36m%-30s\033[0m %-20s %s\n" "DEFAULT_VERSION" "$(DEFAULT_VERSION)" "bundle-isupdated"
+	@printf "\033[36m%-30s\033[0m %-20s %s\n" "VERSION" "$(VERSION)" "bundle, catalog-build, deploy-olm-stsflow, undeploy-olm"
+	@printf "\033[36m%-30s\033[0m %-20s %s\n" "OPERATOR_SDK_VERSION" "$(OPERATOR_SDK_VERSION)" "operator-sdk"
+	@printf "\033[36m%-30s\033[0m %-20s %s\n" "ENVTEST_K8S_VERSION" "$(ENVTEST_K8S_VERSION)" "test"
+	@printf "\033[36m%-30s\033[0m %-20s %s\n" "GOLANGCI_LINT_VERSION" "$(GOLANGCI_LINT_VERSION)" "golangci-lint"
+	@printf "\033[36m%-30s\033[0m %-20s %s\n" "KUSTOMIZE_VERSION" "$(KUSTOMIZE_VERSION)" "kustomize"
+	@printf "\033[36m%-30s\033[0m %-20s %s\n" "CONTROLLER_TOOLS_VERSION" "$(CONTROLLER_TOOLS_VERSION)" "controller-gen"
+	@printf "\033[36m%-30s\033[0m %-20s %s\n" "OPM_VERSION" "$(OPM_VERSION)" "opm"
+	@printf "\033[36m%-30s\033[0m %-20s %s\n" "PREVIOUS_CHANNEL" "$(PREVIOUS_CHANNEL)" "catalog-test-upgrade"
+	@printf "\033[36m%-30s\033[0m %-20s %s\n" "PREVIOUS_CHANNEL_GO_VERSION" "$(PREVIOUS_CHANNEL_GO_VERSION)" "catalog-test-upgrade"
+	@printf "\033[36m%-30s\033[0m %-20s %s\n" "GO_TOOLCHAIN_VERSION" "$(GO_TOOLCHAIN_VERSION)" "(informational only)"
+
 ##@ Development
 
 .PHONY: manifests
@@ -146,12 +165,9 @@ test: vet envtest ## Run unit tests; run Go linters checks; check if api and bun
 	@make bundle-isupdated
 	@make check-go-dependencies
 
-# Extract the toolchain directive from go.mod
-GO_TOOLCHAIN_VERSION := $(shell grep -E "^toolchain" go.mod | awk '{print $$2}')
 
 # Lint CLI needs to be built from the same toolchain version
 GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
-GOLANGCI_LINT_VERSION ?= v2.1.2
 .PHONY: golangci-lint $(GOLANGCI_LINT)
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
@@ -240,10 +256,6 @@ KUSTOMIZE ?= $(LOCALBIN)/kustomize
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 
-## Tool Versions
-KUSTOMIZE_VERSION ?= v5.2.1
-CONTROLLER_TOOLS_VERSION ?= v0.16.5
-
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary. If wrong version is installed, it will be removed before downloading.
 $(KUSTOMIZE): $(LOCALBIN)
@@ -293,7 +305,6 @@ bundle-push: ## Push the bundle image.
 
 .PHONY: opm
 OPM ?= $(LOCALBIN)/opm
-OPM_VERSION ?= v1.23.0
 opm: ## Download opm locally if necessary.
 ifneq ($(shell $(OPM) version | cut -d'"' -f2),$(OPM_VERSION))
 	set -e ;\
@@ -449,6 +460,7 @@ deploy-olm: THIS_OPERATOR_IMAGE?=ttl.sh/oadp-operator-$(GIT_REV):$(TTL_DURATION)
 deploy-olm: THIS_BUNDLE_IMAGE?=ttl.sh/oadp-operator-bundle-$(GIT_REV):$(TTL_DURATION) # Set target specific variable
 deploy-olm: DEPLOY_TMP:=$(shell mktemp -d)/ # Set target specific variable
 deploy-olm: undeploy-olm ## Build current branch operator image, bundle image, push and install via OLM. For more information, check docs/developer/install_from_source.md
+	@make versions
 	@echo "DEPLOY_TMP: $(DEPLOY_TMP)"
 	# build and push operator and bundle image
 	# use $(OPERATOR_SDK) to install bundle to authenticated cluster
@@ -620,9 +632,8 @@ deploy-olm-stsflow-azure: deploy-olm-stsflow ## Deploy via OLM with Azure Worklo
 	fi
 
 # A valid Git branch from https://github.com/openshift/oadp-operator
-PREVIOUS_CHANNEL ?= oadp-1.5
-# Go version in go.mod in that branch
-PREVIOUS_CHANNEL_GO_VERSION ?= 1.23
+# PREVIOUS_CHANNEL is defined at the top of this file
+# Go version in go.mod in that branch - PREVIOUS_CHANNEL_GO_VERSION is defined at the top of this file
 
 .PHONY: catalog-test-upgrade
 catalog-test-upgrade: PREVIOUS_OPERATOR_IMAGE?=ttl.sh/oadp-operator-previous-$(GIT_REV):$(TTL_DURATION)


### PR DESCRIPTION
## Why the changes were made

Moving from branch to branch it's easy to utilize the wrong version of the various tools we use to build



## How to test the changes made

make version
make deploy-olm


# **PR #1928: Enhanced Developer Tool Management**

## **Developer Experience Focus**

This PR transforms how developers interact with build tools in the OADP operator, making version management transparent, automatic, and branch-aware.

### **🔍 Version Visibility**

**Enhanced `make versions` Command**
- **Clear version display**: Shows all tool versions in an organized table format
- **Real-time validation**: Compares installed versions against Makefile requirements  
- **Visual status indicators**: 
  - ✅ Green checkmarks for matching versions
  - ⚠️ Yellow warnings for mismatches  
  - ❌ Red errors for missing tools
- **Go prerequisite check**: Automatically verifies Go is available before running

```bash
make versions
✓ Go binary found in PATH
GO_VERSION                     go1.23.6

Tool and Project Versions:     Value                Used by Targets
OPERATOR_SDK_VERSION           v1.35.0              operator-sdk
GOLANGCI_LINT_VERSION          v2.1.2               golangci-lint
...

Operator-SDK Version Check:
OPERATOR_SDK_LOCAL             v1.35.0              ✓ matches Makefile
```

### **📦 When Tools Are Installed**

**Smart Auto-Installation**
- **On version mismatch**: Tools automatically install the correct version instead of failing
- **On first use**: Missing tools download automatically when targets are run
- **Branch switching**: Different branches maintain separate tool versions
- **Developer feedback**: Clear messages like "✗ Installing the version requested by the Makefile"

**Trigger Points**
- Running `make versions` - validates and installs if needed
- Any target requiring tools (`make build`, `make test`, `make fmt`, etc.)
- Explicit tool targets (`make operator-sdk`, `make golangci-lint`, etc.)

### **📂 Where Tools Are Installed**

**Branch-Specific Tool Directories**
```
bin/
├── oadp-dev/              # oadp-dev branch tools
│   ├── operator-sdk
│   ├── golangci-lint
│   ├── controller-gen
│   └── ...
├── oadp-1.5/              # oadp-1.5 branch tools  
│   ├── operator-sdk
│   ├── golangci-lint
│   └── ...
└── operator-sdk -> oadp-dev/operator-sdk  # Symlinks for compatibility
```

**Installation Strategy**
- **Branch isolation**: `$(LOCALBIN)/$(BRANCH_VERSION)/toolname`
- **Backward compatibility**: Soft links maintain existing tool paths
- **Clean separation**: Each branch has its own tool versions
- **No conflicts**: Switching branches doesn't break existing installations

### **⚡ Developer Workflow Impact**

**Before This PR**
```bash
# Developer switches branches
git checkout oadp-1.5
make build
# ❌ Fails with wrong tool version
# 😞 Developer manually installs correct versions
```

**After This PR**
```bash
# Developer switches branches  
git checkout oadp-1.5
make build
# ✅ Automatically detects version mismatch
# ✅ Downloads and installs oadp-1.5 compatible tools
# ✅ Build succeeds with correct versions
```

### **🛡️ Safety Features**

**Go Binary Validation**
- **Prerequisite check**: All Go-dependent targets verify Go is installed
- **Clear error messages**: "✗ Error: 'go' binary not found in PATH"
- **Installation guidance**: Provides download URL when Go is missing
- **Prevents failures**: Stops early rather than failing mid-build

**Example Developer Interactions**
```bash
# Check what versions are expected
make versions

# Work normally - tools install automatically if needed
make fmt          # ✓ Go check + golangci-lint auto-install
make test         # ✓ All tools validated before running
make build        # ✓ Branch-specific tools used

# Switch branches seamlessly  
git checkout oadp-1.5
make test         # ✓ Different tool versions automatically used
```

This PR eliminates the friction of tool version management, letting developers focus on code rather than environment setup.