### PR TITLE
Updates to mongo and makefile to reduce flakes.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -846,9 +846,15 @@ else
 	TEST_FILTER += && (! cli)
 endif
 
+GINKGO_FLAGS = --vv \
+	--no-color=$(OPENSHIFT_CI) \
+	--label-filter="$(TEST_FILTER)" \
+	--junit-report="$(ARTIFACT_DIR)/junit_report.xml" \
+	--timeout=2h
+
 .PHONY: test-e2e
 test-e2e: test-e2e-setup install-ginkgo ## Run E2E tests against OADP operator installed in cluster. For more information, check docs/developer/testing/TESTING.md
-	ginkgo run -mod=mod tests/e2e/ -- \
+	ginkgo run -mod=mod $(GINKGO_FLAGS) $(GINKGO_ARGS) tests/e2e/ -- \
 	-settings=$(SETTINGS_TMP)/oadpcreds \
 	-provider=$(CLUSTER_TYPE) \
 	-credentials=$(OADP_CRED_FILE) \
@@ -858,14 +864,8 @@ test-e2e: test-e2e-setup install-ginkgo ## Run E2E tests against OADP operator i
 	-artifact_dir=$(ARTIFACT_DIR) \
 	-kvm_emulation=$(KVM_EMULATION) \
 	-hco_upstream=$(HCO_UPSTREAM) \
-        -skipMustGather=$(SKIP_MUST_GATHER) \
-	--ginkgo.vv \
-	--ginkgo.no-color=$(OPENSHIFT_CI) \
-	--ginkgo.label-filter="$(TEST_FILTER)" \
-	--ginkgo.junit-report="$(ARTIFACT_DIR)/junit_report.xml" \
-	--ginkgo.timeout=2h \
-	$(HCP_EXTERNAL_ARGS) \
-	$(GINKGO_ARGS)
+	-skipMustGather=$(SKIP_MUST_GATHER) \
+	$(HCP_EXTERNAL_ARGS)
 
 .PHONY: test-e2e-cleanup
 test-e2e-cleanup: login-required

--- a/tests/e2e/backup_restore_cli_suite_test.go
+++ b/tests/e2e/backup_restore_cli_suite_test.go
@@ -292,17 +292,6 @@ var _ = ginkgo.Describe("Backup and restore tests via OADP CLI", ginkgo.Label("c
 				BackupTimeout:     20 * time.Minute,
 			},
 		}, nil),
-		ginkgo.Entry("Mongo application KOPIA via CLI", ginkgo.FlakeAttempts(flakeAttempts), ApplicationBackupRestoreCase{
-			ApplicationTemplate: "./sample-applications/mongo-persistent/mongo-persistent.yaml",
-			BackupRestoreCase: BackupRestoreCase{
-				Namespace:         "mongo-persistent",
-				Name:              "mongo-kopia-cli-e2e",
-				BackupRestoreType: lib.KOPIA,
-				PreBackupVerify:   todoListReady(true, false, "mongo"),
-				PostRestoreVerify: todoListReady(false, false, "mongo"),
-				BackupTimeout:     20 * time.Minute,
-			},
-		}, nil),
 		ginkgo.Entry("MySQL application KOPIA via CLI", ginkgo.FlakeAttempts(flakeAttempts), ApplicationBackupRestoreCase{
 			ApplicationTemplate: "./sample-applications/mysql-persistent/mysql-persistent.yaml",
 			BackupRestoreCase: BackupRestoreCase{

--- a/tests/e2e/backup_restore_cli_suite_test.go
+++ b/tests/e2e/backup_restore_cli_suite_test.go
@@ -114,10 +114,10 @@ func runApplicationBackupAndRestoreViaCLI(brCase ApplicationBackupRestoreCase, u
 	err := lib.InstallApplication(dpaCR.Client, brCase.ApplicationTemplate)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
+	var pvcPath string
 	if brCase.BackupRestoreType == lib.CSI || brCase.BackupRestoreType == lib.CSIDataMover {
 		log.Printf("Creating pvc for case %s", brCase.Name)
 		var pvcName string
-		var pvcPath string
 
 		pvcName = provider
 		if brCase.PvcSuffixName != "" {
@@ -149,6 +149,21 @@ func runApplicationBackupAndRestoreViaCLI(brCase ApplicationBackupRestoreCase, u
 	log.Printf("Uninstalling app for case %s", brCase.Name)
 	err = lib.UninstallApplication(dpaCR.Client, brCase.ApplicationTemplate)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+	// Ensure that we remove the pvc(s) before waiting for namespace deletion
+	if brCase.BackupRestoreType == lib.CSI || brCase.BackupRestoreType == lib.CSIDataMover {
+		// For CSI/CSIDataMover tests, delete the explicitly created PVC
+		log.Printf("Deleting PVC from %s for case %s", pvcPath, brCase.Name)
+		err = lib.UninstallApplication(dpaCR.Client, pvcPath)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	}
+
+	// Delete all PVCs in the namespace to ensure clean state
+	log.Printf("Deleting all PVCs in namespace %s", brCase.Namespace)
+	err = lib.DeleteAllPVCsInNamespace(kubernetesClientForSuiteRun, brCase.Namespace)
+	if err != nil {
+		log.Printf("Warning: Failed to delete PVCs in namespace %s: %v", brCase.Namespace, err)
+	}
 
 	// Wait for namespace to be deleted
 	gomega.Eventually(lib.IsNamespaceDeleted(kubernetesClientForSuiteRun, brCase.Namespace), time.Minute*4, time.Second*5).Should(gomega.BeTrue())

--- a/tests/e2e/backup_restore_cli_suite_test.go
+++ b/tests/e2e/backup_restore_cli_suite_test.go
@@ -35,8 +35,12 @@ func runBackupViaCLI(brCase BackupRestoreCase, backupName string) bool {
 	describeBackup := lib.DescribeBackupViaCLI(backupName)
 	ginkgo.GinkgoWriter.Println(describeBackup)
 
-	backupLogs, err := lib.BackupLogsViaCLI(backupName)
-	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	var backupLogs string
+	gomega.Eventually(func() error {
+		var err error
+		backupLogs, err = lib.BackupLogsViaCLI(backupName)
+		return err
+	}, time.Minute*2, time.Second*5).Should(gomega.Succeed())
 
 	backupErrorLogs := lib.BackupErrorLogsViaCLI(backupName)
 	accumulatedTestLogs = append(accumulatedTestLogs, describeBackup, backupLogs)
@@ -67,8 +71,12 @@ func runRestoreViaCLI(brCase BackupRestoreCase, backupName, restoreName string, 
 	describeRestore := lib.DescribeRestoreViaCLI(restoreName)
 	ginkgo.GinkgoWriter.Println(describeRestore)
 
-	restoreLogs, err := lib.RestoreLogsViaCLI(restoreName)
-	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	var restoreLogs string
+	gomega.Eventually(func() error {
+		var err error
+		restoreLogs, err = lib.RestoreLogsViaCLI(restoreName)
+		return err
+	}, time.Minute*2, time.Second*5).Should(gomega.Succeed())
 
 	restoreErrorLogs := lib.RestoreErrorLogsViaCLI(restoreName)
 	accumulatedTestLogs = append(accumulatedTestLogs, describeRestore, restoreLogs)

--- a/tests/e2e/backup_restore_suite_test.go
+++ b/tests/e2e/backup_restore_suite_test.go
@@ -111,10 +111,11 @@ func runApplicationBackupAndRestore(brCase ApplicationBackupRestoreCase, updateL
 	log.Printf("Installing application for case %s", brCase.Name)
 	err := lib.InstallApplication(dpaCR.Client, brCase.ApplicationTemplate)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+	var pvcPath string
 	if brCase.BackupRestoreType == lib.CSI || brCase.BackupRestoreType == lib.CSIDataMover {
 		log.Printf("Creating pvc for case %s", brCase.Name)
 		var pvcName string
-		var pvcPath string
 
 		pvcName = provider
 		if brCase.PvcSuffixName != "" {
@@ -146,6 +147,21 @@ func runApplicationBackupAndRestore(brCase ApplicationBackupRestoreCase, updateL
 	log.Printf("Uninstalling app for case %s", brCase.Name)
 	err = lib.UninstallApplication(dpaCR.Client, brCase.ApplicationTemplate)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+	// Ensure that we remove the pvc(s) before waiting for namespace deletion
+	if brCase.BackupRestoreType == lib.CSI || brCase.BackupRestoreType == lib.CSIDataMover {
+		// For CSI/CSIDataMover tests, delete the explicitly created PVC
+		log.Printf("Deleting PVC from %s for case %s", pvcPath, brCase.Name)
+		err = lib.UninstallApplication(dpaCR.Client, pvcPath)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	}
+
+	// Delete all PVCs in the namespace to ensure clean state
+	log.Printf("Deleting all PVCs in namespace %s", brCase.Namespace)
+	err = lib.DeleteAllPVCsInNamespace(kubernetesClientForSuiteRun, brCase.Namespace)
+	if err != nil {
+		log.Printf("Warning: Failed to delete PVCs in namespace %s: %v", brCase.Namespace, err)
+	}
 
 	// Wait for namespace to be deleted
 	gomega.Eventually(lib.IsNamespaceDeleted(kubernetesClientForSuiteRun, brCase.Namespace), time.Minute*4, time.Second*5).Should(gomega.BeTrue())

--- a/tests/e2e/backup_restore_suite_test.go
+++ b/tests/e2e/backup_restore_suite_test.go
@@ -37,7 +37,8 @@ func todoListReady(preBackupState bool, twoVol bool, database string) Verificati
 	return VerificationFunction(func(ocClient client.Client, namespace string) error {
 		log.Printf("checking for the NAMESPACE: %s", namespace)
 		gomega.Eventually(lib.IsDeploymentReady(ocClient, namespace, database), time.Minute*10, time.Second*10).Should(gomega.BeTrue())
-		gomega.Eventually(lib.IsDCReady(ocClient, namespace, "todolist"), time.Minute*10, time.Second*10).Should(gomega.BeTrue())
+		// perhaps we phase out deploymentConfigs?		
+		//gomega.Eventually(lib.IsDCReady(ocClient, namespace, "todolist"), time.Minute*10, time.Second*10).Should(gomega.BeTrue())
 		gomega.Eventually(lib.AreApplicationPodsRunning(kubernetesClientForSuiteRun, namespace), time.Minute*9, time.Second*5).Should(gomega.BeTrue())
 		// This test confirms that SCC restore logic in our plugin is working
 		err := lib.DoesSCCExist(ocClient, database+"-persistent-scc")

--- a/tests/e2e/backup_restore_suite_test.go
+++ b/tests/e2e/backup_restore_suite_test.go
@@ -382,17 +382,6 @@ var _ = ginkgo.Describe("Backup and restore tests", ginkgo.Ordered, func() {
 				BackupTimeout:     20 * time.Minute,
 			},
 		}, nil),
-		ginkgo.Entry("Mongo application KOPIA", ginkgo.FlakeAttempts(flakeAttempts), ApplicationBackupRestoreCase{
-			ApplicationTemplate: "./sample-applications/mongo-persistent/mongo-persistent.yaml",
-			BackupRestoreCase: BackupRestoreCase{
-				Namespace:         "mongo-persistent",
-				Name:              "mongo-kopia-e2e",
-				BackupRestoreType: lib.KOPIA,
-				PreBackupVerify:   todoListReady(true, false, "mongo"),
-				PostRestoreVerify: todoListReady(false, false, "mongo"),
-				BackupTimeout:     20 * time.Minute,
-			},
-		}, nil),
 		ginkgo.Entry("MySQL application KOPIA", ginkgo.FlakeAttempts(flakeAttempts), ApplicationBackupRestoreCase{
 			ApplicationTemplate: "./sample-applications/mysql-persistent/mysql-persistent.yaml",
 			BackupRestoreCase: BackupRestoreCase{

--- a/tests/e2e/backup_restore_suite_test.go
+++ b/tests/e2e/backup_restore_suite_test.go
@@ -37,7 +37,7 @@ func todoListReady(preBackupState bool, twoVol bool, database string) Verificati
 	return VerificationFunction(func(ocClient client.Client, namespace string) error {
 		log.Printf("checking for the NAMESPACE: %s", namespace)
 		gomega.Eventually(lib.IsDeploymentReady(ocClient, namespace, database), time.Minute*10, time.Second*10).Should(gomega.BeTrue())
-		// perhaps we phase out deploymentConfigs?		
+		// perhaps we phase out deploymentConfigs?
 		//gomega.Eventually(lib.IsDCReady(ocClient, namespace, "todolist"), time.Minute*10, time.Second*10).Should(gomega.BeTrue())
 		gomega.Eventually(lib.AreApplicationPodsRunning(kubernetesClientForSuiteRun, namespace), time.Minute*9, time.Second*5).Should(gomega.BeTrue())
 		// This test confirms that SCC restore logic in our plugin is working

--- a/tests/e2e/lib/k8s_common_helpers.go
+++ b/tests/e2e/lib/k8s_common_helpers.go
@@ -273,3 +273,35 @@ func GetPodWithLabel(c *kubernetes.Clientset, namespace string, LabelSelector st
 	}
 	return &podList.Items[0], nil
 }
+
+// DeleteAllPVCsInNamespace deletes all PersistentVolumeClaims in a namespace
+func DeleteAllPVCsInNamespace(clientset *kubernetes.Clientset, namespace string) error {
+	ctx := context.Background()
+
+	// List all PVCs in the namespace
+	pvcList, err := clientset.CoreV1().PersistentVolumeClaims(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Printf("Namespace %s not found, skipping PVC deletion", namespace)
+			return nil
+		}
+		return fmt.Errorf("failed to list PVCs in namespace %s: %w", namespace, err)
+	}
+
+	if len(pvcList.Items) == 0 {
+		log.Printf("No PVCs found in namespace %s", namespace)
+		return nil
+	}
+
+	// Delete each PVC
+	for _, pvc := range pvcList.Items {
+		log.Printf("Deleting PVC %s in namespace %s", pvc.Name, namespace)
+		err := clientset.CoreV1().PersistentVolumeClaims(namespace).Delete(ctx, pvc.Name, metav1.DeleteOptions{})
+		if err != nil && !apierrors.IsNotFound(err) {
+			log.Printf("Warning: Failed to delete PVC %s in namespace %s: %v", pvc.Name, namespace, err)
+		}
+	}
+
+	log.Printf("Deleted %d PVC(s) from namespace %s", len(pvcList.Items), namespace)
+	return nil
+}

--- a/tests/e2e/sample-applications/mongo-persistent/mongo-persistent-block.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/mongo-persistent-block.yaml
@@ -198,7 +198,7 @@ items:
         spec:
           containers:
           - name: todolist
-            image: quay.io/migtools/oadp-ci-todolist-mongo-go-1
+            image: quay.io/migtools/oadp-ci-todolist-mongo-go-3
             env:
               - name: foo
                 value: bar

--- a/tests/e2e/sample-applications/mongo-persistent/mongo-persistent-block.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/mongo-persistent-block.yaml
@@ -198,7 +198,7 @@ items:
         spec:
           containers:
           - name: todolist
-            image: quay.io/migtools/oadp-ci-todolist-mongo-go-3 
+            image: quay.io/migtools/oadp-ci-todolist-mongo-go-4 
             env:
               - name: foo
                 value: bar

--- a/tests/e2e/sample-applications/mongo-persistent/mongo-persistent-block.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/mongo-persistent-block.yaml
@@ -64,6 +64,11 @@ items:
             e2e-app: "true"
             app: mongo
             curl-tool: "true"
+          annotations:
+            pre.hook.backup.velero.io/container: mongo
+            pre.hook.backup.velero.io/command: '["/bin/bash", "-c", "mongosh admin -u \"$MONGO_INITDB_ROOT_USERNAME\" -p \"$MONGO_INITDB_ROOT_PASSWORD\" --eval \"db.fsyncLock()\""]'
+            post.hook.backup.velero.io/container: mongo
+            post.hook.backup.velero.io/command: '["/bin/bash", "-c", "mongosh admin -u \"$MONGO_INITDB_ROOT_USERNAME\" -p \"$MONGO_INITDB_ROOT_PASSWORD\" --eval \"db.fsyncUnlock()\""]'
         spec:
           serviceAccountName: mongo-persistent-sa
           securityContext:
@@ -139,11 +144,10 @@ items:
               startupProbe:
                 exec:
                   command:
-                  - mongosh
-                  - admin
-                  - -u $(MONGO_INITDB_ROOT_USERNAME)
-                  - -p $(MONGO_INITDB_ROOT_PASSWORD)
-                  - --eval 'printjson(db.getCollectionNames())'
+                  - bash
+                  - -c
+                  - |
+                    mongosh admin --authenticationDatabase admin -u "$MONGO_INITDB_ROOT_USERNAME" -p "$MONGO_INITDB_ROOT_PASSWORD" --eval 'db.adminCommand("ping")'
                 initialDelaySeconds: 5
                 periodSeconds: 30
                 timeoutSeconds: 2
@@ -173,8 +177,8 @@ items:
         port: 27017
       selector:
         app: mongo
-  - apiVersion: apps.openshift.io/v1
-    kind: DeploymentConfig
+  - apiVersion: apps/v1
+    kind: Deployment
     metadata:
       name: todolist
       namespace: mongo-persistent
@@ -185,8 +189,9 @@ items:
     spec:
       replicas: 1
       selector:
-        app: todolist
-        service: todolist
+        matchLabels:
+          app: todolist
+          service: todolist
       strategy:
         type: Recreate
       template:
@@ -198,13 +203,25 @@ items:
         spec:
           containers:
           - name: todolist
-            image: quay.io/migtools/oadp-ci-todolist-mongo-go-3
+            image: quay.io/migtools/oadp-ci-todolist-mongo-go-3 
             env:
               - name: foo
                 value: bar
             ports:
               - containerPort: 8000
                 protocol: TCP
+            livenessProbe:
+              httpGet:
+                path: /
+                port: 8000
+              initialDelaySeconds: 10
+              periodSeconds: 10
+            readinessProbe:
+              httpGet:
+                path: /
+                port: 8000
+              initialDelaySeconds: 5
+              periodSeconds: 5
           initContainers:
           - name: init-myservice
             image: docker.io/curlimages/curl:8.5.0

--- a/tests/e2e/sample-applications/mongo-persistent/mongo-persistent-block.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/mongo-persistent-block.yaml
@@ -64,11 +64,6 @@ items:
             e2e-app: "true"
             app: mongo
             curl-tool: "true"
-          annotations:
-            pre.hook.backup.velero.io/container: mongo
-            pre.hook.backup.velero.io/command: '["/bin/bash", "-c", "mongosh admin -u \"$MONGO_INITDB_ROOT_USERNAME\" -p \"$MONGO_INITDB_ROOT_PASSWORD\" --eval \"db.fsyncLock()\""]'
-            post.hook.backup.velero.io/container: mongo
-            post.hook.backup.velero.io/command: '["/bin/bash", "-c", "mongosh admin -u \"$MONGO_INITDB_ROOT_USERNAME\" -p \"$MONGO_INITDB_ROOT_PASSWORD\" --eval \"db.fsyncUnlock()\""]'
         spec:
           serviceAccountName: mongo-persistent-sa
           securityContext:

--- a/tests/e2e/sample-applications/mongo-persistent/mongo-persistent-csi.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/mongo-persistent-csi.yaml
@@ -64,6 +64,11 @@ items:
             e2e-app: "true"
             app: mongo
             curl-tool: "true"
+          annotations:
+            pre.hook.backup.velero.io/container: mongo
+            pre.hook.backup.velero.io/command: '["/bin/bash", "-c", "mongosh admin -u \"$MONGO_INITDB_ROOT_USERNAME\" -p \"$MONGO_INITDB_ROOT_PASSWORD\" --eval \"db.fsyncLock()\""]'
+            post.hook.backup.velero.io/container: mongo
+            post.hook.backup.velero.io/command: '["/bin/bash", "-c", "mongosh admin -u \"$MONGO_INITDB_ROOT_USERNAME\" -p \"$MONGO_INITDB_ROOT_PASSWORD\" --eval \"db.fsyncUnlock()\""]'
         spec:
           serviceAccountName: mongo-persistent-sa
           containers:
@@ -96,11 +101,10 @@ items:
             startupProbe:
               exec:
                 command:
-                - mongosh
-                - admin
-                - -u $(MONGO_INITDB_ROOT_USERNAME)
-                - -p $(MONGO_INITDB_ROOT_PASSWORD)
-                - --eval 'printjson(db.getCollectionNames())'
+                - bash
+                - -c
+                - |
+                  mongosh admin --authenticationDatabase admin -u "$MONGO_INITDB_ROOT_USERNAME" -p "$MONGO_INITDB_ROOT_PASSWORD" --eval 'db.adminCommand("ping")'
               initialDelaySeconds: 5
               periodSeconds: 30
               timeoutSeconds: 2
@@ -130,8 +134,8 @@ items:
         port: 27017
       selector:
         app: mongo
-  - apiVersion: apps.openshift.io/v1
-    kind: DeploymentConfig
+  - apiVersion: apps/v1
+    kind: Deployment
     metadata:
       name: todolist
       namespace: mongo-persistent
@@ -142,8 +146,9 @@ items:
     spec:
       replicas: 1
       selector:
-        app: todolist
-        service: todolist
+        matchLabels:
+          app: todolist
+          service: todolist
       strategy:
         type: Recreate
       template:
@@ -162,6 +167,18 @@ items:
             ports:
               - containerPort: 8000
                 protocol: TCP
+            livenessProbe:
+              httpGet:
+                path: /
+                port: 8000
+              initialDelaySeconds: 10
+              periodSeconds: 10
+            readinessProbe:
+              httpGet:
+                path: /
+                port: 8000
+              initialDelaySeconds: 5
+              periodSeconds: 5
           initContainers:
           - name: init-myservice
             image: docker.io/curlimages/curl:8.5.0

--- a/tests/e2e/sample-applications/mongo-persistent/mongo-persistent-csi.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/mongo-persistent-csi.yaml
@@ -155,7 +155,7 @@ items:
         spec:
           containers:
           - name: todolist
-            image: quay.io/migtools/oadp-ci-todolist-mongo-go-1
+            image: quay.io/migtools/oadp-ci-todolist-mongo-go-3
             env:
               - name: foo
                 value: bar

--- a/tests/e2e/sample-applications/mongo-persistent/mongo-persistent-csi.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/mongo-persistent-csi.yaml
@@ -64,11 +64,6 @@ items:
             e2e-app: "true"
             app: mongo
             curl-tool: "true"
-          annotations:
-            pre.hook.backup.velero.io/container: mongo
-            pre.hook.backup.velero.io/command: '["/bin/bash", "-c", "mongosh admin -u \"$MONGO_INITDB_ROOT_USERNAME\" -p \"$MONGO_INITDB_ROOT_PASSWORD\" --eval \"db.fsyncLock()\""]'
-            post.hook.backup.velero.io/container: mongo
-            post.hook.backup.velero.io/command: '["/bin/bash", "-c", "mongosh admin -u \"$MONGO_INITDB_ROOT_USERNAME\" -p \"$MONGO_INITDB_ROOT_PASSWORD\" --eval \"db.fsyncUnlock()\""]'
         spec:
           serviceAccountName: mongo-persistent-sa
           containers:

--- a/tests/e2e/sample-applications/mongo-persistent/mongo-persistent-csi.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/mongo-persistent-csi.yaml
@@ -155,7 +155,7 @@ items:
         spec:
           containers:
           - name: todolist
-            image: quay.io/migtools/oadp-ci-todolist-mongo-go-3
+            image: quay.io/migtools/oadp-ci-todolist-mongo-go-4
             env:
               - name: foo
                 value: bar

--- a/tests/e2e/sample-applications/mongo-persistent/mongo-persistent.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/mongo-persistent.yaml
@@ -77,6 +77,11 @@ items:
             e2e-app: "true"
             app: mongo
             curl-tool: "true"
+          annotations:
+            pre.hook.backup.velero.io/container: mongo
+            pre.hook.backup.velero.io/command: '["/bin/bash", "-c", "mongosh admin -u \"$MONGO_INITDB_ROOT_USERNAME\" -p \"$MONGO_INITDB_ROOT_PASSWORD\" --eval \"db.fsyncLock()\""]'
+            post.hook.backup.velero.io/container: mongo
+            post.hook.backup.velero.io/command: '["/bin/bash", "-c", "mongosh admin -u \"$MONGO_INITDB_ROOT_USERNAME\" -p \"$MONGO_INITDB_ROOT_PASSWORD\" --eval \"db.fsyncUnlock()\""]'
         spec:
           serviceAccountName: mongo-persistent-sa
           containers:
@@ -109,11 +114,10 @@ items:
             startupProbe:
               exec:
                 command:
-                - mongosh
-                - admin
-                - -u $(MONGO_INITDB_ROOT_USERNAME)
-                - -p $(MONGO_INITDB_ROOT_PASSWORD)
-                - --eval 'printjson(db.getCollectionNames())'
+                - bash
+                - -c
+                - |
+                  mongosh admin --authenticationDatabase admin -u "$MONGO_INITDB_ROOT_USERNAME" -p "$MONGO_INITDB_ROOT_PASSWORD" --eval 'db.adminCommand("ping")'
               initialDelaySeconds: 5
               periodSeconds: 30
               timeoutSeconds: 2
@@ -143,8 +147,8 @@ items:
         port: 27017
       selector:
         app: mongo
-  - apiVersion: apps.openshift.io/v1
-    kind: DeploymentConfig
+  - apiVersion: apps/v1
+    kind: Deployment
     metadata:
       name: todolist
       namespace: mongo-persistent
@@ -155,8 +159,9 @@ items:
     spec:
       replicas: 1
       selector:
-        app: todolist
-        service: todolist
+        matchLabels:
+          app: todolist
+          service: todolist
       strategy:
         type: Recreate
       template:
@@ -175,6 +180,18 @@ items:
             ports:
               - containerPort: 8000
                 protocol: TCP
+            livenessProbe:
+              httpGet:
+                path: /
+                port: 8000
+              initialDelaySeconds: 10
+              periodSeconds: 10
+            readinessProbe:
+              httpGet:
+                path: /
+                port: 8000
+              initialDelaySeconds: 5
+              periodSeconds: 5
           initContainers:
           - name: init-myservice
             image: docker.io/curlimages/curl:8.5.0

--- a/tests/e2e/sample-applications/mongo-persistent/mongo-persistent.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/mongo-persistent.yaml
@@ -168,7 +168,7 @@ items:
         spec:
           containers:
           - name: todolist
-            image: quay.io/migtools/oadp-ci-todolist-mongo-go-1
+            image: quay.io/migtools/oadp-ci-todolist-mongo-go-3
             env:
               - name: foo
                 value: bar

--- a/tests/e2e/sample-applications/mongo-persistent/mongo-persistent.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/mongo-persistent.yaml
@@ -168,7 +168,7 @@ items:
         spec:
           containers:
           - name: todolist
-            image: quay.io/migtools/oadp-ci-todolist-mongo-go-3
+            image: quay.io/migtools/oadp-ci-todolist-mongo-go-4
             env:
               - name: foo
                 value: bar

--- a/tests/e2e/sample-applications/mongo-persistent/mongo-persistent.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/mongo-persistent.yaml
@@ -77,11 +77,6 @@ items:
             e2e-app: "true"
             app: mongo
             curl-tool: "true"
-          annotations:
-            pre.hook.backup.velero.io/container: mongo
-            pre.hook.backup.velero.io/command: '["/bin/bash", "-c", "mongosh admin -u \"$MONGO_INITDB_ROOT_USERNAME\" -p \"$MONGO_INITDB_ROOT_PASSWORD\" --eval \"db.fsyncLock()\""]'
-            post.hook.backup.velero.io/container: mongo
-            post.hook.backup.velero.io/command: '["/bin/bash", "-c", "mongosh admin -u \"$MONGO_INITDB_ROOT_USERNAME\" -p \"$MONGO_INITDB_ROOT_PASSWORD\" --eval \"db.fsyncUnlock()\""]'
         spec:
           serviceAccountName: mongo-persistent-sa
           containers:

--- a/tests/e2e/sample-applications/mongo-persistent/pvc/aws-block-mode.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/pvc/aws-block-mode.yaml
@@ -12,7 +12,7 @@ items:
       volumeMode: Block 
       accessModes:
       - ReadWriteOnce
-      storageClassName: gp2-csi
+      storageClassName: gp3-csi
       resources:
         requests:
           storage: 1Gi

--- a/tests/e2e/sample-applications/mongo-persistent/pvc/aws.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/pvc/aws.yaml
@@ -11,7 +11,7 @@ items:
     spec:
       accessModes:
       - ReadWriteOnce
-      storageClassName: gp2-csi
+      storageClassName: gp3-csi
       resources:
         requests:
           storage: 1Gi

--- a/tests/e2e/sample-applications/mongo-persistent/pvc/ibmcloud-block-mode.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/pvc/ibmcloud-block-mode.yaml
@@ -9,10 +9,10 @@ items:
       labels:
         app: mongo
     spec:
-      volumeMode: Block 
+      volumeMode: Block
       accessModes:
       - ReadWriteOnce
-      storageClassName: ocs-storagecluster-cephfs
+      storageClassName: ocs-storagecluster-ceph-rbd
       resources:
         requests:
           storage: 1Gi


### PR DESCRIPTION
## Why the changes were made

* improve the basic todolist-mongo app iteself
* improve the todolist-mongo openshift manifests
* add retry to oadp cli backup/restore log call
* ginkgo.Entry("Mongo application KOPIA in either b/r suite or cli suite is NOT worth the flakiness imho.. Kill it.
* Update the Makefile to allow GINKGO_ARGS="--focus='FOO' to work again. 

All in the hopes of making tihs app more reliable
https://github.com/konveyor/mig-demo-apps/pull/109

## How to test the changes made
* run the e2e tests in full or a single test

