### PR TITLE
dpa support for parallel backups

### DIFF
--- a/api/v1alpha1/dataprotectionapplication_types.go
+++ b/api/v1alpha1/dataprotectionapplication_types.go
@@ -323,9 +323,13 @@ type VeleroConfig struct {
 	DisableInformerCache *bool `json:"disableInformerCache,omitempty"`
 	// Number of workers in worker pool for processing item backup. This will allow multiple items within
 	// a Velero backup to be backed up at the same time which may improve performance for backups with
-	// a large number of items. Default is 1.
+	// a large number of items. Workers are per backup if concurrent backups are enabled. Default is 1.
 	// +optional
 	ItemBlockWorkerCount int `json:"itemBlockWorkerCount,omitempty"`
+	// Number of backups to process at the same time. Only backups which do not have any namespaces
+	// in common will run at the same time. Default is 1.
+	// +optional
+	ConcurrentBackups int `json:"concurrentBackups,omitempty"`
 	// resourceTimeout defines how long to wait for several Velero resources before timeout occurs,
 	// such as Velero CRD availability, volumeSnapshot deletion, and repo availability.
 	// Default is 10m

--- a/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
@@ -1111,6 +1111,11 @@ spec:
                         client-qps:
                           description: maximum number of requests per second by the server to the Kubernetes API once the burst limit has been reached. (default 100)
                           type: integer
+                        concurrentBackups:
+                          description: |-
+                            Number of backups to process at the same time. Only backups which do not have any namespaces
+                            in common will run at the same time. Default is 1.
+                          type: integer
                         customPlugins:
                           description: customPlugins defines the custom plugin to be installed with Velero
                           items:
@@ -1166,7 +1171,7 @@ spec:
                           description: |-
                             Number of workers in worker pool for processing item backup. This will allow multiple items within
                             a Velero backup to be backed up at the same time which may improve performance for backups with
-                            a large number of items. Default is 1.
+                            a large number of items. Workers are per backup if concurrent backups are enabled. Default is 1.
                           type: integer
                         itemOperationSyncFrequency:
                           description: How often to check status on async backup/restore operations after backup processing. Default value is 2m.

--- a/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
@@ -1111,6 +1111,11 @@ spec:
                         client-qps:
                           description: maximum number of requests per second by the server to the Kubernetes API once the burst limit has been reached. (default 100)
                           type: integer
+                        concurrentBackups:
+                          description: |-
+                            Number of backups to process at the same time. Only backups which do not have any namespaces
+                            in common will run at the same time. Default is 1.
+                          type: integer
                         customPlugins:
                           description: customPlugins defines the custom plugin to be installed with Velero
                           items:
@@ -1166,7 +1171,7 @@ spec:
                           description: |-
                             Number of workers in worker pool for processing item backup. This will allow multiple items within
                             a Velero backup to be backed up at the same time which may improve performance for backups with
-                            a large number of items. Default is 1.
+                            a large number of items. Workers are per backup if concurrent backups are enabled. Default is 1.
                           type: integer
                         itemOperationSyncFrequency:
                           description: How often to check status on async backup/restore operations after backup processing. Default value is 2m.

--- a/internal/controller/velero.go
+++ b/internal/controller/velero.go
@@ -409,6 +409,9 @@ func (r *DataProtectionApplicationReconciler) customizeVeleroDeployment(veleroDe
 	if dpa.Spec.Configuration.Velero.ItemBlockWorkerCount > 0 {
 		veleroContainer.Args = append(veleroContainer.Args, fmt.Sprintf("--item-block-worker-count=%v", dpa.Spec.Configuration.Velero.ItemBlockWorkerCount))
 	}
+	if dpa.Spec.Configuration.Velero.ConcurrentBackups > 0 {
+		veleroContainer.Args = append(veleroContainer.Args, fmt.Sprintf("--concurrent-backups=%v", dpa.Spec.Configuration.Velero.ConcurrentBackups))
+	}
 
 	// check for backup-repository-configmap parameter
 	if isBackupRepositoryCmRequired(dpa.Spec.Configuration.NodeAgent) {

--- a/internal/controller/velero_test.go
+++ b/internal/controller/velero_test.go
@@ -1364,6 +1364,28 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 			}),
 		},
 		{
+			name: "valid DPA CR with ConcurrentBackups set to 2, Velero Deployment is built with ConcurrentBackups set to 2",
+			dpa: createTestDpaWith(
+				nil,
+				oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{
+							ConcurrentBackups: 2,
+						},
+					},
+				},
+			),
+			veleroDeployment: testVeleroDeployment.DeepCopy(),
+			wantVeleroDeployment: createTestBuiltVeleroDeployment(TestBuiltVeleroDeploymentOptions{
+				args: []string{
+					defaultFileSystemBackupTimeout,
+					defaultRestoreResourcePriorities,
+					defaultDisableInformerCache,
+					"--concurrent-backups=2",
+				},
+			}),
+		},
+		{
 			name: "valid DPA CR with DefaultItemOperationTimeout, Velero Deployment is built with DefaultItemOperationTimeout arg",
 			dpa: createTestDpaWith(
 				nil,


### PR DESCRIPTION
## Why the changes were made

Adds dpa support for parallel backups.
## How to test the changes made
Add the following to the dpa spec to enable/test:
```
  spec:
    configuration:
      velero:
        concurrentBackups: 3
```

<!-- Explain how the changes introduced by this PR can be tested and verified, with commands and pictures -->
