### PR TITLE
[oadp-1.3]update mongo templates to match oadp-dev

### DIFF
--- a/tests/e2e/lib/apps.go
+++ b/tests/e2e/lib/apps.go
@@ -260,8 +260,16 @@ func AreVolumeSnapshotsReady(ocClient client.Client, backupName string) wait.Con
 
 func IsDCReady(ocClient client.Client, namespace, dcName string) wait.ConditionFunc {
 	return func() (bool, error) {
+		// Only execute checks if a DeploymentConfig object is detected in the namespace
+		hasDC, err := HasDCsInNamespace(ocClient, namespace)
+		if err != nil {
+			return false, err
+		}
+		if !hasDC {
+			return true, nil
+		}
 		dc := ocpappsv1.DeploymentConfig{}
-		err := ocClient.Get(context.Background(), client.ObjectKey{
+		err = ocClient.Get(context.Background(), client.ObjectKey{
 			Namespace: namespace,
 			Name:      dcName,
 		}, &dc)

--- a/tests/e2e/sample-applications/mongo-persistent/mongo-persistent-block.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/mongo-persistent-block.yaml
@@ -63,6 +63,7 @@ items:
           labels:
             e2e-app: "true"
             app: mongo
+            curl-tool: "true"
         spec:
           serviceAccountName: mongo-persistent-sa
           securityContext:
@@ -70,7 +71,8 @@ items:
           # Used to format the block device (put filesystem on it).
           # This allows Mongo to use the filesystem which lives on block device.
           initContainers:
-            - image: docker.io/library/mongo:latest
+            - image: docker.io/library/mongo:7.0
+              imagePullPolicy: IfNotPresent
               securityContext:
                 privileged: true
               name: setup-block-device
@@ -100,7 +102,7 @@ items:
                 - name: block-volume-pv
                   devicePath: /dev/xvdx
           containers:
-            - image: docker.io/library/mongo:latest
+            - image: docker.io/library/mongo:7.0
               name: mongo
               securityContext:
                 privileged: true
@@ -115,8 +117,10 @@ items:
                 - containerPort: 27017
                   name: mongo
               resources:
-                limits:
+                requests:
                   memory: 512Mi
+                limits:
+                  memory: 1Gi
               command:
                 - "sh"
                 - "-c"
@@ -129,24 +133,41 @@ items:
               volumeDevices:
                 - name:  block-volume-pv
                   devicePath: /dev/xvdx
-              livenessProbe:
-                tcpSocket:
-                  port: mongo
-                initialDelaySeconds: 5
+              readinessProbe:
+                exec:
+                  command:
+                  - /bin/bash
+                  - -c
+                  - "mongosh --eval 'db.runCommand(\"ping\")' --quiet"
+                initialDelaySeconds: 30
                 periodSeconds: 10
+                timeoutSeconds: 5
+                failureThreshold: 3
+              livenessProbe:
+                exec:
+                  command:
+                  - /bin/bash
+                  - -c
+                  - "mongosh --eval 'db.runCommand(\"ping\")' --quiet"
+                initialDelaySeconds: 60
+                periodSeconds: 30
+                timeoutSeconds: 10
+                failureThreshold: 3
               startupProbe:
                 exec:
                   command:
-                  - mongosh
-                  - admin
-                  - -u $(MONGO_INITDB_ROOT_USERNAME)
-                  - -p $(MONGO_INITDB_ROOT_PASSWORD)
-                  - --eval 'printjson(db.getCollectionNames())'
-                initialDelaySeconds: 5
-                periodSeconds: 30
-                timeoutSeconds: 2
+                  - bash
+                  - -c
+                  - |
+                    mongosh admin --authenticationDatabase admin -u "$MONGO_INITDB_ROOT_USERNAME" -p "$MONGO_INITDB_ROOT_PASSWORD" --eval 'db.adminCommand("ping")'
+                initialDelaySeconds: 10
+                periodSeconds: 10
+                timeoutSeconds: 5
                 successThreshold: 1
-                failureThreshold: 40 # 40x30sec before restart pod
+                failureThreshold: 12 # 12x10sec = 2min before restart pod
+            - image: docker.io/curlimages/curl:8.5.0
+              name: curl-tool
+              command: ["/bin/sleep", "infinity"]
           volumes:
           - name: block-volume-pv
             persistentVolumeClaim:
@@ -168,8 +189,8 @@ items:
         port: 27017
       selector:
         app: mongo
-  - apiVersion: apps.openshift.io/v1
-    kind: DeploymentConfig
+  - apiVersion: apps/v1
+    kind: Deployment
     metadata:
       name: todolist
       namespace: mongo-persistent
@@ -180,8 +201,9 @@ items:
     spec:
       replicas: 1
       selector:
-        app: todolist
-        service: todolist
+        matchLabels:
+          app: todolist
+          service: todolist
       strategy:
         type: Recreate
       template:
@@ -193,13 +215,25 @@ items:
         spec:
           containers:
           - name: todolist
-            image: quay.io/migtools/oadp-ci-todolist-mongo-go:latest
+            image: quay.io/migtools/oadp-ci-todolist-mongo-go-4 
             env:
               - name: foo
                 value: bar
             ports:
               - containerPort: 8000
                 protocol: TCP
+            livenessProbe:
+              httpGet:
+                path: /
+                port: 8000
+              initialDelaySeconds: 10
+              periodSeconds: 10
+            readinessProbe:
+              httpGet:
+                path: /
+                port: 8000
+              initialDelaySeconds: 5
+              periodSeconds: 5
           initContainers:
           - name: init-myservice
             image: docker.io/curlimages/curl:8.5.0

--- a/tests/e2e/sample-applications/mongo-persistent/mongo-persistent-csi.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/mongo-persistent-csi.yaml
@@ -63,10 +63,12 @@ items:
           labels:
             e2e-app: "true"
             app: mongo
+            curl-tool: "true"
         spec:
           serviceAccountName: mongo-persistent-sa
           containers:
-          - image: docker.io/library/mongo:latest
+          - image: docker.io/library/mongo:7.0
+            imagePullPolicy: IfNotPresent
             name: mongo
             securityContext:
               privileged: true
@@ -81,29 +83,48 @@ items:
             - containerPort: 27017
               name: mongo
             resources:
-              limits:
+              requests:
                 memory: 512Mi
+              limits:
+                memory: 1Gi
             volumeMounts:
             - name: mongo-data
               mountPath: /data/db
-            livenessProbe:
-              tcpSocket:
-                port: mongo
-              initialDelaySeconds: 5
+            readinessProbe:
+              exec:
+                command:
+                - /bin/bash
+                - -c
+                - "mongosh --eval 'db.runCommand(\"ping\")' --quiet"
+              initialDelaySeconds: 30
               periodSeconds: 10
+              timeoutSeconds: 5
+              failureThreshold: 3
+            livenessProbe:
+              exec:
+                command:
+                - /bin/bash
+                - -c
+                - "mongosh --eval 'db.runCommand(\"ping\")' --quiet"
+              initialDelaySeconds: 60
+              periodSeconds: 30
+              timeoutSeconds: 10
+              failureThreshold: 3
             startupProbe:
               exec:
                 command:
-                - mongosh
-                - admin
-                - -u $(MONGO_INITDB_ROOT_USERNAME)
-                - -p $(MONGO_INITDB_ROOT_PASSWORD)
-                - --eval 'printjson(db.getCollectionNames())'
-              initialDelaySeconds: 5
-              periodSeconds: 30
-              timeoutSeconds: 2
+                - bash
+                - -c
+                - |
+                  mongosh admin --authenticationDatabase admin -u "$MONGO_INITDB_ROOT_USERNAME" -p "$MONGO_INITDB_ROOT_PASSWORD" --eval 'db.adminCommand("ping")'
+              initialDelaySeconds: 10
+              periodSeconds: 10
+              timeoutSeconds: 5
               successThreshold: 1
-              failureThreshold: 40 # 40x30sec before restart pod
+              failureThreshold: 12 # 12x10sec = 2min before restart pod
+          - image: docker.io/curlimages/curl:8.5.0
+            name: curl-tool
+            command: ["/bin/sleep", "infinity"]
           volumes:
           - name: mongo-data
             persistentVolumeClaim:
@@ -125,8 +146,8 @@ items:
         port: 27017
       selector:
         app: mongo
-  - apiVersion: apps.openshift.io/v1
-    kind: DeploymentConfig
+  - apiVersion: apps/v1
+    kind: Deployment
     metadata:
       name: todolist
       namespace: mongo-persistent
@@ -137,8 +158,9 @@ items:
     spec:
       replicas: 1
       selector:
-        app: todolist
-        service: todolist
+        matchLabels:
+          app: todolist
+          service: todolist
       strategy:
         type: Recreate
       template:
@@ -150,13 +172,25 @@ items:
         spec:
           containers:
           - name: todolist
-            image: quay.io/migtools/oadp-ci-todolist-mongo-go:latest
+            image: quay.io/migtools/oadp-ci-todolist-mongo-go-4
             env:
               - name: foo
                 value: bar
             ports:
               - containerPort: 8000
                 protocol: TCP
+            livenessProbe:
+              httpGet:
+                path: /
+                port: 8000
+              initialDelaySeconds: 10
+              periodSeconds: 10
+            readinessProbe:
+              httpGet:
+                path: /
+                port: 8000
+              initialDelaySeconds: 5
+              periodSeconds: 5
           initContainers:
           - name: init-myservice
             image: docker.io/curlimages/curl:8.5.0

--- a/tests/e2e/sample-applications/mongo-persistent/mongo-persistent.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/mongo-persistent.yaml
@@ -76,10 +76,12 @@ items:
           labels:
             e2e-app: "true"
             app: mongo
+            curl-tool: "true"
         spec:
           serviceAccountName: mongo-persistent-sa
           containers:
-          - image: docker.io/library/mongo:latest
+          - image: docker.io/library/mongo:7.0
+            imagePullPolicy: IfNotPresent
             name: mongo
             securityContext:
               privileged: true
@@ -94,29 +96,48 @@ items:
             - containerPort: 27017
               name: mongo
             resources:
-              limits:
+              requests:
                 memory: 512Mi
+              limits:
+                memory: 1Gi
             volumeMounts:
             - name: mongo-data
               mountPath: /data/db
-            livenessProbe:
-              tcpSocket:
-                port: mongo
-              initialDelaySeconds: 5
+            readinessProbe:
+              exec:
+                command:
+                - /bin/bash
+                - -c
+                - "mongosh --eval 'db.runCommand(\"ping\")' --quiet"
+              initialDelaySeconds: 30
               periodSeconds: 10
+              timeoutSeconds: 5
+              failureThreshold: 3
+            livenessProbe:
+              exec:
+                command:
+                - /bin/bash
+                - -c
+                - "mongosh --eval 'db.runCommand(\"ping\")' --quiet"
+              initialDelaySeconds: 60
+              periodSeconds: 30
+              timeoutSeconds: 10
+              failureThreshold: 3
             startupProbe:
               exec:
                 command:
-                - mongosh
-                - admin
-                - -u $(MONGO_INITDB_ROOT_USERNAME)
-                - -p $(MONGO_INITDB_ROOT_PASSWORD)
-                - --eval 'printjson(db.getCollectionNames())'
-              initialDelaySeconds: 5
-              periodSeconds: 30
-              timeoutSeconds: 2
+                - bash
+                - -c
+                - |
+                  mongosh admin --authenticationDatabase admin -u "$MONGO_INITDB_ROOT_USERNAME" -p "$MONGO_INITDB_ROOT_PASSWORD" --eval 'db.adminCommand("ping")'
+              initialDelaySeconds: 10
+              periodSeconds: 10
+              timeoutSeconds: 5
               successThreshold: 1
-              failureThreshold: 40 # 40x30sec before restart pod
+              failureThreshold: 12 # 12x10sec = 2min before restart pod
+          - image: docker.io/curlimages/curl:8.5.0
+            name: curl-tool
+            command: ["/bin/sleep", "infinity"]
           volumes:
           - name: mongo-data
             persistentVolumeClaim:
@@ -138,8 +159,8 @@ items:
         port: 27017
       selector:
         app: mongo
-  - apiVersion: apps.openshift.io/v1
-    kind: DeploymentConfig
+  - apiVersion: apps/v1
+    kind: Deployment
     metadata:
       name: todolist
       namespace: mongo-persistent
@@ -150,8 +171,9 @@ items:
     spec:
       replicas: 1
       selector:
-        app: todolist
-        service: todolist
+        matchLabels:
+          app: todolist
+          service: todolist
       strategy:
         type: Recreate
       template:
@@ -163,13 +185,25 @@ items:
         spec:
           containers:
           - name: todolist
-            image: quay.io/migtools/oadp-ci-todolist-mongo-go:latest
+            image: quay.io/migtools/oadp-ci-todolist-mongo-go-4
             env:
               - name: foo
                 value: bar
             ports:
               - containerPort: 8000
                 protocol: TCP
+            livenessProbe:
+              httpGet:
+                path: /
+                port: 8000
+              initialDelaySeconds: 10
+              periodSeconds: 10
+            readinessProbe:
+              httpGet:
+                path: /
+                port: 8000
+              initialDelaySeconds: 5
+              periodSeconds: 5
           initContainers:
           - name: init-myservice
             image: docker.io/curlimages/curl:8.5.0

--- a/tests/e2e/sample-applications/mongo-persistent/pvc/aws.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/pvc/aws.yaml
@@ -11,7 +11,7 @@ items:
     spec:
       accessModes:
       - ReadWriteOnce
-      storageClassName: gp2-csi
+      storageClassName: gp3-csi
       resources:
         requests:
           storage: 1Gi

--- a/tests/e2e/sample-applications/mongo-persistent/pvc/ibmcloud-block-mode.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/pvc/ibmcloud-block-mode.yaml
@@ -9,10 +9,10 @@ items:
       labels:
         app: mongo
     spec:
-      volumeMode: Block 
+      volumeMode: Block
       accessModes:
       - ReadWriteOnce
-      storageClassName: ocs-storagecluster-cephfs
+      storageClassName: ocs-storagecluster-ceph-rbd
       resources:
         requests:
           storage: 1Gi

--- a/tests/e2e/sample-applications/mongo-persistent/pvc/openstack.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/pvc/openstack.yaml
@@ -9,10 +9,9 @@ items:
       labels:
         app: mongo
     spec:
-      volumeMode: Block 
       accessModes:
       - ReadWriteOnce
-      storageClassName: gp3-csi
+      storageClassName: ocs-storagecluster-ceph-rbd
       resources:
         requests:
           storage: 1Gi


### PR DESCRIPTION
We fixed the reliability of mongo on oadp-dev in https://github.com/openshift/oadp-operator/pull/2013
Ensure the oadp-1.3 branch has the same changes.