### PR TITLE
[oadp-1.5]update mongo templates to match oadp-dev

### DIFF
--- a/tests/e2e/sample-applications/mongo-persistent/mongo-persistent-block.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/mongo-persistent-block.yaml
@@ -72,6 +72,7 @@ items:
           # This allows Mongo to use the filesystem which lives on block device.
           initContainers:
             - image: docker.io/library/mongo:7.0
+              imagePullPolicy: IfNotPresent
               securityContext:
                 privileged: true
               name: setup-block-device
@@ -155,11 +156,10 @@ items:
               startupProbe:
                 exec:
                   command:
-                  - mongosh
-                  - admin
-                  - -u $(MONGO_INITDB_ROOT_USERNAME)
-                  - -p $(MONGO_INITDB_ROOT_PASSWORD)
-                  - --eval 'printjson(db.getCollectionNames())'
+                  - bash
+                  - -c
+                  - |
+                    mongosh admin --authenticationDatabase admin -u "$MONGO_INITDB_ROOT_USERNAME" -p "$MONGO_INITDB_ROOT_PASSWORD" --eval 'db.adminCommand("ping")'
                 initialDelaySeconds: 10
                 periodSeconds: 10
                 timeoutSeconds: 5
@@ -189,8 +189,8 @@ items:
         port: 27017
       selector:
         app: mongo
-  - apiVersion: apps.openshift.io/v1
-    kind: DeploymentConfig
+  - apiVersion: apps/v1
+    kind: Deployment
     metadata:
       name: todolist
       namespace: mongo-persistent
@@ -201,8 +201,9 @@ items:
     spec:
       replicas: 1
       selector:
-        app: todolist
-        service: todolist
+        matchLabels:
+          app: todolist
+          service: todolist
       strategy:
         type: Recreate
       template:
@@ -214,13 +215,25 @@ items:
         spec:
           containers:
           - name: todolist
-            image: quay.io/migtools/oadp-ci-todolist-mongo-go-1
+            image: quay.io/migtools/oadp-ci-todolist-mongo-go-4 
             env:
               - name: foo
                 value: bar
             ports:
               - containerPort: 8000
                 protocol: TCP
+            livenessProbe:
+              httpGet:
+                path: /
+                port: 8000
+              initialDelaySeconds: 10
+              periodSeconds: 10
+            readinessProbe:
+              httpGet:
+                path: /
+                port: 8000
+              initialDelaySeconds: 5
+              periodSeconds: 5
           initContainers:
           - name: init-myservice
             image: docker.io/curlimages/curl:8.5.0

--- a/tests/e2e/sample-applications/mongo-persistent/mongo-persistent-csi.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/mongo-persistent-csi.yaml
@@ -68,6 +68,7 @@ items:
           serviceAccountName: mongo-persistent-sa
           containers:
           - image: docker.io/library/mongo:7.0
+            imagePullPolicy: IfNotPresent
             name: mongo
             securityContext:
               privileged: true
@@ -112,11 +113,10 @@ items:
             startupProbe:
               exec:
                 command:
-                - mongosh
-                - admin
-                - -u $(MONGO_INITDB_ROOT_USERNAME)
-                - -p $(MONGO_INITDB_ROOT_PASSWORD)
-                - --eval 'printjson(db.getCollectionNames())'
+                - bash
+                - -c
+                - |
+                  mongosh admin --authenticationDatabase admin -u "$MONGO_INITDB_ROOT_USERNAME" -p "$MONGO_INITDB_ROOT_PASSWORD" --eval 'db.adminCommand("ping")'
               initialDelaySeconds: 10
               periodSeconds: 10
               timeoutSeconds: 5
@@ -146,8 +146,8 @@ items:
         port: 27017
       selector:
         app: mongo
-  - apiVersion: apps.openshift.io/v1
-    kind: DeploymentConfig
+  - apiVersion: apps/v1
+    kind: Deployment
     metadata:
       name: todolist
       namespace: mongo-persistent
@@ -158,8 +158,9 @@ items:
     spec:
       replicas: 1
       selector:
-        app: todolist
-        service: todolist
+        matchLabels:
+          app: todolist
+          service: todolist
       strategy:
         type: Recreate
       template:
@@ -171,13 +172,25 @@ items:
         spec:
           containers:
           - name: todolist
-            image: quay.io/migtools/oadp-ci-todolist-mongo-go-1
+            image: quay.io/migtools/oadp-ci-todolist-mongo-go-4
             env:
               - name: foo
                 value: bar
             ports:
               - containerPort: 8000
                 protocol: TCP
+            livenessProbe:
+              httpGet:
+                path: /
+                port: 8000
+              initialDelaySeconds: 10
+              periodSeconds: 10
+            readinessProbe:
+              httpGet:
+                path: /
+                port: 8000
+              initialDelaySeconds: 5
+              periodSeconds: 5
           initContainers:
           - name: init-myservice
             image: docker.io/curlimages/curl:8.5.0

--- a/tests/e2e/sample-applications/mongo-persistent/mongo-persistent.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/mongo-persistent.yaml
@@ -81,6 +81,7 @@ items:
           serviceAccountName: mongo-persistent-sa
           containers:
           - image: docker.io/library/mongo:7.0
+            imagePullPolicy: IfNotPresent
             name: mongo
             securityContext:
               privileged: true
@@ -125,11 +126,10 @@ items:
             startupProbe:
               exec:
                 command:
-                - mongosh
-                - admin
-                - -u $(MONGO_INITDB_ROOT_USERNAME)
-                - -p $(MONGO_INITDB_ROOT_PASSWORD)
-                - --eval 'printjson(db.getCollectionNames())'
+                - bash
+                - -c
+                - |
+                  mongosh admin --authenticationDatabase admin -u "$MONGO_INITDB_ROOT_USERNAME" -p "$MONGO_INITDB_ROOT_PASSWORD" --eval 'db.adminCommand("ping")'
               initialDelaySeconds: 10
               periodSeconds: 10
               timeoutSeconds: 5
@@ -159,8 +159,8 @@ items:
         port: 27017
       selector:
         app: mongo
-  - apiVersion: apps.openshift.io/v1
-    kind: DeploymentConfig
+  - apiVersion: apps/v1
+    kind: Deployment
     metadata:
       name: todolist
       namespace: mongo-persistent
@@ -171,8 +171,9 @@ items:
     spec:
       replicas: 1
       selector:
-        app: todolist
-        service: todolist
+        matchLabels:
+          app: todolist
+          service: todolist
       strategy:
         type: Recreate
       template:
@@ -184,13 +185,25 @@ items:
         spec:
           containers:
           - name: todolist
-            image: quay.io/migtools/oadp-ci-todolist-mongo-go-1
+            image: quay.io/migtools/oadp-ci-todolist-mongo-go-4
             env:
               - name: foo
                 value: bar
             ports:
               - containerPort: 8000
                 protocol: TCP
+            livenessProbe:
+              httpGet:
+                path: /
+                port: 8000
+              initialDelaySeconds: 10
+              periodSeconds: 10
+            readinessProbe:
+              httpGet:
+                path: /
+                port: 8000
+              initialDelaySeconds: 5
+              periodSeconds: 5
           initContainers:
           - name: init-myservice
             image: docker.io/curlimages/curl:8.5.0

--- a/tests/e2e/sample-applications/mongo-persistent/pvc/aws-block-mode.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/pvc/aws-block-mode.yaml
@@ -12,7 +12,7 @@ items:
       volumeMode: Block 
       accessModes:
       - ReadWriteOnce
-      storageClassName: gp2-csi
+      storageClassName: gp3-csi
       resources:
         requests:
           storage: 1Gi

--- a/tests/e2e/sample-applications/mongo-persistent/pvc/aws.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/pvc/aws.yaml
@@ -11,7 +11,7 @@ items:
     spec:
       accessModes:
       - ReadWriteOnce
-      storageClassName: gp2-csi
+      storageClassName: gp3-csi
       resources:
         requests:
           storage: 1Gi

--- a/tests/e2e/sample-applications/mongo-persistent/pvc/ibmcloud-block-mode.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/pvc/ibmcloud-block-mode.yaml
@@ -9,10 +9,10 @@ items:
       labels:
         app: mongo
     spec:
-      volumeMode: Block 
+      volumeMode: Block
       accessModes:
       - ReadWriteOnce
-      storageClassName: ocs-storagecluster-cephfs
+      storageClassName: ocs-storagecluster-ceph-rbd
       resources:
         requests:
           storage: 1Gi


### PR DESCRIPTION
## Why the changes were made

We fixed the reliability of mongo on oadp-dev in https://github.com/openshift/oadp-operator/pull/2013
Ensure the oadp-1.5 branch has the same changes.


## How to test the changes made
run ci

