### PR TITLE
oadp-1.5: e2e: mongo is back to play

### DIFF
--- a/tests/e2e/backup_restore_suite_test.go
+++ b/tests/e2e/backup_restore_suite_test.go
@@ -338,7 +338,7 @@ var _ = ginkgo.Describe("Backup and restore tests", ginkgo.Ordered, func() {
 				BackupTimeout:     20 * time.Minute,
 			},
 		}, nil),
-		ginkgo.XEntry("Mongo application CSI", ginkgo.FlakeAttempts(flakeAttempts), ApplicationBackupRestoreCase{
+		ginkgo.Entry("Mongo application CSI", ginkgo.FlakeAttempts(flakeAttempts), ApplicationBackupRestoreCase{
 			ApplicationTemplate: "./sample-applications/mongo-persistent/mongo-persistent-csi.yaml",
 			BackupRestoreCase: BackupRestoreCase{
 				Namespace:         "mongo-persistent",
@@ -360,7 +360,7 @@ var _ = ginkgo.Describe("Backup and restore tests", ginkgo.Ordered, func() {
 				BackupTimeout:     20 * time.Minute,
 			},
 		}, nil),
-		ginkgo.XEntry("Mongo application RESTIC", ginkgo.FlakeAttempts(flakeAttempts), ApplicationBackupRestoreCase{
+		ginkgo.Entry("Mongo application RESTIC", ginkgo.FlakeAttempts(flakeAttempts), ApplicationBackupRestoreCase{
 			ApplicationTemplate: "./sample-applications/mongo-persistent/mongo-persistent.yaml",
 			BackupRestoreCase: BackupRestoreCase{
 				Namespace:         "mongo-persistent",
@@ -382,7 +382,7 @@ var _ = ginkgo.Describe("Backup and restore tests", ginkgo.Ordered, func() {
 				BackupTimeout:     20 * time.Minute,
 			},
 		}, nil),
-		ginkgo.XEntry("Mongo application KOPIA", ginkgo.FlakeAttempts(flakeAttempts), ApplicationBackupRestoreCase{
+		ginkgo.Entry("Mongo application KOPIA", ginkgo.FlakeAttempts(flakeAttempts), ApplicationBackupRestoreCase{
 			ApplicationTemplate: "./sample-applications/mongo-persistent/mongo-persistent.yaml",
 			BackupRestoreCase: BackupRestoreCase{
 				Namespace:         "mongo-persistent",
@@ -404,7 +404,7 @@ var _ = ginkgo.Describe("Backup and restore tests", ginkgo.Ordered, func() {
 				BackupTimeout:     20 * time.Minute,
 			},
 		}, nil),
-		ginkgo.XEntry("Mongo application DATAMOVER", ginkgo.FlakeAttempts(flakeAttempts), ApplicationBackupRestoreCase{
+		ginkgo.Entry("Mongo application DATAMOVER", ginkgo.FlakeAttempts(flakeAttempts), ApplicationBackupRestoreCase{
 			ApplicationTemplate: "./sample-applications/mongo-persistent/mongo-persistent-csi.yaml",
 			BackupRestoreCase: BackupRestoreCase{
 				Namespace:         "mongo-persistent",
@@ -426,7 +426,7 @@ var _ = ginkgo.Describe("Backup and restore tests", ginkgo.Ordered, func() {
 				BackupTimeout:     20 * time.Minute,
 			},
 		}, nil),
-		ginkgo.XEntry("Mongo application BlockDevice DATAMOVER", ginkgo.FlakeAttempts(flakeAttempts), ApplicationBackupRestoreCase{
+		ginkgo.Entry("Mongo application BlockDevice DATAMOVER", ginkgo.FlakeAttempts(flakeAttempts), ApplicationBackupRestoreCase{
 			ApplicationTemplate: "./sample-applications/mongo-persistent/mongo-persistent-block.yaml",
 			PvcSuffixName:       "-block-mode",
 			BackupRestoreCase: BackupRestoreCase{
@@ -449,7 +449,7 @@ var _ = ginkgo.Describe("Backup and restore tests", ginkgo.Ordered, func() {
 				BackupTimeout:     20 * time.Minute,
 			},
 		}, nil),
-		ginkgo.XEntry("Mongo application Native-Snapshots", ginkgo.FlakeAttempts(flakeAttempts), ginkgo.Label("aws", "azure", "gcp"), ApplicationBackupRestoreCase{
+		ginkgo.Entry("Mongo application Native-Snapshots", ginkgo.FlakeAttempts(flakeAttempts), ginkgo.Label("aws", "azure", "gcp"), ApplicationBackupRestoreCase{
 			ApplicationTemplate: "./sample-applications/mongo-persistent/mongo-persistent.yaml",
 			BackupRestoreCase: BackupRestoreCase{
 				Namespace:         "mongo-persistent",

--- a/tests/e2e/sample-applications/mongo-persistent/mongo-persistent-block.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/mongo-persistent-block.yaml
@@ -71,7 +71,7 @@ items:
           # Used to format the block device (put filesystem on it).
           # This allows Mongo to use the filesystem which lives on block device.
           initContainers:
-            - image: docker.io/library/mongo:latest
+            - image: docker.io/library/mongo:7.0
               securityContext:
                 privileged: true
               name: setup-block-device
@@ -101,7 +101,7 @@ items:
                 - name: block-volume-pv
                   devicePath: /dev/xvdx
           containers:
-            - image: docker.io/library/mongo:latest
+            - image: docker.io/library/mongo:7.0
               name: mongo
               securityContext:
                 privileged: true
@@ -116,8 +116,10 @@ items:
                 - containerPort: 27017
                   name: mongo
               resources:
-                limits:
+                requests:
                   memory: 512Mi
+                limits:
+                  memory: 1Gi
               command:
                 - "sh"
                 - "-c"
@@ -130,11 +132,26 @@ items:
               volumeDevices:
                 - name:  block-volume-pv
                   devicePath: /dev/xvdx
-              livenessProbe:
-                tcpSocket:
-                  port: mongo
-                initialDelaySeconds: 5
+              readinessProbe:
+                exec:
+                  command:
+                  - /bin/bash
+                  - -c
+                  - "mongosh --eval 'db.runCommand(\"ping\")' --quiet"
+                initialDelaySeconds: 30
                 periodSeconds: 10
+                timeoutSeconds: 5
+                failureThreshold: 3
+              livenessProbe:
+                exec:
+                  command:
+                  - /bin/bash
+                  - -c
+                  - "mongosh --eval 'db.runCommand(\"ping\")' --quiet"
+                initialDelaySeconds: 60
+                periodSeconds: 30
+                timeoutSeconds: 10
+                failureThreshold: 3
               startupProbe:
                 exec:
                   command:
@@ -143,11 +160,11 @@ items:
                   - -u $(MONGO_INITDB_ROOT_USERNAME)
                   - -p $(MONGO_INITDB_ROOT_PASSWORD)
                   - --eval 'printjson(db.getCollectionNames())'
-                initialDelaySeconds: 5
-                periodSeconds: 30
-                timeoutSeconds: 2
+                initialDelaySeconds: 10
+                periodSeconds: 10
+                timeoutSeconds: 5
                 successThreshold: 1
-                failureThreshold: 40 # 40x30sec before restart pod
+                failureThreshold: 12 # 12x10sec = 2min before restart pod
             - image: docker.io/curlimages/curl:8.5.0
               name: curl-tool
               command: ["/bin/sleep", "infinity"]

--- a/tests/e2e/sample-applications/mongo-persistent/mongo-persistent-csi.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/mongo-persistent-csi.yaml
@@ -67,7 +67,7 @@ items:
         spec:
           serviceAccountName: mongo-persistent-sa
           containers:
-          - image: docker.io/library/mongo:latest
+          - image: docker.io/library/mongo:7.0
             name: mongo
             securityContext:
               privileged: true
@@ -82,16 +82,33 @@ items:
             - containerPort: 27017
               name: mongo
             resources:
-              limits:
+              requests:
                 memory: 512Mi
+              limits:
+                memory: 1Gi
             volumeMounts:
             - name: mongo-data
               mountPath: /data/db
-            livenessProbe:
-              tcpSocket:
-                port: mongo
-              initialDelaySeconds: 5
+            readinessProbe:
+              exec:
+                command:
+                - /bin/bash
+                - -c
+                - "mongosh --eval 'db.runCommand(\"ping\")' --quiet"
+              initialDelaySeconds: 30
               periodSeconds: 10
+              timeoutSeconds: 5
+              failureThreshold: 3
+            livenessProbe:
+              exec:
+                command:
+                - /bin/bash
+                - -c
+                - "mongosh --eval 'db.runCommand(\"ping\")' --quiet"
+              initialDelaySeconds: 60
+              periodSeconds: 30
+              timeoutSeconds: 10
+              failureThreshold: 3
             startupProbe:
               exec:
                 command:
@@ -100,11 +117,11 @@ items:
                 - -u $(MONGO_INITDB_ROOT_USERNAME)
                 - -p $(MONGO_INITDB_ROOT_PASSWORD)
                 - --eval 'printjson(db.getCollectionNames())'
-              initialDelaySeconds: 5
-              periodSeconds: 30
-              timeoutSeconds: 2
+              initialDelaySeconds: 10
+              periodSeconds: 10
+              timeoutSeconds: 5
               successThreshold: 1
-              failureThreshold: 40 # 40x30sec before restart pod
+              failureThreshold: 12 # 12x10sec = 2min before restart pod
           - image: docker.io/curlimages/curl:8.5.0
             name: curl-tool
             command: ["/bin/sleep", "infinity"]

--- a/tests/e2e/sample-applications/mongo-persistent/mongo-persistent.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/mongo-persistent.yaml
@@ -80,7 +80,7 @@ items:
         spec:
           serviceAccountName: mongo-persistent-sa
           containers:
-          - image: docker.io/library/mongo:latest
+          - image: docker.io/library/mongo:7.0
             name: mongo
             securityContext:
               privileged: true
@@ -95,16 +95,33 @@ items:
             - containerPort: 27017
               name: mongo
             resources:
-              limits:
+              requests:
                 memory: 512Mi
+              limits:
+                memory: 1Gi
             volumeMounts:
             - name: mongo-data
               mountPath: /data/db
-            livenessProbe:
-              tcpSocket:
-                port: mongo
-              initialDelaySeconds: 5
+            readinessProbe:
+              exec:
+                command:
+                - /bin/bash
+                - -c
+                - "mongosh --eval 'db.runCommand(\"ping\")' --quiet"
+              initialDelaySeconds: 30
               periodSeconds: 10
+              timeoutSeconds: 5
+              failureThreshold: 3
+            livenessProbe:
+              exec:
+                command:
+                - /bin/bash
+                - -c
+                - "mongosh --eval 'db.runCommand(\"ping\")' --quiet"
+              initialDelaySeconds: 60
+              periodSeconds: 30
+              timeoutSeconds: 10
+              failureThreshold: 3
             startupProbe:
               exec:
                 command:
@@ -113,11 +130,11 @@ items:
                 - -u $(MONGO_INITDB_ROOT_USERNAME)
                 - -p $(MONGO_INITDB_ROOT_PASSWORD)
                 - --eval 'printjson(db.getCollectionNames())'
-              initialDelaySeconds: 5
-              periodSeconds: 30
-              timeoutSeconds: 2
+              initialDelaySeconds: 10
+              periodSeconds: 10
+              timeoutSeconds: 5
               successThreshold: 1
-              failureThreshold: 40 # 40x30sec before restart pod
+              failureThreshold: 12 # 12x10sec = 2min before restart pod
           - image: docker.io/curlimages/curl:8.5.0
             name: curl-tool
             command: ["/bin/sleep", "infinity"]


### PR DESCRIPTION
Signed-off-by: Tiger Kaovilai <tkaovila@redhat.com>

## Why the changes were made
revert https://github.com/openshift/oadp-operator/pull/2011 + fixes from https://github.com/openshift/oadp-operator/pull/2013

<!-- Explain why this PR is important, what problems it fixes, link related issues -->

## How to test the changes made

<!-- Explain how the changes introduced by this PR can be tested and verified, with commands and pictures -->
