### PR TITLE
oadp-1.4:Fix S3 bucket region unit tests by adding mocking support

### DIFF
--- a/controllers/bsl_test.go
+++ b/controllers/bsl_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	configv1 "github.com/openshift/api/config/v1"
 	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
+	"github.com/openshift/oadp-operator/pkg/storage/aws"
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -1488,6 +1489,15 @@ func TestDPAReconciler_ValidateBackupStorageLocations(t *testing.T) {
 			wantErr: true,
 		},
 	}
+	// Mock GetBucketRegionFunc to return a region for all buckets
+	originalGetBucketRegionFunc := aws.GetBucketRegionFunc
+	aws.GetBucketRegionFunc = func(bucket string) (string, error) {
+		// Return us-east-1 for any valid bucket name
+		// This simulates successful region discovery for test buckets
+		return "us-east-1", nil
+	}
+	defer func() { aws.GetBucketRegionFunc = originalGetBucketRegionFunc }()
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fakeClient, err := getFakeClientFromObjects(tt.dpa, tt.secret)

--- a/pkg/storage/aws/s3.go
+++ b/pkg/storage/aws/s3.go
@@ -10,15 +10,24 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 )
 
+// GetBucketRegionFunc is the function used to get bucket region.
+// It can be replaced in tests for mocking.
+var GetBucketRegionFunc = getBucketRegionImpl
+
 func BucketRegionIsDiscoverable(bucket string) bool {
-	_, err := GetBucketRegion(bucket)
+	_, err := GetBucketRegionFunc(bucket)
 	return err == nil
 }
 
 // GetBucketRegion returns the AWS region that a bucket is in, or an error
-// if the region cannot be determined.
-// copied from https://github.com/openshift/openshift-velero-plugin/pull/223/files#diff-da482ef606b3938b09ae46990a60eb0ad49ebfb4885eb1af327d90f215bf58b1
+// if the region cannot be determined. This is a wrapper that calls GetBucketRegionFunc.
 func GetBucketRegion(bucket string) (string, error) {
+	return GetBucketRegionFunc(bucket)
+}
+
+// getBucketRegionImpl is the actual implementation that calls AWS.
+// copied from https://github.com/openshift/openshift-velero-plugin/pull/223/files#diff-da482ef606b3938b09ae46990a60eb0ad49ebfb4885eb1af327d90f215bf58b1
+func getBucketRegionImpl(bucket string) (string, error) {
 	var region string
 
 	session, err := session.NewSession()

--- a/pkg/storage/aws/s3_test.go
+++ b/pkg/storage/aws/s3_test.go
@@ -1,51 +1,66 @@
 package aws
 
 import (
+	"errors"
 	"testing"
 )
 
-// from https://github.com/openshift/openshift-velero-plugin/pull/223/files#diff-4f17f1708744bd4d8cb7a4232212efa0e3bfde2b9c7b12e3a23dcc913b9fc2ec
 func TestGetBucketRegion(t *testing.T) {
 	tests := []struct {
-		name    string
-		bucket  string
-		region  string
-		wantErr bool
+		name       string
+		bucket     string
+		mockRegion string
+		mockErr    error
+		wantRegion string
+		wantErr    bool
 	}{
 		{
-			name:    "openshift-velero-plugin-s3-auto-region-test-1",
-			bucket:  "openshift-velero-plugin-s3-auto-region-test-1",
-			region:  "us-east-1",
-			wantErr: false,
+			name:       "successful region discovery",
+			bucket:     "test-bucket",
+			mockRegion: "us-east-1",
+			mockErr:    nil,
+			wantRegion: "us-east-1",
+			wantErr:    false,
 		},
 		{
-			name:    "openshift-velero-plugin-s3-auto-region-test-2",
-			bucket:  "openshift-velero-plugin-s3-auto-region-test-2",
-			region:  "us-west-1",
-			wantErr: false,
+			name:       "region discovery for eu-central-1",
+			bucket:     "eu-bucket",
+			mockRegion: "eu-central-1",
+			mockErr:    nil,
+			wantRegion: "eu-central-1",
+			wantErr:    false,
 		},
 		{
-			name:    "openshift-velero-plugin-s3-auto-region-test-3",
-			bucket:  "openshift-velero-plugin-s3-auto-region-test-3",
-			region:  "eu-central-1",
-			wantErr: false,
-		},
-		{
-			name:    "openshift-velero-plugin-s3-auto-region-test-4",
-			bucket:  "openshift-velero-plugin-s3-auto-region-test-4",
-			region:  "sa-east-1",
-			wantErr: false,
+			name:       "region discovery fails",
+			bucket:     "non-existent-bucket",
+			mockRegion: "",
+			mockErr:    errors.New("bucket not found"),
+			wantRegion: "",
+			wantErr:    true,
 		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// Save original and restore after test
+			originalFunc := GetBucketRegionFunc
+			defer func() { GetBucketRegionFunc = originalFunc }()
+
+			// Set up mock
+			GetBucketRegionFunc = func(bucket string) (string, error) {
+				if bucket != tt.bucket {
+					t.Errorf("GetBucketRegion called with wrong bucket: got %v, want %v", bucket, tt.bucket)
+				}
+				return tt.mockRegion, tt.mockErr
+			}
+
 			got, err := GetBucketRegion(tt.bucket)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetBucketRegion() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if got != tt.region {
-				t.Errorf("GetBucketRegion() = %v, want %v", got, tt.region)
+			if got != tt.wantRegion {
+				t.Errorf("GetBucketRegion() = %v, want %v", got, tt.wantRegion)
 			}
 		})
 	}
@@ -55,21 +70,44 @@ func TestBucketRegionIsDiscoverable(t *testing.T) {
 	tests := []struct {
 		name         string
 		bucket       string
+		mockRegion   string
+		mockErr      error
 		discoverable bool
 	}{
 		{
-			name:         "openshift-velero-plugin-s3-auto-region-test-1 region is discoverable",
-			bucket:       "openshift-velero-plugin-s3-auto-region-test-1",
+			name:         "bucket region is discoverable",
+			bucket:       "discoverable-bucket",
+			mockRegion:   "us-east-1",
+			mockErr:      nil,
 			discoverable: true,
 		},
 		{
-			name:         "bucketNamesOverSixtyThreeCharactersAndNowItIsAboutTimeToTestThisFunction is an invalid aws bucket name so region is not discoverable",
+			name:         "bucket region is not discoverable due to error",
+			bucket:       "non-existent-bucket",
+			mockRegion:   "",
+			mockErr:      errors.New("bucket not found"),
+			discoverable: false,
+		},
+		{
+			name:         "invalid bucket name - region not discoverable",
 			bucket:       "bucketNamesOverSixtyThreeCharactersAndNowItIsAboutTimeToTestThisFunction",
+			mockRegion:   "",
+			mockErr:      errors.New("invalid bucket name"),
 			discoverable: false,
 		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// Save original and restore after test
+			originalFunc := GetBucketRegionFunc
+			defer func() { GetBucketRegionFunc = originalFunc }()
+
+			// Set up mock
+			GetBucketRegionFunc = func(bucket string) (string, error) {
+				return tt.mockRegion, tt.mockErr
+			}
+
 			if got := BucketRegionIsDiscoverable(tt.bucket); got != tt.discoverable {
 				t.Errorf("BucketRegionIsDiscoverable() = %v, want %v", got, tt.discoverable)
 			}


### PR DESCRIPTION
## Why the changes were made

make test failing due to missing s3 buckets after EOY cleanup

## How to test the changes made

make test