### PR TITLE
Bump 1.4.6 -> 1.4.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ TEST_UPGRADE ?= false
 
 # TOOL VERSIONS
 # All version-related variables are defined here for easy maintenance
-DEFAULT_VERSION := 1.4.6
+DEFAULT_VERSION := 1.4.7
 VERSION ?= $(DEFAULT_VERSION) # the version of the operator
 OPERATOR_SDK_VERSION ?= v1.34.2
 ENVTEST_K8S_VERSION = 1.29 # Kubernetes version from OpenShift 4.16.x
@@ -172,7 +172,7 @@ ENVTEST_K8S_VERSION = 1.29
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-DEFAULT_VERSION := 1.4.6
+DEFAULT_VERSION := 1.4.7
 VERSION ?= $(DEFAULT_VERSION)
 
 # IMAGE_TAG_BASE defines the docker.io namespace and part of the image name for remote images.

--- a/bundle/manifests/oadp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/oadp-operator.clusterserviceversion.yaml
@@ -166,7 +166,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "true"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: '>=0.0.0 <1.4.6'
+    olm.skipRange: '>=0.0.0 <1.4.7'
     operatorframework.io/suggested-namespace: openshift-adp
     operators.openshift.io/infrastructure-features: '["Disconnected"]'
     operators.openshift.io/must-gather-image: quay.io/konveyor/oadp-must-gather:oadp-1.4
@@ -181,7 +181,7 @@ metadata:
     operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
-  name: oadp-operator.v1.4.6
+  name: oadp-operator.v1.4.7
   namespace: openshift-adp
 spec:
   apiservicedefinitions: {}
@@ -1024,5 +1024,5 @@ spec:
     name: hypershift-velero-plugin
   - image: quay.io/konveyor/oadp-must-gather:oadp-1.4
     name: mustgather
-  replaces: oadp-operator.v1.4.5
-  version: 1.4.6
+  replaces: oadp-operator.v1.4.6
+  version: 1.4.7

--- a/bundle/oadp-operator.package.yaml
+++ b/bundle/oadp-operator.package.yaml
@@ -2,5 +2,5 @@
 packageName: redhat-oadp-operator
 channels:
 - name: stable-1.4
-  currentCSV: oadp-operator.v1.4.6
+  currentCSV: oadp-operator.v1.4.7
 defaultChannel: stable-1.4

--- a/config/manifests/bases/oadp-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/oadp-operator.clusterserviceversion.yaml
@@ -20,7 +20,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "true"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: '>=0.0.0 <1.4.6'
+    olm.skipRange: '>=0.0.0 <1.4.7'
     operatorframework.io/suggested-namespace: openshift-adp
     operators.openshift.io/infrastructure-features: '["Disconnected"]'
     operators.openshift.io/must-gather-image: quay.io/konveyor/oadp-must-gather:oadp-1.4
@@ -33,7 +33,7 @@ metadata:
     operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
-  name: oadp-operator.v1.4.6
+  name: oadp-operator.v1.4.7
   namespace: openshift-adp
 spec:
   apiservicedefinitions: {}
@@ -485,5 +485,5 @@ spec:
   maturity: stable
   provider:
     name: Red Hat
-  replaces: oadp-operator.v1.4.5
-  version: 1.4.6
+  replaces: oadp-operator.v1.4.6
+  version: 1.4.7

--- a/docs/version-update.md
+++ b/docs/version-update.md
@@ -1,0 +1,77 @@
+# OADP Operator Version Update Guide
+
+This document outlines the files and fields that need to be updated for OADP operator version bumps.
+
+## Files to Update
+
+For a patch version update (e.g., 1.4.6 → 1.4.7), update these 4 files:
+
+### 1. Makefile
+
+Update `DEFAULT_VERSION` variable (appears twice):
+
+```makefile
+DEFAULT_VERSION := 1.4.7  # was 1.4.6
+```
+
+### 2. config/manifests/bases/oadp-operator.clusterserviceversion.yaml
+
+Update 4 fields:
+
+```yaml
+metadata:
+  annotations:
+    olm.skipRange: '>=0.0.0 <1.4.7'  # was <1.4.6
+  name: oadp-operator.v1.4.7  # was v1.4.6
+
+spec:
+  replaces: oadp-operator.v1.4.6  # was v1.4.5
+  version: 1.4.7  # was 1.4.6
+```
+
+### 3. bundle/manifests/oadp-operator.clusterserviceversion.yaml
+
+Update the same 4 fields as above:
+
+```yaml
+metadata:
+  annotations:
+    olm.skipRange: '>=0.0.0 <1.4.7'
+  name: oadp-operator.v1.4.7
+
+spec:
+  replaces: oadp-operator.v1.4.6
+  version: 1.4.7
+```
+
+### 4. bundle/oadp-operator.package.yaml
+
+Update 1 field:
+
+```yaml
+channels:
+- name: stable-1.4
+  currentCSV: oadp-operator.v1.4.7  # was v1.4.6
+```
+
+## Summary
+
+**Total changes**: 4 files, 11 lines modified
+
+- `Makefile`: 2 changes
+- `config/manifests/bases/oadp-operator.clusterserviceversion.yaml`: 4 changes
+- `bundle/manifests/oadp-operator.clusterserviceversion.yaml`: 4 changes
+- `bundle/oadp-operator.package.yaml`: 1 change
+
+## Field Descriptions
+
+- **DEFAULT_VERSION**: Main version variable used throughout the build process
+- **olm.skipRange**: Tells OLM which versions can be skipped during upgrades
+- **metadata.name**: The full name of this CSV version
+- **spec.replaces**: Points to the immediate previous version (creates upgrade path)
+- **spec.version**: The semantic version number
+- **currentCSV**: Indicates the current version in this channel
+
+## Reference
+
+Example commit: `7f0ad66c` (1.5.1 → 1.5.2 bump)


### PR DESCRIPTION
Version bump from 1.4.6 to 1.4.7

## Changes
- Updated `DEFAULT_VERSION` in Makefile
- Updated version metadata in ClusterServiceVersion files
- Updated currentCSV in package.yaml
- Added version update documentation

## Files Modified
- `Makefile` (2 changes)
- `bundle/manifests/oadp-operator.clusterserviceversion.yaml` (4 changes)
- `bundle/oadp-operator.package.yaml` (1 change)
- `config/manifests/bases/oadp-operator.clusterserviceversion.yaml` (4 changes)
- `docs/version-update.md` (new file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)