### PR TITLE
OADP-6846: Add resourceLabels and resourceAnnotations to DPA spec

### DIFF
--- a/api/v1alpha1/dataprotectionapplication_types.go
+++ b/api/v1alpha1/dataprotectionapplication_types.go
@@ -875,6 +875,15 @@ type DataProtectionApplicationSpec struct {
 	// +optional
 	// Deprecated: Use PodConfig instead
 	PodAnnotations map[string]string `json:"podAnnotations,omitempty"`
+	// resourceLabels defines labels that will be applied to all resources managed by the DPA.
+	// These labels are merged with OADP-required labels. User-provided labels cannot override
+	// core operator labels (app.kubernetes.io/*, openshift.io/oadp).
+	// +optional
+	ResourceLabels map[string]string `json:"resourceLabels,omitempty"`
+	// resourceAnnotations defines annotations that will be applied to all resources managed by the DPA.
+	// Useful for GitOps tools like ArgoCD (e.g., argocd.argoproj.io/ignore-resource-updates: 'true').
+	// +optional
+	ResourceAnnotations map[string]string `json:"resourceAnnotations,omitempty"`
 	// podDnsPolicy defines how a pod's DNS will be configured.
 	// https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
 	// +optional

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -438,6 +438,20 @@ func (in *DataProtectionApplicationSpec) DeepCopyInto(out *DataProtectionApplica
 			(*out)[key] = val
 		}
 	}
+	if in.ResourceLabels != nil {
+		in, out := &in.ResourceLabels, &out.ResourceLabels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.ResourceAnnotations != nil {
+		in, out := &in.ResourceAnnotations, &out.ResourceAnnotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	in.PodDnsConfig.DeepCopyInto(&out.PodDnsConfig)
 	if in.BackupImages != nil {
 		in, out := &in.BackupImages, &out.BackupImages

--- a/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
@@ -2615,6 +2615,21 @@ spec:
                     podDnsPolicy defines how a pod's DNS will be configured.
                     https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
                   type: string
+                resourceAnnotations:
+                  additionalProperties:
+                    type: string
+                  description: |-
+                    resourceAnnotations defines annotations that will be applied to all resources managed by the DPA.
+                    Useful for GitOps tools like ArgoCD (e.g., argocd.argoproj.io/ignore-resource-updates: 'true').
+                  type: object
+                resourceLabels:
+                  additionalProperties:
+                    type: string
+                  description: |-
+                    resourceLabels defines labels that will be applied to all resources managed by the DPA.
+                    These labels are merged with OADP-required labels. User-provided labels cannot override
+                    core operator labels (app.kubernetes.io/*, openshift.io/oadp).
+                  type: object
                 snapshotLocations:
                   description: snapshotLocations defines the list of desired configuration to use for VolumeSnapshotLocations
                   items:

--- a/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
@@ -2615,6 +2615,21 @@ spec:
                     podDnsPolicy defines how a pod's DNS will be configured.
                     https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
                   type: string
+                resourceAnnotations:
+                  additionalProperties:
+                    type: string
+                  description: |-
+                    resourceAnnotations defines annotations that will be applied to all resources managed by the DPA.
+                    Useful for GitOps tools like ArgoCD (e.g., argocd.argoproj.io/ignore-resource-updates: 'true').
+                  type: object
+                resourceLabels:
+                  additionalProperties:
+                    type: string
+                  description: |-
+                    resourceLabels defines labels that will be applied to all resources managed by the DPA.
+                    These labels are merged with OADP-required labels. User-provided labels cannot override
+                    core operator labels (app.kubernetes.io/*, openshift.io/oadp).
+                  type: object
                 snapshotLocations:
                   description: snapshotLocations defines the list of desired configuration to use for VolumeSnapshotLocations
                   items:

--- a/internal/controller/backup_repository.go
+++ b/internal/controller/backup_repository.go
@@ -42,6 +42,12 @@ func (r *DataProtectionApplicationReconciler) updateBackupRepositoryCM(cm *corev
 		oadpv1alpha1.OadpOperatorLabel: "True",
 	}
 
+	// Apply user-provided resource labels (protected labels are filtered)
+	cm.Labels = applyResourceLabels(r.dpa, cm.Labels)
+
+	// Apply user-provided resource annotations
+	cm.Annotations = applyResourceAnnotations(r.dpa, cm.Annotations)
+
 	if cm.Data == nil {
 		cm.Data = make(map[string]string)
 	}

--- a/internal/controller/bsl.go
+++ b/internal/controller/bsl.go
@@ -425,6 +425,12 @@ func (r *DataProtectionApplicationReconciler) updateBSLFromSpec(bsl *velerov1.Ba
 	bsl.Labels["app.kubernetes.io/component"] = "bsl"
 	bsl.Labels[oadpv1alpha1.OadpOperatorLabel] = "True"
 
+	// Apply user-provided resource labels (protected labels are filtered)
+	bsl.Labels = applyResourceLabels(r.dpa, bsl.Labels)
+
+	// Apply user-provided resource annotations
+	bsl.Annotations = applyResourceAnnotations(r.dpa, bsl.Annotations)
+
 	return nil
 }
 

--- a/internal/controller/monitor.go
+++ b/internal/controller/monitor.go
@@ -63,5 +63,12 @@ func (r *DataProtectionApplicationReconciler) updateVeleroMetricsSVC(svc *corev1
 	}
 
 	svc.Labels = getDpaAppLabels(r.dpa)
+
+	// Apply user-provided resource labels (protected labels are filtered)
+	svc.Labels = applyResourceLabels(r.dpa, svc.Labels)
+
+	// Apply user-provided resource annotations
+	svc.Annotations = applyResourceAnnotations(r.dpa, svc.Annotations)
+
 	return nil
 }

--- a/internal/controller/nodeagent.go
+++ b/internal/controller/nodeagent.go
@@ -155,6 +155,12 @@ func (r *DataProtectionApplicationReconciler) updateNodeAgentCM(cm *corev1.Confi
 		oadpv1alpha1.OadpOperatorLabel: "True",
 	}
 
+	// Apply user-provided resource labels (protected labels are filtered)
+	cm.Labels = applyResourceLabels(r.dpa, cm.Labels)
+
+	// Apply user-provided resource annotations
+	cm.Annotations = applyResourceAnnotations(r.dpa, cm.Annotations)
+
 	if cm.Data == nil {
 		cm.Data = make(map[string]string)
 	}
@@ -498,6 +504,15 @@ func (r *DataProtectionApplicationReconciler) customizeNodeAgentDaemonset(ds *ap
 			}
 		}
 	}
+
+	// Apply user-provided resource labels (protected labels are filtered)
+	// Note: NOT applied to Spec.Selector.MatchLabels as those are immutable after creation
+	ds.Labels = applyResourceLabels(dpa, ds.Labels)
+	ds.Spec.Template.Labels = applyResourceLabels(dpa, ds.Spec.Template.Labels)
+
+	// Apply user-provided resource annotations to both daemonset and pod template
+	ds.Annotations = applyResourceAnnotations(dpa, ds.Annotations)
+	ds.Spec.Template.Annotations = applyResourceAnnotations(dpa, ds.Spec.Template.Annotations)
 
 	// fetch nodeAgent container in order to customize it
 	var nodeAgentContainer *corev1.Container

--- a/internal/controller/nodeagent.go
+++ b/internal/controller/nodeagent.go
@@ -9,10 +9,6 @@ import (
 
 	"github.com/go-logr/logr"
 	configv1 "github.com/openshift/api/config/v1"
-	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
-	"github.com/openshift/oadp-operator/pkg/common"
-	"github.com/openshift/oadp-operator/pkg/credentials"
-	"github.com/openshift/oadp-operator/pkg/credentials/stsflow"
 	"github.com/operator-framework/operator-lib/proxy"
 	"github.com/vmware-tanzu/velero/pkg/install"
 	"github.com/vmware-tanzu/velero/pkg/util/kube"
@@ -25,6 +21,11 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
+	"github.com/openshift/oadp-operator/pkg/common"
+	"github.com/openshift/oadp-operator/pkg/credentials"
+	"github.com/openshift/oadp-operator/pkg/credentials/stsflow"
 )
 
 const (

--- a/internal/controller/nodeagent.go
+++ b/internal/controller/nodeagent.go
@@ -9,6 +9,10 @@ import (
 
 	"github.com/go-logr/logr"
 	configv1 "github.com/openshift/api/config/v1"
+	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
+	"github.com/openshift/oadp-operator/pkg/common"
+	"github.com/openshift/oadp-operator/pkg/credentials"
+	"github.com/openshift/oadp-operator/pkg/credentials/stsflow"
 	"github.com/operator-framework/operator-lib/proxy"
 	"github.com/vmware-tanzu/velero/pkg/install"
 	"github.com/vmware-tanzu/velero/pkg/util/kube"
@@ -21,11 +25,6 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-
-	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
-	"github.com/openshift/oadp-operator/pkg/common"
-	"github.com/openshift/oadp-operator/pkg/credentials"
-	"github.com/openshift/oadp-operator/pkg/credentials/stsflow"
 )
 
 const (
@@ -509,6 +508,17 @@ func (r *DataProtectionApplicationReconciler) customizeNodeAgentDaemonset(ds *ap
 	// Note: NOT applied to Spec.Selector.MatchLabels as those are immutable after creation
 	ds.Labels = applyResourceLabels(dpa, ds.Labels)
 	ds.Spec.Template.Labels = applyResourceLabels(dpa, ds.Spec.Template.Labels)
+
+	// Re-assert selector labels to ensure template labels match selector
+	// This prevents user resourceLabels from overriding selector-critical labels
+	if ds.Spec.Selector != nil && ds.Spec.Selector.MatchLabels != nil {
+		if ds.Spec.Template.Labels == nil {
+			ds.Spec.Template.Labels = make(map[string]string)
+		}
+		for k, v := range ds.Spec.Selector.MatchLabels {
+			ds.Spec.Template.Labels[k] = v
+		}
+	}
 
 	// Apply user-provided resource annotations to both daemonset and pod template
 	ds.Annotations = applyResourceAnnotations(dpa, ds.Annotations)

--- a/internal/controller/nonadmin_controller.go
+++ b/internal/controller/nonadmin_controller.go
@@ -8,8 +8,6 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
-	"github.com/openshift/oadp-operator/pkg/common"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/exp/maps"
 	appsv1 "k8s.io/api/apps/v1"
@@ -20,6 +18,9 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
+	"github.com/openshift/oadp-operator/pkg/common"
 )
 
 const (

--- a/internal/controller/nonadmin_controller.go
+++ b/internal/controller/nonadmin_controller.go
@@ -134,6 +134,16 @@ func (r *DataProtectionApplicationReconciler) buildNonAdminDeployment(deployment
 	if err != nil {
 		return err
 	}
+
+	// Apply user-provided resource labels (protected labels are filtered)
+	// Note: NOT applied to Spec.Selector.MatchLabels as those are immutable after creation
+	deploymentObject.Labels = applyResourceLabels(r.dpa, deploymentObject.Labels)
+	deploymentObject.Spec.Template.Labels = applyResourceLabels(r.dpa, deploymentObject.Spec.Template.Labels)
+
+	// Apply user-provided resource annotations to both deployment and pod template
+	deploymentObject.Annotations = applyResourceAnnotations(r.dpa, deploymentObject.Annotations)
+	deploymentObject.Spec.Template.Annotations = applyResourceAnnotations(r.dpa, deploymentObject.Spec.Template.Annotations)
+
 	return nil
 }
 

--- a/internal/controller/nonadmin_controller.go
+++ b/internal/controller/nonadmin_controller.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
+	"github.com/openshift/oadp-operator/pkg/common"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/exp/maps"
 	appsv1 "k8s.io/api/apps/v1"
@@ -18,9 +20,6 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-
-	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
-	"github.com/openshift/oadp-operator/pkg/common"
 )
 
 const (
@@ -139,6 +138,17 @@ func (r *DataProtectionApplicationReconciler) buildNonAdminDeployment(deployment
 	// Note: NOT applied to Spec.Selector.MatchLabels as those are immutable after creation
 	deploymentObject.Labels = applyResourceLabels(r.dpa, deploymentObject.Labels)
 	deploymentObject.Spec.Template.Labels = applyResourceLabels(r.dpa, deploymentObject.Spec.Template.Labels)
+
+	// Re-assert selector labels to ensure template labels match selector
+	// This prevents user resourceLabels from overriding selector-critical labels
+	if deploymentObject.Spec.Selector != nil && deploymentObject.Spec.Selector.MatchLabels != nil {
+		if deploymentObject.Spec.Template.Labels == nil {
+			deploymentObject.Spec.Template.Labels = make(map[string]string)
+		}
+		for k, v := range deploymentObject.Spec.Selector.MatchLabels {
+			deploymentObject.Spec.Template.Labels[k] = v
+		}
+	}
 
 	// Apply user-provided resource annotations to both deployment and pod template
 	deploymentObject.Annotations = applyResourceAnnotations(r.dpa, deploymentObject.Annotations)

--- a/internal/controller/registry.go
+++ b/internal/controller/registry.go
@@ -746,6 +746,12 @@ func (r *DataProtectionApplicationReconciler) patchRegistrySecret(secret *corev1
 		return err
 	}
 
+	// Apply user-provided resource labels (protected labels are filtered)
+	secret.Labels = applyResourceLabels(r.dpa, secret.Labels)
+
+	// Apply user-provided resource annotations
+	secret.Annotations = applyResourceAnnotations(r.dpa, secret.Annotations)
+
 	// when updating the spec fields we update each field individually
 	// to get around the immutable fields
 	provider := bsl.Spec.Provider

--- a/internal/controller/repository_maintenance.go
+++ b/internal/controller/repository_maintenance.go
@@ -36,6 +36,12 @@ func (r *DataProtectionApplicationReconciler) updateRepositoryMaintenanceCM(cm *
 		oadpv1alpha1.OadpOperatorLabel: "True",
 	}
 
+	// Apply user-provided resource labels (protected labels are filtered)
+	cm.Labels = applyResourceLabels(r.dpa, cm.Labels)
+
+	// Apply user-provided resource annotations
+	cm.Annotations = applyResourceAnnotations(r.dpa, cm.Annotations)
+
 	if cm.Data == nil {
 		cm.Data = make(map[string]string)
 	}

--- a/internal/controller/velero.go
+++ b/internal/controller/velero.go
@@ -250,6 +250,15 @@ func (r *DataProtectionApplicationReconciler) customizeVeleroDeployment(veleroDe
 		}
 	}
 
+	// Apply user-provided resource labels (protected labels are filtered)
+	// Note: NOT applied to Spec.Selector.MatchLabels as those are immutable after creation
+	veleroDeployment.Labels = applyResourceLabels(dpa, veleroDeployment.Labels)
+	veleroDeployment.Spec.Template.Labels = applyResourceLabels(dpa, veleroDeployment.Spec.Template.Labels)
+
+	// Apply user-provided resource annotations to both deployment and pod template
+	veleroDeployment.Annotations = applyResourceAnnotations(dpa, veleroDeployment.Annotations)
+	veleroDeployment.Spec.Template.Annotations = applyResourceAnnotations(dpa, veleroDeployment.Spec.Template.Annotations)
+
 	// Selector: veleroDeployment.Spec.Selector,
 	replicas := int32(1)
 	if value, present := os.LookupEnv(VeleroReplicaOverride); present {
@@ -775,6 +784,76 @@ func getAppLabels(instanceName string) map[string]string {
 		labels["app.kubernetes.io/instance"] = instanceName
 	}
 	return labels
+}
+
+// protectedLabelPrefixes are label key prefixes that cannot be overridden by user-provided resourceLabels
+var protectedLabelPrefixes = []string{
+	"app.kubernetes.io/",
+}
+
+// protectedLabels are specific label keys that cannot be overridden by user-provided resourceLabels
+var protectedLabels = []string{
+	oadpv1alpha1.OadpOperatorLabel, // openshift.io/oadp
+	common.RegistryDeploymentLabel,
+}
+
+// isProtectedLabel checks if a label key is protected and cannot be overridden
+func isProtectedLabel(key string) bool {
+	for _, prefix := range protectedLabelPrefixes {
+		if strings.HasPrefix(key, prefix) {
+			return true
+		}
+	}
+	for _, protected := range protectedLabels {
+		if key == protected {
+			return true
+		}
+	}
+	return false
+}
+
+// applyResourceLabels merges DPA resourceLabels with core labels.
+// Core labels take precedence - protected labels from user input are filtered out.
+// Returns a new map containing core labels plus non-protected user labels.
+func applyResourceLabels(dpa *oadpv1alpha1.DataProtectionApplication, coreLabels map[string]string) map[string]string {
+	if dpa == nil || dpa.Spec.ResourceLabels == nil {
+		return coreLabels
+	}
+
+	// Start with core labels
+	result := make(map[string]string)
+	for k, v := range coreLabels {
+		result[k] = v
+	}
+
+	// Add user labels, skipping protected ones
+	for k, v := range dpa.Spec.ResourceLabels {
+		if !isProtectedLabel(k) {
+			result[k] = v
+		}
+	}
+
+	return result
+}
+
+// applyResourceAnnotations merges DPA resourceAnnotations with existing annotations.
+// User-provided annotations are added to existing annotations. User annotations take precedence
+// for any conflicting keys.
+func applyResourceAnnotations(dpa *oadpv1alpha1.DataProtectionApplication, existingAnnotations map[string]string) map[string]string {
+	if dpa == nil || dpa.Spec.ResourceAnnotations == nil {
+		return existingAnnotations
+	}
+
+	result := make(map[string]string)
+	for k, v := range existingAnnotations {
+		result[k] = v
+	}
+
+	for k, v := range dpa.Spec.ResourceAnnotations {
+		result[k] = v
+	}
+
+	return result
 }
 
 // getResourceListFrom get the values of cpu, memory and ephemeral-storage from

--- a/internal/controller/velero.go
+++ b/internal/controller/velero.go
@@ -9,11 +9,6 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
-	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
-	"github.com/openshift/oadp-operator/pkg/common"
-	"github.com/openshift/oadp-operator/pkg/credentials"
-	"github.com/openshift/oadp-operator/pkg/credentials/stsflow"
-	veleroserver "github.com/openshift/oadp-operator/pkg/velero/server"
 	"github.com/operator-framework/operator-lib/proxy"
 	"github.com/sirupsen/logrus"
 	"github.com/vmware-tanzu/velero/pkg/install"
@@ -30,6 +25,12 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
+	"github.com/openshift/oadp-operator/pkg/common"
+	"github.com/openshift/oadp-operator/pkg/credentials"
+	"github.com/openshift/oadp-operator/pkg/credentials/stsflow"
+	veleroserver "github.com/openshift/oadp-operator/pkg/velero/server"
 )
 
 const (

--- a/internal/controller/velero.go
+++ b/internal/controller/velero.go
@@ -9,6 +9,11 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
+	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
+	"github.com/openshift/oadp-operator/pkg/common"
+	"github.com/openshift/oadp-operator/pkg/credentials"
+	"github.com/openshift/oadp-operator/pkg/credentials/stsflow"
+	veleroserver "github.com/openshift/oadp-operator/pkg/velero/server"
 	"github.com/operator-framework/operator-lib/proxy"
 	"github.com/sirupsen/logrus"
 	"github.com/vmware-tanzu/velero/pkg/install"
@@ -25,12 +30,6 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-
-	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
-	"github.com/openshift/oadp-operator/pkg/common"
-	"github.com/openshift/oadp-operator/pkg/credentials"
-	"github.com/openshift/oadp-operator/pkg/credentials/stsflow"
-	veleroserver "github.com/openshift/oadp-operator/pkg/velero/server"
 )
 
 const (
@@ -855,10 +854,13 @@ func filterOutResourceLabels(dpa *oadpv1alpha1.DataProtectionApplication, labels
 		result[k] = v
 	}
 
-	// Remove resourceLabels if present
+	// Remove resourceLabels if present, but skip protected labels
+	// Protected labels should always be preserved in matchLabels
 	if dpa != nil && dpa.Spec.ResourceLabels != nil {
 		for k := range dpa.Spec.ResourceLabels {
-			delete(result, k)
+			if !isProtectedLabel(k) {
+				delete(result, k)
+			}
 		}
 	}
 

--- a/internal/controller/velero.go
+++ b/internal/controller/velero.go
@@ -188,6 +188,10 @@ func (r *DataProtectionApplicationReconciler) buildVeleroDeployment(veleroDeploy
 		uploaderType = dpa.Spec.Configuration.NodeAgent.UploaderType
 	}
 
+	// Filter out resourceLabels before passing to install.Deployment
+	// This ensures matchLabels don't contain resourceLabels (which would cause immutable selector errors on reconcile)
+	labelsForInstall := filterOutResourceLabels(dpa, veleroDeployment.Labels)
+
 	installDeployment := install.Deployment(veleroDeployment.Namespace,
 		install.WithResources(veleroResourceReqs),
 		install.WithImage(getVeleroImage(dpa)),
@@ -195,7 +199,7 @@ func (r *DataProtectionApplicationReconciler) buildVeleroDeployment(veleroDeploy
 		install.WithFeatures(dpa.Spec.Configuration.Velero.FeatureFlags),
 		install.WithUploaderType(uploaderType),
 		// last label overrides previous ones
-		install.WithLabels(veleroDeployment.Labels),
+		install.WithLabels(labelsForInstall),
 		// use WithSecret false even if we have secret because we use a different VolumeMounts and EnvVars
 		// see: https://github.com/vmware-tanzu/velero/blob/ed5809b7fc22f3661eeef10bdcb63f0d74472b76/pkg/install/deployment.go#L223-L261
 		// our secrets are appended to containers/volumeMounts in credentials.AppendPluginSpecificSpecs function
@@ -234,7 +238,10 @@ func (r *DataProtectionApplicationReconciler) customizeVeleroDeployment(veleroDe
 	if veleroDeployment.Spec.Selector.MatchLabels == nil {
 		veleroDeployment.Spec.Selector.MatchLabels = make(map[string]string)
 	}
-	veleroDeployment.Spec.Selector.MatchLabels, err = common.AppendUniqueKeyTOfTMaps(veleroDeployment.Spec.Selector.MatchLabels, veleroDeployment.Labels, getDpaAppLabels(dpa))
+	// Filter out resourceLabels from veleroDeployment.Labels before adding to matchLabels
+	// matchLabels are immutable, so we must not include resourceLabels which are user-configurable
+	labelsForMatchLabels := filterOutResourceLabels(dpa, veleroDeployment.Labels)
+	veleroDeployment.Spec.Selector.MatchLabels, err = common.AppendUniqueKeyTOfTMaps(veleroDeployment.Spec.Selector.MatchLabels, labelsForMatchLabels, getDpaAppLabels(dpa))
 	if err != nil {
 		return fmt.Errorf("velero deployment selector label: %v", err)
 	}
@@ -830,6 +837,28 @@ func applyResourceLabels(dpa *oadpv1alpha1.DataProtectionApplication, coreLabels
 	for k, v := range dpa.Spec.ResourceLabels {
 		if !isProtectedLabel(k) {
 			result[k] = v
+		}
+	}
+
+	return result
+}
+
+// filterOutResourceLabels removes resourceLabels from the given labels map.
+// This is used to get labels that are safe for matchLabels (which are immutable).
+func filterOutResourceLabels(dpa *oadpv1alpha1.DataProtectionApplication, labels map[string]string) map[string]string {
+	if labels == nil {
+		return nil
+	}
+
+	result := make(map[string]string)
+	for k, v := range labels {
+		result[k] = v
+	}
+
+	// Remove resourceLabels if present
+	if dpa != nil && dpa.Spec.ResourceLabels != nil {
+		for k := range dpa.Spec.ResourceLabels {
+			delete(result, k)
 		}
 	}
 

--- a/internal/controller/velero_test.go
+++ b/internal/controller/velero_test.go
@@ -3404,3 +3404,268 @@ func TestDPAReconciler_buildVeleroDeploymentWithAzureWorkloadIdentity(t *testing
 		})
 	}
 }
+
+func TestIsProtectedLabel(t *testing.T) {
+	tests := []struct {
+		name     string
+		key      string
+		expected bool
+	}{
+		{
+			name:     "app.kubernetes.io prefix is protected",
+			key:      "app.kubernetes.io/name",
+			expected: true,
+		},
+		{
+			name:     "app.kubernetes.io/managed-by is protected",
+			key:      "app.kubernetes.io/managed-by",
+			expected: true,
+		},
+		{
+			name:     "app.kubernetes.io/custom is protected",
+			key:      "app.kubernetes.io/custom-label",
+			expected: true,
+		},
+		{
+			name:     "openshift.io/oadp is protected",
+			key:      oadpv1alpha1.OadpOperatorLabel,
+			expected: true,
+		},
+		{
+			name:     "oadp.openshift.io/registry is protected",
+			key:      common.RegistryDeploymentLabel,
+			expected: true,
+		},
+		{
+			name:     "custom label is not protected",
+			key:      "custom-label",
+			expected: false,
+		},
+		{
+			name:     "argocd annotation key is not protected",
+			key:      "argocd.argoproj.io/sync-options",
+			expected: false,
+		},
+		{
+			name:     "team label is not protected",
+			key:      "team.example.com/owner",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isProtectedLabel(tt.key)
+			if result != tt.expected {
+				t.Errorf("isProtectedLabel(%q) = %v, expected %v", tt.key, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestApplyResourceLabels(t *testing.T) {
+	tests := []struct {
+		name           string
+		dpa            *oadpv1alpha1.DataProtectionApplication
+		coreLabels     map[string]string
+		expectedLabels map[string]string
+	}{
+		{
+			name: "nil DPA returns core labels",
+			dpa:  nil,
+			coreLabels: map[string]string{
+				"app.kubernetes.io/name": "velero",
+			},
+			expectedLabels: map[string]string{
+				"app.kubernetes.io/name": "velero",
+			},
+		},
+		{
+			name: "nil resourceLabels returns core labels",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					ResourceLabels: nil,
+				},
+			},
+			coreLabels: map[string]string{
+				"app.kubernetes.io/name": "velero",
+			},
+			expectedLabels: map[string]string{
+				"app.kubernetes.io/name": "velero",
+			},
+		},
+		{
+			name: "user labels are merged with core labels",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					ResourceLabels: map[string]string{
+						"custom-label": "custom-value",
+						"team":         "backup",
+					},
+				},
+			},
+			coreLabels: map[string]string{
+				"app.kubernetes.io/name": "velero",
+			},
+			expectedLabels: map[string]string{
+				"app.kubernetes.io/name": "velero",
+				"custom-label":           "custom-value",
+				"team":                   "backup",
+			},
+		},
+		{
+			name: "protected labels are filtered from user input",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					ResourceLabels: map[string]string{
+						"app.kubernetes.io/name":       "user-override", // should be ignored
+						"app.kubernetes.io/managed-by": "user-manager", // should be ignored
+						"custom-label":                 "custom-value", // should be included
+					},
+				},
+			},
+			coreLabels: map[string]string{
+				"app.kubernetes.io/name":       "velero",
+				"app.kubernetes.io/managed-by": common.OADPOperator,
+			},
+			expectedLabels: map[string]string{
+				"app.kubernetes.io/name":       "velero",       // core label preserved
+				"app.kubernetes.io/managed-by": common.OADPOperator, // core label preserved
+				"custom-label":                 "custom-value", // user label added
+			},
+		},
+		{
+			name: "argocd labels are allowed",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					ResourceLabels: map[string]string{
+						"argocd.argoproj.io/sync-options": "ServerSideApply=true",
+					},
+				},
+			},
+			coreLabels: map[string]string{
+				"app.kubernetes.io/name": "velero",
+			},
+			expectedLabels: map[string]string{
+				"app.kubernetes.io/name":          "velero",
+				"argocd.argoproj.io/sync-options": "ServerSideApply=true",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := applyResourceLabels(tt.dpa, tt.coreLabels)
+			if !reflect.DeepEqual(result, tt.expectedLabels) {
+				t.Errorf("applyResourceLabels() = %v, expected %v", result, tt.expectedLabels)
+			}
+		})
+	}
+}
+
+func TestApplyResourceAnnotations(t *testing.T) {
+	tests := []struct {
+		name                string
+		dpa                 *oadpv1alpha1.DataProtectionApplication
+		existingAnnotations map[string]string
+		expectedAnnotations map[string]string
+	}{
+		{
+			name: "nil DPA returns existing annotations",
+			dpa:  nil,
+			existingAnnotations: map[string]string{
+				"existing": "annotation",
+			},
+			expectedAnnotations: map[string]string{
+				"existing": "annotation",
+			},
+		},
+		{
+			name: "nil resourceAnnotations returns existing annotations",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					ResourceAnnotations: nil,
+				},
+			},
+			existingAnnotations: map[string]string{
+				"existing": "annotation",
+			},
+			expectedAnnotations: map[string]string{
+				"existing": "annotation",
+			},
+		},
+		{
+			name: "user annotations are merged with existing",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					ResourceAnnotations: map[string]string{
+						"custom-annotation": "custom-value",
+					},
+				},
+			},
+			existingAnnotations: map[string]string{
+				"existing": "annotation",
+			},
+			expectedAnnotations: map[string]string{
+				"existing":          "annotation",
+				"custom-annotation": "custom-value",
+			},
+		},
+		{
+			name: "user annotations override existing on conflict",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					ResourceAnnotations: map[string]string{
+						"existing": "user-value",
+					},
+				},
+			},
+			existingAnnotations: map[string]string{
+				"existing": "annotation",
+			},
+			expectedAnnotations: map[string]string{
+				"existing": "user-value", // user value wins
+			},
+		},
+		{
+			name: "argocd ignore-resource-updates annotation",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					ResourceAnnotations: map[string]string{
+						"argocd.argoproj.io/ignore-resource-updates": "true",
+					},
+				},
+			},
+			existingAnnotations: map[string]string{
+				"prometheus.io/scrape": "true",
+			},
+			expectedAnnotations: map[string]string{
+				"prometheus.io/scrape":                       "true",
+				"argocd.argoproj.io/ignore-resource-updates": "true",
+			},
+		},
+		{
+			name: "nil existing annotations",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					ResourceAnnotations: map[string]string{
+						"custom": "value",
+					},
+				},
+			},
+			existingAnnotations: nil,
+			expectedAnnotations: map[string]string{
+				"custom": "value",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := applyResourceAnnotations(tt.dpa, tt.existingAnnotations)
+			if !reflect.DeepEqual(result, tt.expectedAnnotations) {
+				t.Errorf("applyResourceAnnotations() = %v, expected %v", result, tt.expectedAnnotations)
+			}
+		})
+	}
+}

--- a/internal/controller/velero_test.go
+++ b/internal/controller/velero_test.go
@@ -21,6 +21,10 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
+	oadpclient "github.com/openshift/oadp-operator/pkg/client"
+	"github.com/openshift/oadp-operator/pkg/common"
+	"github.com/openshift/oadp-operator/pkg/credentials/stsflow"
 	"github.com/operator-framework/operator-lib/proxy"
 	"github.com/sirupsen/logrus"
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
@@ -33,11 +37,6 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
-	oadpclient "github.com/openshift/oadp-operator/pkg/client"
-	"github.com/openshift/oadp-operator/pkg/common"
-	"github.com/openshift/oadp-operator/pkg/credentials/stsflow"
 )
 
 const (
@@ -3519,8 +3518,8 @@ func TestApplyResourceLabels(t *testing.T) {
 				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
 					ResourceLabels: map[string]string{
 						"app.kubernetes.io/name":       "user-override", // should be ignored
-						"app.kubernetes.io/managed-by": "user-manager", // should be ignored
-						"custom-label":                 "custom-value", // should be included
+						"app.kubernetes.io/managed-by": "user-manager",  // should be ignored
+						"custom-label":                 "custom-value",  // should be included
 					},
 				},
 			},
@@ -3529,9 +3528,9 @@ func TestApplyResourceLabels(t *testing.T) {
 				"app.kubernetes.io/managed-by": common.OADPOperator,
 			},
 			expectedLabels: map[string]string{
-				"app.kubernetes.io/name":       "velero",       // core label preserved
+				"app.kubernetes.io/name":       "velero",            // core label preserved
 				"app.kubernetes.io/managed-by": common.OADPOperator, // core label preserved
-				"custom-label":                 "custom-value", // user label added
+				"custom-label":                 "custom-value",      // user label added
 			},
 		},
 		{

--- a/internal/controller/velero_test.go
+++ b/internal/controller/velero_test.go
@@ -21,10 +21,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
-	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
-	oadpclient "github.com/openshift/oadp-operator/pkg/client"
-	"github.com/openshift/oadp-operator/pkg/common"
-	"github.com/openshift/oadp-operator/pkg/credentials/stsflow"
 	"github.com/operator-framework/operator-lib/proxy"
 	"github.com/sirupsen/logrus"
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
@@ -37,6 +33,11 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
+	oadpclient "github.com/openshift/oadp-operator/pkg/client"
+	"github.com/openshift/oadp-operator/pkg/common"
+	"github.com/openshift/oadp-operator/pkg/credentials/stsflow"
 )
 
 const (

--- a/internal/controller/vmfilerestore_controller.go
+++ b/internal/controller/vmfilerestore_controller.go
@@ -135,6 +135,16 @@ func (r *DataProtectionApplicationReconciler) buildVMFileRestoreDeployment(deplo
 	if err != nil {
 		return err
 	}
+
+	// Apply user-provided resource labels (protected labels are filtered)
+	// Note: NOT applied to Spec.Selector.MatchLabels as those are immutable after creation
+	deploymentObject.Labels = applyResourceLabels(r.dpa, deploymentObject.Labels)
+	deploymentObject.Spec.Template.Labels = applyResourceLabels(r.dpa, deploymentObject.Spec.Template.Labels)
+
+	// Apply user-provided resource annotations to both deployment and pod template
+	deploymentObject.Annotations = applyResourceAnnotations(r.dpa, deploymentObject.Annotations)
+	deploymentObject.Spec.Template.Annotations = applyResourceAnnotations(r.dpa, deploymentObject.Spec.Template.Annotations)
+
 	return nil
 }
 

--- a/internal/controller/vmfilerestore_controller.go
+++ b/internal/controller/vmfilerestore_controller.go
@@ -7,8 +7,6 @@ import (
 	"strconv"
 
 	"github.com/go-logr/logr"
-	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
-	"github.com/openshift/oadp-operator/pkg/common"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/exp/maps"
 	appsv1 "k8s.io/api/apps/v1"
@@ -21,6 +19,9 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
+	"github.com/openshift/oadp-operator/pkg/common"
 )
 
 const (

--- a/internal/controller/vmfilerestore_controller.go
+++ b/internal/controller/vmfilerestore_controller.go
@@ -7,6 +7,8 @@ import (
 	"strconv"
 
 	"github.com/go-logr/logr"
+	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
+	"github.com/openshift/oadp-operator/pkg/common"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/exp/maps"
 	appsv1 "k8s.io/api/apps/v1"
@@ -19,9 +21,6 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-
-	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
-	"github.com/openshift/oadp-operator/pkg/common"
 )
 
 const (
@@ -140,6 +139,17 @@ func (r *DataProtectionApplicationReconciler) buildVMFileRestoreDeployment(deplo
 	// Note: NOT applied to Spec.Selector.MatchLabels as those are immutable after creation
 	deploymentObject.Labels = applyResourceLabels(r.dpa, deploymentObject.Labels)
 	deploymentObject.Spec.Template.Labels = applyResourceLabels(r.dpa, deploymentObject.Spec.Template.Labels)
+
+	// Re-assert selector labels to ensure template labels match selector
+	// This prevents user resourceLabels from overriding selector-critical labels
+	if deploymentObject.Spec.Selector != nil && deploymentObject.Spec.Selector.MatchLabels != nil {
+		if deploymentObject.Spec.Template.Labels == nil {
+			deploymentObject.Spec.Template.Labels = make(map[string]string)
+		}
+		for k, v := range deploymentObject.Spec.Selector.MatchLabels {
+			deploymentObject.Spec.Template.Labels[k] = v
+		}
+	}
 
 	// Apply user-provided resource annotations to both deployment and pod template
 	deploymentObject.Annotations = applyResourceAnnotations(r.dpa, deploymentObject.Annotations)

--- a/internal/controller/vsl.go
+++ b/internal/controller/vsl.go
@@ -227,6 +227,12 @@ func (r *DataProtectionApplicationReconciler) ReconcileVolumeSnapshotLocations(l
 				oadpv1alpha1.OadpOperatorLabel: "True",
 			}
 
+			// Apply user-provided resource labels (protected labels are filtered)
+			vsl.Labels = applyResourceLabels(dpa, vsl.Labels)
+
+			// Apply user-provided resource annotations
+			vsl.Annotations = applyResourceAnnotations(dpa, vsl.Annotations)
+
 			vsl.Spec = *vslSpec.Velero
 			return nil
 		})


### PR DESCRIPTION
## Summary
- Add `resourceLabels` and `resourceAnnotations` fields to the DataProtectionApplication spec
- These fields propagate user-defined labels/annotations to all child resources managed by the DPA
- Primary use case: Setting `argocd.argoproj.io/ignore-resource-updates: 'true'` to prevent ArgoCD from reconciling on BSL status updates

## Scope

**This feature is scoped ONLY to resources that the OADP operator creates and reconciles.** It does NOT affect:
- User-created resources in the namespace
- Velero-created resources (Backup, Restore, PodVolumeBackup, etc.)

The labels and annotations are applied during the DPA reconciliation loop to resources that the OADP operator directly manages.

## Resources Affected
- BackupStorageLocations
- VolumeSnapshotLocations
- Velero Deployment
- NodeAgent DaemonSet and ConfigMap
- BackupRepository ConfigMap
- RepositoryMaintenance ConfigMap
- VeleroMetrics Service
- Registry Secrets
- NonAdmin Controller Deployment
- VMFileRestore Controller Deployment

## Usage Example
```yaml
apiVersion: oadp.openshift.io/v1alpha1
kind: DataProtectionApplication
metadata:
  name: velero-dpa
spec:
  resourceLabels:
    custom-label: custom-value
  resourceAnnotations:
    argocd.argoproj.io/ignore-resource-updates: "true"
  # ... rest of spec
```

## Test plan
- [ ] Unit tests added for helper functions (`TestIsProtectedLabel`, `TestApplyResourceLabels`, `TestApplyResourceAnnotations`)
- [ ] Verify labels/annotations propagate to BSL
- [ ] Verify labels/annotations propagate to VSL
- [ ] Verify labels/annotations propagate to Velero Deployment
- [ ] Verify labels/annotations propagate to NodeAgent DaemonSet
- [ ] Verify protected labels (app.kubernetes.io/*) cannot be overridden

Fixes: https://issues.redhat.com/browse/OADP-6846

🤖 Generated with [Claude Code](https://claude.com/claude-code)