### PR TITLE
Konflux: IndexError: list index out of range

### DIFF
--- a/bundle/oadp-operator.package.yaml
+++ b/bundle/oadp-operator.package.yaml
@@ -1,0 +1,6 @@
+---
+packageName: redhat-oadp-operator
+channels:
+- name: stable
+  currentCSV: oadp-operator.v1.5.1
+defaultChannel: stable


### PR DESCRIPTION
https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Foadp/37/console

```
2025-09-12 14:15:04,788 doozerlib.cli.images_konflux ERROR Failed to rebase/build OLM bundle for oadp-operator: list index out of range; Traceback (most recent call last):
  File "/mnt/jenkins-workspace/aos-cd-builds_build_oadp/art-tools/doozer/doozerlib/cli/images_konflux.py", line 412, in _rebase_and_build
    nvr = await rebaser.rebase(image_meta, operator_build, input_release)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/jenkins-workspace/aos-cd-builds_build_oadp/art-tools/doozer/doozerlib/backend/konflux_olm_bundler.py", line 114, in rebase
    nvr = await self._rebase_dir(metadata, operator_dir, bundle_dir, operator_build, input_release)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/jenkins-workspace/aos-cd-builds_build_oadp/art-tools/doozer/doozerlib/backend/konflux_olm_bundler.py", line 155, in _rebase_dir
    file_path = glob.glob(f'{operator_manifests_dir}/*package.yaml')[0]
                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^
IndexError: list index out of range
```

