### PR TITLE
Improve documentation for custom plugin images usage

### DIFF
--- a/docs/config/custom_plugin_images.md
+++ b/docs/config/custom_plugin_images.md
@@ -1,6 +1,6 @@
 style="height:1px;border:none;color:#333;">
 <h1 align="center">Usage of Custom Plugin Images for Velero</h1>
->style="height:1px;border:none;color:#333;">
+<hr style="height:1px;border:none;color:#333;">
 The OADP Operator supports custom plugin images under the `unsupportedOverrides` field as detailed in the YAML below. This feature can be used to support rapid development and testing of custom images for supported plugins and provides a way for developers to quickly deploy and test their changes.
 
 Details for supported plugins and their usage is given below, and please use the respective keys for the plugins. All keys must be entered in the Velero CR under a new field called as `unsupportedOverrides`, and with the key below for reference and corresponding image tag as their value.

--- a/docs/config/custom_plugin_images.md
+++ b/docs/config/custom_plugin_images.md
@@ -1,4 +1,4 @@
-style="height:1px;border:none;color:#333;">
+<hr style="height:1px;border:none;color:#333;">
 <h1 align="center">Usage of Custom Plugin Images for Velero</h1>
 <hr style="height:1px;border:none;color:#333;">
 The OADP Operator supports custom plugin images under the `unsupportedOverrides` field as detailed in the YAML below. This feature can be used to support rapid development and testing of custom images for supported plugins and provides a way for developers to quickly deploy and test their changes.

--- a/docs/config/custom_plugin_images.md
+++ b/docs/config/custom_plugin_images.md
@@ -1,22 +1,25 @@
-<hr style="height:1px;border:none;color:#333;">
+style="height:1px;border:none;color:#333;">
 <h1 align="center">Usage of Custom Plugin Images for Velero</h1>
-<hr style="height:1px;border:none;color:#333;">
-
+>style="height:1px;border:none;color:#333;">
 The OADP Operator supports custom plugin images under the `unsupportedOverrides` field as detailed in the YAML below. This feature can be used to support rapid development and testing of custom images for supported plugins and provides a way for developers to quickly deploy and test their changes.
 
 Details for supported plugins and their usage is given below, and please use the respective keys for the plugins. All keys must be entered in the Velero CR under a new field called as `unsupportedOverrides`, and with the key below for reference and corresponding image tag as their value.
+ 
+- Velero Imagekey  -> `veleroImageFqin` 
+- AWS Plugin ImageKey  -> `awsPluginImageFqin` 
+- OpenShift Plugin ImageKey  -> `openshiftPluginImageFqin` 
+- Azure Plugin ImageKey -> `azurePluginImageFqin` 
+- GCP Plugin ImageKey  -> `gcpPluginImageFqin` 
+- CSI Plugin ImageKey  -> `csiPluginImageFqin` 
+- Restic Restore ImageKey -> `resticRestoreImageFqin` 
+- Data Mover Imagekey -> `dataMoverImageFqin`
+- Legacy AWS Plugin ImageKey -> `legacyAWSPluginImageFqin`
+- KubeVirt Plugin ImageKey -> `kubevirtPluginImageFqin`
+- Hypershift Plugin ImageKey -> `hypershiftPluginImageFqin`
+- Non-Admin Controller ImageKey -> `nonAdminControllerImageFqin`
 
+Below is an example DataProtectionApplication (DPA) CR with the unsupportedOverrides key added for reference. Please note that the `<image_placeholder with tag>` is to be replaced with the plugin image and tag.
 
- - Velero Imagekey  -> `veleroImageFqin`
- - AWS Plugin ImageKey  -> `awsPluginImageFqin`
- - OpenShift Plugin ImageKey  -> `openshiftPluginImageFqin`
- - Azure Plugin ImageKey -> `azurePluginImageFqin`
- - GCP Plugin ImageKey  -> `gcpPluginImageFqin`
- - CSI Plugin ImageKey  -> `csiPluginImageFqin`
- - Restic Restore ImageKey -> `resticRestoreImageFqin`
- - Data Mover Imagekey -> `dataMoverImageFqin`
-
-Below is an example DataProtectionApplication (DPA) CR with the unsupportedOverrides key added for reference. Please note that the `<IMAGE_PLACEHOLDER WITH TAG>` is to be replaced with the plugin image and tag.
 ```
 apiVersion: oadp.openshift.io/v1alpha1
 kind: DataProtectionApplication
@@ -53,7 +56,6 @@ spec:
           region: us-west-2
           profile: "default"
   unsupportedOverrides:
-    awsPluginImageFqin: <IMAGE_PLACEHOLDER WITH TAG>
-    openshiftPluginImageFqin: <IMAGE_PLACEHOLDER WITH TAG>
-
+    awsPluginImageFqin: <image_placeholder with tag>
+    openshiftPluginImageFqin: <image_placeholder with tag>
 ```


### PR DESCRIPTION
Updated the documentation for custom plugin images in Velero, correcting formatting and providing clearer examples for the unsupportedOverrides field.

## Why the changes were made

<!-- Explain why this PR is important, what problems it fixes, link related issues -->

## How to test the changes made

<!-- Explain how the changes introduced by this PR can be tested and verified, with commands and pictures -->
