### PR TITLE
Add kubevirt-datamover plugin support to DPA

### DIFF
--- a/api/v1alpha1/dataprotectionapplication_types.go
+++ b/api/v1alpha1/dataprotectionapplication_types.go
@@ -54,7 +54,7 @@ const (
 
 const OadpOperatorLabel = "openshift.io/oadp"
 
-// +kubebuilder:validation:Enum=aws;legacy-aws;gcp;azure;csi;vsm;openshift;kubevirt;hypershift
+// +kubebuilder:validation:Enum=aws;legacy-aws;gcp;azure;csi;vsm;openshift;kubevirt;kubevirt-datamover;hypershift
 type DefaultPlugin string
 
 const DefaultPluginAWS DefaultPlugin = "aws"
@@ -65,6 +65,7 @@ const DefaultPluginCSI DefaultPlugin = "csi"
 const DefaultPluginVSM DefaultPlugin = "vsm"
 const DefaultPluginOpenShift DefaultPlugin = "openshift"
 const DefaultPluginKubeVirt DefaultPlugin = "kubevirt"
+const DefaultPluginKubeVirtDataMover DefaultPlugin = "kubevirt-datamover"
 const DefaultPluginHypershift DefaultPlugin = "hypershift"
 
 type CustomPlugin struct {
@@ -89,6 +90,7 @@ const OpenShiftPluginImageKey UnsupportedImageKey = "openshiftPluginImageFqin"
 const AzurePluginImageKey UnsupportedImageKey = "azurePluginImageFqin"
 const GCPPluginImageKey UnsupportedImageKey = "gcpPluginImageFqin"
 const KubeVirtPluginImageKey UnsupportedImageKey = "kubevirtPluginImageFqin"
+const KubeVirtDatamoverImageKey UnsupportedImageKey = "kubevirtDatamoverPluginImageFqin"
 const HypershiftPluginImageKey UnsupportedImageKey = "hypershiftPluginImageFqin"
 const NonAdminControllerImageKey UnsupportedImageKey = "nonAdminControllerImageFqin"
 const VMFileRestoreControllerImageKey UnsupportedImageKey = "vmFileRestoreControllerImageFqin"
@@ -879,6 +881,7 @@ type DataProtectionApplicationSpec struct {
 	//   - azurePluginImageFqin
 	//   - gcpPluginImageFqin
 	//   - kubevirtPluginImageFqin
+	//   - kubevirtDatamoverPluginImageFqin
 	//   - hypershiftPluginImageFqin
 	//   - nonAdminControllerImageFqin
 	//   - vmFileRestoreControllerImageFqin

--- a/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
@@ -1146,6 +1146,7 @@ spec:
                               - vsm
                               - openshift
                               - kubevirt
+                              - kubevirt-datamover
                               - hypershift
                             type: string
                           type: array
@@ -2675,6 +2676,7 @@ spec:
                       - azurePluginImageFqin
                       - gcpPluginImageFqin
                       - kubevirtPluginImageFqin
+                      - kubevirtDatamoverPluginImageFqin
                       - hypershiftPluginImageFqin
                       - nonAdminControllerImageFqin
                       - vmFileRestoreControllerImageFqin

--- a/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
@@ -1146,6 +1146,7 @@ spec:
                               - vsm
                               - openshift
                               - kubevirt
+                              - kubevirt-datamover
                               - hypershift
                             type: string
                           type: array
@@ -2675,6 +2676,7 @@ spec:
                       - azurePluginImageFqin
                       - gcpPluginImageFqin
                       - kubevirtPluginImageFqin
+                      - kubevirtDatamoverPluginImageFqin
                       - hypershiftPluginImageFqin
                       - nonAdminControllerImageFqin
                       - vmFileRestoreControllerImageFqin

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -66,15 +66,16 @@ var DefaultRestoreResourcePriorities = types.Priorities{
 
 // Images
 const (
-	VeleroImage           = "quay.io/konveyor/velero:latest"
-	OpenshiftPluginImage  = "quay.io/konveyor/openshift-velero-plugin:latest"
-	AWSPluginImage        = "quay.io/konveyor/velero-plugin-for-aws:latest"
-	LegacyAWSPluginImage  = "quay.io/konveyor/velero-plugin-for-legacy-aws:latest"
-	AzurePluginImage      = "quay.io/konveyor/velero-plugin-for-microsoft-azure:latest"
-	GCPPluginImage        = "quay.io/konveyor/velero-plugin-for-gcp:latest"
-	RegistryImage         = "quay.io/konveyor/registry:latest"
-	KubeVirtPluginImage   = "quay.io/konveyor/kubevirt-velero-plugin:latest"
-	HypershiftPluginImage = "quay.io/redhat-user-workloads/ocp-art-tenant/oadp-hypershift-oadp-plugin-main:main"
+	VeleroImage                  = "quay.io/konveyor/velero:latest"
+	OpenshiftPluginImage         = "quay.io/konveyor/openshift-velero-plugin:latest"
+	AWSPluginImage               = "quay.io/konveyor/velero-plugin-for-aws:latest"
+	LegacyAWSPluginImage         = "quay.io/konveyor/velero-plugin-for-legacy-aws:latest"
+	AzurePluginImage             = "quay.io/konveyor/velero-plugin-for-microsoft-azure:latest"
+	GCPPluginImage               = "quay.io/konveyor/velero-plugin-for-gcp:latest"
+	RegistryImage                = "quay.io/konveyor/registry:latest"
+	KubeVirtPluginImage          = "quay.io/konveyor/kubevirt-velero-plugin:latest"
+	KubeVirtDatamoverPluginImage = "quay.io/konveyor/kubevirt-datamover-plugin:latest"
+	HypershiftPluginImage        = "quay.io/redhat-user-workloads/ocp-art-tenant/oadp-hypershift-oadp-plugin-main:main"
 )
 
 // Plugin names
@@ -85,6 +86,7 @@ const (
 	VeleroPluginForGCP       = "velero-plugin-for-gcp"
 	VeleroPluginForOpenshift = "openshift-velero-plugin"
 	KubeVirtPlugin           = "kubevirt-velero-plugin"
+	KubeVirtDatamoverPlugin  = "kubevirt-datamover-plugin"
 	HypershiftPlugin         = "hypershift-oadp-plugin"
 )
 

--- a/pkg/credentials/credentials.go
+++ b/pkg/credentials/credentials.go
@@ -78,6 +78,10 @@ var (
 			IsCloudProvider: false,
 			PluginName:      common.KubeVirtPlugin,
 		},
+		oadpv1alpha1.DefaultPluginKubeVirtDataMover: {
+			IsCloudProvider: false,
+			PluginName:      common.KubeVirtDatamoverPlugin,
+		},
 		oadpv1alpha1.DefaultPluginHypershift: {
 			IsCloudProvider: false,
 			PluginName:      common.HypershiftPlugin,
@@ -163,6 +167,16 @@ func getKubeVirtPluginImage(dpa *oadpv1alpha1.DataProtectionApplication) string 
 	return os.Getenv("RELATED_IMAGE_KUBEVIRT_VELERO_PLUGIN")
 }
 
+func getKubeVirtDatamoverPluginImage(dpa *oadpv1alpha1.DataProtectionApplication) string {
+	if dpa.Spec.UnsupportedOverrides[oadpv1alpha1.KubeVirtDatamoverImageKey] != "" {
+		return dpa.Spec.UnsupportedOverrides[oadpv1alpha1.KubeVirtDatamoverImageKey]
+	}
+	if os.Getenv("RELATED_IMAGE_KUBEVIRT_DATAMOVER_PLUGIN") == "" {
+		return common.KubeVirtDatamoverPluginImage
+	}
+	return os.Getenv("RELATED_IMAGE_KUBEVIRT_DATAMOVER_PLUGIN")
+}
+
 func getHypershiftPluginImage(dpa *oadpv1alpha1.DataProtectionApplication) string {
 	if dpa.Spec.UnsupportedOverrides[oadpv1alpha1.HypershiftPluginImageKey] != "" {
 		return dpa.Spec.UnsupportedOverrides[oadpv1alpha1.HypershiftPluginImageKey]
@@ -193,6 +207,9 @@ func GetPluginImage(defaultPlugin oadpv1alpha1.DefaultPlugin, dpa *oadpv1alpha1.
 
 	case oadpv1alpha1.DefaultPluginKubeVirt:
 		return getKubeVirtPluginImage(dpa)
+
+	case oadpv1alpha1.DefaultPluginKubeVirtDataMover:
+		return getKubeVirtDatamoverPluginImage(dpa)
 
 	case oadpv1alpha1.DefaultPluginHypershift:
 		return getHypershiftPluginImage(dpa)


### PR DESCRIPTION
## Why the changes were made

Adds support for the kubevirt-datamover plugin as a new default plugin option in the DataProtectionApplication CRD. This plugin enables data movement capabilities for KubeVirt virtual machines during backup and restore operations.

Changes include:
- Add DefaultPluginKubeVirtDataMover constant to DefaultPlugin enum
- Add KubeVirtDatamoverImageKey to unsupportedOverrides configuration
- Add plugin image constant and name mapping in pkg/common
- Add credentials and image retrieval logic in pkg/credentials
- Update CRD validation to accept 'kubevirt-datamover' plugin value
- Update bundle manifests with new plugin enum value

Users can now specify 'kubevirt-datamover' in the DPA spec:
  spec:
    configuration:
      velero:
        defaultPlugins:
        - kubevirt-datamover

This will close #2065 

## How to test the changes made

Once the kubevirt-datamover image exists to be tested, supplying the `kubevirt-datamover` in `defaultPlugins` should work