### PR TITLE
Add uploader-type argument to Velero deployment configuration when configuration.args is used.

### DIFF
--- a/internal/controller/velero.go
+++ b/internal/controller/velero.go
@@ -679,6 +679,14 @@ func (r *DataProtectionApplicationReconciler) customizeVeleroContainer(veleroCon
 		if err != nil {
 			return err
 		}
+		// Re-add uploader-type since GetArgs() doesn't include it
+		// but it comes from NodeAgent configuration, not Velero.Args
+		if dpa.Spec.Configuration.NodeAgent != nil &&
+			len(dpa.Spec.Configuration.NodeAgent.UploaderType) > 0 {
+			uploaderType := dpa.Spec.Configuration.NodeAgent.UploaderType
+			veleroContainer.Args = append(veleroContainer.Args,
+				fmt.Sprintf("--uploader-type=%s", uploaderType))
+		}
 	}
 	return nil
 }

--- a/internal/controller/velero_test.go
+++ b/internal/controller/velero_test.go
@@ -2350,11 +2350,11 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 			veleroDeployment: testVeleroDeployment.DeepCopy(),
 			wantVeleroDeployment: createTestBuiltVeleroDeployment(TestBuiltVeleroDeploymentOptions{
 				args: []string{
-					// should be present... "--uploader-type=kopia",
 					"--client-burst=321",
 					"--client-qps=321",
 					"--fs-backup-timeout=4h0m0s",
 					defaultRestoreResourcePriorities,
+					"--uploader-type=kopia",
 					defaultDisableInformerCache,
 				},
 			}),


### PR DESCRIPTION
## Problem

When `spec.configuration.velero.args` is used to customize Velero server arguments, the `--uploader-type` flag gets lost. This happens because:

1. `--uploader-type` is set via `install.WithUploaderType()` based on `spec.configuration.nodeAgent.uploaderType`
2. When `spec.configuration.velero.args` is specified, `veleroserver.GetArgs()` completely rebuilds the args array from scratch
3. Since `--uploader-type` comes from NodeAgent config (not Velero.Args), it gets overwritten

This was previously fixed in commit 3739f23a (May 2024) but regressed in commit b51ce21d3 (August 2024).

## Solution

After calling `GetArgs()`, check if `NodeAgent.UploaderType` is configured and re-append the `--uploader-type` flag to preserve it.

## Verification

Tested with:
```bash
go test -v -run TestDPAReconciler_buildVeleroDeployment/valid_DPA_CR_with_Velero_Args_burst_and_qps
```

✅ All 58 tests passed. The test case now correctly verifies that `--uploader-type=kopia` appears in Velero container args even when custom `Velero.Args` are specified.

## Expected Args Order
```yaml
- server
- --client-burst=321
- --client-qps=321  
- --fs-backup-timeout=4h0m0s
- --restore-resource-priorities=...
- --uploader-type=kopia  # ✅ Now preserved
- --disable-informer-cache=false
```

https://redhat-internal.slack.com/archives/C0144ECKUJ0/p1760474313952109