### PR TITLE
Add PrepareQueueLength field to LoadConcurrency

### DIFF
--- a/api/v1alpha1/dataprotectionapplication_types.go
+++ b/api/v1alpha1/dataprotectionapplication_types.go
@@ -393,6 +393,9 @@ type LoadConcurrency struct {
 
 	// PerNodeConfig specifies the concurrency number to nodes matched by rules
 	PerNodeConfig []RuledConfigs `json:"perNodeConfig,omitempty"`
+
+	// PrepareQueueLength specifies the max number of loads that are under expose
+	PrepareQueueLength int `json:"prepareQueueLength,omitempty"`
 }
 
 // Below struct should be same as:

--- a/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
@@ -366,6 +366,9 @@ spec:
                                   - number
                                 type: object
                               type: array
+                            prepareQueueLength:
+                              description: PrepareQueueLength specifies the max number of loads that are under expose
+                              type: integer
                           type: object
                         podConfig:
                           description: Pod specific configuration

--- a/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
@@ -366,6 +366,9 @@ spec:
                                   - number
                                 type: object
                               type: array
+                            prepareQueueLength:
+                              description: PrepareQueueLength specifies the max number of loads that are under expose
+                              type: integer
                           type: object
                         podConfig:
                           description: Pod specific configuration

--- a/docs/scheduling_and_node_affinity.md
+++ b/docs/scheduling_and_node_affinity.md
@@ -91,6 +91,17 @@ Global configuration is applied to all nodes. Per-node configuration is applied 
 
 The `nodeSelector` uses the same syntax for selecting nodes as `loadAffinity.nodeSelector` and it may be used in combination with `matchExpressions` for advanced node selection.
 
+#### Prepare Queue Length
+
+The `prepareQueueLength` field specifies the maximum number of loads that are allowed to be in the prepare phase (Accepted or Prepared state) at the same time. This helps prevent excessive creation of data mover pods and volume snapshots before they can actually be processed.
+
+When set to a positive number, the mechanism will throttle new loads, keeping them in the "New" state until there is available capacity in the prepare queue. This is useful in environments where:
+- There is a pod limit per node or throughout the cluster
+- System disk space is limited and too many inactive data mover pods would cause issues
+- Large numbers of snapshots could degrade storage performance
+
+If not set or set to 0, there will be no throttling at the prepare phase.
+
 ```yaml
 spec:
   configuration:
@@ -98,6 +109,7 @@ spec:
       enable: true
       loadConcurrency:
         globalConfig: 2
+        prepareQueueLength: 2
         perNodeConfig:
           - nodeSelector:
               matchLabels:

--- a/internal/controller/nodeagent_test.go
+++ b/internal/controller/nodeagent_test.go
@@ -1457,6 +1457,53 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 			}),
 		},
 		{
+			name: "valid DPA CR with LoadConcurrency and PrepareQueueLength, NodeAgent DaemonSet is built with pointer to the config map",
+			dpa: createTestDpaWith(
+				nil,
+				oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{},
+						NodeAgent: &oadpv1alpha1.NodeAgentConfig{
+							NodeAgentCommonFields: oadpv1alpha1.NodeAgentCommonFields{},
+							NodeAgentConfigMapSettings: oadpv1alpha1.NodeAgentConfigMapSettings{
+								LoadConcurrency: &oadpv1alpha1.LoadConcurrency{
+									GlobalConfig:       10,
+									PrepareQueueLength: 5,
+									PerNodeConfig: []oadpv1alpha1.RuledConfigs{
+										{
+											NodeSelector: metav1.LabelSelector{
+												MatchLabels: map[string]string{"app": "velero"},
+											},
+											Number: 1,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			),
+			clientObjects: []client.Object{
+				testGenericInfrastructure,
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      common.NodeAgentConfigMapPrefix + testDpaName,
+						Namespace: testNamespaceName,
+					},
+					Data: map[string]string{
+						"loadConcurrency": `{"globalConfig":10,"perNodeConfig":[{"nodeSelector":{"app":"velero"},"number":1}],"prepareQueueLength":5}`,
+					},
+				},
+			},
+			nodeAgentDaemonSet: testNodeAgentDaemonSet.DeepCopy(),
+			wantNodeAgentDaemonSet: createTestBuiltNodeAgentDaemonSet(TestBuiltNodeAgentDaemonSetOptions{
+				args: []string{
+					"--node-agent-configmap=node-agent-test-DPA-CR",
+				},
+				labels: map[string]string{"openshift.io/node-agent-cm-version": "999"},
+			}),
+		},
+		{
 			name: "valid DPA CR with NodeSelector from PodConfig, NodeAgent DaemonSet is built with pointer to the config map",
 			dpa: createTestDpaWith(
 				nil,
@@ -1646,6 +1693,67 @@ func TestDPAReconciler_updateNodeAgentCM(t *testing.T) {
 							}
 						}
 					],
+					"privilegedFsBackup": true
+				}`,
+			}),
+		},
+		{
+			name: "Given DPA CR instance, appropriate NodeAgent config cm is created with LoadConcurrency including PrepareQueueLength",
+			nodeAgentConfigMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      common.NodeAgentConfigMapPrefix + testCmName,
+					Namespace: testCmNs,
+				},
+			},
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testCmName,
+					Namespace: testCmNs,
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{
+							DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
+								oadpv1alpha1.DefaultPluginAWS,
+							},
+						},
+						NodeAgent: &oadpv1alpha1.NodeAgentConfig{
+							NodeAgentCommonFields: oadpv1alpha1.NodeAgentCommonFields{},
+							NodeAgentConfigMapSettings: oadpv1alpha1.NodeAgentConfigMapSettings{
+								LoadConcurrency: &oadpv1alpha1.LoadConcurrency{
+									GlobalConfig:       10,
+									PrepareQueueLength: 5,
+									PerNodeConfig: []oadpv1alpha1.RuledConfigs{
+										{
+											NodeSelector: metav1.LabelSelector{
+												MatchLabels: map[string]string{"app": "velero"},
+											},
+											Number: 1,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+			wantNodeAgentConfigMap: createTestBuiltNodeAgentCM(map[string]string{
+				"node-agent-config": `{
+					"loadConcurrency": {
+						"globalConfig": 10,
+						"prepareQueueLength": 5,
+						"perNodeConfig": [
+							{
+								"nodeSelector": {
+									"matchLabels": {
+										"app": "velero"
+									}
+								},
+								"number": 1
+							}
+						]
+					},
 					"privilegedFsBackup": true
 				}`,
 			}),


### PR DESCRIPTION
Adds PrepareQueueLength to control max loads in prepare phase, matching upstream Velero PR #9064.

Fixes: [OADP-7070](https://issues.redhat.com//browse/OADP-7070)
