### PR TITLE
Migrate away from deprecated ioutil

### DIFF
--- a/pkg/leaderelection/leaderelection.go
+++ b/pkg/leaderelection/leaderelection.go
@@ -3,8 +3,8 @@ package leaderelection
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"math"
+	"os"
 	"strings"
 	"time"
 
@@ -89,7 +89,7 @@ func LeaderElectionDefaulting(config configv1.LeaderElection, defaultNamespace, 
 			ret.Namespace = defaultNamespace
 		} else {
 			// Fall back to the namespace associated with the service account token, if available
-			if data, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
+			if data, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
 				if ns := strings.TrimSpace(string(data)); len(ns) > 0 {
 					ret.Namespace = ns
 				}

--- a/tests/e2e/lib/common_helpers.go
+++ b/tests/e2e/lib/common_helpers.go
@@ -3,7 +3,7 @@ package lib
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	neturl "net/url"
@@ -27,7 +27,7 @@ const (
 )
 
 func ReadFile(path string) ([]byte, error) {
-	file, err := ioutil.ReadFile(path)
+	file, err := os.ReadFile(path)
 	return file, err
 }
 
@@ -282,7 +282,7 @@ func MakeHTTPRequest(url string, requestMethod HTTPMethod, payload string) (stri
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return "", string(body), fmt.Errorf("Error reading response body: %v", err)
 		}
@@ -291,7 +291,7 @@ func MakeHTTPRequest(url string, requestMethod HTTPMethod, payload string) (stri
 
 	// The response status code indicates an error
 	// Read the error response body
-	responseBody, responseErr := ioutil.ReadAll(resp.Body)
+	responseBody, responseErr := io.ReadAll(resp.Body)
 	if responseErr != nil {
 		return "", string(responseBody), fmt.Errorf("HTTP request failed with status code %d: %v", resp.StatusCode, responseErr)
 	}


### PR DESCRIPTION
`ioutil` has been deprecated since Go 1.16: https://go.dev/doc/go1.16#ioutil

Tracking issue: https://github.com/redhat-best-practices-for-k8s/telco-bot/issues/52