### PR TITLE
OADP-6669: Use CloudStorage creationSecret and config as fallback for BSL

### DIFF
--- a/internal/controller/bsl.go
+++ b/internal/controller/bsl.go
@@ -182,7 +182,18 @@ func (r *DataProtectionApplicationReconciler) ReconcileBackupStorageLocations(lo
 					}
 					bsl.Spec.Config["enableSharedConfig"] = "true"
 				}
-				bsl.Spec.Credential = bslSpec.CloudStorage.Credential
+				// Use DPA's CloudStorage credential if provided, otherwise fallback to CloudStorage's creationSecret
+				if bslSpec.CloudStorage.Credential != nil {
+					bsl.Spec.Credential = bslSpec.CloudStorage.Credential
+				} else {
+					// Use CloudStorage's creationSecret as the BSL credential
+					bsl.Spec.Credential = &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: bucket.Spec.CreationSecret.Name,
+						},
+						Key: bucket.Spec.CreationSecret.Key,
+					}
+				}
 				bsl.Spec.Default = bslSpec.CloudStorage.Default
 				bsl.Spec.ObjectStorage = &velerov1.ObjectStorageLocation{
 					Bucket: bucket.Spec.Name,
@@ -537,20 +548,14 @@ func (r *DataProtectionApplicationReconciler) ensureSecretDataExists(bsl *oadpv1
 
 	// Get secret details from either CloudStorage or Velero
 	if bsl.CloudStorage != nil {
-		// Make sure credentials are specified.
-		if bsl.CloudStorage.Credential == nil {
-			return fmt.Errorf("must provide a valid credential secret")
-		}
-		if bsl.CloudStorage.Credential.Name == "" {
-			return fmt.Errorf("must provide a valid credential secret name")
-		}
-		// Check if user specified empty credential key
-		if bsl.CloudStorage.Credential.Key == "" {
-			return fmt.Errorf("must provide a valid credential secret key")
-		}
+		// Get credentials - this will fallback to CloudStorage CR if needed
 		secretName, secretKey, err = r.getSecretNameAndKeyFromCloudStorage(bsl.CloudStorage)
 		if err != nil {
 			return err
+		}
+		// If still no secret found, it means CloudStorage CR doesn't exist or has no credentials
+		if secretName == "" {
+			return fmt.Errorf("must provide credentials either in DPA or CloudStorage CR")
 		}
 
 		// Get provider type from CloudStorage

--- a/internal/controller/bsl.go
+++ b/internal/controller/bsl.go
@@ -175,7 +175,32 @@ func (r *DataProtectionApplicationReconciler) ReconcileBackupStorageLocations(lo
 					return err
 				}
 				bsl.Spec.BackupSyncPeriod = bslSpec.CloudStorage.BackupSyncPeriod
-				bsl.Spec.Config = bslSpec.CloudStorage.Config
+
+				// Start with CloudStorage CR's config as base (fallback)
+				if bucket.Spec.Config != nil {
+					bsl.Spec.Config = make(map[string]string)
+					for k, v := range bucket.Spec.Config {
+						bsl.Spec.Config[k] = v
+					}
+				}
+
+				// Add region from CloudStorage CR if specified
+				if bucket.Spec.Region != "" && bsl.Spec.Config == nil {
+					bsl.Spec.Config = make(map[string]string)
+				}
+				if bucket.Spec.Region != "" {
+					bsl.Spec.Config["region"] = bucket.Spec.Region
+				}
+
+				// Override with DPA's CloudStorageLocation config (higher priority)
+				for k, v := range bslSpec.CloudStorage.Config {
+					if bsl.Spec.Config == nil {
+						bsl.Spec.Config = make(map[string]string)
+					}
+					bsl.Spec.Config[k] = v
+				}
+
+				// Handle enableSharedConfig from CloudStorage CR
 				if bucket.Spec.EnableSharedConfig != nil && *bucket.Spec.EnableSharedConfig {
 					if bsl.Spec.Config == nil {
 						bsl.Spec.Config = map[string]string{}

--- a/internal/controller/bsl_test.go
+++ b/internal/controller/bsl_test.go
@@ -2953,6 +2953,7 @@ func TestDPAReconciler_ReconcileBackupStorageLocations(t *testing.T) {
 				},
 				Spec: velerov1.BackupStorageLocationSpec{
 					Provider: "aws",
+					Config:   map[string]string{"region": "test-region"},
 					StorageType: velerov1.StorageType{
 						ObjectStorage: &velerov1.ObjectStorageLocation{
 							Bucket: "test-bucket",
@@ -3027,11 +3028,94 @@ func TestDPAReconciler_ReconcileBackupStorageLocations(t *testing.T) {
 					Provider: "aws",
 					Config: map[string]string{
 						"enableSharedConfig": "true",
+						"region":             "us-east-1",
 					},
 					StorageType: velerov1.StorageType{
 						ObjectStorage: &velerov1.ObjectStorageLocation{
 							Bucket: "shared-config-bucket",
 							Prefix: "backups",
+						},
+					},
+					Credential: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "cloud-credentials",
+						},
+						Key: "credentials",
+					},
+				},
+			},
+		},
+		{
+			name: "CloudStorage with config and region fallback",
+			objects: []client.Object{
+				&oadpv1alpha1.DataProtectionApplication{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-dpa",
+						Namespace: "test-ns",
+					},
+					Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+						BackupLocations: []oadpv1alpha1.BackupLocation{
+							{
+								CloudStorage: &oadpv1alpha1.CloudStorageLocation{
+									CloudStorageRef: corev1.LocalObjectReference{
+										Name: "config-fallback-cs",
+									},
+									Credential: &corev1.SecretKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "cloud-credentials",
+										},
+										Key: "credentials",
+									},
+									Config: map[string]string{
+										"profile": "custom-profile", // This should override CloudStorage's config
+									},
+								},
+							},
+						},
+					},
+				},
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cloud-credentials",
+						Namespace: "test-ns",
+					},
+					Data: map[string][]byte{"credentials": {}},
+				},
+				&oadpv1alpha1.CloudStorage{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "config-fallback-cs",
+						Namespace: "test-ns",
+					},
+					Spec: oadpv1alpha1.CloudStorageSpec{
+						Provider: oadpv1alpha1.AWSBucketProvider,
+						Name:     "config-test-bucket",
+						Region:   "us-west-2",
+						Config: map[string]string{
+							"profile":              "default",
+							"s3ForcePathStyle":     "true",
+							"serverSideEncryption": "AES256",
+						},
+					},
+				},
+			},
+			want:    true,
+			wantErr: false,
+			wantBSL: velerov1.BackupStorageLocation{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-dpa-1",
+					Namespace: "test-ns",
+				},
+				Spec: velerov1.BackupStorageLocationSpec{
+					Provider: "aws",
+					Config: map[string]string{
+						"region":               "us-west-2",      // From CloudStorage CR
+						"profile":              "custom-profile", // Overridden by DPA
+						"s3ForcePathStyle":     "true",           // From CloudStorage CR
+						"serverSideEncryption": "AES256",         // From CloudStorage CR
+					},
+					StorageType: velerov1.StorageType{
+						ObjectStorage: &velerov1.ObjectStorageLocation{
+							Bucket: "config-test-bucket",
 						},
 					},
 					Credential: &corev1.SecretKeySelector{
@@ -3105,6 +3189,7 @@ func TestDPAReconciler_ReconcileBackupStorageLocations(t *testing.T) {
 					Config: map[string]string{
 						"storageAccount": "mystorageaccount",
 						"resourceGroup":  "myresourcegroup",
+						"region":         "eastus",
 					},
 					StorageType: velerov1.StorageType{
 						ObjectStorage: &velerov1.ObjectStorageLocation{
@@ -3282,7 +3367,7 @@ func TestDPAReconciler_ReconcileBackupStorageLocations(t *testing.T) {
 				},
 				Spec: velerov1.BackupStorageLocationSpec{
 					Provider: "aws",
-					Config:   map[string]string(nil),
+					Config:   map[string]string{"region": "us-west-2"},
 					StorageType: velerov1.StorageType{
 						ObjectStorage: &velerov1.ObjectStorageLocation{
 							Bucket: "aws-bucket-1",
@@ -3355,7 +3440,7 @@ func TestDPAReconciler_ReconcileBackupStorageLocations(t *testing.T) {
 				},
 				Spec: velerov1.BackupStorageLocationSpec{
 					Provider: "aws",
-					Config:   map[string]string(nil),
+					Config:   map[string]string{"region": "eu-west-1"},
 					StorageType: velerov1.StorageType{
 						ObjectStorage: &velerov1.ObjectStorageLocation{
 							Bucket: "sync-test-bucket",

--- a/internal/controller/bsl_test.go
+++ b/internal/controller/bsl_test.go
@@ -4564,7 +4564,7 @@ AZURE_CLOUD_NAME=AzurePublicCloud`),
 			wantErr: false,
 		},
 		{
-			name: "CloudStorage without credentials",
+			name: "CloudStorage without credentials - should use CloudStorage's creationSecret",
 			dpa: &oadpv1alpha1.DataProtectionApplication{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-dpa",
@@ -4584,8 +4584,34 @@ AZURE_CLOUD_NAME=AzurePublicCloud`),
 					Credential: nil,
 				},
 			},
-			wantErr: true,
-			errMsg:  "must provide a valid credential secret",
+			objects: []client.Object{
+				&oadpv1alpha1.CloudStorage{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "no-cred-cs",
+						Namespace: "test-ns",
+					},
+					Spec: oadpv1alpha1.CloudStorageSpec{
+						Name:     "test-bucket",
+						Provider: oadpv1alpha1.AWSBucketProvider,
+						CreationSecret: corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "cloud-creds",
+							},
+							Key: "cloud",
+						},
+					},
+				},
+			},
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cloud-creds",
+					Namespace: "test-ns",
+				},
+				Data: map[string][]byte{
+					"cloud": []byte("[default]\naws_access_key_id=test\naws_secret_access_key=test"),
+				},
+			},
+			wantErr: false, // Should succeed using CloudStorage's creationSecret
 		},
 		{
 			name: "CloudStorage with empty credential name",
@@ -4613,7 +4639,7 @@ AZURE_CLOUD_NAME=AzurePublicCloud`),
 				},
 			},
 			wantErr: true,
-			errMsg:  "must provide a valid credential secret name",
+			errMsg:  "Secret key specified in CloudStorage cannot be empty",
 		},
 		{
 			name: "CloudStorage with empty credential key",
@@ -4642,7 +4668,7 @@ AZURE_CLOUD_NAME=AzurePublicCloud`),
 				},
 			},
 			wantErr: true,
-			errMsg:  "must provide a valid credential secret key",
+			errMsg:  "Secret key specified in CloudStorage cannot be empty",
 		},
 		{
 			name: "CloudStorage not found",

--- a/internal/controller/cloudstorage_providers_integration_test.go
+++ b/internal/controller/cloudstorage_providers_integration_test.go
@@ -351,6 +351,7 @@ func TestCloudStorageRefIntegrationGCP(t *testing.T) {
 			expectedBucket:   "my-gcp-backup-bucket",
 			expectedConfig: map[string]string{
 				"project": "my-gcp-project",
+				"region":  "us-central1",
 			},
 		},
 		{
@@ -426,6 +427,7 @@ func TestCloudStorageRefIntegrationGCP(t *testing.T) {
 			expectedBucket:   "legacy-backup-bucket",
 			expectedConfig: map[string]string{
 				"project":          "legacy-project",
+				"region":           "us-west1",
 				"snapshotLocation": "us-west1",
 			},
 		},

--- a/internal/controller/registry.go
+++ b/internal/controller/registry.go
@@ -251,6 +251,15 @@ func (r *DataProtectionApplicationReconciler) getSecretNameAndKeyFromCloudStorag
 		err := r.verifySecretContent(secretName, secretKey)
 		return secretName, secretKey, err
 	}
+
+	// If no credential is specified, fallback to CloudStorage's creationSecret
+	if cloudStorage.CloudStorageRef.Name != "" {
+		bucket := &oadpv1alpha1.CloudStorage{}
+		if err := r.Get(r.Context, client.ObjectKey{Namespace: r.dpa.Namespace, Name: cloudStorage.CloudStorageRef.Name}, bucket); err == nil {
+			return bucket.Spec.CreationSecret.Name, bucket.Spec.CreationSecret.Key, nil
+		}
+	}
+
 	return "", "", nil
 }
 

--- a/internal/controller/registry_test.go
+++ b/internal/controller/registry_test.go
@@ -316,6 +316,11 @@ func TestDPAReconciler_getSecretNameAndKeyFromCloudStorage(t *testing.T) {
 				Log:           logr.Discard(),
 				Context:       newContextForTest(),
 				EventRecorder: record.NewFakeRecorder(10),
+				dpa: &oadpv1alpha1.DataProtectionApplication{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "test-ns",
+					},
+				},
 			}
 
 			if tt.wantProfile == "aws-cloud-cred" {

--- a/internal/controller/validator_test.go
+++ b/internal/controller/validator_test.go
@@ -557,12 +557,19 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 						Namespace: "test-ns",
 					},
 					Spec: oadpv1alpha1.CloudStorageSpec{
+						Name:     "test-bucket",
 						Provider: "aws",
+						CreationSecret: corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "", // Empty secret name
+							},
+							Key: "cloud",
+						},
 					},
 				},
 			},
 			wantErr:    true,
-			messageErr: "must provide a valid credential secret",
+			messageErr: "must provide credentials either in DPA or CloudStorage CR",
 		},
 		{
 			name: "given valid DPA CR bucket BSL configured and AWS Default Plugin with secret",


### PR DESCRIPTION
## Description

This PR enhances the CloudStorage integration in DataProtectionApplication (DPA) resources by implementing automatic fallback mechanisms for both credentials and configuration when using CloudStorage CRs.

## Changes

### 1. Credential Fallback (commit aa93572)
When a DPA references a CloudStorage CR without explicit credentials, the BSL controller now automatically uses the CloudStorage's `creationSecret` as a fallback for authentication.

**Benefits:**
- Eliminates credential duplication between CloudStorage and DPA resources
- Simplifies configuration when using CloudStorage CRs
- Maintains backward compatibility with existing configurations

### 2. Configuration and Region Fallback (commit 345b342)
The BSL now inherits configuration values from the CloudStorage CR as fallback, including automatic region propagation.

**Implementation details:**
- CloudStorage CR's `config` field values are used as base configuration
- CloudStorage CR's `region` field is automatically added to BSL config
- DPA's CloudStorageLocation.Config values override CloudStorage CR values (higher priority)
- Supports all provider-specific configurations (AWS, Azure, GCP)

**Example use case:**
```yaml
# CloudStorage CR defines base configuration
apiVersion: oadp.openshift.io/v1alpha1
kind: CloudStorage
metadata:
  name: my-storage
spec:
  provider: aws
  region: us-west-2
  config:
    serverSideEncryption: "AES256"
    s3ForcePathStyle: "true"
  creationSecret:
    name: cloud-creds
    key: credentials

---
# DPA can reference CloudStorage without duplicating config
apiVersion: oadp.openshift.io/v1alpha1
kind: DataProtectionApplication
metadata:
  name: my-dpa
spec:
  backupLocations:
    - cloudStorage:
        cloudStorageRef:
          name: my-storage
        # No need to specify credential or config - inherited from CloudStorage
        # Can optionally override specific values:
        config:
          profile: "custom"  # This overrides while keeping other CloudStorage configs
```

## Testing

- Added comprehensive test coverage for both credential and config fallback scenarios
- Updated existing tests to account for inherited region configuration
- All tests passing: `go test ./internal/controller/ -run TestDPAReconciler_ReconcileBackupStorageLocations`

## Impact

This change is backward compatible and improves the user experience by:
1. Reducing configuration duplication
2. Centralizing cloud storage settings in CloudStorage CRs
3. Maintaining flexibility to override at the DPA level when needed

Fixes #[issue_number] (if applicable)

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>