### PR TITLE
feat: Enable ROSA cluster support in HCP backup/restore tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,9 +65,13 @@ IMG ?= quay.io/konveyor/oadp-operator:latest
 # You can override this with environment variable (e.g., export TTL_DURATION=4h)
 TTL_DURATION ?= 1h
 
-# HC_NAME is the name of the HostedCluster to use for HCP tests when
-# hc_backup_restore_mode is set to external. Otherwise, HC_NAME is ignored.
+# HC_BACKUP_RESTORE_MODE is the mode of the HostedCluster to use for HCP tests.
+HC_BACKUP_RESTORE_MODE ?= external # create, external, external-rosa
+# HC_NAME is the name of the HostedCluster to use for HCP tests when HC_BACKUP_RESTORE_MODE is
+# set to external. Otherwise, HC_NAME is ignored.
 HC_NAME ?= ""
+# HC_NAMESPACE is the namespace for HostedClusters to use for HCP tests.
+HC_NAMESPACE ?= clusters
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -747,6 +751,7 @@ CI_CRED_FILE ?= ${CLUSTER_PROFILE_DIR}/.awscred
 BSL_REGION ?= us-east-1
 VSL_REGION ?= ${LEASED_RESOURCE}
 BSL_AWS_PROFILE ?= default
+VSL_AWS_PROFILE ?= default
 # BSL_AWS_PROFILE ?= migration-engineering
 
 # bucket file
@@ -800,6 +805,7 @@ test-e2e-setup: login-required build-must-gather
 	OADP_CRED_FILE="$(OADP_CRED_FILE)" \
 	BUCKET="$(OADP_BUCKET)" \
 	TARGET_CI_CRED_FILE="$(CI_CRED_FILE)" \
+	VSL_AWS_PROFILE="$(VSL_AWS_PROFILE)" \
 	VSL_REGION="$(VSL_REGION)" \
 	BSL_REGION="$(BSL_REGION)" \
 	BSL_AWS_PROFILE="$(BSL_AWS_PROFILE)" \
@@ -836,7 +842,7 @@ else
 endif
 ifeq ($(TEST_HCP_EXTERNAL),true)
 	TEST_FILTER += && (hcp_external)
-	HCP_EXTERNAL_ARGS = -hc_backup_restore_mode=external -hc_name=$(HC_NAME)
+	HCP_EXTERNAL_ARGS = -hc_backup_restore_mode=$(HC_BACKUP_RESTORE_MODE) -hc_name=$(HC_NAME) -hc_namespace=$(HC_NAMESPACE) -sc_kubeconfig=$(SC_KUBECONFIG)
 else
 	TEST_FILTER += && (! hcp_external)
 endif

--- a/docs/developer/testing/TESTING.md
+++ b/docs/developer/testing/TESTING.md
@@ -110,6 +110,23 @@ HC_NAME=hc1 \
 make test-e2e
 ```
 
+### Run selected test for HCP against external HostedControlPlane on ROSA
+
+* KUBECONFIG must point to the management cluster
+* SC_KUBECONFIG must point to the Service Cluster with ManifestWork resources
+* To break the guest cluster, the tests delete ManifestWork resources on the Service Cluster.
+
+
+```bash
+TEST_HCP_EXTERNAL=true \
+HC_BACKUP_RESTORE_MODE=external-rosa \
+HC_NAME=hc1 \
+HC_NAMESPACE=xyz \
+SC_KUBECONFIG=/path/to/service/cluster/kubeconfig \
+make test-e2e
+```
+
+
 ### Run tests with custom images
 
 You can run tests with custom images by setting the following environment variables:

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	k8s.io/apimachinery v0.33.3
 	k8s.io/client-go v0.33.3
 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738
+	open-cluster-management.io/api v0.15.0
 	sigs.k8s.io/controller-runtime v0.21.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -739,8 +739,9 @@ github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/ginkgo v1.14.0/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
 github.com/onsi/ginkgo v1.16.2/go.mod h1:CObGmKUOKaSC0RjmoAK7tKyn4Azo5P2IWuoMnvwxz1E=
-github.com/onsi/ginkgo v1.16.4 h1:29JGrr5oVBm5ulCWet69zQkzWipVXIol6ygQUe/EzNc=
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
+github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
+github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=
 github.com/onsi/ginkgo/v2 v2.22.0 h1:Yed107/8DjTr0lKCNt7Dn8yQ6ybuDRQoMGrNFKzMfHg=
 github.com/onsi/ginkgo/v2 v2.22.0/go.mod h1:7Du3c42kxCUegi0IImZ1wUQzMBVecgIHjR1C+NkhLQo=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
@@ -1567,6 +1568,8 @@ k8s.io/utils v0.0.0-20210707171843-4b05e18ac7d9/go.mod h1:jPW/WVKK9YHAvNhRxK0md/
 k8s.io/utils v0.0.0-20210802155522-efc7438f0176/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 h1:M3sRQVHv7vB20Xc2ybTt7ODCeFj6JSWYFzOFnYeS6Ro=
 k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
+open-cluster-management.io/api v0.15.0 h1:lRee1KOlGHZb2scTA7ff9E9Fxt2hJc7jpkHnaCbvkOU=
+open-cluster-management.io/api v0.15.0/go.mod h1:9erZEWEn4bEqh0nIX2wA7f/s3KCuFycQdBrPrRzi0QM=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/tests/e2e/backup_restore_cli_suite_test.go
+++ b/tests/e2e/backup_restore_cli_suite_test.go
@@ -231,7 +231,7 @@ var _ = ginkgo.Describe("Backup and restore tests via OADP CLI", ginkgo.Label("c
 
 	var _ = ginkgo.AfterAll(func() {
 		// Same cleanup as original
-		waitOADPReadiness(lib.KOPIA)
+		NewOADPDeploymentOperationDefault().Deploy(lib.KOPIA)
 
 		log.Printf("Creating real DataProtectionTest before must-gather")
 		bsls, err := dpaCR.ListBSLs()

--- a/tests/e2e/backup_restore_suite_test.go
+++ b/tests/e2e/backup_restore_suite_test.go
@@ -43,6 +43,108 @@ type ApplicationBackupRestoreCase struct {
 	PvcSuffixName       string
 }
 
+// OADPDeploymentOperation is a helper to deploy OADP resources for a given backup restore type.
+type OADPDeploymentOperation struct {
+	CreateDPA                 bool
+	CreateVolumeSnapshotClass bool
+	CreateBSL                 bool
+	CreateVSL                 bool
+}
+
+func NewOADPDeploymentOperationDefault() *OADPDeploymentOperation {
+	return &OADPDeploymentOperation{
+		CreateDPA:                 true,
+		CreateVolumeSnapshotClass: true,
+		CreateBSL:                 false,
+		CreateVSL:                 false,
+	}
+}
+
+func NewOADPDeploymentOperationROSA() *OADPDeploymentOperation {
+	return &OADPDeploymentOperation{
+		CreateDPA:                 false,
+		CreateVolumeSnapshotClass: false,
+		CreateBSL:                 true,
+		CreateVSL:                 true,
+	}
+}
+
+func (o *OADPDeploymentOperation) Deploy(backupRestoreType lib.BackupRestoreType) {
+	if o.CreateDPA {
+		err := dpaCR.CreateOrUpdate(dpaCR.Build(backupRestoreType))
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		log.Print("Checking if DPA is reconciled")
+		gomega.Eventually(dpaCR.IsReconciledTrue(), time.Minute*3, time.Second*5).Should(gomega.BeTrue())
+
+		if backupRestoreType == lib.KOPIA || backupRestoreType == lib.CSIDataMover {
+			log.Printf("Waiting for Node Agent pods to be running")
+			gomega.Eventually(lib.AreNodeAgentPodsRunning(kubernetesClientForSuiteRun, namespace), time.Minute*3, time.Second*5).Should(gomega.BeTrue())
+		}
+	}
+
+	log.Printf("Waiting for Velero Pod to be running")
+	gomega.Eventually(lib.VeleroPodIsRunning(kubernetesClientForSuiteRun, namespace), time.Minute*3, time.Second*5).Should(gomega.BeTrue())
+
+	if o.CreateVolumeSnapshotClass {
+		if backupRestoreType == lib.CSI || backupRestoreType == lib.CSIDataMover {
+			if provider == "aws" || provider == "ibmcloud" || provider == "gcp" || provider == "azure" || provider == "openstack" {
+				log.Printf("Creating VolumeSnapshotClass for CSI backuprestore")
+				snapshotClassPath := fmt.Sprintf("./sample-applications/snapclass-csi/%s.yaml", provider)
+				err := lib.InstallApplication(dpaCR.Client, snapshotClassPath)
+				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			}
+		}
+	}
+
+	if o.CreateBSL {
+		log.Print("Creating BSL")
+		err := dpaCR.CreateBackupStorageLocation()
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	}
+
+	log.Print("Checking if BSL is available")
+	gomega.Eventually(dpaCR.BSLsAreAvailable(), time.Minute*3, time.Second*5).Should(gomega.BeTrue())
+
+	if o.CreateVSL {
+		log.Print("Creating VSL")
+		err := dpaCR.CreateVolumeSnapshotLocation()
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		// Velero does not change status of VSL objects.
+		// Users can only confirm if VSLs are correct configured when running a native snapshot backup/restore
+	}
+}
+
+func (o *OADPDeploymentOperation) Undeploy(backupRestoreType lib.BackupRestoreType) {
+	if o.CreateVolumeSnapshotClass {
+		if backupRestoreType == lib.CSI || backupRestoreType == lib.CSIDataMover {
+			log.Printf("Deleting VolumeSnapshot for CSI backuprestore")
+			snapshotClassPath := fmt.Sprintf("./sample-applications/snapclass-csi/%s.yaml", provider)
+			err := lib.UninstallApplication(dpaCR.Client, snapshotClassPath)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		}
+	}
+
+	if o.CreateDPA {
+		log.Printf("Deleting DPA")
+		err := dpaCR.Delete()
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		gomega.Eventually(dpaCR.IsDeleted(), time.Minute*2, time.Second*5).Should(gomega.BeTrue())
+	}
+
+	if o.CreateBSL {
+		log.Printf("Deleting BSL")
+		err := dpaCR.DeleteBackupStorageLocation()
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	}
+
+	if o.CreateVSL {
+		log.Printf("Deleting VSL")
+		err := dpaCR.DeleteVolumeSnapshotLocation()
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	}
+}
+
 func todoListReady(preBackupState bool, twoVol bool, database string) VerificationFunction {
 	return VerificationFunction(func(ocClient client.Client, namespace string) error {
 		log.Printf("checking for the NAMESPACE: %s", namespace)
@@ -72,40 +174,10 @@ func parksAppReady(preBackupState bool, twoVol bool, DCReadyCheck bool) Verifica
 	})
 }
 
-func waitOADPReadiness(backupRestoreType lib.BackupRestoreType) {
-	err := dpaCR.CreateOrUpdate(dpaCR.Build(backupRestoreType))
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-	log.Print("Checking if DPA is reconciled")
-	gomega.Eventually(dpaCR.IsReconciledTrue(), time.Minute*3, time.Second*5).Should(gomega.BeTrue())
-
-	log.Printf("Waiting for Velero Pod to be running")
-	gomega.Eventually(lib.VeleroPodIsRunning(kubernetesClientForSuiteRun, namespace), time.Minute*3, time.Second*5).Should(gomega.BeTrue())
-
-	if backupRestoreType == lib.KOPIA || backupRestoreType == lib.CSIDataMover {
-		log.Printf("Waiting for Node Agent pods to be running")
-		gomega.Eventually(lib.AreNodeAgentPodsRunning(kubernetesClientForSuiteRun, namespace), time.Minute*3, time.Second*5).Should(gomega.BeTrue())
-	}
-
-	// Velero does not change status of VSL objects. Users can only confirm if VSLs are correct configured when running a native snapshot backup/restore
-
-	log.Print("Checking if BSL is available")
-	gomega.Eventually(dpaCR.BSLsAreAvailable(), time.Minute*3, time.Second*5).Should(gomega.BeTrue())
-}
-
 func prepareBackupAndRestore(brCase BackupRestoreCase, updateLastInstallTime func()) (string, string) {
 	updateLastInstallTime()
 
-	waitOADPReadiness(brCase.BackupRestoreType)
-
-	if brCase.BackupRestoreType == lib.CSI || brCase.BackupRestoreType == lib.CSIDataMover {
-		if provider == "aws" || provider == "ibmcloud" || provider == "gcp" || provider == "azure" || provider == "openstack" {
-			log.Printf("Creating VolumeSnapshotClass for CSI backuprestore of %s", brCase.Name)
-			snapshotClassPath := fmt.Sprintf("./sample-applications/snapclass-csi/%s.yaml", provider)
-			err := lib.InstallApplication(dpaCR.Client, snapshotClassPath)
-			gomega.Expect(err).ToNot(gomega.HaveOccurred())
-		}
-	}
+	NewOADPDeploymentOperationDefault().Deploy(brCase.BackupRestoreType)
 
 	// TODO: check registry deployments are deleted
 	// TODO: check S3 for images
@@ -319,20 +391,8 @@ func getFailedTestLogs(oadpNamespace string, appNamespace string, installTime ti
 func tearDownBackupAndRestore(brCase BackupRestoreCase, installTime time.Time, report ginkgo.SpecReport) {
 	log.Println("Post backup and restore state: ", report.State.String())
 	gatherLogs(brCase, installTime, report)
-	tearDownDPAResources(brCase)
+	NewOADPDeploymentOperationDefault().Undeploy(brCase.BackupRestoreType)
 	deleteNamespace(brCase.Namespace)
-}
-
-func tearDownDPAResources(brCase BackupRestoreCase) {
-	if brCase.BackupRestoreType == lib.CSI || brCase.BackupRestoreType == lib.CSIDataMover {
-		log.Printf("Deleting VolumeSnapshot for CSI backuprestore of %s", brCase.Name)
-		snapshotClassPath := fmt.Sprintf("./sample-applications/snapclass-csi/%s.yaml", provider)
-		err := lib.UninstallApplication(dpaCR.Client, snapshotClassPath)
-		gomega.Expect(err).ToNot(gomega.HaveOccurred())
-	}
-
-	err := dpaCR.Delete()
-	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 }
 
 func gatherLogs(brCase BackupRestoreCase, installTime time.Time, report ginkgo.SpecReport) {
@@ -366,7 +426,7 @@ var _ = ginkgo.Describe("Backup and restore tests", ginkgo.Ordered, func() {
 	var _ = ginkgo.AfterAll(func() {
 		// DPA just needs to have BSL so gathering of backups/restores logs/describe work
 		// using kopia to collect more info (DaemonSet)
-		waitOADPReadiness(lib.KOPIA)
+		NewOADPDeploymentOperationDefault().Deploy(lib.KOPIA)
 
 		//DPT Test and MustGather should be paired together
 		log.Printf("skipMustGather: %v", skipMustGather)

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"strconv"
 	"testing"
-	"time"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -14,20 +13,24 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	workv1 "open-cluster-management.io/api/work/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/openshift/oadp-operator/tests/e2e/lib"
+	libhcp "github.com/openshift/oadp-operator/tests/e2e/lib/hcp"
 )
 
 var (
 	// Common vars obtained from flags passed in ginkgo.
-	bslCredFile, namespace, instanceName, provider, vslCredFile, settings, artifact_dir string
-	flakeAttempts                                                                       int64
+	bslCredFile, namespace, instanceName, provider, vslCredFile, settings, artifact_dir, scKubeconfig string
+	flakeAttempts                                                                                     int64
 
 	kubernetesClientForSuiteRun *kubernetes.Clientset
+	crClientForServiceCluster   client.Client
 	runTimeClientForSuiteRun    client.Client
 	dynamicClientForSuiteRun    dynamic.Interface
 
@@ -37,6 +40,7 @@ var (
 	vslSecretName                   string
 
 	kubeConfig          *rest.Config
+	kubeConfigForSC     *rest.Config
 	knownFlake          bool
 	accumulatedTestLogs []string
 
@@ -45,6 +49,7 @@ var (
 	skipMustGather      bool
 	hcBackupRestoreMode string
 	hcName              string
+	hcNamespace         string
 )
 
 func init() {
@@ -63,6 +68,8 @@ func init() {
 	flag.BoolVar(&skipMustGather, "skipMustGather", false, "avoid errors with local execution and cluster architecture")
 	flag.StringVar(&hcBackupRestoreMode, "hc_backup_restore_mode", string(HCModeCreate), "Type of HC test to run")
 	flag.StringVar(&hcName, "hc_name", "", "Name of the HostedCluster to use for HCP tests")
+	flag.StringVar(&hcNamespace, "hc_namespace", libhcp.ClustersNamespace, "Namespace for HostedClusters")
+	flag.StringVar(&scKubeconfig, "sc_kubeconfig", "", "Path to kubeconfig file for Service Cluster. Only used for HCP tests and ROSA.")
 
 	// helps with launching debug sessions from IDE
 	if os.Getenv("E2E_USE_ENV_FLAGS") == "true" {
@@ -127,6 +134,9 @@ func init() {
 		if os.Getenv("HC_NAME") != "" {
 			hcName = os.Getenv("HC_NAME")
 		}
+		if os.Getenv("SC_KUBECONFIG") != "" {
+			scKubeconfig = os.Getenv("SC_KUBECONFIG")
+		}
 	}
 }
 
@@ -143,6 +153,20 @@ func TestOADPE2E(t *testing.T) {
 
 	kubernetesClientForSuiteRun, err = kubernetes.NewForConfig(kubeConfig)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	// Set up kubeConfigForSC if sc_kubeconfig flag is provided
+	if scKubeconfig != "" {
+		kubeConfigForSC, err = clientcmd.BuildConfigFromFlags("", scKubeconfig)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		kubeConfigForSC.QPS = kubeConfig.QPS
+		kubeConfigForSC.Burst = kubeConfig.Burst
+
+		scheme := lib.Scheme
+		workv1.Install(scheme)
+		crClientForServiceCluster, err = client.New(kubeConfigForSC, client.Options{Scheme: scheme})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	}
 
 	runTimeClientForSuiteRun, err = client.New(kubeConfig, client.Options{Scheme: lib.Scheme})
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -213,8 +237,9 @@ var _ = ginkgo.AfterSuite(func() {
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 	err = lib.DeleteSecret(kubernetesClientForSuiteRun, namespace, bslSecretNameWithCarriageReturn)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
-	log.Printf("Deleting DPA")
-	err = dpaCR.Delete()
-	gomega.Expect(err).ToNot(gomega.HaveOccurred())
-	gomega.Eventually(dpaCR.IsDeleted(), time.Minute*2, time.Second*5).Should(gomega.BeTrue())
+	oadpDeploymentOperation := NewOADPDeploymentOperationDefault()
+	if HCBackupRestoreMode(hcBackupRestoreMode) == HCModeExternalROSA {
+		oadpDeploymentOperation = NewOADPDeploymentOperationROSA()
+	}
+	oadpDeploymentOperation.Undeploy(lib.KOPIA)
 })

--- a/tests/e2e/hcp_backup_restore_suite_test.go
+++ b/tests/e2e/hcp_backup_restore_suite_test.go
@@ -60,7 +60,7 @@ func runHCPBackupAndRestore(
 		gomega.Eventually(libhcp.IsHCPPluginAdded(h.Client, dpaCR.Namespace, dpaCR.Name), 3*time.Minute, 1*time.Second).Should(gomega.BeTrue())
 	}
 
-	h.HCPNamespace = libhcp.GetHCPNamespace(brCase.BackupRestoreCase.Name, libhcp.ClustersNamespace)
+	h.HCPNamespace = libhcp.GetHCPNamespace(brCase.BackupRestoreCase.Name, hcNamespace)
 
 	// Unified HostedCluster setup
 	switch brCase.Mode {

--- a/tests/e2e/hcp_backup_restore_suite_test.go
+++ b/tests/e2e/hcp_backup_restore_suite_test.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -17,9 +18,9 @@ import (
 type HCBackupRestoreMode string
 
 const (
-	HCModeCreate   HCBackupRestoreMode = "create"   // Create new HostedCluster for test
-	HCModeExternal HCBackupRestoreMode = "external" // Get external HostedCluster
-	// TODO: Add HCModeExternalROSA for ROSA where DPA and some other resources are already installed
+	HCModeCreate       HCBackupRestoreMode = "create"        // Create new HostedCluster for test
+	HCModeExternal     HCBackupRestoreMode = "external"      // Get external HostedCluster
+	HCModeExternalROSA HCBackupRestoreMode = "external-rosa" // Get external HostedCluster for ROSA where DPA and some other resources are already installed
 )
 
 // runHCPBackupAndRestore is the unified function that handles both create and external HC modes
@@ -29,18 +30,35 @@ func runHCPBackupAndRestore(
 	updateLastInstallTime func(),
 	h *libhcp.HCHandler,
 ) {
+	var err error
 	updateLastBRcase(brCase)
 	updateLastInstallTime()
 
 	log.Printf("Preparing backup and restore")
-	backupName, restoreName := prepareBackupAndRestore(brCase.BackupRestoreCase, func() {})
 
-	err := h.AddHCPPluginToDPA(dpaCR.Namespace, dpaCR.Name, false)
-	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "failed to add HCP plugin to DPA: %v", err)
-	// TODO: move the wait for HC just after the DPA modification to allow reconciliation to go ahead without waiting for the HC to be created
+	backupUid, _ := uuid.NewUUID()
+	restoreUid, _ := uuid.NewUUID()
+	backupName := fmt.Sprintf("%s-%s", brCase.Name, backupUid.String())
+	restoreName := fmt.Sprintf("%s-%s", brCase.Name, restoreUid.String())
 
-	// Wait for HCP plugin to be added
-	gomega.Eventually(libhcp.IsHCPPluginAdded(h.Client, dpaCR.Namespace, dpaCR.Name), 3*time.Minute, 1*time.Second).Should(gomega.BeTrue())
+	oadpDeploymentOperation := NewOADPDeploymentOperationDefault()
+	if brCase.Mode == HCModeExternalROSA {
+		oadpDeploymentOperation = NewOADPDeploymentOperationROSA()
+	}
+	oadpDeploymentOperation.Deploy(brCase.BackupRestoreType)
+
+	// Ensure that an existing backup repository is deleted
+	err = lib.DeleteBackupRepositories(runTimeClientForSuiteRun, namespace)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+	// For ROSA the DPA is managed by ManifestWork in service cluster and would be reverted back.
+	if brCase.Mode != HCModeExternalROSA {
+		err := h.AddHCPPluginToDPA(dpaCR.Namespace, dpaCR.Name, false)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "failed to add HCP plugin to DPA: %v", err)
+		// TODO: move the wait for HC just after the DPA modification to allow reconciliation to go ahead without waiting for the HC to be created
+		// Wait for HCP plugin to be added
+		gomega.Eventually(libhcp.IsHCPPluginAdded(h.Client, dpaCR.Namespace, dpaCR.Name), 3*time.Minute, 1*time.Second).Should(gomega.BeTrue())
+	}
 
 	h.HCPNamespace = libhcp.GetHCPNamespace(brCase.BackupRestoreCase.Name, libhcp.ClustersNamespace)
 
@@ -48,11 +66,11 @@ func runHCPBackupAndRestore(
 	switch brCase.Mode {
 	case HCModeCreate:
 		// Create new HostedCluster for test
-		h.HostedCluster, err = h.DeployHCManifest(brCase.Template, brCase.Provider, brCase.BackupRestoreCase.Name)
+		h.HostedCluster, err = h.DeployHCManifest(brCase.Template, brCase.Provider, brCase.BackupRestoreCase.Name, hcNamespace)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
-	case HCModeExternal:
-		// Get external HostedCluster
-		h.HostedCluster, err = h.GetHostedCluster(brCase.BackupRestoreCase.Name, libhcp.ClustersNamespace)
+	case HCModeExternal, HCModeExternalROSA:
+		// Get existing HostedCluster
+		h.HostedCluster, err = h.GetHostedCluster(brCase.BackupRestoreCase.Name, hcNamespace)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 	default:
 		ginkgo.Fail(fmt.Sprintf("unknown HCP mode: %s", brCase.Mode))
@@ -65,7 +83,7 @@ func runHCPBackupAndRestore(
 		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "failed to run HCP pre-backup verification: %v", err)
 	}
 
-	if brCase.Mode == HCModeExternal {
+	if brCase.Mode == HCModeExternal || brCase.Mode == HCModeExternalROSA {
 		// Pre-backup verification for guest cluster
 		if brCase.PreBackupVerifyGuest != nil {
 			log.Printf("Validating guest cluster pre-backup")
@@ -83,14 +101,24 @@ func runHCPBackupAndRestore(
 	log.Printf("Backing up HC")
 	includedResources := libhcp.HCPIncludedResources
 	excludedResources := libhcp.HCPExcludedResources
-	includedNamespaces := append(libhcp.HCPIncludedNamespaces, libhcp.GetHCPNamespace(h.HostedCluster.Name, libhcp.ClustersNamespace))
+	includedNamespaces := []string{hcNamespace, libhcp.GetHCPNamespace(h.HostedCluster.Name, hcNamespace)}
 
 	nsRequiresResticDCWorkaround := runHCPBackup(brCase.BackupRestoreCase, backupName, h, includedNamespaces, includedResources, excludedResources)
 
 	// Delete everything in HCP namespace
 	log.Printf("Deleting HCP & HC")
-	err = h.RemoveHCP(libhcp.Wait10Min)
-	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "failed to remove HCP: %v", err)
+	switch brCase.Mode {
+	case HCModeExternalROSA:
+		err = h.BackupManifestWork()
+		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "failed to backup ManifestWork: %v", err)
+		// For ROSA the DPA is managed by ManifestWork in service cluster.
+		// Need to delete the ManifestWork.
+		err = h.DeleteManifestWork(libhcp.Wait30Min)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "failed to delete ManifestWork: %v", err)
+	default:
+		err = h.RemoveHCP(libhcp.Wait10Min)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "failed to remove HCP: %v", err)
+	}
 
 	// Restore HC
 	log.Printf("Restoring HC")
@@ -103,7 +131,7 @@ func runHCPBackupAndRestore(
 		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "failed to run HCP post-restore verification: %v", err)
 	}
 
-	if brCase.Mode == HCModeExternal {
+	if brCase.Mode == HCModeExternal || brCase.Mode == HCModeExternalROSA {
 		// Post-restore verification for guest cluster
 		if brCase.PostRestoreVerifyGuest != nil {
 			log.Printf("Validating guest cluster post-restore")
@@ -111,7 +139,7 @@ func runHCPBackupAndRestore(
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			crClientForHC, err := client.New(hcKubeconfig, client.Options{Scheme: lib.Scheme})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
-			gomega.Eventually(h.ValidateClient(crClientForHC), 5*time.Minute, 2*time.Second).Should(gomega.BeTrue())
+			gomega.Eventually(h.ValidateClient(crClientForHC), libhcp.ValidateHCPTimeout, libhcp.WaitForNextCheckTimeout).Should(gomega.BeTrue())
 			err = brCase.PostRestoreVerifyGuest(crClientForHC, "" /*unused*/)
 			gomega.Expect(err).ToNot(gomega.HaveOccurred(), "failed to run post-restore verification for guest cluster: %v", err)
 		}

--- a/tests/e2e/hcp_external_cluster_backup_restore_suite_test.go
+++ b/tests/e2e/hcp_external_cluster_backup_restore_suite_test.go
@@ -2,6 +2,7 @@ package e2e_test
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
@@ -11,6 +12,10 @@ import (
 
 	"github.com/openshift/oadp-operator/tests/e2e/lib"
 	libhcp "github.com/openshift/oadp-operator/tests/e2e/lib/hcp"
+)
+
+const (
+	testNamespace = "test"
 )
 
 // External cluster backup and restore tests will skip creating HostedCluster resource. They expect the cluster
@@ -32,21 +37,27 @@ var _ = ginkgo.Describe("HCP external cluster Backup and Restore tests", ginkgo.
 	}
 
 	var _ = ginkgo.BeforeAll(func() {
-		if hcBackupRestoreMode != string(HCModeExternal) {
+		if HCBackupRestoreMode(hcBackupRestoreMode) != HCModeExternal &&
+			HCBackupRestoreMode(hcBackupRestoreMode) != HCModeExternalROSA {
 			ginkgo.Skip("Skipping HCP full backup and restore test for non-existent HCP")
 		}
 
 		h = &libhcp.HCHandler{
-			Ctx:            context.Background(),
-			Client:         runTimeClientForSuiteRun,
-			HCOCPTestImage: libhcp.HCOCPTestImage,
+			Ctx:                  context.Background(),
+			Client:               runTimeClientForSuiteRun,
+			ClientServiceCluster: crClientForServiceCluster,
+			HCOCPTestImage:       libhcp.HCOCPTestImage,
 		}
 	})
 
 	// After Each
 	var _ = ginkgo.AfterEach(func(ctx ginkgo.SpecContext) {
 		gatherLogs(lastBRCase.BackupRestoreCase, lastInstallTime, ctx.SpecReport())
-		tearDownDPAResources(lastBRCase.BackupRestoreCase)
+		oadpDeploymentOperation := NewOADPDeploymentOperationDefault()
+		if HCBackupRestoreMode(hcBackupRestoreMode) == HCModeExternalROSA {
+			oadpDeploymentOperation = NewOADPDeploymentOperationROSA()
+		}
+		oadpDeploymentOperation.Undeploy(lastBRCase.BackupRestoreCase.BackupRestoreType)
 	})
 
 	ginkgo.It("HCP external cluster backup and restore test", ginkgo.Label("hcp_external"), func() {
@@ -55,14 +66,14 @@ var _ = ginkgo.Describe("HCP external cluster Backup and Restore tests", ginkgo.
 		}
 
 		runHCPBackupAndRestore(HCPBackupRestoreCase{
-			Mode:                   HCModeExternal,
+			Mode:                   HCBackupRestoreMode(hcBackupRestoreMode),
 			PreBackupVerifyGuest:   preBackupVerifyGuest(),
 			PostRestoreVerifyGuest: postBackupVerifyGuest(),
 			BackupRestoreCase: BackupRestoreCase{
 				Name:              hcName,
 				BackupRestoreType: lib.CSIDataMover,
-				PreBackupVerify:   libhcp.ValidateHCP(libhcp.ValidateHCPTimeout, libhcp.Wait10Min, []string{}, libhcp.GetHCPNamespace(hcName, libhcp.ClustersNamespace)),
-				PostRestoreVerify: libhcp.ValidateHCP(libhcp.ValidateHCPTimeout, libhcp.Wait10Min, []string{}, libhcp.GetHCPNamespace(hcName, libhcp.ClustersNamespace)),
+				PreBackupVerify:   libhcp.ValidateHCP(libhcp.ValidateHCPTimeout, libhcp.Wait10Min, []string{}, libhcp.GetHCPNamespace(hcName, hcNamespace)),
+				PostRestoreVerify: libhcp.ValidateHCP(libhcp.ValidateHCPTimeout, libhcp.Wait10Min, []string{}, libhcp.GetHCPNamespace(hcName, hcNamespace)),
 				BackupTimeout:     libhcp.HCPBackupTimeout,
 			},
 		}, updateLastBRcase, updateLastInstallTime, h)
@@ -70,24 +81,38 @@ var _ = ginkgo.Describe("HCP external cluster Backup and Restore tests", ginkgo.
 })
 
 func preBackupVerifyGuest() VerificationFunctionGuest {
-	return func(crClientGuest client.Client, namespace string) error {
-		ns := &corev1.Namespace{}
-		ns.Name = "test"
-		err := crClientGuest.Create(context.Background(), ns)
-		if err != nil && !apierrors.IsAlreadyExists(err) {
-			return err
-		}
-		return nil
+	return func(crClientGuest client.Client, _ string) error {
+		var errs []error
+		errs = append(errs, createTestNamespace(crClientGuest))
+		// Add more verifications here if needed
+		return errors.Join(errs...)
 	}
 }
 
 func postBackupVerifyGuest() VerificationFunctionGuest {
-	return func(crClientGuest client.Client, namespace string) error {
-		ns := &corev1.Namespace{}
-		err := crClientGuest.Get(context.Background(), client.ObjectKey{Name: "test"}, ns)
-		if err != nil {
-			return err
-		}
-		return nil
+	return func(crClientGuest client.Client, _ string) error {
+		var errs []error
+		errs = append(errs, validateTestNamespace(crClientGuest))
+		// Add more verifications here if needed
+		return errors.Join(errs...)
 	}
+}
+
+func createTestNamespace(crClientGuest client.Client) error {
+	ns := &corev1.Namespace{}
+	ns.Name = testNamespace
+	err := crClientGuest.Create(context.Background(), ns)
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		return err
+	}
+	return nil
+}
+
+func validateTestNamespace(crClientGuest client.Client) error {
+	ns := &corev1.Namespace{}
+	err := crClientGuest.Get(context.Background(), client.ObjectKey{Name: testNamespace}, ns)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/tests/e2e/lib/dpa_helpers.go
+++ b/tests/e2e/lib/dpa_helpers.go
@@ -76,24 +76,7 @@ func (v *DpaCustomResource) Build(backupRestoreType BackupRestoreType) *oadpv1al
 		SnapshotLocations: v.SnapshotLocations,
 		BackupLocations: []oadpv1alpha1.BackupLocation{
 			{
-				Velero: &velero.BackupStorageLocationSpec{
-					Provider: v.BSLProvider,
-					Default:  true,
-					Config:   v.BSLConfig,
-					Credential: &corev1.SecretKeySelector{
-						LocalObjectReference: corev1.LocalObjectReference{
-							Name: v.BSLSecretName,
-						},
-						Key: "cloud",
-					},
-					StorageType: velero.StorageType{
-						ObjectStorage: &velero.ObjectStorageLocation{
-							Bucket: v.BSLBucket,
-							Prefix: v.BSLBucketPrefix,
-							CACert: v.BSLCacert,
-						},
-					},
-				},
+				Velero: v.BackupStorageLocationSpec(),
 			},
 		},
 		UnsupportedOverrides: v.UnsupportedOverrides,
@@ -125,6 +108,98 @@ func (v *DpaCustomResource) Build(backupRestoreType BackupRestoreType) *oadpv1al
 	}
 
 	return &dpaSpec
+}
+
+func (v *DpaCustomResource) BackupStorageLocationSpec() *velero.BackupStorageLocationSpec {
+	backupStorageLocationSpec := velero.BackupStorageLocationSpec{
+		Provider: v.BSLProvider,
+		Default:  true,
+		Config:   v.BSLConfig,
+		Credential: &corev1.SecretKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{
+				Name: v.BSLSecretName,
+			},
+			Key: "cloud",
+		},
+		StorageType: velero.StorageType{
+			ObjectStorage: &velero.ObjectStorageLocation{
+				Bucket: v.BSLBucket,
+				Prefix: v.BSLBucketPrefix,
+				CACert: v.BSLCacert,
+			},
+		},
+	}
+	return &backupStorageLocationSpec
+}
+
+func (v *DpaCustomResource) CreateBackupStorageLocation() error {
+	bsl := velero.BackupStorageLocation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      v.Name,
+			Namespace: v.Namespace,
+		},
+		Spec: *v.BackupStorageLocationSpec(),
+	}
+	if err := v.Client.Create(context.Background(), &bsl); err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			return nil
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (v *DpaCustomResource) DeleteBackupStorageLocation() error {
+	if err := v.Client.Delete(context.Background(), &velero.BackupStorageLocation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      v.Name,
+			Namespace: v.Namespace,
+		},
+	}); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+func (v *DpaCustomResource) CreateVolumeSnapshotLocation() error {
+	if len(v.SnapshotLocations) == 0 {
+		return fmt.Errorf("no snapshot locations found")
+	}
+	vslSpec := v.SnapshotLocations[0].Velero
+	vsl := velero.VolumeSnapshotLocation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      v.Name,
+			Namespace: v.Namespace,
+		},
+		Spec: *vslSpec,
+	}
+	if err := v.Client.Create(context.Background(), &vsl); err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			return nil
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (v *DpaCustomResource) DeleteVolumeSnapshotLocation() error {
+	if err := v.Client.Delete(context.Background(), &velero.VolumeSnapshotLocation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      v.Name,
+			Namespace: v.Namespace,
+		},
+	}); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	return nil
 }
 
 func (v *DpaCustomResource) Create(dpa *oadpv1alpha1.DataProtectionApplication) error {

--- a/tests/e2e/lib/dpa_helpers.go
+++ b/tests/e2e/lib/dpa_helpers.go
@@ -170,6 +170,9 @@ func (v *DpaCustomResource) CreateVolumeSnapshotLocation() error {
 		return fmt.Errorf("no snapshot locations found")
 	}
 	vslSpec := v.SnapshotLocations[0].Velero
+	if vslSpec == nil {
+		return fmt.Errorf("snapshot location Velero spec is nil")
+	}
 	vsl := velero.VolumeSnapshotLocation{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      v.Name,

--- a/tests/e2e/lib/hcp/hcp.go
+++ b/tests/e2e/lib/hcp/hcp.go
@@ -3,8 +3,10 @@ package hcp
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"log"
+	"os"
 	"time"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -19,6 +21,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/utils/ptr"
+	workv1 "open-cluster-management.io/api/work/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -382,17 +387,17 @@ func (h *HCHandler) NukeHostedCluster() error {
 }
 
 // DeployHCManifest deploys a HostedCluster manifest
-func (h *HCHandler) DeployHCManifest(tmpl, provider string, hcName string) (*hypershiftv1.HostedCluster, error) {
+func (h *HCHandler) DeployHCManifest(tmpl, provider string, hcName, hcNamespace string) (*hypershiftv1.HostedCluster, error) {
 	log.Printf("Deploying HostedCluster manifest - %s", provider)
-	// Create the clusters ns
-	clustersNS := &corev1.Namespace{
+	// Create the HC namespace
+	hcNS := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: ClustersNamespace,
+			Name: hcNamespace,
 		},
 	}
 
 	log.Printf("Creating clusters namespace")
-	err := h.Client.Create(h.Ctx, clustersNS)
+	err := h.Client.Create(h.Ctx, hcNS)
 	if err != nil {
 		if !apierrors.IsAlreadyExists(err) {
 			return nil, fmt.Errorf("failed to create clusters namespace: %v", err)
@@ -408,7 +413,7 @@ func (h *HCHandler) DeployHCManifest(tmpl, provider string, hcName string) (*hyp
 	log.Printf("Applying pull secret manifest")
 	err = ApplyYAMLTemplate(h.Ctx, h.Client, PullSecretManifest, true, map[string]interface{}{
 		"HostedClusterName": hcName,
-		"ClustersNamespace": ClustersNamespace,
+		"ClustersNamespace": hcNamespace,
 		"PullSecret":        base64.StdEncoding.EncodeToString([]byte(pullSecret)),
 	})
 	if err != nil {
@@ -418,7 +423,7 @@ func (h *HCHandler) DeployHCManifest(tmpl, provider string, hcName string) (*hyp
 	log.Printf("Applying encryption key manifest")
 	err = ApplyYAMLTemplate(h.Ctx, h.Client, EtcdEncryptionKeyManifest, true, map[string]interface{}{
 		"HostedClusterName": hcName,
-		"ClustersNamespace": ClustersNamespace,
+		"ClustersNamespace": hcNamespace,
 		"EtcdEncryptionKey": SampleETCDEncryptionKey,
 	})
 	if err != nil {
@@ -428,7 +433,7 @@ func (h *HCHandler) DeployHCManifest(tmpl, provider string, hcName string) (*hyp
 	if provider == "Agent" {
 		log.Printf("Applying capi-provider-role manifest")
 		err = ApplyYAMLTemplate(h.Ctx, h.Client, CapiProviderRoleManifest, true, map[string]interface{}{
-			"ClustersNamespace": ClustersNamespace,
+			"ClustersNamespace": hcNamespace,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to apply capi-provider-role manifest from %s: %v", CapiProviderRoleManifest, err)
@@ -438,7 +443,7 @@ func (h *HCHandler) DeployHCManifest(tmpl, provider string, hcName string) (*hyp
 	log.Printf("Applying HostedCluster manifest")
 	err = ApplyYAMLTemplate(h.Ctx, h.Client, tmpl, false, map[string]interface{}{
 		"HostedClusterName": hcName,
-		"ClustersNamespace": ClustersNamespace,
+		"ClustersNamespace": hcNamespace,
 		"HCOCPTestImage":    h.HCOCPTestImage,
 		"InfraIDSeed":       "test",
 	})
@@ -451,7 +456,7 @@ func (h *HCHandler) DeployHCManifest(tmpl, provider string, hcName string) (*hyp
 	err = wait.PollUntilContextTimeout(h.Ctx, WaitForNextCheckTimeout, Wait10Min, true, func(ctx context.Context) (bool, error) {
 		err := h.Client.Get(ctx, types.NamespacedName{
 			Name:      hcName,
-			Namespace: ClustersNamespace,
+			Namespace: hcNamespace,
 		}, &hc)
 		if err != nil {
 			if !apierrors.IsNotFound(err) && !apierrors.IsTooManyRequests(err) && !apierrors.IsServerTimeout(err) && !apierrors.IsTimeout(err) {
@@ -689,6 +694,15 @@ func RestartHCPPods(HCPNamespace string, c client.Client) error {
 	return nil
 }
 
+// Read kubeconfig from bytes and return the Config object
+func ReadKubeconfigFromBytes(kubeconfigData []byte) (*clientcmdapi.Config, error) {
+	config, err := clientcmd.Load(kubeconfigData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load kubeconfig: %v", err)
+	}
+	return config, nil
+}
+
 func buildConfigFromBytes(kubeconfigData []byte) (*rest.Config, error) {
 	clientConfig, err := clientcmd.NewClientConfigFromBytes(kubeconfigData)
 	if err != nil {
@@ -711,8 +725,8 @@ func (h *HCHandler) GetHostedClusterKubeconfig(hc *hypershiftv1.HostedCluster) (
 	if err != nil {
 		return nil, err
 	}
-	kubeconfigData := kubeconfigSecret.Data["kubeconfig"]
-	return buildConfigFromBytes(kubeconfigData)
+
+	return buildConfigFromBytes(kubeconfigSecret.Data["kubeconfig"])
 }
 
 func (h *HCHandler) ValidateClient(c client.Client) wait.ConditionFunc {
@@ -722,6 +736,147 @@ func (h *HCHandler) ValidateClient(c client.Client) wait.ConditionFunc {
 			log.Printf("Error getting cluster version: %v", err)
 			return false, nil
 		}
+		log.Printf("Client successfully validated")
 		return true, nil
 	}
+}
+
+func (h *HCHandler) GetManifestWorkNamespace(clusterID string) (string, error) {
+	manifestWorks := &workv1.ManifestWorkList{}
+	err := h.ClientServiceCluster.List(h.Ctx, manifestWorks, &client.ListOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to list ManifestWorks: %v", err)
+	}
+	for _, manifestWork := range manifestWorks.Items {
+		if manifestWork.Name == clusterID {
+			return manifestWork.Namespace, nil
+		}
+	}
+	return "", fmt.Errorf("ManifestWork %s not found", clusterID)
+}
+
+func (h *HCHandler) DeleteManifestWork(timeout time.Duration) error {
+	clusterID, ok := h.HostedCluster.Labels["api.openshift.com/id"]
+	if !ok {
+		return fmt.Errorf("HostedCluster does not have a label api.openshift.com/id")
+	}
+	namespace, err := h.GetManifestWorkNamespace(clusterID)
+	if err != nil {
+		return fmt.Errorf("failed to get ManifestWork namespace: %v", err)
+	}
+
+	manifestWorkNames := []string{
+		clusterID,
+		clusterID + "-workers",
+		clusterID + "-00-namespaces",
+	}
+
+	for _, manifestWorkName := range manifestWorkNames {
+		err := h.ClientServiceCluster.Delete(h.Ctx, &workv1.ManifestWork{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      manifestWorkName,
+			},
+		}, &client.DeleteOptions{
+			GracePeriodSeconds: ptr.To(int64(0)),
+		})
+		if err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete ManifestWork %s/%s: %v", h.HCPNamespace, clusterID, err)
+		}
+	}
+
+	log.Printf("Waiting for ManifestWorks to be deleted")
+	for _, manifestWorkName := range manifestWorkNames {
+		err := wait.PollUntilContextTimeout(h.Ctx, WaitForNextCheckTimeout, timeout, true, func(ctx context.Context) (bool, error) {
+			deleted, err := IsManifestWorkDeleted(h, manifestWorkName, namespace)
+			if err != nil {
+				// Return the error to stop polling and propagate the error details
+				return false, err
+			}
+			if deleted {
+				log.Printf("ManifestWork %s/%s deleted", h.HCPNamespace, manifestWorkName)
+			}
+			return deleted, nil
+		})
+		if err != nil {
+			return fmt.Errorf("failed to delete ManifestWork %s/%s: %v", h.HCPNamespace, clusterID, err)
+		}
+	}
+
+	return nil
+}
+
+func (h *HCHandler) BackupManifestWork() error {
+	clusterID, ok := h.HostedCluster.Labels["api.openshift.com/id"]
+	if !ok {
+		return fmt.Errorf("HostedCluster does not have a label api.openshift.com/id")
+	}
+	namespace, err := h.GetManifestWorkNamespace(clusterID)
+	if err != nil {
+		return fmt.Errorf("failed to get ManifestWork namespace: %v", err)
+	}
+
+	manifestWorkNames := []string{
+		clusterID,
+		clusterID + "-workers",
+		clusterID + "-00-namespaces",
+	}
+
+	timestamp := time.Now().UnixMilli()
+	manifestWork := &workv1.ManifestWork{}
+	for _, manifestWorkName := range manifestWorkNames {
+		if h.ClientServiceCluster == nil {
+			return fmt.Errorf("ClientServiceCluster is nil")
+		}
+		err := h.ClientServiceCluster.Get(h.Ctx, client.ObjectKey{
+			Namespace: namespace,
+			Name:      manifestWorkName,
+		}, manifestWork)
+
+		manifestWork.APIVersion = workv1.SchemeGroupVersion.String()
+		manifestWork.Kind = "ManifestWork"
+
+		if err != nil {
+			return fmt.Errorf("failed to get ManifestWork: %v", err)
+		}
+		// Marshal the manifestWork to JSON and store it in a temporary directory under /tmp
+		jsonBytes, err := json.MarshalIndent(manifestWork, "", "    ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal ManifestWork %s to JSON: %v", manifestWorkName, err)
+		}
+
+		tmpDir := os.Getenv("TMP_DIR")
+		if tmpDir == "" {
+			tmpDir = "/tmp"
+		}
+
+		tmpDir = fmt.Sprintf("%s/hc_manifestwork_backup/%d", tmpDir, timestamp)
+		if err := os.MkdirAll(tmpDir, 0755); err != nil {
+			return fmt.Errorf("failed to create backup directory %s: %v", tmpDir, err)
+		}
+
+		filePath := fmt.Sprintf("%s/%s.json", tmpDir, manifestWorkName)
+		if err := os.WriteFile(filePath, jsonBytes, 0644); err != nil {
+			return fmt.Errorf("failed to write ManifestWork YAML to file %s: %v", filePath, err)
+		}
+		log.Printf("ManifestWork %s backed up to %s", manifestWorkName, filePath)
+	}
+
+	return nil
+}
+
+func IsManifestWorkDeleted(h *HCHandler, manifestWorkName string, namespace string) (bool, error) {
+	manifestWork := &workv1.ManifestWork{}
+	err := h.ClientServiceCluster.Get(h.Ctx, client.ObjectKey{
+		Namespace: namespace,
+		Name:      manifestWorkName},
+		manifestWork)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Printf("ManifestWork %s is deleted", manifestWorkName)
+			return true, nil
+		}
+		return false, fmt.Errorf("failed to check ManifestWork deletion: %w", err)
+	}
+	return false, nil
 }

--- a/tests/e2e/lib/hcp/hcp.go
+++ b/tests/e2e/lib/hcp/hcp.go
@@ -742,6 +742,9 @@ func (h *HCHandler) ValidateClient(c client.Client) wait.ConditionFunc {
 }
 
 func (h *HCHandler) GetManifestWorkNamespace(clusterID string) (string, error) {
+	if h.ClientServiceCluster == nil {
+		return "", fmt.Errorf("service-cluster client is not initialized; make sure SC_KUBECONFIG is configured")
+	}
 	manifestWorks := &workv1.ManifestWorkList{}
 	err := h.ClientServiceCluster.List(h.Ctx, manifestWorks, &client.ListOptions{})
 	if err != nil {
@@ -756,6 +759,12 @@ func (h *HCHandler) GetManifestWorkNamespace(clusterID string) (string, error) {
 }
 
 func (h *HCHandler) DeleteManifestWork(timeout time.Duration) error {
+	if h.ClientServiceCluster == nil {
+		return fmt.Errorf("service-cluster client is not initialized; make sure SC_KUBECONFIG is configured")
+	}
+	if h.HostedCluster == nil {
+		return fmt.Errorf("hosted cluster reference is nil; ensure HCHandler.HostedCluster is populated before deleting ManifestWorks")
+	}
 	clusterID, ok := h.HostedCluster.Labels["api.openshift.com/id"]
 	if !ok {
 		return fmt.Errorf("HostedCluster does not have a label api.openshift.com/id")

--- a/tests/e2e/lib/hcp/types.go
+++ b/tests/e2e/lib/hcp/types.go
@@ -96,10 +96,6 @@ var (
 		"openshift-route-controller-manager",
 	}
 
-	HCPIncludedNamespaces = []string{
-		ClustersNamespace,
-	}
-
 	HCPIncludedResources = []string{
 		"sa",
 		"role",
@@ -136,18 +132,20 @@ var (
 
 	// Timeout constants
 	Wait10Min               = 10 * time.Minute
+	Wait30Min               = 30 * time.Minute
 	WaitForNextCheckTimeout = 10 * time.Second
 	ValidateHCPTimeout      = 25 * time.Minute
-	HCPBackupTimeout        = 30 * time.Minute
+	HCPBackupTimeout        = Wait30Min
 )
 
 // HCHandler handles operations related to HostedClusters
 type HCHandler struct {
-	Ctx            context.Context
-	Client         client.Client
-	HCOCPTestImage string
-	HCPNamespace   string
-	HostedCluster  *hypershiftv1.HostedCluster
+	Ctx                  context.Context
+	Client               client.Client
+	ClientServiceCluster client.Client
+	HCOCPTestImage       string
+	HCPNamespace         string
+	HostedCluster        *hypershiftv1.HostedCluster
 }
 
 type RequiredOperator struct {

--- a/tests/e2e/scripts/aws_settings.sh
+++ b/tests/e2e/scripts/aws_settings.sh
@@ -40,7 +40,7 @@ cat > $TMP_DIR/oadpcreds <<EOF
          "velero": {
            "provider": "$PROVIDER",
            "config": {
-             "profile": "default",
+             "profile": "$VSL_AWS_PROFILE",
              "region": "$VSL_REGION"
            }
          }

--- a/tests/e2e/virt_backup_restore_suite_test.go
+++ b/tests/e2e/virt_backup_restore_suite_test.go
@@ -217,7 +217,7 @@ var _ = ginkgo.Describe("VM backup and restore tests", ginkgo.Ordered, func() {
 	var _ = ginkgo.AfterAll(func() {
 		// DPA just needs to have BSL so gathering of backups/restores logs/describe work
 		// using kopia to collect more info (DaemonSet)
-		waitOADPReadiness(lib.KOPIA)
+		NewOADPDeploymentOperationDefault().Deploy(lib.KOPIA)
 
 		log.Printf("Creating real DataProtectionTest before must-gather")
 		bsls, err := dpaCR.ListBSLs()


### PR DESCRIPTION
This PRs builds on top of https://github.com/openshift/oadp-operator/pull/1921 and adds one more commit with the changes described below. Please review that PR first and then the last commit from the current PR. When pull/1921 is merged the current PR needs to be rebased.

- Add external-rosa mode for HC_BACKUP_RESTORE_MODE to support existing ROSA clusters
- Introduce HC_NAMESPACE parameter for configurable cluster namespace management
- Add service cluster kubeconfig support via SC_KUBECONFIG parameter for ROSA ManifestWork operations
- Implement ManifestWork backup/deletion functionality for ROSA cluster lifecycle management
- Add open-cluster-management.io/api dependency to support ManifestWork operations
- Create separate OADP deployment operations for default vs ROSA scenarios
- Skip DPA HCP plugin modification for ROSA where DPA is managed via ManifestWork
- Add VSL_AWS_PROFILE parameter for volume snapshot location AWS profile configuration
- Refactor backup/restore suite to use pluggable deployment strategies
- Update test configuration to handle both regular HCP and ROSA cluster workflows

## Why the changes were made

- This is important for testing OADP hypershift plugin in ROSA and for testing bug fixes such as [OCPBUGS-56430](https://issues.redhat.com/browse/OCPBUGS-56430). So far it was a manual process, but this PR extends the test suite so that the whole procedure can be run automatically.

## How to test the changes made

- Steps are described in TESTING.md where a new section was added for HCP/ROSA.

<!-- Explain how the changes introduced by this PR can be tested and verified, with commands and pictures -->
