### PR TITLE
Bump 1.3.8 -> 1.3.9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ ENVTEST_K8S_VERSION = 1.29
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-DEFAULT_VERSION := 1.3.8
+DEFAULT_VERSION := 1.3.9
 VERSION ?= $(DEFAULT_VERSION)
 
 # CHANNELS define the bundle channels used in the bundle.

--- a/bundle/manifests/oadp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/oadp-operator.clusterserviceversion.yaml
@@ -167,7 +167,7 @@ metadata:
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
     olm.properties: '[{"type": "olm.maxOpenShiftVersion", "value": "4.15"}]'
-    olm.skipRange: '>=0.0.0 <1.3.8'
+    olm.skipRange: '>=0.0.0 <1.3.9'
     operatorframework.io/suggested-namespace: openshift-adp
     operators.openshift.io/infrastructure-features: '["Disconnected"]'
     operators.openshift.io/must-gather-image: quay.io/konveyor/oadp-must-gather:oadp-1.3
@@ -182,7 +182,7 @@ metadata:
     operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
-  name: oadp-operator.v1.3.8
+  name: oadp-operator.v1.3.9
   namespace: openshift-adp
 spec:
   apiservicedefinitions: {}
@@ -1014,5 +1014,5 @@ spec:
     name: kubevirt-velero-plugin
   - image: quay.io/konveyor/oadp-must-gather:oadp-1.3
     name: mustgather
-  replaces: oadp-operator.v1.3.7
-  version: 1.3.8
+  replaces: oadp-operator.v1.3.8
+  version: 1.3.9

--- a/bundle/oadp-operator.package.yaml
+++ b/bundle/oadp-operator.package.yaml
@@ -2,5 +2,5 @@
 packageName: redhat-oadp-operator
 channels:
 - name: stable-1.3
-  currentCSV: oadp-operator.v1.3.8
+  currentCSV: oadp-operator.v1.3.9
 defaultChannel: stable-1.3

--- a/config/manifests/bases/oadp-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/oadp-operator.clusterserviceversion.yaml
@@ -21,7 +21,7 @@ metadata:
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
     olm.properties: '[{"type": "olm.maxOpenShiftVersion", "value": "4.15"}]'
-    olm.skipRange: '>=0.0.0 <1.3.8'
+    olm.skipRange: '>=0.0.0 <1.3.9'
     operatorframework.io/suggested-namespace: openshift-adp
     operators.openshift.io/infrastructure-features: '["Disconnected"]'
     operators.openshift.io/must-gather-image: quay.io/konveyor/oadp-must-gather:oadp-1.3
@@ -486,5 +486,5 @@ spec:
   maturity: stable
   provider:
     name: Red Hat
-  replaces: oadp-operator.v1.3.7
-  version: 1.3.8
+  replaces: oadp-operator.v1.3.8
+  version: 1.3.9

--- a/docs/version-update.md
+++ b/docs/version-update.md
@@ -1,0 +1,81 @@
+# OADP Operator Version Update Guide
+
+This document outlines the files and fields that need to be updated for OADP operator version bumps.
+
+## Files to Update
+
+For a patch version update (e.g., 1.3.8 → 1.3.9), update these 4 files:
+
+### 1. Makefile
+
+Update `DEFAULT_VERSION` variable:
+
+```makefile
+DEFAULT_VERSION := 1.3.9  # was 1.3.8
+```
+
+### 2. config/manifests/bases/oadp-operator.clusterserviceversion.yaml
+
+Update 3 fields:
+
+```yaml
+metadata:
+  annotations:
+    olm.skipRange: '>=0.0.0 <1.3.9'  # was <1.3.8
+  name: oadp-operator.v1.3.0  # UNCHANGED - base version for 1.3.x branch
+spec:
+  replaces: oadp-operator.v1.3.8  # was v1.3.7
+  version: 1.3.9  # was 1.3.8
+```
+
+### 3. bundle/manifests/oadp-operator.clusterserviceversion.yaml
+
+Update 4 fields:
+
+```yaml
+metadata:
+  annotations:
+    olm.skipRange: '>=0.0.0 <1.3.9'  # was <1.3.8
+  name: oadp-operator.v1.3.9  # was v1.3.8
+spec:
+  replaces: oadp-operator.v1.3.8  # was v1.3.7
+  version: 1.3.9  # was 1.3.8
+```
+
+### 4. bundle/oadp-operator.package.yaml
+
+Update 1 field:
+
+```yaml
+channels:
+- name: stable-1.3
+  currentCSV: oadp-operator.v1.3.9  # was v1.3.8
+```
+
+## Summary
+
+**Total changes**: 4 files, 9 lines modified
+
+- `Makefile`: 1 change
+- `config/manifests/bases/oadp-operator.clusterserviceversion.yaml`: 3 changes
+- `bundle/manifests/oadp-operator.clusterserviceversion.yaml`: 4 changes
+- `bundle/oadp-operator.package.yaml`: 1 change
+
+## Field Descriptions
+
+- **DEFAULT_VERSION**: Main version variable used throughout the build process
+- **olm.skipRange**: Tells OLM which versions can be skipped during upgrades
+- **metadata.name**: The full name of this CSV version
+  - In `config/manifests/bases`: Always remains `oadp-operator.v1.3.0` (base version)
+  - In `bundle/manifests`: Updated to current version (e.g., `oadp-operator.v1.3.9`)
+- **spec.replaces**: Points to the immediate previous version (creates upgrade path)
+- **spec.version**: The semantic version number
+- **currentCSV**: Indicates the current version in this channel
+
+## Notes
+
+- The `config/manifests/bases` file keeps `metadata.name` as `v1.3.0` (base version for 1.3.x)
+- The `bundle/manifests` file updates `metadata.name` to the current version
+- Channel name is `stable-1.3` (not just `stable`)
+- Always verify changes with `git diff` before committing
+- Ensure the `replaces` field points to the immediately previous version to maintain the upgrade path


### PR DESCRIPTION
Version bump from 1.3.8 to 1.3.9

## Changes
- Updated `DEFAULT_VERSION` in Makefile
- Updated version metadata in ClusterServiceVersion files
- Updated currentCSV in package.yaml
- Added version update documentation for oadp-1.3 branch

## Files Modified
- `Makefile` (1 change)
- `bundle/manifests/oadp-operator.clusterserviceversion.yaml` (4 changes)
- `bundle/oadp-operator.package.yaml` (1 change)
- `config/manifests/bases/oadp-operator.clusterserviceversion.yaml` (3 changes)
- `docs/version-update.md` (new file)

## Summary

**Total changes**: 5 files (4 modified + 1 new), 9 lines modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)