### PR TITLE
[oadp-1.4] Fix IBU delay on SNO by waiting for CRDs and disabling leader election

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"time"
 
 	configv1 "github.com/openshift/api/config/v1"
 	routev1 "github.com/openshift/api/route/v1"
@@ -32,6 +33,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -80,6 +82,13 @@ const (
 	warnLabel      = psaLabelPrefix + "warn"
 
 	privileged = "privileged"
+
+	// CRD availability wait configuration for IBU (Image-Based Upgrade) scenarios.
+	// During IBU on SNO clusters, the node reboots into a new OS image and OpenShift
+	// CRDs may not be immediately available while the API server initializes.
+	// See: https://issues.redhat.com/browse/OADP-7419
+	crdWaitInterval = 10 * time.Second
+	crdWaitTimeout  = 10 * time.Minute
 )
 
 func init() {
@@ -130,6 +139,16 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Wait for required OpenShift CRDs before starting the manager.
+	// During IBU (Image-Based Upgrade) on SNO clusters, the node reboots and external
+	// OpenShift operators may not have registered their CRDs yet. Without this wait,
+	// the controller crashes trying to watch Route/SCC resources that don't exist.
+	// See: https://issues.redhat.com/browse/OADP-7419
+	if err := waitForRequiredCRDs(context.Background(), kubeconf); err != nil {
+		setupLog.Error(err, "failed waiting for required CRDs")
+		os.Exit(1)
+	}
+
 	// check if this is standardized STS workflow via OLM and CCO
 	if common.CCOWorkflow() {
 		setupLog.Info("AWS Role ARN specified by the user, following standardized STS workflow")
@@ -168,11 +187,19 @@ func main() {
 			},
 		},
 		HealthProbeBindAddress: probeAddr,
-		LeaderElection:         enableLeaderElection,
-		LeaseDuration:          &leConfig.LeaseDuration.Duration,
-		RenewDeadline:          &leConfig.RenewDeadline.Duration,
-		RetryPeriod:            &leConfig.RetryPeriod.Duration,
-		LeaderElectionID:       "oadp.openshift.io",
+		// Enable leader election only if requested via flag AND not disabled by config.
+		// On SNO clusters, leConfig.Disable is set to true to avoid leader election
+		// overhead and delays during IBU. See: https://issues.redhat.com/browse/OADP-7419
+		LeaderElection:   enableLeaderElection && !leConfig.Disable,
+		LeaseDuration:    &leConfig.LeaseDuration.Duration,
+		RenewDeadline:    &leConfig.RenewDeadline.Duration,
+		RetryPeriod:      &leConfig.RetryPeriod.Duration,
+		LeaderElectionID: "oadp.openshift.io",
+		// LeaderElectionReleaseOnCancel ensures the leader lease is released when the
+		// controller crashes or shuts down. Without this, on SNO clusters with 270s lease
+		// duration, a crashed controller would block the new instance from acquiring
+		// leadership for ~4.5 minutes. See: https://issues.redhat.com/browse/OADP-7419
+		LeaderElectionReleaseOnCancel: true,
 		Cache: cache.Options{
 			DefaultNamespaces: map[string]cache.Config{
 				watchNamespace: {},
@@ -396,4 +423,119 @@ func CreateOrUpdateCredRequest(roleARN string, WITP string, secretNS string, kub
 	}
 	setupLog.Info("Custom resource credentialsrequest " + verb + " successfully")
 	return nil
+}
+
+// requiredCRD represents a CRD that must be available before the controller can start.
+type requiredCRD struct {
+	groupVersion string
+	resourceName string
+}
+
+// getRequiredCRDs returns the list of CRDs that must be available before the OADP
+// controller can start.
+//
+// Why only Route and SecurityContextConstraints?
+//
+// The DPA controller watches several resource types via Owns() calls:
+//   - Core K8s resources (Deployment, Service, ConfigMap, etc.) - always available
+//   - OADP CRDs (DPA, CloudStorage) - installed by OLM before operator starts
+//   - Velero CRDs (BSL, VSL) - part of OADP CSV bundle, OLM guarantees availability
+//   - OpenShift CRDs (Route, SCC) - registered by OTHER OpenShift operators
+//
+// Route and SCC are the only CRDs that are:
+//  1. Required by the DPA controller (via Owns() in SetupWithManager)
+//  2. NOT installed by OADP itself
+//  3. Registered by external OpenShift operators (openshift-apiserver, authentication-operator)
+//
+// During Image-Based Upgrade (IBU) on SNO clusters, the node reboots and these
+// external operators may not have registered their CRDs yet when OADP starts.
+// This causes cache sync failures and controller crashes.
+//
+// See: https://issues.redhat.com/browse/OADP-7419
+func getRequiredCRDs() []requiredCRD {
+	return []requiredCRD{
+		{groupVersion: "route.openshift.io/v1", resourceName: "routes"},
+		{groupVersion: "security.openshift.io/v1", resourceName: "securitycontextconstraints"},
+	}
+}
+
+// waitForRequiredCRDs waits for external OpenShift CRDs to be registered before
+// starting the controller.
+//
+// Context: During Image-Based Upgrade (IBU) on Single Node OpenShift (SNO) clusters,
+// the node reboots into a new OS image. The kube-apiserver starts before OpenShift
+// operators have registered their CRDs (Route, SecurityContextConstraints).
+//
+// Without this wait, the controller attempts to create informers for these CRDs,
+// fails with "no matches for kind", and crashes after the cache sync timeout (2 min).
+// Combined with the SNO leader lease duration (270s), this causes an ~8 minute delay
+// before the DPA can reconcile.
+//
+// By explicitly waiting for CRDs via the discovery API, we avoid the crash entirely
+// and allow the controller to start as soon as the CRDs are available.
+//
+// See: https://issues.redhat.com/browse/OADP-7419
+func waitForRequiredCRDs(ctx context.Context, kubeconf *rest.Config) error {
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(kubeconf)
+	if err != nil {
+		return fmt.Errorf("failed to create discovery client: %w", err)
+	}
+	return waitForRequiredCRDsWithClient(ctx, discoveryClient)
+}
+
+// waitForRequiredCRDsWithClient is the internal implementation that accepts a
+// discovery client directly. This allows for easier unit testing with mock clients.
+func waitForRequiredCRDsWithClient(ctx context.Context, discoveryClient discovery.DiscoveryInterface) error {
+	requiredCRDs := getRequiredCRDs()
+
+	setupLog.Info("Waiting for required OpenShift CRDs to be available",
+		"crds", requiredCRDs,
+		"timeout", crdWaitTimeout.String())
+
+	// Use a shorter interval for testing (context deadline will control actual timeout)
+	interval := crdWaitInterval
+	timeout := crdWaitTimeout
+
+	// If context has a deadline shorter than our default timeout, use that
+	if deadline, ok := ctx.Deadline(); ok {
+		remaining := time.Until(deadline)
+		if remaining < timeout {
+			timeout = remaining
+		}
+		// Use shorter interval for short timeouts (testing)
+		if remaining < 1*time.Second {
+			interval = 10 * time.Millisecond
+		}
+	}
+
+	return wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
+		for _, crd := range requiredCRDs {
+			if !isCRDAvailable(discoveryClient, crd.groupVersion, crd.resourceName) {
+				setupLog.Info("Waiting for CRD to be registered",
+					"groupVersion", crd.groupVersion,
+					"resource", crd.resourceName)
+				return false, nil
+			}
+		}
+		setupLog.Info("All required CRDs are available, proceeding with controller startup")
+		return true, nil
+	})
+}
+
+// isCRDAvailable checks if a specific CRD is registered with the API server
+// by querying the discovery API for the given group version and resource name.
+// Returns true if the CRD is available, false otherwise (including on errors).
+func isCRDAvailable(discoveryClient discovery.DiscoveryInterface, groupVersion, resourceName string) bool {
+	resourceList, err := discoveryClient.ServerResourcesForGroupVersion(groupVersion)
+	if err != nil {
+		// If the group version doesn't exist, the CRD is not available
+		return false
+	}
+
+	for _, resource := range resourceList.APIResources {
+		if resource.Name == resourceName {
+			return true
+		}
+	}
+	return false
 }

--- a/main_test.go
+++ b/main_test.go
@@ -18,10 +18,14 @@ package main
 
 import (
 	"context"
+	"errors"
 	"testing"
+	"time"
 
-	coreV1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/discovery"
+	fakediscovery "k8s.io/client-go/discovery/fake"
 	"k8s.io/client-go/kubernetes/fake"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
@@ -80,8 +84,8 @@ func TestAddPodSecurityPrivilegedLabels(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create a new namespace with the existing labels
-			namespace := coreV1.Namespace{
-				ObjectMeta: v1.ObjectMeta{
+			namespace := corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:   testNamespaceName,
 					Labels: tt.existingLabels,
 				},
@@ -91,7 +95,7 @@ func TestAddPodSecurityPrivilegedLabels(t *testing.T) {
 			if err != nil {
 				t.Errorf("addPodSecurityPrivilegedLabels() error = %v", err)
 			}
-			testNamespace, err := testClient.CoreV1().Namespaces().Get(context.TODO(), testNamespaceName, v1.GetOptions{})
+			testNamespace, err := testClient.CoreV1().Namespaces().Get(context.TODO(), testNamespaceName, metav1.GetOptions{})
 			if err != nil {
 				t.Errorf("Get test namespace error = %v", err)
 			}
@@ -110,5 +114,307 @@ func TestAddPodSecurityPrivilegedLabels(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestGetRequiredCRDs verifies that getRequiredCRDs returns the expected CRDs
+func TestGetRequiredCRDs(t *testing.T) {
+	crds := getRequiredCRDs()
+
+	if len(crds) != 2 {
+		t.Errorf("expected 2 required CRDs, got %d", len(crds))
+	}
+
+	// Verify Route CRD is included
+	foundRoute := false
+	foundSCC := false
+	for _, crd := range crds {
+		if crd.groupVersion == "route.openshift.io/v1" && crd.resourceName == "routes" {
+			foundRoute = true
+		}
+		if crd.groupVersion == "security.openshift.io/v1" && crd.resourceName == "securitycontextconstraints" {
+			foundSCC = true
+		}
+	}
+
+	if !foundRoute {
+		t.Error("expected Route CRD (route.openshift.io/v1/routes) to be in required CRDs")
+	}
+	if !foundSCC {
+		t.Error("expected SCC CRD (security.openshift.io/v1/securitycontextconstraints) to be in required CRDs")
+	}
+}
+
+// mockDiscoveryClient implements discovery.DiscoveryInterface for testing
+type mockDiscoveryClient struct {
+	fakediscovery.FakeDiscovery
+	resources      map[string]*metav1.APIResourceList
+	resourcesError error
+}
+
+func (m *mockDiscoveryClient) ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
+	if m.resourcesError != nil {
+		return nil, m.resourcesError
+	}
+	if resources, ok := m.resources[groupVersion]; ok {
+		return resources, nil
+	}
+	// Return error if group version not found (simulates CRD not registered)
+	return nil, errors.New("the server could not find the requested resource")
+}
+
+// Ensure mockDiscoveryClient implements the interface we need
+var _ discovery.DiscoveryInterface = &mockDiscoveryClient{}
+
+// TestIsCRDAvailable tests the isCRDAvailable function
+func TestIsCRDAvailable(t *testing.T) {
+	tests := []struct {
+		name         string
+		groupVersion string
+		resourceName string
+		resources    map[string]*metav1.APIResourceList
+		expectError  error
+		expected     bool
+	}{
+		{
+			name:         "CRD is available",
+			groupVersion: "route.openshift.io/v1",
+			resourceName: "routes",
+			resources: map[string]*metav1.APIResourceList{
+				"route.openshift.io/v1": {
+					GroupVersion: "route.openshift.io/v1",
+					APIResources: []metav1.APIResource{
+						{Name: "routes", Kind: "Route"},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name:         "CRD group version exists but resource not found",
+			groupVersion: "route.openshift.io/v1",
+			resourceName: "routes",
+			resources: map[string]*metav1.APIResourceList{
+				"route.openshift.io/v1": {
+					GroupVersion: "route.openshift.io/v1",
+					APIResources: []metav1.APIResource{
+						{Name: "otherresource", Kind: "Other"},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name:         "CRD group version does not exist",
+			groupVersion: "route.openshift.io/v1",
+			resourceName: "routes",
+			resources:    map[string]*metav1.APIResourceList{},
+			expected:     false,
+		},
+		{
+			name:         "SCC CRD is available",
+			groupVersion: "security.openshift.io/v1",
+			resourceName: "securitycontextconstraints",
+			resources: map[string]*metav1.APIResourceList{
+				"security.openshift.io/v1": {
+					GroupVersion: "security.openshift.io/v1",
+					APIResources: []metav1.APIResource{
+						{Name: "securitycontextconstraints", Kind: "SecurityContextConstraints"},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name:         "Multiple resources in group version",
+			groupVersion: "security.openshift.io/v1",
+			resourceName: "securitycontextconstraints",
+			resources: map[string]*metav1.APIResourceList{
+				"security.openshift.io/v1": {
+					GroupVersion: "security.openshift.io/v1",
+					APIResources: []metav1.APIResource{
+						{Name: "podsecuritypolicyselfsubjectreviews", Kind: "PodSecurityPolicySelfSubjectReview"},
+						{Name: "securitycontextconstraints", Kind: "SecurityContextConstraints"},
+						{Name: "rangeallocations", Kind: "RangeAllocation"},
+					},
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &mockDiscoveryClient{
+				resources:      tt.resources,
+				resourcesError: tt.expectError,
+			}
+
+			available := isCRDAvailable(mockClient, tt.groupVersion, tt.resourceName)
+			if available != tt.expected {
+				t.Errorf("isCRDAvailable() = %v, expected %v", available, tt.expected)
+			}
+		})
+	}
+}
+
+// TestIsCRDAvailableWithDiscoveryError tests isCRDAvailable when discovery API returns an error
+func TestIsCRDAvailableWithDiscoveryError(t *testing.T) {
+	mockClient := &mockDiscoveryClient{
+		resources:      nil,
+		resourcesError: errors.New("connection refused"),
+	}
+
+	// When discovery returns an error, isCRDAvailable should return false
+	// because this indicates the CRD is not available (yet)
+	available := isCRDAvailable(mockClient, "route.openshift.io/v1", "routes")
+	if available {
+		t.Error("isCRDAvailable() should return false when discovery fails")
+	}
+}
+
+// dynamicMockDiscoveryClient is a mock that can change its responses over time
+// to simulate CRDs becoming available after some delay
+type dynamicMockDiscoveryClient struct {
+	fakediscovery.FakeDiscovery
+	pollCount      int // Number of complete poll iterations
+	availableAfter int // CRDs become available after this many poll iterations
+	resources      map[string]*metav1.APIResourceList
+	routeCalls     int // Track individual calls for debugging
+	sccCalls       int
+}
+
+func (m *dynamicMockDiscoveryClient) ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
+	// Track which CRD is being checked
+	if groupVersion == "route.openshift.io/v1" {
+		m.routeCalls++
+		// Count poll iterations based on Route checks (called first)
+		m.pollCount = m.routeCalls
+	} else if groupVersion == "security.openshift.io/v1" {
+		m.sccCalls++
+	}
+
+	if m.pollCount >= m.availableAfter {
+		if resources, ok := m.resources[groupVersion]; ok {
+			return resources, nil
+		}
+	}
+	// CRDs not yet available
+	return nil, errors.New("the server could not find the requested resource")
+}
+
+var _ discovery.DiscoveryInterface = &dynamicMockDiscoveryClient{}
+
+// TestWaitForRequiredCRDs_CRDsAvailableImmediately tests that waitForRequiredCRDs
+// returns immediately when all CRDs are already available
+func TestWaitForRequiredCRDs_CRDsAvailableImmediately(t *testing.T) {
+	// Create a mock that has CRDs available from the start
+	mockClient := &dynamicMockDiscoveryClient{
+		availableAfter: 1, // Available on first call
+		resources: map[string]*metav1.APIResourceList{
+			"route.openshift.io/v1": {
+				GroupVersion: "route.openshift.io/v1",
+				APIResources: []metav1.APIResource{
+					{Name: "routes", Kind: "Route"},
+				},
+			},
+			"security.openshift.io/v1": {
+				GroupVersion: "security.openshift.io/v1",
+				APIResources: []metav1.APIResource{
+					{Name: "securitycontextconstraints", Kind: "SecurityContextConstraints"},
+				},
+			},
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := waitForRequiredCRDsWithClient(ctx, mockClient)
+	if err != nil {
+		t.Errorf("waitForRequiredCRDs() unexpected error = %v", err)
+	}
+}
+
+// TestWaitForRequiredCRDs_CRDsBecomeAvailable tests that waitForRequiredCRDs
+// waits and succeeds when CRDs become available after some delay
+func TestWaitForRequiredCRDs_CRDsBecomeAvailable(t *testing.T) {
+	// Create a mock that has CRDs available after 3 poll iterations
+	mockClient := &dynamicMockDiscoveryClient{
+		availableAfter: 3,
+		resources: map[string]*metav1.APIResourceList{
+			"route.openshift.io/v1": {
+				GroupVersion: "route.openshift.io/v1",
+				APIResources: []metav1.APIResource{
+					{Name: "routes", Kind: "Route"},
+				},
+			},
+			"security.openshift.io/v1": {
+				GroupVersion: "security.openshift.io/v1",
+				APIResources: []metav1.APIResource{
+					{Name: "securitycontextconstraints", Kind: "SecurityContextConstraints"},
+				},
+			},
+		},
+	}
+
+	// Use longer timeout to allow for poll iterations
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	err := waitForRequiredCRDsWithClient(ctx, mockClient)
+	if err != nil {
+		t.Errorf("waitForRequiredCRDs() unexpected error = %v", err)
+	}
+
+	// Verify we actually waited (polled multiple times)
+	if mockClient.pollCount < 3 {
+		t.Errorf("expected at least 3 poll iterations, got %d", mockClient.pollCount)
+	}
+}
+
+// TestWaitForRequiredCRDs_Timeout tests that waitForRequiredCRDs returns an error
+// when context times out before CRDs become available
+func TestWaitForRequiredCRDs_Timeout(t *testing.T) {
+	// Create a mock that never has CRDs available
+	mockClient := &dynamicMockDiscoveryClient{
+		availableAfter: 1000, // Never becomes available within test timeout
+		resources:      map[string]*metav1.APIResourceList{},
+	}
+
+	// Use a very short timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	err := waitForRequiredCRDsWithClient(ctx, mockClient)
+	if err == nil {
+		t.Error("waitForRequiredCRDs() expected timeout error, got nil")
+	}
+}
+
+// TestWaitForRequiredCRDs_PartialAvailability tests that waitForRequiredCRDs
+// waits until ALL required CRDs are available, not just some
+func TestWaitForRequiredCRDs_PartialAvailability(t *testing.T) {
+	// Create a mock where only Route is available, SCC is not
+	mockClient := &dynamicMockDiscoveryClient{
+		availableAfter: 1,
+		resources: map[string]*metav1.APIResourceList{
+			"route.openshift.io/v1": {
+				GroupVersion: "route.openshift.io/v1",
+				APIResources: []metav1.APIResource{
+					{Name: "routes", Kind: "Route"},
+				},
+			},
+			// SCC is missing
+		},
+	}
+
+	// Use a short timeout - should fail because SCC is never available
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	err := waitForRequiredCRDsWithClient(ctx, mockClient)
+	if err == nil {
+		t.Error("waitForRequiredCRDs() expected error when not all CRDs available, got nil")
 	}
 }

--- a/pkg/leaderelection/leaderelection.go
+++ b/pkg/leaderelection/leaderelection.go
@@ -35,7 +35,20 @@ func GetLeaderElectionConfig(restConfig *rest.Config, enabled bool) configv1.Lea
 			klog.Infof("infrastructure object status: %v", infra)
 			// check if the cluster is a SNO (Single Node Openshift) Cluster
 			if infra.ControlPlaneTopology == configv1.SingleReplicaTopologyMode {
-				return LeaderElectionSNOConfig(defaultLeaderElection)
+				// On SNO clusters, disable leader election entirely.
+				//
+				// Rationale:
+				// 1. SNO has only one node, so there's only ever one replica of the operator
+				// 2. Leader election provides no benefit with a single replica
+				// 3. During IBU (Image-Based Upgrade), leader election can cause significant
+				//    delays if the controller crashes - the new instance must wait for the
+				//    lease to expire (270s with previous SNO config)
+				// 4. Without leader election, the controller starts immediately on restart
+				//
+				// See: https://issues.redhat.com/browse/OADP-7419
+				klog.Info("SNO topology detected, disabling leader election")
+				defaultLeaderElection.Disable = true
+				return defaultLeaderElection
 			}
 		} else {
 			klog.Warningf("unable to get cluster infrastructure status, using HA cluster values for leader election: %v", err)

--- a/pkg/leaderelection/leaderelection_test.go
+++ b/pkg/leaderelection/leaderelection_test.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package leaderelection
+
+import (
+	"testing"
+	"time"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+// TestLeaderElectionDefaulting tests the default leader election configuration
+func TestLeaderElectionDefaulting(t *testing.T) {
+	config := LeaderElectionDefaulting(configv1.LeaderElection{}, "", "")
+
+	// Verify default values for HA clusters
+	if config.LeaseDuration.Duration != 137*time.Second {
+		t.Errorf("expected LeaseDuration 137s, got %v", config.LeaseDuration.Duration)
+	}
+	if config.RenewDeadline.Duration != 107*time.Second {
+		t.Errorf("expected RenewDeadline 107s, got %v", config.RenewDeadline.Duration)
+	}
+	if config.RetryPeriod.Duration != 26*time.Second {
+		t.Errorf("expected RetryPeriod 26s, got %v", config.RetryPeriod.Duration)
+	}
+}
+
+// TestLeaderElectionDefaulting_DisabledWhenNotEnabled tests that leader election
+// is disabled when enabled=false is passed
+func TestLeaderElectionDefaulting_DisabledWhenNotEnabled(t *testing.T) {
+	config := LeaderElectionDefaulting(
+		configv1.LeaderElection{
+			Disable: true,
+		},
+		"", "",
+	)
+
+	if !config.Disable {
+		t.Error("expected Disable to be true when passed as true")
+	}
+}
+
+// TestLeaderElectionSNOConfig_Deprecated tests the old SNO config function
+// Note: This function is no longer used for SNO (we disable LE instead),
+// but we test it to ensure it still works if needed for reference
+func TestLeaderElectionSNOConfig_Deprecated(t *testing.T) {
+	baseConfig := LeaderElectionDefaulting(configv1.LeaderElection{}, "", "")
+	snoConfig := LeaderElectionSNOConfig(baseConfig)
+
+	// Verify SNO-specific extended values
+	if snoConfig.LeaseDuration.Duration != 270*time.Second {
+		t.Errorf("expected SNO LeaseDuration 270s, got %v", snoConfig.LeaseDuration.Duration)
+	}
+	if snoConfig.RenewDeadline.Duration != 240*time.Second {
+		t.Errorf("expected SNO RenewDeadline 240s, got %v", snoConfig.RenewDeadline.Duration)
+	}
+	if snoConfig.RetryPeriod.Duration != 60*time.Second {
+		t.Errorf("expected SNO RetryPeriod 60s, got %v", snoConfig.RetryPeriod.Duration)
+	}
+}
+
+// TestGetLeaderElectionConfig_DisabledWhenNotEnabled tests that leader election
+// is disabled when enableLeaderElection is false
+func TestGetLeaderElectionConfig_DisabledWhenNotEnabled(t *testing.T) {
+	// When enabled=false, the config should have Disable=true
+	config := configv1.LeaderElection{
+		Disable: true, // !enabled
+	}
+	defaulted := LeaderElectionDefaulting(config, "", "")
+
+	if !defaulted.Disable {
+		t.Error("expected Disable to be true when leader election is not enabled")
+	}
+}
+
+// TestGetLeaderElectionConfig_EnabledForHA tests that leader election
+// uses HA defaults when enabled on a non-SNO cluster
+func TestGetLeaderElectionConfig_EnabledForHA(t *testing.T) {
+	config := LeaderElectionDefaulting(
+		configv1.LeaderElection{
+			Disable: false, // enabled
+		},
+		"", "",
+	)
+
+	if config.Disable {
+		t.Error("expected Disable to be false for HA cluster")
+	}
+	if config.LeaseDuration.Duration != 137*time.Second {
+		t.Errorf("expected HA LeaseDuration 137s, got %v", config.LeaseDuration.Duration)
+	}
+}
+
+// TestSNOLeaderElectionDisabled tests that for SNO topology, we return
+// a config with Disable=true (the new behavior for OADP-7419)
+func TestSNOLeaderElectionDisabled(t *testing.T) {
+	// Simulate what GetLeaderElectionConfig does for SNO
+	// We can't easily test the full function without mocking the k8s client,
+	// but we can verify the logic by checking what happens when SNO is detected
+
+	defaultConfig := LeaderElectionDefaulting(
+		configv1.LeaderElection{
+			Disable: false, // Initially enabled
+		},
+		"", "",
+	)
+
+	// Simulate SNO detection - set Disable to true
+	defaultConfig.Disable = true
+
+	if !defaultConfig.Disable {
+		t.Error("expected Disable to be true for SNO cluster")
+	}
+}
+
+// TestLeaderElectionClockSkewTolerance verifies the clock skew tolerance
+// calculation for HA clusters (leaseDuration - renewDeadline = 30s)
+func TestLeaderElectionClockSkewTolerance(t *testing.T) {
+	config := LeaderElectionDefaulting(configv1.LeaderElection{}, "", "")
+
+	clockSkew := config.LeaseDuration.Duration - config.RenewDeadline.Duration
+	expectedClockSkew := 30 * time.Second
+
+	if clockSkew != expectedClockSkew {
+		t.Errorf("expected clock skew tolerance of %v, got %v", expectedClockSkew, clockSkew)
+	}
+}
+
+// TestLeaderElectionRetryAttempts verifies the number of retry attempts
+// for HA clusters (renewDeadline / retryPeriod = 4 attempts)
+func TestLeaderElectionRetryAttempts(t *testing.T) {
+	config := LeaderElectionDefaulting(configv1.LeaderElection{}, "", "")
+
+	retryAttempts := int(config.RenewDeadline.Duration / config.RetryPeriod.Duration)
+	expectedRetries := 4 // 107s / 26s = 4
+
+	if retryAttempts != expectedRetries {
+		t.Errorf("expected %d retry attempts, got %d", expectedRetries, retryAttempts)
+	}
+}


### PR DESCRIPTION
## Summary

Cherry-pick of #2082 to oadp-1.4 branch.

Fixes ~8 minute delay during Image-Based Upgrade (IBU) on SNO clusters by:
- Waiting for Route/SCC CRDs before starting controller
- Disabling leader election on SNO (single replica, no benefit)
- Adding LeaderElectionReleaseOnCancel for faster recovery on crash

See https://issues.redhat.com/browse/OADP-7419

## Test plan
- [x] Unit tests pass
- [x] IBU testing on SNO cluster

🤖 Generated with [Claude Code](https://claude.ai/code)