### PR TITLE
fix(e2e): improve MongoDB test application stability and resource configuration

### DIFF
--- a/tests/e2e/sample-applications/mongo-persistent/mongo-persistent-block.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/mongo-persistent-block.yaml
@@ -71,7 +71,7 @@ items:
           # Used to format the block device (put filesystem on it).
           # This allows Mongo to use the filesystem which lives on block device.
           initContainers:
-            - image: docker.io/library/mongo:latest
+            - image: docker.io/library/mongo:7.0
               imagePullPolicy: IfNotPresent
               securityContext:
                 privileged: true
@@ -102,7 +102,7 @@ items:
                 - name: block-volume-pv
                   devicePath: /dev/xvdx
           containers:
-            - image: docker.io/library/mongo:latest
+            - image: docker.io/library/mongo:7.0
               name: mongo
               securityContext:
                 privileged: true
@@ -117,8 +117,10 @@ items:
                 - containerPort: 27017
                   name: mongo
               resources:
-                limits:
+                requests:
                   memory: 512Mi
+                limits:
+                  memory: 1Gi
               command:
                 - "sh"
                 - "-c"
@@ -131,11 +133,26 @@ items:
               volumeDevices:
                 - name:  block-volume-pv
                   devicePath: /dev/xvdx
-              livenessProbe:
-                tcpSocket:
-                  port: mongo
-                initialDelaySeconds: 5
+              readinessProbe:
+                exec:
+                  command:
+                  - /bin/bash
+                  - -c
+                  - "mongosh --eval 'db.runCommand(\"ping\")' --quiet"
+                initialDelaySeconds: 30
                 periodSeconds: 10
+                timeoutSeconds: 5
+                failureThreshold: 3
+              livenessProbe:
+                exec:
+                  command:
+                  - /bin/bash
+                  - -c
+                  - "mongosh --eval 'db.runCommand(\"ping\")' --quiet"
+                initialDelaySeconds: 60
+                periodSeconds: 30
+                timeoutSeconds: 10
+                failureThreshold: 3
               startupProbe:
                 exec:
                   command:
@@ -143,11 +160,11 @@ items:
                   - -c
                   - |
                     mongosh admin --authenticationDatabase admin -u "$MONGO_INITDB_ROOT_USERNAME" -p "$MONGO_INITDB_ROOT_PASSWORD" --eval 'db.adminCommand("ping")'
-                initialDelaySeconds: 5
-                periodSeconds: 30
-                timeoutSeconds: 2
+                initialDelaySeconds: 10
+                periodSeconds: 10
+                timeoutSeconds: 5
                 successThreshold: 1
-                failureThreshold: 40 # 40x30sec before restart pod
+                failureThreshold: 12 # 12x10sec = 2min before restart pod
             - image: docker.io/curlimages/curl:8.5.0
               name: curl-tool
               command: ["/bin/sleep", "infinity"]

--- a/tests/e2e/sample-applications/mongo-persistent/mongo-persistent-csi.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/mongo-persistent-csi.yaml
@@ -67,7 +67,7 @@ items:
         spec:
           serviceAccountName: mongo-persistent-sa
           containers:
-          - image: docker.io/library/mongo:latest
+          - image: docker.io/library/mongo:7.0
             imagePullPolicy: IfNotPresent
             name: mongo
             securityContext:
@@ -83,16 +83,33 @@ items:
             - containerPort: 27017
               name: mongo
             resources:
-              limits:
+              requests:
                 memory: 512Mi
+              limits:
+                memory: 1Gi
             volumeMounts:
             - name: mongo-data
               mountPath: /data/db
-            livenessProbe:
-              tcpSocket:
-                port: mongo
-              initialDelaySeconds: 5
+            readinessProbe:
+              exec:
+                command:
+                - /bin/bash
+                - -c
+                - "mongosh --eval 'db.runCommand(\"ping\")' --quiet"
+              initialDelaySeconds: 30
               periodSeconds: 10
+              timeoutSeconds: 5
+              failureThreshold: 3
+            livenessProbe:
+              exec:
+                command:
+                - /bin/bash
+                - -c
+                - "mongosh --eval 'db.runCommand(\"ping\")' --quiet"
+              initialDelaySeconds: 60
+              periodSeconds: 30
+              timeoutSeconds: 10
+              failureThreshold: 3
             startupProbe:
               exec:
                 command:
@@ -100,11 +117,11 @@ items:
                 - -c
                 - |
                   mongosh admin --authenticationDatabase admin -u "$MONGO_INITDB_ROOT_USERNAME" -p "$MONGO_INITDB_ROOT_PASSWORD" --eval 'db.adminCommand("ping")'
-              initialDelaySeconds: 5
-              periodSeconds: 30
-              timeoutSeconds: 2
+              initialDelaySeconds: 10
+              periodSeconds: 10
+              timeoutSeconds: 5
               successThreshold: 1
-              failureThreshold: 40 # 40x30sec before restart pod
+              failureThreshold: 12 # 12x10sec = 2min before restart pod
           - image: docker.io/curlimages/curl:8.5.0
             name: curl-tool
             command: ["/bin/sleep", "infinity"]

--- a/tests/e2e/sample-applications/mongo-persistent/mongo-persistent.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/mongo-persistent.yaml
@@ -80,7 +80,7 @@ items:
         spec:
           serviceAccountName: mongo-persistent-sa
           containers:
-          - image: docker.io/library/mongo:latest
+          - image: docker.io/library/mongo:7.0
             imagePullPolicy: IfNotPresent
             name: mongo
             securityContext:
@@ -96,16 +96,33 @@ items:
             - containerPort: 27017
               name: mongo
             resources:
-              limits:
+              requests:
                 memory: 512Mi
+              limits:
+                memory: 1Gi
             volumeMounts:
             - name: mongo-data
               mountPath: /data/db
-            livenessProbe:
-              tcpSocket:
-                port: mongo
-              initialDelaySeconds: 5
+            readinessProbe:
+              exec:
+                command:
+                - /bin/bash
+                - -c
+                - "mongosh --eval 'db.runCommand(\"ping\")' --quiet"
+              initialDelaySeconds: 30
               periodSeconds: 10
+              timeoutSeconds: 5
+              failureThreshold: 3
+            livenessProbe:
+              exec:
+                command:
+                - /bin/bash
+                - -c
+                - "mongosh --eval 'db.runCommand(\"ping\")' --quiet"
+              initialDelaySeconds: 60
+              periodSeconds: 30
+              timeoutSeconds: 10
+              failureThreshold: 3
             startupProbe:
               exec:
                 command:
@@ -113,11 +130,11 @@ items:
                 - -c
                 - |
                   mongosh admin --authenticationDatabase admin -u "$MONGO_INITDB_ROOT_USERNAME" -p "$MONGO_INITDB_ROOT_PASSWORD" --eval 'db.adminCommand("ping")'
-              initialDelaySeconds: 5
-              periodSeconds: 30
-              timeoutSeconds: 2
+              initialDelaySeconds: 10
+              periodSeconds: 10
+              timeoutSeconds: 5
               successThreshold: 1
-              failureThreshold: 40 # 40x30sec before restart pod
+              failureThreshold: 12 # 12x10sec = 2min before restart pod
           - image: docker.io/curlimages/curl:8.5.0
             name: curl-tool
             command: ["/bin/sleep", "infinity"]


### PR DESCRIPTION
## Summary

This PR improves the reliability and stability of the MongoDB persistent test application used in E2E tests across all deployment variants (standard, CSI, and block storage).

## Changes Made

### 1. Image Version Pinning
- **Changed**: MongoDB image from `latest` to `7.0`
- **Why**: Using `latest` can introduce unexpected breaking changes and make tests non-deterministic. Pinning to MongoDB 7.0 ensures consistent behavior across test runs.

### 2. Resource Configuration Improvements
- **Changed**: Added explicit resource requests (512Mi) alongside limits (1Gi)
- **Why**: 
  - Kubernetes best practice to define both requests and limits
  - Prevents pod eviction under memory pressure
  - Ensures proper QoS class assignment for better scheduling
  - Gives MongoDB more headroom (1Gi limit vs 512Mi request) for stability

### 3. Enhanced Health Probes
- **Readiness Probe** (new):
  - Uses `mongosh` with database ping command
  - Initial delay: 30s, Period: 10s
  - Ensures pod only receives traffic when MongoDB is ready to serve requests

- **Liveness Probe** (improved):
  - Changed from TCP socket check to exec-based `mongosh` ping
  - Initial delay: 60s, Period: 30s
  - More accurate health detection (validates MongoDB process is functional, not just port is open)

- **Startup Probe** (optimized):
  - Reduced period from 30s to 10s for faster startup detection
  - Reduced failure threshold from 40 to 12 (still allows 2 minutes for startup)
  - More responsive to actual MongoDB readiness

## Why These Changes Were Made

The MongoDB test pods were experiencing stability issues in CI environments, particularly:
- Pods being marked ready before MongoDB was actually ready to serve requests
- OOMKilled events due to insufficient memory limits
- False negative health checks using TCP probes that couldn't detect MongoDB-specific issues
- Slow startup detection causing delays in test execution

## How to Test

1. Deploy the MongoDB test application:
   ```bash
   kubectl apply -f tests/e2e/sample-applications/mongo-persistent/mongo-persistent.yaml
   # Or for CSI variant:
   kubectl apply -f tests/e2e/sample-applications/mongo-persistent/mongo-persistent-csi.yaml
   # Or for block storage variant:
   kubectl apply -f tests/e2e/sample-applications/mongo-persistent/mongo-persistent-block.yaml
   ```

2. Verify pod startup and readiness:
   ```bash
   kubectl get pods -n mongo-persistent -w
   ```

3. Check probe status and resource usage:
   ```bash
   kubectl describe pod -n mongo-persistent -l app=todolist
   kubectl top pod -n mongo-persistent
   ```

4. Run E2E tests that use this application to verify backup/restore functionality still works correctly.

## Impact

- **Test Reliability**: Improved stability of MongoDB-based E2E tests
- **CI Success Rate**: Should reduce flaky test failures related to MongoDB pod issues
- **No Breaking Changes**: Changes are internal to test fixtures only

> [!Note]
> Responses generated with Claude