### PR TITLE
Fix e2e tests to handle new Velero backup phases (Queued, ReadyToStart)

### DIFF
--- a/tests/e2e/lib/backup.go
+++ b/tests/e2e/lib/backup.go
@@ -73,6 +73,8 @@ func IsBackupDone(ocClient client.Client, veleroNamespace, name string) wait.Con
 		}
 		var phasesNotDone = []velero.BackupPhase{
 			velero.BackupPhaseNew,
+			velero.BackupPhaseQueued,
+			velero.BackupPhaseReadyToStart,
 			velero.BackupPhaseInProgress,
 			velero.BackupPhaseWaitingForPluginOperations,
 			velero.BackupPhaseWaitingForPluginOperationsPartiallyFailed,


### PR DESCRIPTION
## Summary
- Add `BackupPhaseQueued` and `BackupPhaseReadyToStart` to the `phasesNotDone` list in `IsBackupDone` function

## Problem
The Velero update in PR #2031 introduces two new backup phases: `Queued` and `ReadyToStart`. The `IsBackupDone` function in `tests/e2e/lib/backup.go` was not aware of these phases, causing it to incorrectly return `true` (done) when a backup was in one of these new phases.

This triggered premature test teardown while backups were still waiting in the queue, resulting in all e2e tests failing with "BackupStorageLocation is in unavailable state" errors.

## Fix
Add the two new phases to the `phasesNotDone` slice so `IsBackupDone` correctly waits for backups in `Queued` or `ReadyToStart` phases.

## Related
Fixes CI failures in PR #2031