### PR TITLE
[oadp-1.4]update mongo templates to match oadp-dev

### DIFF
--- a/tests/e2e/sample-applications/mongo-persistent/mongo-persistent-block.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/mongo-persistent-block.yaml
@@ -71,7 +71,8 @@ items:
           # Used to format the block device (put filesystem on it).
           # This allows Mongo to use the filesystem which lives on block device.
           initContainers:
-            - image: docker.io/library/mongo:latest
+            - image: docker.io/library/mongo:7.0
+              imagePullPolicy: IfNotPresent
               securityContext:
                 privileged: true
               name: setup-block-device
@@ -101,7 +102,7 @@ items:
                 - name: block-volume-pv
                   devicePath: /dev/xvdx
           containers:
-            - image: docker.io/library/mongo:latest
+            - image: docker.io/library/mongo:7.0
               name: mongo
               securityContext:
                 privileged: true
@@ -116,8 +117,10 @@ items:
                 - containerPort: 27017
                   name: mongo
               resources:
-                limits:
+                requests:
                   memory: 512Mi
+                limits:
+                  memory: 1Gi
               command:
                 - "sh"
                 - "-c"
@@ -130,24 +133,38 @@ items:
               volumeDevices:
                 - name:  block-volume-pv
                   devicePath: /dev/xvdx
-              livenessProbe:
-                tcpSocket:
-                  port: mongo
-                initialDelaySeconds: 5
+              readinessProbe:
+                exec:
+                  command:
+                  - /bin/bash
+                  - -c
+                  - "mongosh --eval 'db.runCommand(\"ping\")' --quiet"
+                initialDelaySeconds: 30
                 periodSeconds: 10
+                timeoutSeconds: 5
+                failureThreshold: 3
+              livenessProbe:
+                exec:
+                  command:
+                  - /bin/bash
+                  - -c
+                  - "mongosh --eval 'db.runCommand(\"ping\")' --quiet"
+                initialDelaySeconds: 60
+                periodSeconds: 30
+                timeoutSeconds: 10
+                failureThreshold: 3
               startupProbe:
                 exec:
                   command:
-                  - mongosh
-                  - admin
-                  - -u $(MONGO_INITDB_ROOT_USERNAME)
-                  - -p $(MONGO_INITDB_ROOT_PASSWORD)
-                  - --eval 'printjson(db.getCollectionNames())'
-                initialDelaySeconds: 5
-                periodSeconds: 30
-                timeoutSeconds: 2
+                  - bash
+                  - -c
+                  - |
+                    mongosh admin --authenticationDatabase admin -u "$MONGO_INITDB_ROOT_USERNAME" -p "$MONGO_INITDB_ROOT_PASSWORD" --eval 'db.adminCommand("ping")'
+                initialDelaySeconds: 10
+                periodSeconds: 10
+                timeoutSeconds: 5
                 successThreshold: 1
-                failureThreshold: 40 # 40x30sec before restart pod
+                failureThreshold: 12 # 12x10sec = 2min before restart pod
             - image: docker.io/curlimages/curl:8.5.0
               name: curl-tool
               command: ["/bin/sleep", "infinity"]
@@ -172,8 +189,8 @@ items:
         port: 27017
       selector:
         app: mongo
-  - apiVersion: apps.openshift.io/v1
-    kind: DeploymentConfig
+  - apiVersion: apps/v1
+    kind: Deployment
     metadata:
       name: todolist
       namespace: mongo-persistent
@@ -184,8 +201,9 @@ items:
     spec:
       replicas: 1
       selector:
-        app: todolist
-        service: todolist
+        matchLabels:
+          app: todolist
+          service: todolist
       strategy:
         type: Recreate
       template:
@@ -197,13 +215,25 @@ items:
         spec:
           containers:
           - name: todolist
-            image: quay.io/migtools/oadp-ci-todolist-mongo-go-1
+            image: quay.io/migtools/oadp-ci-todolist-mongo-go-4 
             env:
               - name: foo
                 value: bar
             ports:
               - containerPort: 8000
                 protocol: TCP
+            livenessProbe:
+              httpGet:
+                path: /
+                port: 8000
+              initialDelaySeconds: 10
+              periodSeconds: 10
+            readinessProbe:
+              httpGet:
+                path: /
+                port: 8000
+              initialDelaySeconds: 5
+              periodSeconds: 5
           initContainers:
           - name: init-myservice
             image: docker.io/curlimages/curl:8.5.0

--- a/tests/e2e/sample-applications/mongo-persistent/mongo-persistent-csi.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/mongo-persistent-csi.yaml
@@ -67,7 +67,8 @@ items:
         spec:
           serviceAccountName: mongo-persistent-sa
           containers:
-          - image: docker.io/library/mongo:latest
+          - image: docker.io/library/mongo:7.0
+            imagePullPolicy: IfNotPresent
             name: mongo
             securityContext:
               privileged: true
@@ -82,29 +83,45 @@ items:
             - containerPort: 27017
               name: mongo
             resources:
-              limits:
+              requests:
                 memory: 512Mi
+              limits:
+                memory: 1Gi
             volumeMounts:
             - name: mongo-data
               mountPath: /data/db
-            livenessProbe:
-              tcpSocket:
-                port: mongo
-              initialDelaySeconds: 5
+            readinessProbe:
+              exec:
+                command:
+                - /bin/bash
+                - -c
+                - "mongosh --eval 'db.runCommand(\"ping\")' --quiet"
+              initialDelaySeconds: 30
               periodSeconds: 10
+              timeoutSeconds: 5
+              failureThreshold: 3
+            livenessProbe:
+              exec:
+                command:
+                - /bin/bash
+                - -c
+                - "mongosh --eval 'db.runCommand(\"ping\")' --quiet"
+              initialDelaySeconds: 60
+              periodSeconds: 30
+              timeoutSeconds: 10
+              failureThreshold: 3
             startupProbe:
               exec:
                 command:
-                - mongosh
-                - admin
-                - -u $(MONGO_INITDB_ROOT_USERNAME)
-                - -p $(MONGO_INITDB_ROOT_PASSWORD)
-                - --eval 'printjson(db.getCollectionNames())'
-              initialDelaySeconds: 5
-              periodSeconds: 30
-              timeoutSeconds: 2
+                - bash
+                - -c
+                - |
+                  mongosh admin --authenticationDatabase admin -u "$MONGO_INITDB_ROOT_USERNAME" -p "$MONGO_INITDB_ROOT_PASSWORD" --eval 'db.adminCommand("ping")'
+              initialDelaySeconds: 10
+              periodSeconds: 10
+              timeoutSeconds: 5
               successThreshold: 1
-              failureThreshold: 40 # 40x30sec before restart pod
+              failureThreshold: 12 # 12x10sec = 2min before restart pod
           - image: docker.io/curlimages/curl:8.5.0
             name: curl-tool
             command: ["/bin/sleep", "infinity"]
@@ -129,8 +146,8 @@ items:
         port: 27017
       selector:
         app: mongo
-  - apiVersion: apps.openshift.io/v1
-    kind: DeploymentConfig
+  - apiVersion: apps/v1
+    kind: Deployment
     metadata:
       name: todolist
       namespace: mongo-persistent
@@ -141,8 +158,9 @@ items:
     spec:
       replicas: 1
       selector:
-        app: todolist
-        service: todolist
+        matchLabels:
+          app: todolist
+          service: todolist
       strategy:
         type: Recreate
       template:
@@ -154,13 +172,25 @@ items:
         spec:
           containers:
           - name: todolist
-            image: quay.io/migtools/oadp-ci-todolist-mongo-go-1
+            image: quay.io/migtools/oadp-ci-todolist-mongo-go-4
             env:
               - name: foo
                 value: bar
             ports:
               - containerPort: 8000
                 protocol: TCP
+            livenessProbe:
+              httpGet:
+                path: /
+                port: 8000
+              initialDelaySeconds: 10
+              periodSeconds: 10
+            readinessProbe:
+              httpGet:
+                path: /
+                port: 8000
+              initialDelaySeconds: 5
+              periodSeconds: 5
           initContainers:
           - name: init-myservice
             image: docker.io/curlimages/curl:8.5.0

--- a/tests/e2e/sample-applications/mongo-persistent/mongo-persistent.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/mongo-persistent.yaml
@@ -80,7 +80,8 @@ items:
         spec:
           serviceAccountName: mongo-persistent-sa
           containers:
-          - image: docker.io/library/mongo:latest
+          - image: docker.io/library/mongo:7.0
+            imagePullPolicy: IfNotPresent
             name: mongo
             securityContext:
               privileged: true
@@ -95,29 +96,45 @@ items:
             - containerPort: 27017
               name: mongo
             resources:
-              limits:
+              requests:
                 memory: 512Mi
+              limits:
+                memory: 1Gi
             volumeMounts:
             - name: mongo-data
               mountPath: /data/db
-            livenessProbe:
-              tcpSocket:
-                port: mongo
-              initialDelaySeconds: 5
+            readinessProbe:
+              exec:
+                command:
+                - /bin/bash
+                - -c
+                - "mongosh --eval 'db.runCommand(\"ping\")' --quiet"
+              initialDelaySeconds: 30
               periodSeconds: 10
+              timeoutSeconds: 5
+              failureThreshold: 3
+            livenessProbe:
+              exec:
+                command:
+                - /bin/bash
+                - -c
+                - "mongosh --eval 'db.runCommand(\"ping\")' --quiet"
+              initialDelaySeconds: 60
+              periodSeconds: 30
+              timeoutSeconds: 10
+              failureThreshold: 3
             startupProbe:
               exec:
                 command:
-                - mongosh
-                - admin
-                - -u $(MONGO_INITDB_ROOT_USERNAME)
-                - -p $(MONGO_INITDB_ROOT_PASSWORD)
-                - --eval 'printjson(db.getCollectionNames())'
-              initialDelaySeconds: 5
-              periodSeconds: 30
-              timeoutSeconds: 2
+                - bash
+                - -c
+                - |
+                  mongosh admin --authenticationDatabase admin -u "$MONGO_INITDB_ROOT_USERNAME" -p "$MONGO_INITDB_ROOT_PASSWORD" --eval 'db.adminCommand("ping")'
+              initialDelaySeconds: 10
+              periodSeconds: 10
+              timeoutSeconds: 5
               successThreshold: 1
-              failureThreshold: 40 # 40x30sec before restart pod
+              failureThreshold: 12 # 12x10sec = 2min before restart pod
           - image: docker.io/curlimages/curl:8.5.0
             name: curl-tool
             command: ["/bin/sleep", "infinity"]
@@ -142,8 +159,8 @@ items:
         port: 27017
       selector:
         app: mongo
-  - apiVersion: apps.openshift.io/v1
-    kind: DeploymentConfig
+  - apiVersion: apps/v1
+    kind: Deployment
     metadata:
       name: todolist
       namespace: mongo-persistent
@@ -154,8 +171,9 @@ items:
     spec:
       replicas: 1
       selector:
-        app: todolist
-        service: todolist
+        matchLabels:
+          app: todolist
+          service: todolist
       strategy:
         type: Recreate
       template:
@@ -167,13 +185,25 @@ items:
         spec:
           containers:
           - name: todolist
-            image: quay.io/migtools/oadp-ci-todolist-mongo-go-1
+            image: quay.io/migtools/oadp-ci-todolist-mongo-go-4
             env:
               - name: foo
                 value: bar
             ports:
               - containerPort: 8000
                 protocol: TCP
+            livenessProbe:
+              httpGet:
+                path: /
+                port: 8000
+              initialDelaySeconds: 10
+              periodSeconds: 10
+            readinessProbe:
+              httpGet:
+                path: /
+                port: 8000
+              initialDelaySeconds: 5
+              periodSeconds: 5
           initContainers:
           - name: init-myservice
             image: docker.io/curlimages/curl:8.5.0

--- a/tests/e2e/sample-applications/mongo-persistent/pvc/aws-block-mode.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/pvc/aws-block-mode.yaml
@@ -12,7 +12,7 @@ items:
       volumeMode: Block 
       accessModes:
       - ReadWriteOnce
-      storageClassName: gp2-csi
+      storageClassName: gp3-csi
       resources:
         requests:
           storage: 1Gi

--- a/tests/e2e/sample-applications/mongo-persistent/pvc/aws.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/pvc/aws.yaml
@@ -11,7 +11,7 @@ items:
     spec:
       accessModes:
       - ReadWriteOnce
-      storageClassName: gp2-csi
+      storageClassName: gp3-csi
       resources:
         requests:
           storage: 1Gi

--- a/tests/e2e/sample-applications/mongo-persistent/pvc/ibmcloud-block-mode.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/pvc/ibmcloud-block-mode.yaml
@@ -9,10 +9,10 @@ items:
       labels:
         app: mongo
     spec:
-      volumeMode: Block 
+      volumeMode: Block
       accessModes:
       - ReadWriteOnce
-      storageClassName: ocs-storagecluster-cephfs
+      storageClassName: ocs-storagecluster-ceph-rbd
       resources:
         requests:
           storage: 1Gi


### PR DESCRIPTION
We fixed the reliability of mongo on oadp-dev in https://github.com/openshift/oadp-operator/pull/2013
Ensure the oadp-1.4 branch has the same changes.
