### PR TITLE
Bump 1.5.3 -> 1.5.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # TOOL VERSIONS
 # All version-related variables are defined here for easy maintenance
-DEFAULT_VERSION := 1.5.3
+DEFAULT_VERSION := 1.5.4
 VERSION ?= $(DEFAULT_VERSION)
 OPERATOR_SDK_VERSION ?= v1.34.2
 ENVTEST_K8S_VERSION = 1.32 #refers to the version of kubebuilder assets to be downloaded by envtest binary # Kubernetes version from OpenShift 4.19.x

--- a/bundle/manifests/oadp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/oadp-operator.clusterserviceversion.yaml
@@ -281,7 +281,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "true"
     features.operators.openshift.io/token-auth-azure: "true"
     features.operators.openshift.io/token-auth-gcp: "true"
-    olm.skipRange: '>=1.4.0 <1.5.3'
+    olm.skipRange: '>=1.4.0 <1.5.4'
     operatorframework.io/suggested-namespace: openshift-adp
     operators.openshift.io/infrastructure-features: '["Disconnected"]'
     operators.openshift.io/must-gather-image: quay.io/konveyor/oadp-must-gather:oadp-1.5
@@ -296,7 +296,7 @@ metadata:
     operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
-  name: oadp-operator.v1.5.3
+  name: oadp-operator.v1.5.4
   namespace: openshift-adp
 spec:
   apiservicedefinitions: {}
@@ -1292,5 +1292,5 @@ spec:
     name: mustgather
   - image: quay.io/konveyor/oadp-non-admin:oadp-1.5
     name: non-admin-controller
-  replaces: oadp-operator.v1.5.2
-  version: 1.5.3
+  replaces: oadp-operator.v1.5.3
+  version: 1.5.4

--- a/bundle/oadp-operator.package.yaml
+++ b/bundle/oadp-operator.package.yaml
@@ -2,5 +2,5 @@
 packageName: redhat-oadp-operator
 channels:
 - name: stable
-  currentCSV: oadp-operator.v1.5.3
+  currentCSV: oadp-operator.v1.5.4
 defaultChannel: stable

--- a/config/manifests/bases/oadp-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/oadp-operator.clusterserviceversion.yaml
@@ -20,7 +20,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "true"
     features.operators.openshift.io/token-auth-azure: "true"
     features.operators.openshift.io/token-auth-gcp: "true"
-    olm.skipRange: '>=1.4.0 <1.5.3'
+    olm.skipRange: '>=1.4.0 <1.5.4'
     operatorframework.io/suggested-namespace: openshift-adp
     operators.openshift.io/infrastructure-features: '["Disconnected"]'
     operators.openshift.io/must-gather-image: quay.io/konveyor/oadp-must-gather:oadp-1.5
@@ -33,7 +33,7 @@ metadata:
     operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
-  name: oadp-operator.v1.5.3
+  name: oadp-operator.v1.5.4
   namespace: openshift-adp
 spec:
   apiservicedefinitions: {}
@@ -516,5 +516,5 @@ spec:
   maturity: stable
   provider:
     name: Red Hat
-  replaces: oadp-operator.v1.5.2
-  version: 1.5.3
+  replaces: oadp-operator.v1.5.3
+  version: 1.5.4

--- a/docs/version-update.md
+++ b/docs/version-update.md
@@ -1,0 +1,77 @@
+# OADP Operator Version Update Guide
+
+This document outlines the files and fields that need to be updated for OADP operator version bumps.
+
+## Files to Update
+
+For a patch version update (e.g., 1.5.3 → 1.5.4), update these 4 files:
+
+### 1. Makefile
+
+Update `DEFAULT_VERSION` variable:
+
+```makefile
+DEFAULT_VERSION := 1.5.4  # was 1.5.3
+```
+
+### 2. config/manifests/bases/oadp-operator.clusterserviceversion.yaml
+
+Update 4 fields:
+
+```yaml
+metadata:
+  annotations:
+    olm.skipRange: '>=1.4.0 <1.5.4'  # was <1.5.3
+  name: oadp-operator.v1.5.4  # was v1.5.3
+spec:
+  replaces: oadp-operator.v1.5.3  # was v1.5.2
+  version: 1.5.4  # was 1.5.3
+```
+
+### 3. bundle/manifests/oadp-operator.clusterserviceversion.yaml
+
+Update 4 fields (same as above):
+
+```yaml
+metadata:
+  annotations:
+    olm.skipRange: '>=1.4.0 <1.5.4'  # was <1.5.3
+  name: oadp-operator.v1.5.4  # was v1.5.3
+spec:
+  replaces: oadp-operator.v1.5.3  # was v1.5.2
+  version: 1.5.4  # was 1.5.3
+```
+
+### 4. bundle/oadp-operator.package.yaml
+
+Update 1 field:
+
+```yaml
+channels:
+- name: stable
+  currentCSV: oadp-operator.v1.5.4  # was v1.5.3
+```
+
+## Summary
+
+**Total changes**: 4 files, 10 lines modified
+
+- `Makefile`: 1 change
+- `config/manifests/bases/oadp-operator.clusterserviceversion.yaml`: 4 changes
+- `bundle/manifests/oadp-operator.clusterserviceversion.yaml`: 4 changes
+- `bundle/oadp-operator.package.yaml`: 1 change
+
+## Field Descriptions
+
+- **DEFAULT_VERSION**: Main version variable used throughout the build process
+- **olm.skipRange**: Tells OLM which versions can be skipped during upgrades
+- **metadata.name**: The full name of this CSV version
+- **spec.replaces**: Points to the immediate previous version (creates upgrade path)
+- **spec.version**: The semantic version number
+- **currentCSV**: Indicates the current version in this channel
+
+## Notes
+
+- The Makefile structure was refactored to define `DEFAULT_VERSION` only once (previously it appeared twice)
+- Always verify changes with `git diff` before committing
+- Ensure the `replaces` field points to the immediately previous version to maintain the upgrade path


### PR DESCRIPTION
Version bump from 1.5.3 to 1.5.4

## Changes
- Updated `DEFAULT_VERSION` in Makefile
- Updated version metadata in ClusterServiceVersion files
- Updated currentCSV in package.yaml
- Added version update documentation for oadp-1.5 branch

## Files Modified
- `Makefile` (1 change)
- `bundle/manifests/oadp-operator.clusterserviceversion.yaml` (4 changes)
- `bundle/oadp-operator.package.yaml` (1 change)
- `config/manifests/bases/oadp-operator.clusterserviceversion.yaml` (4 changes)
- `docs/version-update.md` (new file)

## Summary

**Total changes**: 5 files (4 modified + 1 new), 10 lines modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)