### PR TITLE
golang lint ci v2 oadp 1.5

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,127 +1,102 @@
-# Documentation reference https://github.com/golangci/golangci-lint/blob/v1.55.2/.golangci.reference.yml
+version: "2"
 run:
-  skip-dirs-use-default: false
   modules-download-mode: readonly
   allow-parallel-runners: false
-
-output:
-  format: colored-line-number
-  print-issued-lines: true
-  print-linter-name: true
-  uniq-by-line: true
-  sort-results: true
-
-linters-settings:
-  dogsled:
-    max-blank-identifiers: 2
-  errcheck:
-    check-type-assertions: true
-    check-blank: true
-  gci:
-    sections:
-      - standard
-      - default
-      - prefix(github.com/openshift/oadp-operator)
-  goconst:
-    min-len: 3
-    min-occurrences: 5
-  gofmt:
-    simplify: true
-  goheader:
-    # copy from ./hack/boilerplate.go.txt
-    template: |-
-      Copyright 2021.
-
-      Licensed under the Apache License, Version 2.0 (the "License");
-      you may not use this file except in compliance with the License.
-      You may obtain a copy of the License at
-
-          http://www.apache.org/licenses/LICENSE-2.0
-
-      Unless required by applicable law or agreed to in writing, software
-      distributed under the License is distributed on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-      See the License for the specific language governing permissions and
-      limitations under the License.
-  govet:
-    enable-all: true
-  misspell:
-    locale: US
-  nakedret:
-    max-func-lines: 30
-  nolintlint:
-    allow-unused: false
-    allow-no-explanation: []
-    require-explanation: true
-    require-specific: true
-  revive:
-    # TODO enable!
-    # enable-all-rules: true
-    rules:
-      - name: line-length-limit
-        disabled: true
-      # TODO delete after
-      - name: blank-imports
-      - name: dot-imports
-      - name: duplicated-imports
-      - name: import-alias-naming
-      - name: import-shadowing
-      - name: redundant-import-alias
-  unparam:
-    check-exported: true
-
 linters:
-  disable-all: true
-  # TODO enable commented ones
+  default: none
   enable:
     - asasalint
     - asciicheck
     - bidichk
-    # - bodyclose
     - dogsled
-    # - dupword
-    # - durationcheck
-    # - errcheck
     - errchkjson
-    - exportloopref
-    - gci
-    # - ginkgolinter
-    # - goconst
-    - gofmt
-    # - goheader
     - goprintffuncname
-    # - gosec
-    # - gosimple
-    # - govet
-    # - ineffassign
     - loggercheck
-    # - misspell
     - nakedret
-    # - nilerr
-    # - noctx
     - nolintlint
     - nosprintfhostport
     - revive
-    # - staticcheck
-    # - stylecheck
-    # - unconvert
     - unparam
-    # - unused
     - usestdlibvars
-  fast: false
+  settings:
+    dogsled:
+      max-blank-identifiers: 2
+    errcheck:
+      check-type-assertions: true
+      check-blank: true
+    goconst:
+      min-len: 3
+      min-occurrences: 5
+    goheader:
+      template: |-
+        Copyright 2021.
 
+        Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+    govet:
+      enable-all: true
+    misspell:
+      locale: US
+    nakedret:
+      max-func-lines: 30
+    nolintlint:
+      require-explanation: true
+      require-specific: true
+      allow-unused: false
+    revive:
+      rules:
+        - name: line-length-limit
+          disabled: true
+        - name: blank-imports
+        - name: dot-imports
+        - name: duplicated-imports
+        - name: import-alias-naming
+        - name: import-shadowing
+        - name: redundant-import-alias
+    unparam:
+      check-exported: true
+  exclusions:
+    generated: lax
+    rules:
+      - linters:
+          - revive
+        text: '^struct-tag: unknown option ''inline'' in JSON tag$'
+      - linters:
+          - staticcheck
+        text: 'ST1000:|ST1020:|ST1021:|ST1022:'
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 issues:
-  exclude-use-default: false
-  exclude-rules:
-    - linters:
-        - revive
-      text: "^struct-tag: unknown option 'inline' in JSON tag$"
-    - linters:
-        - stylecheck
-      text: "ST1000:|ST1020:|ST1021:|ST1022:"
   max-issues-per-linter: 0
   max-same-issues: 0
-
 severity:
-  default-severity: error
-  case-sensitive: false
+  default: error
+formatters:
+  enable:
+    - gci
+    - gofmt
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(github.com/openshift/oadp-operator)
+    gofmt:
+      simplify: true
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ DEFAULT_VERSION := 1.5.4
 VERSION ?= $(DEFAULT_VERSION)
 OPERATOR_SDK_VERSION ?= v1.34.2
 ENVTEST_K8S_VERSION = 1.32 #refers to the version of kubebuilder assets to be downloaded by envtest binary # Kubernetes version from OpenShift 4.19.x
-GOLANGCI_LINT_VERSION ?= v1.55.2
+GOLANGCI_LINT_VERSION ?= v1.64.8
 KUSTOMIZE_VERSION ?= v5.2.1
 CONTROLLER_TOOLS_VERSION ?= v0.16.5
 OPM_VERSION ?= v1.23.0
@@ -193,11 +193,17 @@ test: check-go vet envtest ## Run unit tests; run Go linters checks; check if ap
 	@make bundle-isupdated
 	@make check-go-dependencies
 
+# Lint CLI needs to be built from the same toolchain version
 GOLANGCI_LINT = $(LOCALBIN)/$(BRANCH_VERSION)/golangci-lint
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
-	$(call go-install-tool-branch,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION))
+	@if [ -f $(GOLANGCI_LINT) ] && $(GOLANGCI_LINT) --version | grep -q $(GOLANGCI_LINT_VERSION); then \
+		echo "golangci-lint $(GOLANGCI_LINT_VERSION) is already installed"; \
+	else \
+		echo "Installing golangci-lint $(GOLANGCI_LINT_VERSION)"; \
+		$(call go-install-tool-branch,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)); \
+	fi
 	@if [ -L "$(LOCALBIN)/golangci-lint" ]; then \
 		unlink "$(LOCALBIN)/golangci-lint"; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ DEFAULT_VERSION := 1.5.4
 VERSION ?= $(DEFAULT_VERSION)
 OPERATOR_SDK_VERSION ?= v1.34.2
 ENVTEST_K8S_VERSION = 1.32 #refers to the version of kubebuilder assets to be downloaded by envtest binary # Kubernetes version from OpenShift 4.19.x
-GOLANGCI_LINT_VERSION ?= v1.64.8
+GOLANGCI_LINT_VERSION ?= v2.1.2
 KUSTOMIZE_VERSION ?= v5.2.1
 CONTROLLER_TOOLS_VERSION ?= v0.16.5
 OPM_VERSION ?= v1.23.0
@@ -202,7 +202,7 @@ $(GOLANGCI_LINT): $(LOCALBIN)
 		echo "golangci-lint $(GOLANGCI_LINT_VERSION) is already installed"; \
 	else \
 		echo "Installing golangci-lint $(GOLANGCI_LINT_VERSION)"; \
-		$(call go-install-tool-branch,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)); \
+		$(call go-install-tool-branch,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)); \
 	fi
 	@if [ -L "$(LOCALBIN)/golangci-lint" ]; then \
 		unlink "$(LOCALBIN)/golangci-lint"; \


### PR DESCRIPTION
- **bump to latest v1 linter prep for v2**
- **updated lint to v2.1.2**

## Why the changes were made

Fixes https://github.com/openshift/oadp-operator/issues/1970#issuecomment-3767199157

CP #1721 

## How to test the changes made

<!-- Explain how the changes introduced by this PR can be tested and verified, with commands and pictures -->
