### PR TITLE
Add logic within makefile to sync kubevirt-dm rbac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -954,6 +954,20 @@ endif
 		$(SED) -i "s%resources:%resources:\n- $$file_name%" $(shell pwd)/config/samples/kustomization.yaml;done
 	@make bundle
 
+.PHONY: update-kubevirt-datamover-manifests
+update-kubevirt-datamover-manifests: KUBEVIRT_DATAMOVER_CONTROLLER_IMG?=quay.io/konveyor/kubevirt-datamover-controller:latest
+update-kubevirt-datamover-manifests: yq ## Update KubeVirt Datamover Controller RBAC manifests shipped with OADP, from KUBEVIRT_DATAMOVER_PATH
+ifeq ($(KUBEVIRT_DATAMOVER_PATH),)
+	$(error You must set KUBEVIRT_DATAMOVER_PATH to run this command)
+endif
+	$(YQ) -i 'select(.kind == "Deployment")|= .spec.template.spec.containers[0].env |= .[] |= select(.name == "RELATED_IMAGE_KUBEVIRT_DATAMOVER_CONTROLLER") |= .value="$(KUBEVIRT_DATAMOVER_CONTROLLER_IMG)"' config/manager/manager.yaml
+	@mkdir -p $(shell pwd)/config/kubevirt-datamover-controller_rbac
+	@for file_name in $(shell grep -I '^\-' $(KUBEVIRT_DATAMOVER_PATH)/config/rbac/kustomization.yaml | awk -F'- ' '{print $$2}');do \
+		cp $(KUBEVIRT_DATAMOVER_PATH)/config/rbac/$$file_name $(shell pwd)/config/kubevirt-datamover-controller_rbac/$$file_name;done
+	@cp $(KUBEVIRT_DATAMOVER_PATH)/config/rbac/kustomization.yaml $(shell pwd)/config/kubevirt-datamover-controller_rbac/kustomization.yaml
+	@$(SED) -i '1i namePrefix: oadp-kubevirt-datamover-' $(shell pwd)/config/kubevirt-datamover-controller_rbac/kustomization.yaml
+	@make bundle
+
 .PHONY: build-must-gather
 build-must-gather: check-go ## Build OADP Must-gather binary must-gather/oadp-must-gather
 ifeq ($(SKIP_MUST_GATHER),true)

--- a/config/kubevirt-datamover-controller_rbac/kustomization.yaml
+++ b/config/kubevirt-datamover-controller_rbac/kustomization.yaml
@@ -1,0 +1,21 @@
+namePrefix: oadp-kubevirt-datamover-
+resources:
+# All RBAC will be applied under this service account in
+# the deployment namespace. You may comment out this resource
+# if your manager will use a service account that exists at
+# runtime. Be sure to update RoleBinding and ClusterRoleBinding
+# subjects if changing service account names.
+- service_account.yaml
+- role.yaml
+- role_binding.yaml
+- leader_election_role.yaml
+- leader_election_role_binding.yaml
+# The following RBAC configurations are used to protect
+# the metrics endpoint with authn/authz. These configurations
+# ensure that only authorized users and service accounts
+# can access the metrics endpoint. Comment the following
+# permissions if you want to disable this protection.
+# More info: https://book.kubebuilder.io/reference/metrics.html
+- metrics_auth_role.yaml
+- metrics_auth_role_binding.yaml
+- metrics_reader_role.yaml

--- a/config/kubevirt-datamover-controller_rbac/leader_election_role.yaml
+++ b/config/kubevirt-datamover-controller_rbac/leader_election_role.yaml
@@ -1,0 +1,40 @@
+# permissions to do leader election.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/name: kubevirt-datamover-controller
+    app.kubernetes.io/managed-by: kustomize
+  name: leader-election-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch

--- a/config/kubevirt-datamover-controller_rbac/leader_election_role_binding.yaml
+++ b/config/kubevirt-datamover-controller_rbac/leader_election_role_binding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: kubevirt-datamover-controller
+    app.kubernetes.io/managed-by: kustomize
+  name: leader-election-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: system

--- a/config/kubevirt-datamover-controller_rbac/metrics_auth_role.yaml
+++ b/config/kubevirt-datamover-controller_rbac/metrics_auth_role.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: metrics-auth-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create

--- a/config/kubevirt-datamover-controller_rbac/metrics_auth_role_binding.yaml
+++ b/config/kubevirt-datamover-controller_rbac/metrics_auth_role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: metrics-auth-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: metrics-auth-role
+subjects:
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: system

--- a/config/kubevirt-datamover-controller_rbac/metrics_reader_role.yaml
+++ b/config/kubevirt-datamover-controller_rbac/metrics_reader_role.yaml
@@ -1,0 +1,9 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: metrics-reader
+rules:
+- nonResourceURLs:
+  - "/metrics"
+  verbs:
+  - get

--- a/config/kubevirt-datamover-controller_rbac/role.yaml
+++ b/config/kubevirt-datamover-controller_rbac/role.yaml
@@ -1,0 +1,64 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - backup.kubevirt.io
+  resources:
+  - virtualmachinebackups
+  - virtualmachinebackuptrackers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - backup.kubevirt.io
+  resources:
+  - virtualmachinebackups/status
+  - virtualmachinebackuptrackers/status
+  verbs:
+  - get
+- apiGroups:
+  - kubevirt.io
+  resources:
+  - virtualmachines
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - velero.io
+  resources:
+  - datauploads
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - velero.io
+  resources:
+  - datauploads/status
+  verbs:
+  - get
+  - patch
+  - update

--- a/config/kubevirt-datamover-controller_rbac/role_binding.yaml
+++ b/config/kubevirt-datamover-controller_rbac/role_binding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: kubevirt-datamover-controller
+    app.kubernetes.io/managed-by: kustomize
+  name: manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: manager-role
+subjects:
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: system

--- a/config/kubevirt-datamover-controller_rbac/service_account.yaml
+++ b/config/kubevirt-datamover-controller_rbac/service_account.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/name: kubevirt-datamover-controller
+    app.kubernetes.io/managed-by: kustomize
+  name: controller-manager
+  namespace: system


### PR DESCRIPTION
Adds Makefile target with rbac roles for the kubevirt-dm.

Part of the https://github.com/openshift/oadp-operator/issues/2065