### PR TITLE
fix: update container images to use quay.io for consistency and security

### DIFF
--- a/tests/e2e/sample-applications/minimal-8csivol/minimal-3csivol.yaml
+++ b/tests/e2e/sample-applications/minimal-8csivol/minimal-3csivol.yaml
@@ -53,7 +53,7 @@ spec:
           limits:
             cpu: 100m
             memory: 100Mi
-        image: alpine
+        image: quay.io/migtools/alpine:latest
         securityContext:
           runAsNonRoot: true
           allowPrivilegeEscalation: false

--- a/tests/e2e/sample-applications/minimal-8csivol/minimal-8csivol.yaml
+++ b/tests/e2e/sample-applications/minimal-8csivol/minimal-8csivol.yaml
@@ -37,7 +37,7 @@ spec:
           limits:
             cpu: 100m
             memory: 100Mi
-        image: alpine
+        image: quay.io/migtools/alpine:latest
         securityContext:
           runAsNonRoot: true
           allowPrivilegeEscalation: false

--- a/tests/e2e/sample-applications/mongo-persistent/mongo-persistent-block.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/mongo-persistent-block.yaml
@@ -71,7 +71,7 @@ items:
           # Used to format the block device (put filesystem on it).
           # This allows Mongo to use the filesystem which lives on block device.
           initContainers:
-            - image: docker.io/library/mongo:7.0
+            - image: quay.io/migtools/mongo:7.0.28
               imagePullPolicy: IfNotPresent
               securityContext:
                 privileged: true
@@ -102,7 +102,7 @@ items:
                 - name: block-volume-pv
                   devicePath: /dev/xvdx
           containers:
-            - image: docker.io/library/mongo:7.0
+            - image: quay.io/migtools/mongo:7.0.28
               name: mongo
               securityContext:
                 privileged: true
@@ -165,7 +165,7 @@ items:
                 timeoutSeconds: 5
                 successThreshold: 1
                 failureThreshold: 12 # 12x10sec = 2min before restart pod
-            - image: docker.io/curlimages/curl:8.5.0
+            - image: registry.access.redhat.com/ubi8/ubi:latest
               name: curl-tool
               command: ["/bin/sleep", "infinity"]
           volumes:
@@ -236,7 +236,7 @@ items:
               periodSeconds: 5
           initContainers:
           - name: init-myservice
-            image: docker.io/curlimages/curl:8.5.0
+            image: registry.access.redhat.com/ubi8/ubi:latest
             command: ['sh', '-c', 'sleep 30; max_attempts=180; attempt=0; until curl -s --connect-timeout 2 mongo:27017 || [ $attempt -ge $max_attempts ]; do attempt=$((attempt+1)); echo "Attempt $attempt/$max_attempts: Trying to connect to mongo DB port"; sleep 5; done; if [ $attempt -ge $max_attempts ]; then echo "ERROR: Failed to connect to mongo after $max_attempts attempts"; exit 1; fi; echo "mongo DB port reachable"']
   - apiVersion: v1
     kind: Service

--- a/tests/e2e/sample-applications/mongo-persistent/mongo-persistent-csi.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/mongo-persistent-csi.yaml
@@ -67,7 +67,7 @@ items:
         spec:
           serviceAccountName: mongo-persistent-sa
           containers:
-          - image: docker.io/library/mongo:7.0
+          - image: quay.io/migtools/mongo:7.0.28
             imagePullPolicy: IfNotPresent
             name: mongo
             securityContext:
@@ -122,7 +122,7 @@ items:
               timeoutSeconds: 5
               successThreshold: 1
               failureThreshold: 12 # 12x10sec = 2min before restart pod
-          - image: docker.io/curlimages/curl:8.5.0
+          - image: registry.access.redhat.com/ubi8/ubi:latest
             name: curl-tool
             command: ["/bin/sleep", "infinity"]
           volumes:
@@ -193,7 +193,7 @@ items:
               periodSeconds: 5
           initContainers:
           - name: init-myservice
-            image: docker.io/curlimages/curl:8.5.0
+            image: registry.access.redhat.com/ubi8/ubi:latest
             command: ['sh', '-c', 'sleep 30; max_attempts=180; attempt=0; until curl -s --connect-timeout 2 mongo:27017 || [ $attempt -ge $max_attempts ]; do attempt=$((attempt+1)); echo "Attempt $attempt/$max_attempts: Trying to connect to mongo DB port"; sleep 5; done; if [ $attempt -ge $max_attempts ]; then echo "ERROR: Failed to connect to mongo after $max_attempts attempts"; exit 1; fi; echo "mongo DB port reachable"']
   - apiVersion: v1
     kind: Service

--- a/tests/e2e/sample-applications/mongo-persistent/mongo-persistent.yaml
+++ b/tests/e2e/sample-applications/mongo-persistent/mongo-persistent.yaml
@@ -80,7 +80,7 @@ items:
         spec:
           serviceAccountName: mongo-persistent-sa
           containers:
-          - image: docker.io/library/mongo:7.0
+          - image: quay.io/migtools/mongo:7.0.28
             imagePullPolicy: IfNotPresent
             name: mongo
             securityContext:
@@ -135,7 +135,7 @@ items:
               timeoutSeconds: 5
               successThreshold: 1
               failureThreshold: 12 # 12x10sec = 2min before restart pod
-          - image: docker.io/curlimages/curl:8.5.0
+          - image: registry.access.redhat.com/ubi8/ubi:latest
             name: curl-tool
             command: ["/bin/sleep", "infinity"]
           volumes:
@@ -206,7 +206,7 @@ items:
               periodSeconds: 5
           initContainers:
           - name: init-myservice
-            image: docker.io/curlimages/curl:8.5.0
+            image: registry.access.redhat.com/ubi8/ubi:latest
             command: ['sh', '-c', 'sleep 30; max_attempts=180; attempt=0; until curl -s --connect-timeout 2 mongo:27017 || [ $attempt -ge $max_attempts ]; do attempt=$((attempt+1)); echo "Attempt $attempt/$max_attempts: Trying to connect to mongo DB port"; sleep 5; done; if [ $attempt -ge $max_attempts ]; then echo "ERROR: Failed to connect to mongo after $max_attempts attempts"; exit 1; fi; echo "mongo DB port reachable"']
   - apiVersion: v1
     kind: Service

--- a/tests/e2e/sample-applications/mysql-persistent/mysql-persistent-csi.yaml
+++ b/tests/e2e/sample-applications/mysql-persistent/mysql-persistent-csi.yaml
@@ -155,7 +155,7 @@ items:
               timeoutSeconds: 2
               successThreshold: 1
               failureThreshold: 40 # 40x30sec before restart pod
-          - image: docker.io/curlimages/curl:8.5.0
+          - image: registry.access.redhat.com/ubi8/ubi:latest
             name: curl-tool
             command: ["/bin/sleep", "infinity"]
           volumes:
@@ -226,7 +226,7 @@ items:
               periodSeconds: 5
           initContainers:
           - name: init-myservice
-            image: docker.io/curlimages/curl:8.5.0
+            image: registry.access.redhat.com/ubi8/ubi:latest
             command: ['sh', '-c', 'sleep 30; max_attempts=180; attempt=0; until /usr/bin/nc -z -w 1 mysql 3306 || [ $attempt -ge $max_attempts ]; do attempt=$((attempt+1)); echo "Attempt $attempt/$max_attempts: Trying to connect to mysql DB port"; sleep 5; done; if [ $attempt -ge $max_attempts ]; then echo "ERROR: Failed to connect to mysql after $max_attempts attempts"; exit 1; fi; echo "mysql DB port reachable"']
   - apiVersion: route.openshift.io/v1
     kind: Route

--- a/tests/e2e/sample-applications/mysql-persistent/mysql-persistent-twovol-csi.yaml
+++ b/tests/e2e/sample-applications/mysql-persistent/mysql-persistent-twovol-csi.yaml
@@ -147,7 +147,7 @@ items:
               timeoutSeconds: 2
               successThreshold: 1
               failureThreshold: 40 # 40x30sec before restart pod
-          - image: docker.io/curlimages/curl:8.5.0
+          - image: registry.access.redhat.com/ubi8/ubi:latest
             name: curl-tool
             command: ["/bin/sleep", "infinity"]
           volumes:
@@ -224,7 +224,7 @@ items:
               claimName: applog
           initContainers:
           - name: init-myservice
-            image: docker.io/curlimages/curl:8.5.0
+            image: registry.access.redhat.com/ubi8/ubi:latest
             command: ['sh', '-c', 'sleep 30; max_attempts=180; attempt=0; until /usr/bin/nc -z -w 1 mysql 3306 || [ $attempt -ge $max_attempts ]; do attempt=$((attempt+1)); echo "Attempt $attempt/$max_attempts: Trying to connect to mysql DB port"; sleep 5; done; if [ $attempt -ge $max_attempts ]; then echo "ERROR: Failed to connect to mysql after $max_attempts attempts"; exit 1; fi; echo "mysql DB port reachable"']
   - apiVersion: route.openshift.io/v1
     kind: Route

--- a/tests/e2e/sample-applications/mysql-persistent/mysql-persistent.yaml
+++ b/tests/e2e/sample-applications/mysql-persistent/mysql-persistent.yaml
@@ -168,7 +168,7 @@ items:
               timeoutSeconds: 2
               successThreshold: 1
               failureThreshold: 40 # 40x30sec before restart pod
-          - image: docker.io/curlimages/curl:8.5.0
+          - image: registry.access.redhat.com/ubi8/ubi:latest
             name: curl-tool
             command: ["/bin/sleep", "infinity"]
           volumes:
@@ -239,7 +239,7 @@ items:
               periodSeconds: 5
           initContainers:
           - name: init-myservice
-            image: docker.io/curlimages/curl:8.5.0
+            image: registry.access.redhat.com/ubi8/ubi:latest
             command: ['sh', '-c', 'sleep 30; max_attempts=180; attempt=0; until /usr/bin/nc -z -w 1 mysql 3306 || [ $attempt -ge $max_attempts ]; do attempt=$((attempt+1)); echo "Attempt $attempt/$max_attempts: Trying to connect to mysql DB port"; sleep 5; done; if [ $attempt -ge $max_attempts ]; then echo "ERROR: Failed to connect to mysql after $max_attempts attempts"; exit 1; fi; echo "mysql DB port reachable"']
   - apiVersion: route.openshift.io/v1
     kind: Route

--- a/tests/e2e/sample-applications/nginx/nginx-deployment.yaml
+++ b/tests/e2e/sample-applications/nginx/nginx-deployment.yaml
@@ -37,7 +37,7 @@ items:
           app: nginx
       spec:
         containers:
-        - image: bitnamisecure/nginx
+        - image: quay.io/migtools/nginx:latest
           name: nginx
           ports:
           - containerPort: 8080

--- a/tests/e2e/sample-applications/parks-app/manifest.yaml
+++ b/tests/e2e/sample-applications/parks-app/manifest.yaml
@@ -94,7 +94,7 @@ items:
           emptyDir: {}
         initContainers:
         - name: wait-for-mongodb
-          image: 'docker.io/library/mongo:7.0'
+          image: 'quay.io/migtools/mongo:7.0.28'
           command:
           - /bin/bash
           - -c
@@ -267,7 +267,7 @@ items:
       spec:
         containers:
         - name: mongodb-container
-          image: 'docker.io/library/mongo:7.0'
+          image: 'quay.io/migtools/mongo:7.0.28'
           ports:
           - containerPort: 27017
             protocol: TCP

--- a/tests/e2e/sample-applications/virtual-machines/fedora-todolist/fedora-todolist.yaml
+++ b/tests/e2e/sample-applications/virtual-machines/fedora-todolist/fedora-todolist.yaml
@@ -140,7 +140,7 @@ items:
               timeoutSeconds: 2
               successThreshold: 1
               failureThreshold: 40 # 40x30sec before restart pod
-          - image: docker.io/curlimages/curl:8.5.0
+          - image: registry.access.redhat.com/ubi8/ubi:latest
             name: curl-tool
             command: ["/bin/sleep", "infinity"]
           volumes:
@@ -199,7 +199,7 @@ items:
                 protocol: TCP
           initContainers:
           - name: init-myservice
-            image: docker.io/curlimages/curl:8.5.0
+            image: registry.access.redhat.com/ubi8/ubi:latest
             command: ['sh', '-c', 'sleep 30; max_attempts=180; attempt=0; until /usr/bin/nc -z -w 1 mysql 3306 || [ $attempt -ge $max_attempts ]; do attempt=$((attempt+1)); echo "Attempt $attempt/$max_attempts: Trying to connect to mysql DB port"; sleep 5; done; if [ $attempt -ge $max_attempts ]; then echo "ERROR: Failed to connect to mysql after $max_attempts attempts"; exit 1; fi; echo "mysql DB port reachable"']
   - apiVersion: route.openshift.io/v1
     kind: Route


### PR DESCRIPTION
Signed-off-by: Tiger Kaovilai <tkaovila@redhat.com>

## Why the changes were made

pull rate limits in ci

Mirrors automation live here
https://github.com/migtools/mig-demo-apps/tree/master/.github/workflows

## How to test the changes made
retest?
