### PR TITLE
update operator-sdk version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -545,7 +545,8 @@ deploy-olm: undeploy-olm ## Build current branch operator image, bundle image, p
 	IMG=$(THIS_OPERATOR_IMAGE) BUNDLE_IMG=$(THIS_BUNDLE_IMAGE) \
 		make docker-build docker-push bundle bundle-build bundle-push; \
 	chmod -R 777 $(DEPLOY_TMP) && rm -rf $(DEPLOY_TMP)
-	$(OPERATOR_SDK) run bundle --security-context-config restricted $(THIS_BUNDLE_IMAGE) --namespace $(OADP_TEST_NAMESPACE)
+	$(OC_CLI) label --overwrite ns $(OADP_TEST_NAMESPACE) pod-security.kubernetes.io/enforce=privileged security.openshift.io/scc.podSecurityLabelSync=false || true
+	$(OPERATOR_SDK) run bundle --security-context-config restricted $(THIS_BUNDLE_IMAGE) --namespace $(OADP_TEST_NAMESPACE) --timeout 5m
 
 .PHONY: undeploy-olm
 undeploy-olm: login-required operator-sdk ## Uninstall current branch operator via OLM

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # All version-related variables are defined here for easy maintenance
 DEFAULT_VERSION := 99.0.0
 VERSION ?= $(DEFAULT_VERSION) # the version of the operator
-OPERATOR_SDK_VERSION ?= v1.35.0
+OPERATOR_SDK_VERSION ?= v1.42.0
 ENVTEST_K8S_VERSION = 1.32 #refers to the version of kubebuilder assets to be downloaded by envtest binary # Kubernetes version from OpenShift 4.19.x
 GOLANGCI_LINT_VERSION ?= v2.6.1
 KUSTOMIZE_VERSION ?= v5.2.1


### PR DESCRIPTION
## Why the changes were made

make deploy-olm was failing w/
```
INFO[0012] Creating a File-Based Catalog of the bundle "ttl.sh/oadp-operator-bundle-f509f50a:1h" 
INFO[0014] Generated a valid File-Based Catalog         
FATA[0015] Failed to run bundle: create catalog: error creating registry pod: error creating pod: pods "ttl-sh-oadp-operator-bundle-f509f50a-1h" is forbidden: violates PodSecurity "restricted:latest": allowPrivilegeEscalation != false (container "registry-grpc-init" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "registry-grpc-init" must set securityContext.capabilities.drop=["ALL"]) 
make: *** [Makefile:545: deploy-olm] Error 1
```

## How to test the changes made

On a OCP 4.21 cluster I was unable to deploy the dev build