### PR TITLE
Ensure proper kubevirt plugin is used.

### DIFF
--- a/bundle/manifests/oadp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/oadp-operator.clusterserviceversion.yaml
@@ -1277,7 +1277,7 @@ spec:
                 - name: RELATED_IMAGE_VELERO_PLUGIN_FOR_GCP
                   value: quay.io/konveyor/velero-plugin-for-gcp:latest
                 - name: RELATED_IMAGE_KUBEVIRT_VELERO_PLUGIN
-                  value: quay.io/konveyor/kubevirt-velero-plugin:v0.7.0
+                  value: quay.io/konveyor/kubevirt-velero-plugin:latest
                 - name: RELATED_IMAGE_HYPERSHIFT_VELERO_PLUGIN
                   value: quay.io/redhat-user-workloads/ocp-art-tenant/oadp-hypershift-oadp-plugin-main:main
                 - name: RELATED_IMAGE_MUSTGATHER
@@ -1446,7 +1446,7 @@ spec:
     name: velero-plugin-for-microsoft-azure
   - image: quay.io/konveyor/velero-plugin-for-gcp:latest
     name: velero-plugin-for-gcp
-  - image: quay.io/konveyor/kubevirt-velero-plugin:v0.7.0
+  - image: quay.io/konveyor/kubevirt-velero-plugin:latest
     name: kubevirt-velero-plugin
   - image: quay.io/redhat-user-workloads/ocp-art-tenant/oadp-hypershift-oadp-plugin-main:main
     name: hypershift-velero-plugin

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -81,7 +81,7 @@ spec:
             - name: RELATED_IMAGE_VELERO_PLUGIN_FOR_GCP
               value: quay.io/konveyor/velero-plugin-for-gcp:latest
             - name: RELATED_IMAGE_KUBEVIRT_VELERO_PLUGIN
-              value: quay.io/konveyor/kubevirt-velero-plugin:v0.7.0
+              value: quay.io/konveyor/kubevirt-velero-plugin:latest
             - name: RELATED_IMAGE_HYPERSHIFT_VELERO_PLUGIN
               value: quay.io/redhat-user-workloads/ocp-art-tenant/oadp-hypershift-oadp-plugin-main:main
             - name: RELATED_IMAGE_MUSTGATHER

--- a/docs/developer/PROW_CI.md
+++ b/docs/developer/PROW_CI.md
@@ -295,7 +295,7 @@ Update `pkg/common/common.go`, changing the following (if release branch was cre
 -	GCPPluginImage       = "quay.io/konveyor/velero-plugin-for-gcp:latest"
 +	GCPPluginImage       = "quay.io/konveyor/velero-plugin-for-gcp:oadp-1.4"
 	RegistryImage        = "quay.io/konveyor/registry:latest"
-	KubeVirtPluginImage  = "quay.io/konveyor/kubevirt-velero-plugin:v0.7.0"
+	KubeVirtPluginImage  = "quay.io/konveyor/kubevirt-velero-plugin:latest"
  )
 ...
 ```

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -73,7 +73,7 @@ const (
 	AzurePluginImage      = "quay.io/konveyor/velero-plugin-for-microsoft-azure:latest"
 	GCPPluginImage        = "quay.io/konveyor/velero-plugin-for-gcp:latest"
 	RegistryImage         = "quay.io/konveyor/registry:latest"
-	KubeVirtPluginImage   = "quay.io/konveyor/kubevirt-velero-plugin:v0.7.0"
+	KubeVirtPluginImage   = "quay.io/konveyor/kubevirt-velero-plugin:latest"
 	HypershiftPluginImage = "quay.io/redhat-user-workloads/ocp-art-tenant/oadp-hypershift-oadp-plugin-main:main"
 )
 

--- a/pkg/credentials/credentials_test.go
+++ b/pkg/credentials/credentials_test.go
@@ -400,7 +400,7 @@ func TestCredentials_getPluginImage(t *testing.T) {
 				},
 			},
 			pluginName: oadpv1alpha1.DefaultPluginKubeVirt,
-			wantImage:  "quay.io/konveyor/kubevirt-velero-plugin:v0.7.0",
+			wantImage:  "quay.io/konveyor/kubevirt-velero-plugin:latest",
 		},
 		{
 			name: "given default Velero CR with env var set, image should be built via env vars",


### PR DESCRIPTION
For the oadp-dev branch use altest kubevirt plugin.

## Why the changes were made

To allow VMFR use proper plugin by default.

