### PR TITLE
mysql use deployments only

### DIFF
--- a/tests/e2e/sample-applications/mysql-persistent/mysql-persistent-csi.yaml
+++ b/tests/e2e/sample-applications/mysql-persistent/mysql-persistent-csi.yaml
@@ -151,8 +151,8 @@ items:
       selector:
         app: todolist
         service: todolist
-  - apiVersion: apps.openshift.io/v1
-    kind: DeploymentConfig
+  - apiVersion: apps/v1
+    kind: Deployment
     metadata:
       name: todolist
       namespace: mysql-persistent
@@ -163,8 +163,9 @@ items:
     spec:
       replicas: 1
       selector:
-        app: todolist
-        service: todolist
+        matchLabels:
+          app: todolist
+          service: todolist
       strategy:
         type: Recreate
       template:

--- a/tests/e2e/sample-applications/mysql-persistent/mysql-persistent-twovol-csi.yaml
+++ b/tests/e2e/sample-applications/mysql-persistent/mysql-persistent-twovol-csi.yaml
@@ -142,8 +142,8 @@ items:
       selector:
         app: todolist
         service: todolist
-  - apiVersion: apps.openshift.io/v1
-    kind: DeploymentConfig
+  - apiVersion: apps/v1
+    kind: Deployment
     metadata:
       name: todolist
       namespace: mysql-persistent
@@ -154,8 +154,9 @@ items:
     spec:
       replicas: 1
       selector:
-        app: todolist
-        service: todolist
+        matchLabels:
+          app: todolist
+          service: todolist
       strategy:
         type: Recreate
       template:

--- a/tests/e2e/sample-applications/mysql-persistent/mysql-persistent.yaml
+++ b/tests/e2e/sample-applications/mysql-persistent/mysql-persistent.yaml
@@ -164,8 +164,8 @@ items:
       selector:
         app: todolist
         service: todolist
-  - apiVersion: apps.openshift.io/v1
-    kind: DeploymentConfig
+  - apiVersion: apps/v1
+    kind: Deployment
     metadata:
       name: todolist
       namespace: mysql-persistent
@@ -176,8 +176,9 @@ items:
     spec:
       replicas: 1
       selector:
-        app: todolist
-        service: todolist
+        matchLabels:
+          app: todolist
+          service: todolist
       strategy:
         type: Recreate
       template:


### PR DESCRIPTION
## Why the changes were made

For a higher percentage pass rate, use deployments and not deploymentConfigs for mysql
* deploymentConfig is now convered by parks-app and downstream

## How to test the changes made

via prow is probably fine :)