### PR TITLE
kubevirt-datamover-controller deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ DEFAULT_VERSION := 99.0.0
 VERSION ?= $(DEFAULT_VERSION) # the version of the operator
 OPERATOR_SDK_VERSION ?= v1.35.0
 ENVTEST_K8S_VERSION = 1.32 #refers to the version of kubebuilder assets to be downloaded by envtest binary # Kubernetes version from OpenShift 4.19.x
-GOLANGCI_LINT_VERSION ?= v2.6.1
+GOLANGCI_LINT_VERSION ?= v2.9.0
 KUSTOMIZE_VERSION ?= v5.2.1
 CONTROLLER_TOOLS_VERSION ?= v0.16.5
 OPM_VERSION ?= v1.23.0
@@ -472,7 +472,7 @@ TMP_DIR=$$(mktemp -d) ;\
 cd $$TMP_DIR ;\
 go mod init tmp ;\
 echo "Downloading $(2) to branch directory" ;\
-GOBIN=$(dir $(1)) go install -mod=mod $(2) ;\
+GOBIN=$(dir $(1)) go install -a -mod=mod $(2) ;\
 rm -rf $$TMP_DIR ;\
 }
 endef

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ IMAGE_TAG_BASE ?= openshift.io/oadp-operator
 BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(VERSION)
 
 # BUNDLE_GEN_FLAGS are the flags passed to the operator-sdk generate bundle command
-BUNDLE_GEN_FLAGS ?= -q --extra-service-accounts "velero,non-admin-controller,oadp-vm-file-restore-controller-manager" --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
+BUNDLE_GEN_FLAGS ?= -q --extra-service-accounts "velero,non-admin-controller,oadp-vm-file-restore-controller-manager,oadp-kubevirt-datamover-controller-manager" --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
 
 # USE_IMAGE_DIGESTS defines if images are resolved via tags or digests
 # You can enable this value if you would like to use SHA Based Digests

--- a/api/v1alpha1/dataprotectionapplication_types.go
+++ b/api/v1alpha1/dataprotectionapplication_types.go
@@ -36,10 +36,11 @@ const ReconcileCompleteMessage = "Reconcile complete"
 
 // Readiness Conditions
 const (
-	ConditionVeleroReady        = "VeleroReady"
-	ConditionNodeAgentReady     = "NodeAgentReady"
-	ConditionNonAdminReady      = "NonAdminReady"
-	ConditionVMFileRestoreReady = "VMFileRestoreReady"
+	ConditionVeleroReady            = "VeleroReady"
+	ConditionNodeAgentReady         = "NodeAgentReady"
+	ConditionNonAdminReady          = "NonAdminReady"
+	ConditionVMFileRestoreReady     = "VMFileRestoreReady"
+	ConditionKubevirtDatamoverReady = "KubevirtDatamoverReady"
 )
 
 // Readiness condition reasons

--- a/bundle/manifests/oadp-kubevirt-datamover-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/oadp-kubevirt-datamover-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,10 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: oadp-kubevirt-datamover-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get

--- a/bundle/manifests/oadp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/oadp-operator.clusterserviceversion.yaml
@@ -874,6 +874,78 @@ spec:
         - apiGroups:
           - ""
           resources:
+          - persistentvolumeclaims
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - backup.kubevirt.io
+          resources:
+          - virtualmachinebackups
+          - virtualmachinebackuptrackers
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - backup.kubevirt.io
+          resources:
+          - virtualmachinebackups/status
+          - virtualmachinebackuptrackers/status
+          verbs:
+          - get
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - virtualmachines
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - velero.io
+          resources:
+          - datauploads
+          verbs:
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - velero.io
+          resources:
+          - datauploads/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        serviceAccountName: oadp-kubevirt-datamover-controller-manager
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
           - namespaces
           - pods
           - secrets
@@ -1342,6 +1414,8 @@ spec:
                   value: quay.io/konveyor/oadp-vmfr-access-filebrowser:latest
                 - name: RELATED_IMAGE_CONSOLE_CLI_DOWNLOAD
                   value: quay.io/konveyor/oadp-cli-binaries:latest
+                - name: RELATED_IMAGE_KUBEVIRT_DATAMOVER_CONTROLLER
+                  value: quay.io/konveyor/kubevirt-datamover-controller:latest
                 image: quay.io/konveyor/oadp-operator:latest
                 imagePullPolicy: Always
                 livenessProbe:
@@ -1398,6 +1472,39 @@ spec:
               - emptyDir: {}
                 name: tmp-dir
       permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        serviceAccountName: oadp-kubevirt-datamover-controller-manager
       - rules:
         - apiGroups:
           - ""
@@ -1547,4 +1654,6 @@ spec:
     name: vm-file-restore-browser
   - image: quay.io/konveyor/oadp-cli-binaries:latest
     name: console-cli-download
+  - image: quay.io/konveyor/kubevirt-datamover-controller:latest
+    name: kubevirt-datamover-controller
   version: 99.0.0

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -98,6 +98,8 @@ spec:
               value: quay.io/konveyor/oadp-vmfr-access-filebrowser:latest
             - name: RELATED_IMAGE_CONSOLE_CLI_DOWNLOAD
               value: quay.io/konveyor/oadp-cli-binaries:latest
+            - name: RELATED_IMAGE_KUBEVIRT_DATAMOVER_CONTROLLER
+              value: quay.io/konveyor/kubevirt-datamover-controller:latest
           args:
             - --leader-elect
           image: controller:latest

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
 - ../velero
 - ../non-admin-controller_rbac
 - ../vm-file-restore-controller_rbac
+- ../kubevirt-datamover-controller_rbac
 
 # [WEBHOOK] To enable webhooks, uncomment all the sections with [WEBHOOK] prefix.
 # Do NOT uncomment sections with prefix [CERTMANAGER], as OLM does not support cert-manager.

--- a/docs/design/tech-debt/controller-state-management.md
+++ b/docs/design/tech-debt/controller-state-management.md
@@ -1,0 +1,142 @@
+# Controller State Management - Known Technical Debt
+
+## Overview
+
+Several controllers in the OADP operator use package-level variables to track state across reconciliation loops. While this pattern is established and functional in practice, it technically represents a data race when multiple reconciliations run concurrently.
+
+## Affected Controllers
+
+The following controllers use mutable package-level state without synchronization:
+
+### 1. KubeVirt DataMover Controller
+**File**: `internal/controller/kubevirt_datamover_controller.go:46-47`
+
+```go
+var (
+    kdmDpaResourceVersion            = ""
+    previousKubevirtDatamoverEnabled = false
+)
+```
+
+Used in `ensureKubevirtDatamoverRequiredSpecs()` at lines 181-184 to track DPA resource version and plugin enablement state.
+
+### 2. VM File Restore Controller
+**File**: `internal/controller/vmfilerestore_controller.go:47-48`
+
+```go
+var (
+    vmfrDpaResourceVersion                                         = ""
+    previousVMFileRestoreConfiguration *oadpv1alpha1.VMFileRestore = nil
+)
+```
+
+Used to track DPA resource version and VM file restore configuration changes.
+
+### 3. Non-Admin Controller
+**File**: `internal/controller/nonadmin_controller.go:46-48`
+
+```go
+var (
+    dpaResourceVersion                                   = ""
+    previousNonAdminConfiguration *oadpv1alpha1.NonAdmin = nil
+    previousDefaultBSLSyncPeriod  *time.Duration         = nil
+)
+```
+
+Used to track DPA resource version, non-admin configuration, and BSL sync period.
+
+## Technical Race Condition
+
+### The Issue
+
+Controller-runtime can execute concurrent reconciliations of the same DPA resource when:
+- The DPA is updated rapidly (multiple events queued)
+- Periodic resyncs overlap with event-driven reconciliations
+- Status updates trigger new reconciles while one is in-flight
+- Manual reconciliation is triggered
+
+Multiple goroutines can read/write these package-level variables simultaneously without synchronization, creating a data race.
+
+### Example Race Scenario
+
+```go
+// Goroutine 1: Reconcile DPA v1
+if len(kdmDpaResourceVersion) == 0 || ... {  // READ
+    kdmDpaResourceVersion = "v1"              // WRITE
+}
+
+// Goroutine 2: Reconcile DPA v2 (concurrent)
+if len(kdmDpaResourceVersion) == 0 || ... {  // READ (interleaved)
+    kdmDpaResourceVersion = "v2"              // WRITE (interleaved)
+}
+```
+
+## Why This Works in Practice
+
+1. **DPA Singleton Validation**: The validator at `internal/controller/validator.go:33-34` ensures only one DPA CR exists per namespace:
+   ```go
+   if len(dpaList.Items) > 1 {
+       return false, errors.New("only one DPA CR can exist per OADP installation namespace")
+   }
+   ```
+
+2. **Low Contention**: With a single DPA, reconciliation events are relatively infrequent.
+
+3. **Simple State**: The cached state is just resource versions and configuration snapshots, not complex data structures.
+
+4. **Controller-Runtime Behavior**: In practice, controller-runtime may serialize reconciles more than the API guarantees.
+
+## Potential Fixes (Future Work)
+
+If this race becomes problematic, any fix must be applied **consistently across all three controllers**. Options include:
+
+### Option 1: Add Mutex Synchronization
+```go
+type DataProtectionApplicationReconciler struct {
+    // ... existing fields ...
+    kdmMutex                         sync.RWMutex
+    kdmDpaResourceVersion            string
+    previousKubevirtDatamoverEnabled bool
+}
+
+// In reconcile logic:
+r.kdmMutex.Lock()
+defer r.kdmMutex.Unlock()
+if len(r.kdmDpaResourceVersion) == 0 || ... {
+    r.kdmDpaResourceVersion = dpa.GetResourceVersion()
+}
+```
+
+**Note**: No controllers in the codebase currently use mutexes on reconciler structs. Mutexes are only used locally within functions for explicit goroutine parallelism (e.g., `dataprotectiontest_controller.go:522`).
+
+### Option 2: Store in DPA Annotations (Recommended)
+Remove in-memory state entirely and read from Kubernetes API each time:
+```go
+podAnnotations := map[string]string{
+    kdmDpaResourceVersionAnnotation: dpa.GetResourceVersion(), // Always use current
+}
+```
+
+This is more idiomatic for Kubernetes operators and eliminates the race.
+
+### Option 3: Per-Namespace State Map
+```go
+type DataProtectionApplicationReconciler struct {
+    kdmStateMutex sync.RWMutex
+    kdmState      map[string]*kdmState  // namespace -> state
+}
+```
+
+## Decision
+
+**Status**: Documented, no immediate action required
+
+**Rationale**: This is an established pattern across multiple controllers. The singleton DPA constraint and low reconciliation frequency make the race low-risk in practice. Any fix would require coordinated changes across three controllers.
+
+**Future Action**: If Go's race detector flags this in CI, or if concurrent reconciliation issues arise, implement Option 2 (DPA annotations) consistently across all affected controllers.
+
+## References
+
+- Singleton validation: `internal/controller/validator.go:27-35`
+- Controller setup: `cmd/main.go:272-277`
+- Controller-runtime concurrency: https://github.com/kubernetes-sigs/controller-runtime/blob/main/FAQ.md#q-how-do-i-have-different-logic-in-my-reconciler-for-different-types-of-events-eg-create-update-delete

--- a/docs/design/tech-debt/image-pull-policy-error-handling.md
+++ b/docs/design/tech-debt/image-pull-policy-error-handling.md
@@ -1,0 +1,163 @@
+# Image Pull Policy Error Handling - Known Technical Debt
+
+## Overview
+
+Multiple controllers call `common.GetImagePullPolicy()` but only log errors instead of returning them. This means regex validation failures are silently swallowed, and deployments continue with potentially unexpected image pull policies.
+
+## Affected Locations
+
+All 7 usages follow the same pattern of logging errors without returning them:
+
+### 1. KubeVirt DataMover Controller
+**File**: `internal/controller/kubevirt_datamover_controller.go:96-99`
+```go
+imagePullPolicy, err := common.GetImagePullPolicy(r.dpa.Spec.ImagePullPolicy, kubevirtDatamoverControllerImage)
+if err != nil {
+    r.Log.Error(err, "imagePullPolicy regex failed")
+}
+```
+
+### 2. Non-Admin Controller
+**File**: `internal/controller/nonadmin_controller.go:128-131`
+```go
+imagePullPolicy, err := common.GetImagePullPolicy(r.dpa.Spec.ImagePullPolicy, nonAdminImage)
+if err != nil {
+    r.Log.Error(err, "imagePullPolicy regex failed")
+}
+```
+
+### 3. Node Agent
+**File**: `internal/controller/nodeagent.go:620-623`
+```go
+imagePullPolicy, err := common.GetImagePullPolicy(dpa.Spec.ImagePullPolicy, getVeleroImage(dpa))
+if err != nil {
+    r.Log.Error(err, "imagePullPolicy regex failed")
+}
+```
+
+### 4. VM File Restore Controller
+**File**: `internal/controller/vmfilerestore_controller.go:129-132`
+```go
+imagePullPolicy, err := common.GetImagePullPolicy(r.dpa.Spec.ImagePullPolicy, vmFileRestoreControllerImage)
+if err != nil {
+    r.Log.Error(err, "imagePullPolicy regex failed")
+}
+```
+
+### 5. Velero - Plugin Containers
+**File**: `internal/controller/velero.go:495-498`
+```go
+imagePullPolicy, err := common.GetImagePullPolicy(dpa.Spec.ImagePullPolicy, credentials.GetPluginImage(plugin, dpa))
+if err != nil {
+    r.Log.Error(err, "imagePullPolicy regex failed")
+}
+```
+
+### 6. Velero - Custom Plugins
+**File**: `internal/controller/velero.go:566-569`
+```go
+imagePullPolicy, err := common.GetImagePullPolicy(dpa.Spec.ImagePullPolicy, plugin.Image)
+if err != nil {
+    r.Log.Error(err, "imagePullPolicy regex failed")
+}
+```
+
+### 7. Velero - Main Container
+**File**: `internal/controller/velero.go:608-611`
+```go
+imagePullPolicy, err := common.GetImagePullPolicy(dpa.Spec.ImagePullPolicy, getVeleroImage(dpa))
+if err != nil {
+    r.Log.Error(err, "imagePullPolicy regex failed")
+}
+```
+
+## Function Behavior
+
+**File**: `pkg/common/common.go:216-237`
+
+The `GetImagePullPolicy` function:
+1. Returns the user override if provided
+2. Compiles regex patterns for SHA256 and SHA512 digests
+3. Returns `corev1.PullIfNotPresent` if image has a digest
+4. Returns `corev1.PullAlways` as default
+
+**On error**, it returns `corev1.PullAlways` as a safe fallback:
+```go
+sha256regex, err := regexp.Compile("@sha256:[a-f0-9]{64}")
+if err != nil {
+    return corev1.PullAlways, err  // Safe default
+}
+```
+
+## Current Impact
+
+**Risk Level**: Low
+
+The error can only occur if regex compilation fails. Since the regex patterns are hardcoded constants:
+- `"@sha256:[a-f0-9]{64}"`
+- `"@sha512:[a-f0-9]{128}"`
+
+Regex compilation failure is **extremely unlikely** (would require a Go runtime bug).
+
+**Current behavior when error occurs**:
+- Error is logged to operator logs
+- Deployment continues with `corev1.PullAlways` policy
+- User may not notice unless they check logs
+
+**Potential issues**:
+- Configuration problems are not surfaced to the user via DPA status
+- Unexpected `PullAlways` behavior when user expects `PullIfNotPresent` (for digest-based images)
+- Silent failures make troubleshooting harder
+
+## Potential Fixes (Future Work)
+
+Any fix must be applied **consistently across all 7 locations**.
+
+### Option 1: Return Error (Recommended)
+```go
+imagePullPolicy, err := common.GetImagePullPolicy(r.dpa.Spec.ImagePullPolicy, image)
+if err != nil {
+    return err  // Propagate to caller, surfaces in DPA reconciliation
+}
+```
+
+**Pros**: Configuration problems become visible in DPA status conditions
+**Cons**: Breaks current behavior; requires updating all 7 call sites
+
+### Option 2: Emit Kubernetes Event
+```go
+imagePullPolicy, err := common.GetImagePullPolicy(r.dpa.Spec.ImagePullPolicy, image)
+if err != nil {
+    r.Log.Error(err, "imagePullPolicy regex failed")
+    r.EventRecorder.Event(r.dpa, corev1.EventTypeWarning, "ImagePullPolicyValidationFailed",
+        fmt.Sprintf("Failed to determine image pull policy: %v", err))
+}
+```
+
+**Pros**: More visible to users than logs alone
+**Cons**: Still allows deployment with unexpected policy
+
+### Option 3: Remove Error Return from GetImagePullPolicy
+If regex compilation can never realistically fail, simplify the function:
+```go
+func GetImagePullPolicy(override *corev1.PullPolicy, image string) corev1.PullPolicy {
+    // ... no error return
+    // Use regexp.MustCompile since patterns are constants
+}
+```
+
+**Pros**: Cleaner API, acknowledges error is unrealistic
+**Cons**: Panics on malformed regex (acceptable for hardcoded patterns)
+
+## Decision
+
+**Status**: Documented, no immediate action required
+
+**Rationale**: This is an established pattern across 7 call sites. The error scenario is extremely unlikely (hardcoded regex patterns), and the fallback behavior (`PullAlways`) is safe. The impact on users is minimal.
+
+**Future Action**: If this becomes problematic, implement Option 1 (return error) consistently across all 7 locations to surface configuration issues in DPA status conditions.
+
+## References
+
+- GetImagePullPolicy implementation: `pkg/common/common.go:216-237`
+- Velero controller note on using GetImagePullPolicy: `internal/controller/velero.go:332`

--- a/internal/controller/dataprotectionapplication_controller.go
+++ b/internal/controller/dataprotectionapplication_controller.go
@@ -115,6 +115,7 @@ func (r *DataProtectionApplicationReconciler) Reconcile(ctx context.Context, req
 		r.ReconcileVeleroMetricsSVC,
 		r.ReconcileNonAdminController,
 		r.ReconcileVMFileRestoreController,
+		r.ReconcileKubevirtDatamoverController,
 	)
 
 	if err != nil {

--- a/internal/controller/kubevirt_datamover_controller.go
+++ b/internal/controller/kubevirt_datamover_controller.go
@@ -1,0 +1,350 @@
+package controller
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/go-logr/logr"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/exp/maps"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	k8serror "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
+	"github.com/openshift/oadp-operator/pkg/common"
+)
+
+const (
+	kubevirtDatamoverObjectName        = "oadp-kubevirt-datamover-controller-manager"
+	kubevirtDatamoverControlPlaneKey   = "control-plane"
+	kubevirtDatamoverControlPlaneValue = "oadp-kubevirt-datamover-controller"
+	kdmDpaResourceVersionAnnotation    = oadpv1alpha1.OadpOperatorLabel + "-kdm-dpa-resource-version"
+)
+
+var (
+	kubevirtDatamoverControlPlaneLabel = map[string]string{
+		kubevirtDatamoverControlPlaneKey: kubevirtDatamoverControlPlaneValue,
+	}
+	kubevirtDatamoverDeploymentLabels = map[string]string{
+		"app.kubernetes.io/component":  "manager",
+		"app.kubernetes.io/created-by": common.OADPOperator,
+		"app.kubernetes.io/instance":   kubevirtDatamoverObjectName,
+		"app.kubernetes.io/managed-by": "kustomize",
+		"app.kubernetes.io/name":       "deployment",
+		"app.kubernetes.io/part-of":    common.OADPOperator,
+	}
+
+	kdmDpaResourceVersion            = ""
+	previousKubevirtDatamoverEnabled = false
+)
+
+// ReconcileKubevirtDatamoverController manages the kubevirt-datamover controller deployment
+func (r *DataProtectionApplicationReconciler) ReconcileKubevirtDatamoverController(log logr.Logger) (bool, error) {
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      kubevirtDatamoverObjectName,
+			Namespace: r.NamespacedName.Namespace,
+		},
+	}
+
+	// Delete deployment if plugin not enabled
+	if !r.checkKubevirtDatamoverEnabled() {
+		if err := r.Get(r.Context, types.NamespacedName{Name: deployment.Name, Namespace: deployment.Namespace}, deployment); err != nil {
+			if k8serror.IsNotFound(err) {
+				return true, nil
+			}
+			return false, err
+		}
+		if err := r.Delete(r.Context, deployment, &client.DeleteOptions{PropagationPolicy: ptr.To(metav1.DeletePropagationForeground)}); err != nil {
+			r.EventRecorder.Event(deployment, corev1.EventTypeWarning, "KubevirtDatamoverDeploymentDeleteFailed",
+				fmt.Sprintf("Could not delete kubevirt-datamover controller deployment %s/%s: %s", deployment.Namespace, deployment.Name, err))
+			return false, err
+		}
+		r.EventRecorder.Event(deployment, corev1.EventTypeNormal, "KubevirtDatamoverDeploymentDeleteSucceed",
+			fmt.Sprintf("Kubevirt-datamover controller deployment %s/%s deleted", deployment.Namespace, deployment.Name))
+		return true, nil
+	}
+
+	// Create or update deployment
+	operation, err := controllerutil.CreateOrUpdate(r.Context, r.Client, deployment, func() error {
+		if err := r.buildKubevirtDatamoverDeployment(deployment); err != nil {
+			return err
+		}
+		return controllerutil.SetControllerReference(r.dpa, deployment, r.Scheme)
+	})
+	if err != nil {
+		return false, err
+	}
+	if operation != controllerutil.OperationResultNone {
+		r.EventRecorder.Event(deployment, corev1.EventTypeNormal, "KubevirtDatamoverDeploymentReconciled",
+			fmt.Sprintf("Kubevirt-datamover controller deployment %s/%s %s", deployment.Namespace, deployment.Name, operation))
+	}
+	return true, nil
+}
+
+func (r *DataProtectionApplicationReconciler) buildKubevirtDatamoverDeployment(deploymentObject *appsv1.Deployment) error {
+	kubevirtDatamoverControllerImage := r.getKubevirtDatamoverControllerImage()
+	imagePullPolicy, err := common.GetImagePullPolicy(r.dpa.Spec.ImagePullPolicy, kubevirtDatamoverControllerImage)
+	if err != nil {
+		r.Log.Error(err, "imagePullPolicy regex failed")
+	}
+	ensureKubevirtDatamoverRequiredLabels(deploymentObject)
+	err = ensureKubevirtDatamoverRequiredSpecs(deploymentObject, r.dpa, kubevirtDatamoverControllerImage, imagePullPolicy, r)
+	if err != nil {
+		return err
+	}
+
+	// Apply user-provided resource labels (protected labels are filtered)
+	// Note: NOT applied to Spec.Selector.MatchLabels as those are immutable after creation
+	deploymentObject.Labels = applyResourceLabels(r.dpa, deploymentObject.Labels)
+	deploymentObject.Spec.Template.Labels = applyResourceLabels(r.dpa, deploymentObject.Spec.Template.Labels)
+
+	// Re-assert selector labels to ensure template labels match selector
+	// This prevents user resourceLabels from overriding selector-critical labels
+	if deploymentObject.Spec.Selector != nil && deploymentObject.Spec.Selector.MatchLabels != nil {
+		if deploymentObject.Spec.Template.Labels == nil {
+			deploymentObject.Spec.Template.Labels = make(map[string]string)
+		}
+		for k, v := range deploymentObject.Spec.Selector.MatchLabels {
+			deploymentObject.Spec.Template.Labels[k] = v
+		}
+	}
+
+	// Apply user-provided resource annotations to both deployment and pod template
+	deploymentObject.Annotations = applyResourceAnnotations(r.dpa, deploymentObject.Annotations)
+	deploymentObject.Spec.Template.Annotations = applyResourceAnnotations(r.dpa, deploymentObject.Spec.Template.Annotations)
+
+	return nil
+}
+
+func ensureKubevirtDatamoverRequiredLabels(deploymentObject *appsv1.Deployment) {
+	maps.Copy(kubevirtDatamoverDeploymentLabels, kubevirtDatamoverControlPlaneLabel)
+	deploymentObjectLabels := deploymentObject.GetLabels()
+	if deploymentObjectLabels == nil {
+		deploymentObject.SetLabels(kubevirtDatamoverDeploymentLabels)
+	} else {
+		for key, value := range kubevirtDatamoverDeploymentLabels {
+			deploymentObjectLabels[key] = value
+		}
+		deploymentObject.SetLabels(deploymentObjectLabels)
+	}
+}
+
+func ensureKubevirtDatamoverRequiredSpecs(
+	deploymentObject *appsv1.Deployment,
+	dpa *oadpv1alpha1.DataProtectionApplication,
+	image string,
+	imagePullPolicy corev1.PullPolicy,
+	r *DataProtectionApplicationReconciler,
+) error {
+	// Build environment variables
+	envVars := []corev1.EnvVar{
+		{
+			Name:  "WATCH_NAMESPACE",
+			Value: deploymentObject.Namespace,
+		},
+	}
+
+	// Add log level if configured
+	if dpa.Spec.Configuration != nil && dpa.Spec.Configuration.Velero != nil {
+		envVars = append(envVars, corev1.EnvVar{
+			Name: common.LogLevelEnvVar,
+			Value: func() string {
+				level, err := logrus.ParseLevel(dpa.Spec.Configuration.Velero.LogLevel)
+				if err != nil {
+					return ""
+				}
+				return strconv.FormatUint(uint64(level), 10)
+			}(),
+		})
+	}
+
+	// Add log format if configured
+	if len(dpa.Spec.LogFormat) > 0 {
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  common.LogFormatEnvVar,
+			Value: string(dpa.Spec.LogFormat),
+		})
+	}
+
+	// Track DPA resource version for change detection
+	currentKubevirtDatamoverEnabled := r.checkKubevirtDatamoverEnabled()
+	if len(kdmDpaResourceVersion) == 0 ||
+		currentKubevirtDatamoverEnabled != previousKubevirtDatamoverEnabled {
+		kdmDpaResourceVersion = dpa.GetResourceVersion()
+		previousKubevirtDatamoverEnabled = currentKubevirtDatamoverEnabled
+	}
+
+	podAnnotations := map[string]string{
+		kdmDpaResourceVersionAnnotation: kdmDpaResourceVersion,
+	}
+
+	// Get resource requirements
+	resources := r.getKubevirtDatamoverResources()
+
+	// Set deployment spec
+	deploymentObject.Spec.Replicas = ptr.To(int32(1))
+	deploymentObject.Spec.Selector = &metav1.LabelSelector{
+		MatchLabels: kubevirtDatamoverControlPlaneLabel,
+	}
+
+	// Set template labels
+	templateObjectLabels := deploymentObject.Spec.Template.GetLabels()
+	if templateObjectLabels == nil {
+		deploymentObject.Spec.Template.SetLabels(kubevirtDatamoverControlPlaneLabel)
+	} else {
+		templateObjectLabels[kubevirtDatamoverControlPlaneKey] = kubevirtDatamoverControlPlaneLabel[kubevirtDatamoverControlPlaneKey]
+		deploymentObject.Spec.Template.SetLabels(templateObjectLabels)
+	}
+
+	// Set template annotations
+	templateObjectAnnotations := deploymentObject.Spec.Template.GetAnnotations()
+	if templateObjectAnnotations == nil {
+		deploymentObject.Spec.Template.SetAnnotations(podAnnotations)
+	} else {
+		templateObjectAnnotations[kdmDpaResourceVersionAnnotation] = podAnnotations[kdmDpaResourceVersionAnnotation]
+		deploymentObject.Spec.Template.SetAnnotations(templateObjectAnnotations)
+	}
+
+	// Set pod security context only if not already set (to avoid reconciliation loops)
+	if deploymentObject.Spec.Template.Spec.SecurityContext == nil {
+		deploymentObject.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
+			RunAsNonRoot: ptr.To(true),
+			SeccompProfile: &corev1.SeccompProfile{
+				Type: corev1.SeccompProfileTypeRuntimeDefault,
+			},
+		}
+	}
+
+	// Build container spec
+	kubevirtDatamoverContainerFound := false
+	containerSpec := corev1.Container{
+		Name:            "manager",
+		Image:           image,
+		ImagePullPolicy: imagePullPolicy,
+		Command:         []string{"/manager"},
+		Args: []string{
+			"--leader-elect",
+			"--health-probe-bind-address=:8081",
+			"--metrics-bind-address=:8443",
+			"--metrics-secure=true",
+		},
+		Env: envVars,
+		Ports: []corev1.ContainerPort{
+			{
+				Name:          "https",
+				ContainerPort: 8443,
+				Protocol:      corev1.ProtocolTCP,
+			},
+		},
+		Resources: resources,
+		SecurityContext: &corev1.SecurityContext{
+			AllowPrivilegeEscalation: ptr.To(false),
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{"ALL"},
+			},
+			ReadOnlyRootFilesystem: ptr.To(true),
+		},
+		LivenessProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path:   "/healthz",
+					Port:   intstr.FromInt(8081),
+					Scheme: corev1.URISchemeHTTP,
+				},
+			},
+			InitialDelaySeconds: 15,
+			PeriodSeconds:       20,
+		},
+		ReadinessProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path:   "/readyz",
+					Port:   intstr.FromInt(8081),
+					Scheme: corev1.URISchemeHTTP,
+				},
+			},
+			InitialDelaySeconds: 5,
+			PeriodSeconds:       10,
+		},
+		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+	}
+
+	if len(deploymentObject.Spec.Template.Spec.Containers) == 0 {
+		deploymentObject.Spec.Template.Spec.Containers = []corev1.Container{containerSpec}
+		kubevirtDatamoverContainerFound = true
+	} else {
+		for index, container := range deploymentObject.Spec.Template.Spec.Containers {
+			if container.Name == "manager" {
+				// Update only dynamic fields that can change based on DPA configuration
+				// Static fields (Command, Args, Ports, SecurityContext, Probes) are left as-is
+				kubevirtDatamoverContainer := &deploymentObject.Spec.Template.Spec.Containers[index]
+				kubevirtDatamoverContainer.Image = image
+				kubevirtDatamoverContainer.ImagePullPolicy = imagePullPolicy
+				kubevirtDatamoverContainer.Env = envVars
+				kubevirtDatamoverContainer.Resources = resources
+				kubevirtDatamoverContainer.TerminationMessagePolicy = corev1.TerminationMessageFallbackToLogsOnError
+				kubevirtDatamoverContainerFound = true
+				break
+			}
+		}
+	}
+
+	if !kubevirtDatamoverContainerFound {
+		return fmt.Errorf("could not find kubevirt-datamover container in Deployment")
+	}
+
+	deploymentObject.Spec.Template.Spec.RestartPolicy = corev1.RestartPolicyAlways
+	deploymentObject.Spec.Template.Spec.ServiceAccountName = kubevirtDatamoverObjectName
+	return nil
+}
+
+func (r *DataProtectionApplicationReconciler) checkKubevirtDatamoverEnabled() bool {
+	if r.dpa.Spec.Configuration == nil || r.dpa.Spec.Configuration.Velero == nil {
+		return false
+	}
+	if r.dpa.Spec.Configuration.Velero.DefaultPlugins != nil {
+		for _, plugin := range r.dpa.Spec.Configuration.Velero.DefaultPlugins {
+			if plugin == oadpv1alpha1.DefaultPluginKubeVirtDataMover {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (r *DataProtectionApplicationReconciler) getKubevirtDatamoverControllerImage() string {
+	// Priority 1: UnsupportedOverrides
+	if unsupportedOverride := r.dpa.Spec.UnsupportedOverrides[oadpv1alpha1.KubeVirtDatamoverImageKey]; unsupportedOverride != "" {
+		return unsupportedOverride
+	}
+	// Priority 2: Environment variable
+	if envVar := os.Getenv("RELATED_IMAGE_KUBEVIRT_DATAMOVER_CONTROLLER"); envVar != "" {
+		return envVar
+	}
+	// Priority 3: Default
+	return "quay.io/konveyor/kubevirt-datamover-controller:latest"
+}
+
+func (r *DataProtectionApplicationReconciler) getKubevirtDatamoverResources() corev1.ResourceRequirements {
+	// Conservative defaults matching vmfilerestore pattern
+	return corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("500m"),
+			corev1.ResourceMemory: resource.MustParse("128Mi"),
+		},
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("10m"),
+			corev1.ResourceMemory: resource.MustParse("64Mi"),
+		},
+	}
+}

--- a/internal/controller/kubevirt_datamover_controller_test.go
+++ b/internal/controller/kubevirt_datamover_controller_test.go
@@ -1,0 +1,1060 @@
+package controller
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
+
+	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
+)
+
+const (
+	defaultKubevirtDatamoverImage = "quay.io/konveyor/kubevirt-datamover-controller:latest"
+)
+
+type ReconcileKubevirtDatamoverControllerScenario struct {
+	namespace                string
+	dpa                      string
+	errMessage               string
+	eventWords               []string
+	kubevirtDatamoverEnabled bool
+	deployment               *appsv1.Deployment
+}
+
+func createTestKubevirtDatamoverDeployment(namespace string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      kubevirtDatamoverObjectName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"test":                            "test",
+				"app.kubernetes.io/name":          "wrong",
+				kubevirtDatamoverControlPlaneKey:  "super-wrong",
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: ptr.To(int32(2)),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: kubevirtDatamoverControlPlaneLabel,
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: kubevirtDatamoverControlPlaneLabel,
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "manager",
+							Image: "wrong",
+						},
+					},
+					ServiceAccountName: "wrong-one",
+				},
+			},
+		},
+	}
+}
+
+func runReconcileKubevirtDatamoverControllerTest(
+	scenario ReconcileKubevirtDatamoverControllerScenario,
+	updateTestScenario func(scenario ReconcileKubevirtDatamoverControllerScenario),
+	ctx context.Context,
+	imageEnvValue string,
+) {
+	updateTestScenario(scenario)
+
+	namespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: scenario.namespace,
+		},
+	}
+	gomega.Expect(k8sClient.Create(ctx, namespace)).To(gomega.Succeed())
+
+	dpa := &oadpv1alpha1.DataProtectionApplication{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      scenario.dpa,
+			Namespace: scenario.namespace,
+		},
+		Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+			Configuration: &oadpv1alpha1.ApplicationConfig{
+				Velero: &oadpv1alpha1.VeleroConfig{
+					DefaultPlugins: []oadpv1alpha1.DefaultPlugin{},
+				},
+			},
+		},
+	}
+
+	if scenario.kubevirtDatamoverEnabled {
+		dpa.Spec.Configuration.Velero.DefaultPlugins = append(
+			dpa.Spec.Configuration.Velero.DefaultPlugins,
+			oadpv1alpha1.DefaultPluginKubeVirtDataMover,
+		)
+	}
+
+	gomega.Expect(k8sClient.Create(ctx, dpa)).To(gomega.Succeed())
+
+	if scenario.deployment != nil {
+		gomega.Expect(k8sClient.Create(ctx, scenario.deployment)).To(gomega.Succeed())
+	}
+
+	os.Setenv("RELATED_IMAGE_KUBEVIRT_DATAMOVER_CONTROLLER", imageEnvValue)
+
+	event := record.NewFakeRecorder(5)
+	r := &DataProtectionApplicationReconciler{
+		Client:  k8sClient,
+		Scheme:  testEnv.Scheme,
+		Context: ctx,
+		NamespacedName: types.NamespacedName{
+			Name:      scenario.dpa,
+			Namespace: scenario.namespace,
+		},
+		EventRecorder: event,
+		dpa:           dpa,
+	}
+	result, err := r.ReconcileKubevirtDatamoverController(logr.Discard())
+
+	if len(scenario.errMessage) == 0 {
+		gomega.Expect(result).To(gomega.BeTrue())
+		gomega.Expect(err).To(gomega.Not(gomega.HaveOccurred()))
+	} else {
+		gomega.Expect(result).To(gomega.BeFalse())
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring(scenario.errMessage))
+	}
+
+	if scenario.eventWords != nil {
+		gomega.Expect(len(event.Events)).To(gomega.Equal(1))
+		message := <-event.Events
+		for _, word := range scenario.eventWords {
+			gomega.Expect(message).To(gomega.ContainSubstring(word))
+		}
+	} else {
+		gomega.Expect(len(event.Events)).To(gomega.Equal(0))
+	}
+}
+
+var _ = ginkgo.Describe("Test ReconcileKubevirtDatamoverController function", func() {
+	var (
+		ctx                 = context.Background()
+		currentTestScenario ReconcileKubevirtDatamoverControllerScenario
+		updateTestScenario  = func(scenario ReconcileKubevirtDatamoverControllerScenario) {
+			currentTestScenario = scenario
+		}
+	)
+
+	ginkgo.AfterEach(func() {
+		os.Unsetenv("RELATED_IMAGE_KUBEVIRT_DATAMOVER_CONTROLLER")
+
+		deployment := &appsv1.Deployment{}
+		if k8sClient.Get(
+			ctx,
+			types.NamespacedName{
+				Name:      kubevirtDatamoverObjectName,
+				Namespace: currentTestScenario.namespace,
+			},
+			deployment,
+		) == nil {
+			gomega.Expect(k8sClient.Delete(ctx, deployment)).To(gomega.Succeed())
+		}
+
+		dpa := &oadpv1alpha1.DataProtectionApplication{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      currentTestScenario.dpa,
+				Namespace: currentTestScenario.namespace,
+			},
+		}
+		gomega.Expect(k8sClient.Delete(ctx, dpa)).To(gomega.Succeed())
+
+		namespace := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: currentTestScenario.namespace,
+			},
+		}
+		gomega.Expect(k8sClient.Delete(ctx, namespace)).To(gomega.Succeed())
+	})
+
+	ginkgo.DescribeTable("Reconcile is true",
+		func(scenario ReconcileKubevirtDatamoverControllerScenario) {
+			runReconcileKubevirtDatamoverControllerTest(
+				scenario,
+				updateTestScenario,
+				ctx,
+				defaultKubevirtDatamoverImage,
+			)
+		},
+		ginkgo.Entry("Should create kubevirt-datamover deployment", ReconcileKubevirtDatamoverControllerScenario{
+			namespace:                "kdm-test-1",
+			dpa:                      "kdm-test-1-dpa",
+			eventWords:               []string{"Normal", "KubevirtDatamoverDeploymentReconciled", "created"},
+			kubevirtDatamoverEnabled: true,
+		}),
+		ginkgo.Entry("Should update kubevirt-datamover deployment", ReconcileKubevirtDatamoverControllerScenario{
+			namespace:                "kdm-test-2",
+			dpa:                      "kdm-test-2-dpa",
+			eventWords:               []string{"Normal", "KubevirtDatamoverDeploymentReconciled", "updated"},
+			kubevirtDatamoverEnabled: true,
+			deployment:               createTestKubevirtDatamoverDeployment("kdm-test-2"),
+		}),
+		ginkgo.Entry("Should delete kubevirt-datamover deployment", ReconcileKubevirtDatamoverControllerScenario{
+			namespace:                "kdm-test-3",
+			dpa:                      "kdm-test-3-dpa",
+			eventWords:               []string{"Normal", "KubevirtDatamoverDeploymentDeleteSucceed", "deleted"},
+			kubevirtDatamoverEnabled: false,
+			deployment:               createTestKubevirtDatamoverDeployment("kdm-test-3"),
+		}),
+		ginkgo.Entry("Should do nothing when disabled", ReconcileKubevirtDatamoverControllerScenario{
+			namespace:                "kdm-test-4",
+			dpa:                      "kdm-test-4-dpa",
+			kubevirtDatamoverEnabled: false,
+		}),
+	)
+
+	ginkgo.DescribeTable("Reconcile is false",
+		func(scenario ReconcileKubevirtDatamoverControllerScenario) {
+			runReconcileKubevirtDatamoverControllerTest(
+				scenario,
+				updateTestScenario,
+				ctx,
+				defaultKubevirtDatamoverImage,
+			)
+		},
+		ginkgo.Entry("Should error because manager container was not found in Deployment", ReconcileKubevirtDatamoverControllerScenario{
+			namespace:                "kdm-test-error-1",
+			dpa:                      "kdm-test-error-1-dpa",
+			errMessage:               "could not find kubevirt-datamover container in Deployment",
+			kubevirtDatamoverEnabled: true,
+			deployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      kubevirtDatamoverObjectName,
+					Namespace: "kdm-test-error-1",
+				},
+				Spec: appsv1.DeploymentSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: kubevirtDatamoverControlPlaneLabel,
+					},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: kubevirtDatamoverControlPlaneLabel,
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{
+								Name:  "wrong",
+								Image: defaultKubevirtDatamoverImage,
+							}},
+						},
+					},
+				},
+			},
+		}),
+	)
+})
+
+func TestCheckKubevirtDatamoverEnabled(t *testing.T) {
+	tests := []struct {
+		name           string
+		dpa            *oadpv1alpha1.DataProtectionApplication
+		expectedResult bool
+	}{
+		{
+			name: "Should return false when Configuration is nil",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: nil,
+				},
+			},
+			expectedResult: false,
+		},
+		{
+			name: "Should return false when Velero config is nil",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: nil,
+					},
+				},
+			},
+			expectedResult: false,
+		},
+		{
+			name: "Should return false when DefaultPlugins is nil",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{
+							DefaultPlugins: nil,
+						},
+					},
+				},
+			},
+			expectedResult: false,
+		},
+		{
+			name: "Should return false when plugin not in list",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{
+							DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
+								oadpv1alpha1.DefaultPluginAWS,
+								oadpv1alpha1.DefaultPluginKubeVirt,
+							},
+						},
+					},
+				},
+			},
+			expectedResult: false,
+		},
+		{
+			name: "Should return true when plugin in list",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{
+							DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
+								oadpv1alpha1.DefaultPluginAWS,
+								oadpv1alpha1.DefaultPluginKubeVirtDataMover,
+							},
+						},
+					},
+				},
+			},
+			expectedResult: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &DataProtectionApplicationReconciler{dpa: tt.dpa}
+			result := r.checkKubevirtDatamoverEnabled()
+
+			if result != tt.expectedResult {
+				t.Errorf("expected %v, got %v", tt.expectedResult, result)
+			}
+		})
+	}
+}
+
+func TestGetKubevirtDatamoverControllerImage(t *testing.T) {
+	tests := []struct {
+		name           string
+		envValue       string
+		overrideValue  string
+		expectedResult string
+	}{
+		{
+			name:           "Should return override value when set",
+			envValue:       "env-image:v1",
+			overrideValue:  "override-image:v1",
+			expectedResult: "override-image:v1",
+		},
+		{
+			name:           "Should return env value when override not set",
+			envValue:       "env-image:v1",
+			overrideValue:  "",
+			expectedResult: "env-image:v1",
+		},
+		{
+			name:           "Should return default when neither set",
+			envValue:       "",
+			overrideValue:  "",
+			expectedResult: defaultKubevirtDatamoverImage,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envValue != "" {
+				os.Setenv("RELATED_IMAGE_KUBEVIRT_DATAMOVER_CONTROLLER", tt.envValue)
+				defer os.Unsetenv("RELATED_IMAGE_KUBEVIRT_DATAMOVER_CONTROLLER")
+			}
+
+			dpa := &oadpv1alpha1.DataProtectionApplication{
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{},
+			}
+
+			if tt.overrideValue != "" {
+				dpa.Spec.UnsupportedOverrides = map[oadpv1alpha1.UnsupportedImageKey]string{
+					oadpv1alpha1.KubeVirtDatamoverImageKey: tt.overrideValue,
+				}
+			}
+
+			r := &DataProtectionApplicationReconciler{dpa: dpa}
+			result := r.getKubevirtDatamoverControllerImage()
+
+			if result != tt.expectedResult {
+				t.Errorf("expected %s, got %s", tt.expectedResult, result)
+			}
+		})
+	}
+}
+
+func TestGetKubevirtDatamoverResources(t *testing.T) {
+	tests := []struct {
+		name               string
+		expectedCPULimit   string
+		expectedMemLimit   string
+		expectedCPURequest string
+		expectedMemRequest string
+	}{
+		{
+			name:               "Should return default resources",
+			expectedCPULimit:   "500m",
+			expectedMemLimit:   "128Mi",
+			expectedCPURequest: "10m",
+			expectedMemRequest: "64Mi",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dpa := &oadpv1alpha1.DataProtectionApplication{
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{},
+			}
+
+			r := &DataProtectionApplicationReconciler{dpa: dpa}
+			result := r.getKubevirtDatamoverResources()
+
+			if result.Limits.Cpu().String() != tt.expectedCPULimit {
+				t.Errorf("CPU limit: expected %s, got %s", tt.expectedCPULimit, result.Limits.Cpu().String())
+			}
+			if result.Limits.Memory().String() != tt.expectedMemLimit {
+				t.Errorf("Memory limit: expected %s, got %s", tt.expectedMemLimit, result.Limits.Memory().String())
+			}
+			if result.Requests.Cpu().String() != tt.expectedCPURequest {
+				t.Errorf("CPU request: expected %s, got %s", tt.expectedCPURequest, result.Requests.Cpu().String())
+			}
+			if result.Requests.Memory().String() != tt.expectedMemRequest {
+				t.Errorf("Memory request: expected %s, got %s", tt.expectedMemRequest, result.Requests.Memory().String())
+			}
+		})
+	}
+}
+
+func TestEnsureKubevirtDatamoverRequiredLabels(t *testing.T) {
+	tests := []struct {
+		name           string
+		existingLabels map[string]string
+		expectedLabels map[string]string
+	}{
+		{
+			name:           "Should set labels when deployment has no labels",
+			existingLabels: nil,
+			expectedLabels: map[string]string{
+				"control-plane":                "oadp-kubevirt-datamover-controller",
+				"app.kubernetes.io/component":  "manager",
+				"app.kubernetes.io/created-by": "oadp-operator",
+				"app.kubernetes.io/instance":   "oadp-kubevirt-datamover-controller-manager",
+				"app.kubernetes.io/managed-by": "kustomize",
+				"app.kubernetes.io/name":       "deployment",
+				"app.kubernetes.io/part-of":    "oadp-operator",
+			},
+		},
+		{
+			name: "Should preserve existing labels and add required labels",
+			existingLabels: map[string]string{
+				"custom-label": "custom-value",
+			},
+			expectedLabels: map[string]string{
+				"custom-label":                 "custom-value",
+				"control-plane":                "oadp-kubevirt-datamover-controller",
+				"app.kubernetes.io/component":  "manager",
+				"app.kubernetes.io/created-by": "oadp-operator",
+				"app.kubernetes.io/instance":   "oadp-kubevirt-datamover-controller-manager",
+				"app.kubernetes.io/managed-by": "kustomize",
+				"app.kubernetes.io/name":       "deployment",
+				"app.kubernetes.io/part-of":    "oadp-operator",
+			},
+		},
+		{
+			name: "Should overwrite existing required labels with correct values",
+			existingLabels: map[string]string{
+				"control-plane":               "wrong-value",
+				"app.kubernetes.io/component": "wrong-component",
+			},
+			expectedLabels: map[string]string{
+				"control-plane":                "oadp-kubevirt-datamover-controller",
+				"app.kubernetes.io/component":  "manager",
+				"app.kubernetes.io/created-by": "oadp-operator",
+				"app.kubernetes.io/instance":   "oadp-kubevirt-datamover-controller-manager",
+				"app.kubernetes.io/managed-by": "kustomize",
+				"app.kubernetes.io/name":       "deployment",
+				"app.kubernetes.io/part-of":    "oadp-operator",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			deployment := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: tt.existingLabels,
+				},
+			}
+
+			ensureKubevirtDatamoverRequiredLabels(deployment)
+
+			labels := deployment.GetLabels()
+			for key, expectedValue := range tt.expectedLabels {
+				if actualValue, exists := labels[key]; !exists {
+					t.Errorf("expected label %s to exist", key)
+				} else if actualValue != expectedValue {
+					t.Errorf("label %s: expected %s, got %s", key, expectedValue, actualValue)
+				}
+			}
+
+			// Verify no unexpected labels were added (beyond expected and existing custom ones)
+			for key := range labels {
+				if _, expected := tt.expectedLabels[key]; !expected {
+					t.Errorf("unexpected label %s in deployment", key)
+				}
+			}
+		})
+	}
+}
+
+func TestEnsureKubevirtDatamoverRequiredSpecs(t *testing.T) {
+	tests := []struct {
+		name               string
+		dpa                *oadpv1alpha1.DataProtectionApplication
+		existingContainers []corev1.Container
+		expectedEnvCount   int
+		expectError        bool
+		errorContains      string
+	}{
+		{
+			name: "Should create container when no containers exist",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "test-dpa",
+					Namespace:       "test-namespace",
+					ResourceVersion: "12345",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{},
+					},
+				},
+			},
+			existingContainers: nil,
+			expectedEnvCount:   2, // WATCH_NAMESPACE, LOG_LEVEL (empty value)
+			expectError:        false,
+		},
+		{
+			name: "Should update existing manager container",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "test-dpa",
+					Namespace:       "test-namespace",
+					ResourceVersion: "12345",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{},
+					},
+				},
+			},
+			existingContainers: []corev1.Container{{Name: "manager", Image: "old"}},
+			expectedEnvCount:   2, // WATCH_NAMESPACE, LOG_LEVEL (empty value)
+			expectError:        false,
+		},
+		{
+			name: "Should include LOG_LEVEL env var when configured",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "test-dpa",
+					Namespace:       "test-namespace",
+					ResourceVersion: "12345",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{
+							LogLevel: "info",
+						},
+					},
+				},
+			},
+			existingContainers: nil,
+			expectedEnvCount:   2, // WATCH_NAMESPACE, LOG_LEVEL with value
+			expectError:        false,
+		},
+		{
+			name: "Should include LOG_FORMAT env var when configured",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "test-dpa",
+					Namespace:       "test-namespace",
+					ResourceVersion: "12345",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{},
+					},
+					LogFormat: oadpv1alpha1.LogFormatJSON,
+				},
+			},
+			existingContainers: nil,
+			expectedEnvCount:   3, // WATCH_NAMESPACE, LOG_LEVEL (empty), LOG_FORMAT
+			expectError:        false,
+		},
+		{
+			name: "Should include both LOG_LEVEL and LOG_FORMAT when configured",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "test-dpa",
+					Namespace:       "test-namespace",
+					ResourceVersion: "12345",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{
+							LogLevel: "debug",
+						},
+					},
+					LogFormat: oadpv1alpha1.LogFormatText,
+				},
+			},
+			existingContainers: nil,
+			expectedEnvCount:   3, // WATCH_NAMESPACE, LOG_LEVEL, LOG_FORMAT
+			expectError:        false,
+		},
+		{
+			name: "Should include WATCH_NAMESPACE and empty LOG_LEVEL when log level not configured",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "test-dpa",
+					Namespace:       "test-namespace",
+					ResourceVersion: "12345",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{},
+					},
+				},
+			},
+			existingContainers: nil,
+			expectedEnvCount:   2, // WATCH_NAMESPACE, LOG_LEVEL (empty value)
+			expectError:        false,
+		},
+		{
+			name: "Should set pod security context when not already set",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "test-dpa",
+					Namespace:       "test-namespace",
+					ResourceVersion: "12345",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{},
+					},
+				},
+			},
+			existingContainers: nil,
+			expectedEnvCount:   2, // WATCH_NAMESPACE, LOG_LEVEL (empty)
+			expectError:        false,
+		},
+		{
+			name: "Should error when manager container not found",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "test-dpa",
+					Namespace:       "test-namespace",
+					ResourceVersion: "12345",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{},
+					},
+				},
+			},
+			existingContainers: []corev1.Container{{Name: "wrong", Image: "wrong"}},
+			expectError:        true,
+			errorContains:      "could not find kubevirt-datamover container",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &DataProtectionApplicationReconciler{
+				dpa: tt.dpa,
+			}
+
+			deployment := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      kubevirtDatamoverObjectName,
+					Namespace: tt.dpa.Namespace,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: tt.existingContainers,
+						},
+					},
+				},
+			}
+
+			err := ensureKubevirtDatamoverRequiredSpecs(deployment, tt.dpa, defaultKubevirtDatamoverImage, corev1.PullAlways, r)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error but got none")
+				} else if tt.errorContains != "" && !strings.Contains(err.Error(), tt.errorContains) {
+					t.Errorf("expected error to contain '%s', got: %v", tt.errorContains, err)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			// Verify replicas
+			if *deployment.Spec.Replicas != 1 {
+				t.Errorf("replicas: expected 1, got %d", *deployment.Spec.Replicas)
+			}
+
+			// Verify service account name
+			if deployment.Spec.Template.Spec.ServiceAccountName != kubevirtDatamoverObjectName {
+				t.Errorf("serviceAccountName: expected %s, got %s", kubevirtDatamoverObjectName, deployment.Spec.Template.Spec.ServiceAccountName)
+			}
+
+			// Verify container
+			if len(deployment.Spec.Template.Spec.Containers) == 0 {
+				t.Fatalf("no containers found in deployment")
+			}
+
+			container := deployment.Spec.Template.Spec.Containers[0]
+			if container.Name != "manager" {
+				t.Errorf("container name: expected 'manager', got %s", container.Name)
+			}
+
+			// Verify environment variables
+			if len(container.Env) != tt.expectedEnvCount {
+				t.Errorf("env var count: expected %d, got %d", tt.expectedEnvCount, len(container.Env))
+			}
+
+			// Verify WATCH_NAMESPACE is always present
+			hasWatchNamespace := false
+			for _, env := range container.Env {
+				if env.Name == "WATCH_NAMESPACE" {
+					hasWatchNamespace = true
+					if env.Value != deployment.Namespace {
+						t.Errorf("WATCH_NAMESPACE: expected %s, got %s", deployment.Namespace, env.Value)
+					}
+					break
+				}
+			}
+			if !hasWatchNamespace {
+				t.Error("WATCH_NAMESPACE env var not found")
+			}
+
+			// Verify security contexts (only checked for new deployments)
+			// Note: The function only sets security contexts when creating new containers,
+			// not when updating existing ones (static fields are not changed)
+			if len(tt.existingContainers) == 0 {
+				if deployment.Spec.Template.Spec.SecurityContext == nil {
+					t.Error("expected pod security context to be set")
+				} else {
+					if deployment.Spec.Template.Spec.SecurityContext.RunAsNonRoot == nil || !*deployment.Spec.Template.Spec.SecurityContext.RunAsNonRoot {
+						t.Error("expected runAsNonRoot to be true")
+					}
+					if deployment.Spec.Template.Spec.SecurityContext.SeccompProfile == nil {
+						t.Error("expected seccomp profile to be set")
+					}
+				}
+
+				if container.SecurityContext == nil {
+					t.Error("expected container security context to be set")
+				} else {
+					if container.SecurityContext.AllowPrivilegeEscalation == nil || *container.SecurityContext.AllowPrivilegeEscalation {
+						t.Error("expected allowPrivilegeEscalation to be false")
+					}
+
+					if container.SecurityContext.ReadOnlyRootFilesystem == nil || !*container.SecurityContext.ReadOnlyRootFilesystem {
+						t.Error("expected readOnlyRootFilesystem to be true")
+					}
+				}
+
+				// Verify probes (only for new containers)
+				if container.LivenessProbe == nil {
+					t.Error("expected liveness probe to be set")
+				} else if container.LivenessProbe.HTTPGet == nil || container.LivenessProbe.HTTPGet.Path != "/healthz" {
+					t.Error("expected liveness probe path to be /healthz")
+				}
+
+				if container.ReadinessProbe == nil {
+					t.Error("expected readiness probe to be set")
+				} else if container.ReadinessProbe.HTTPGet == nil || container.ReadinessProbe.HTTPGet.Path != "/readyz" {
+					t.Error("expected readiness probe path to be /readyz")
+				}
+
+				// Verify ports (only for new containers)
+				if len(container.Ports) == 0 {
+					t.Error("expected container ports to be set")
+				} else if container.Ports[0].Name != "https" || container.Ports[0].ContainerPort != 8443 {
+					t.Error("expected https port 8443")
+				}
+			}
+
+			// Verify template labels include control-plane
+			if deployment.Spec.Template.Labels == nil {
+				t.Error("expected template labels to be set")
+			} else if deployment.Spec.Template.Labels[kubevirtDatamoverControlPlaneKey] != kubevirtDatamoverControlPlaneValue {
+				t.Errorf("expected control-plane label to be %s", kubevirtDatamoverControlPlaneValue)
+			}
+
+			// Verify template annotations include DPA resource version
+			if deployment.Spec.Template.Annotations == nil {
+				t.Error("expected template annotations to be set")
+			} else if _, exists := deployment.Spec.Template.Annotations[kdmDpaResourceVersionAnnotation]; !exists {
+				t.Error("expected DPA resource version annotation")
+			}
+		})
+	}
+}
+
+func TestBuildKubevirtDatamoverDeployment(t *testing.T) {
+	tests := []struct {
+		name             string
+		dpa              *oadpv1alpha1.DataProtectionApplication
+		envVars          map[string]string
+		expectedImage    string
+		expectedEnvCount int
+		expectedReplicas int32
+		expectedSAName   string
+		expectError      bool
+		errorContains    string
+	}{
+		{
+			name: "Should build deployment with default configuration",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "test-dpa",
+					Namespace:       "test-namespace",
+					ResourceVersion: "12345",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{},
+					},
+				},
+			},
+			expectedImage:    defaultKubevirtDatamoverImage,
+			expectedEnvCount: 2, // WATCH_NAMESPACE, LOG_LEVEL (empty)
+			expectedReplicas: 1,
+			expectedSAName:   kubevirtDatamoverObjectName,
+			expectError:      false,
+		},
+		{
+			name: "Should use custom image via override",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "test-dpa",
+					Namespace:       "test-namespace",
+					ResourceVersion: "12345",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{},
+					},
+					UnsupportedOverrides: map[oadpv1alpha1.UnsupportedImageKey]string{
+						oadpv1alpha1.KubeVirtDatamoverImageKey: "custom-registry.io/kdm:v1.0",
+					},
+				},
+			},
+			expectedImage:    "custom-registry.io/kdm:v1.0",
+			expectedEnvCount: 2, // WATCH_NAMESPACE, LOG_LEVEL (empty)
+			expectedReplicas: 1,
+			expectedSAName:   kubevirtDatamoverObjectName,
+			expectError:      false,
+		},
+		{
+			name: "Should use custom image via env var",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "test-dpa",
+					Namespace:       "test-namespace",
+					ResourceVersion: "12345",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{},
+					},
+				},
+			},
+			envVars: map[string]string{
+				"RELATED_IMAGE_KUBEVIRT_DATAMOVER_CONTROLLER": "env-registry.io/kdm:v2.0",
+			},
+			expectedImage:    "env-registry.io/kdm:v2.0",
+			expectedEnvCount: 2, // WATCH_NAMESPACE, LOG_LEVEL (empty)
+			expectedReplicas: 1,
+			expectedSAName:   kubevirtDatamoverObjectName,
+			expectError:      false,
+		},
+		{
+			name: "Should include log level and format env vars",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "test-dpa",
+					Namespace:       "test-namespace",
+					ResourceVersion: "12345",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{
+							LogLevel: "debug",
+						},
+					},
+					LogFormat: oadpv1alpha1.LogFormatJSON,
+				},
+			},
+			expectedImage:    defaultKubevirtDatamoverImage,
+			expectedEnvCount: 3, // WATCH_NAMESPACE, LOG_LEVEL, LOG_FORMAT
+			expectedReplicas: 1,
+			expectedSAName:   kubevirtDatamoverObjectName,
+			expectError:      false,
+		},
+		{
+			name: "Should apply resource labels and annotations correctly",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "test-dpa",
+					Namespace:       "test-namespace",
+					ResourceVersion: "12345",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{},
+					},
+				},
+			},
+			expectedImage:    defaultKubevirtDatamoverImage,
+			expectedEnvCount: 2, // WATCH_NAMESPACE, LOG_LEVEL (empty)
+			expectedReplicas: 1,
+			expectedSAName:   kubevirtDatamoverObjectName,
+			expectError:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set environment variables if provided
+			for key, value := range tt.envVars {
+				os.Setenv(key, value)
+				defer os.Unsetenv(key)
+			}
+
+			r := &DataProtectionApplicationReconciler{
+				dpa: tt.dpa,
+			}
+
+			deployment := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      kubevirtDatamoverObjectName,
+					Namespace: tt.dpa.Namespace,
+				},
+			}
+
+			err := r.buildKubevirtDatamoverDeployment(deployment)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error but got none")
+				} else if tt.errorContains != "" && !strings.Contains(err.Error(), tt.errorContains) {
+					t.Errorf("expected error to contain '%s', got: %v", tt.errorContains, err)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			// Verify deployment spec
+			if *deployment.Spec.Replicas != tt.expectedReplicas {
+				t.Errorf("replicas: expected %d, got %d", tt.expectedReplicas, *deployment.Spec.Replicas)
+			}
+
+			if deployment.Spec.Template.Spec.ServiceAccountName != tt.expectedSAName {
+				t.Errorf("serviceAccountName: expected %s, got %s", tt.expectedSAName, deployment.Spec.Template.Spec.ServiceAccountName)
+			}
+
+			// Verify container exists and has correct image
+			if len(deployment.Spec.Template.Spec.Containers) == 0 {
+				t.Fatalf("no containers found in deployment")
+			}
+
+			container := deployment.Spec.Template.Spec.Containers[0]
+			if container.Name != "manager" {
+				t.Errorf("container name: expected 'manager', got %s", container.Name)
+			}
+
+			if container.Image != tt.expectedImage {
+				t.Errorf("container image: expected %s, got %s", tt.expectedImage, container.Image)
+			}
+
+			// Verify environment variables
+			if len(container.Env) != tt.expectedEnvCount {
+				t.Errorf("env var count: expected %d, got %d", tt.expectedEnvCount, len(container.Env))
+			}
+
+			// Verify security contexts
+			if deployment.Spec.Template.Spec.SecurityContext.RunAsNonRoot == nil || !*deployment.Spec.Template.Spec.SecurityContext.RunAsNonRoot {
+				t.Error("expected runAsNonRoot to be true")
+			}
+
+			if container.SecurityContext.AllowPrivilegeEscalation == nil || *container.SecurityContext.AllowPrivilegeEscalation {
+				t.Error("expected allowPrivilegeEscalation to be false")
+			}
+
+			if container.SecurityContext.ReadOnlyRootFilesystem == nil || !*container.SecurityContext.ReadOnlyRootFilesystem {
+				t.Error("expected readOnlyRootFilesystem to be true")
+			}
+
+			// Verify probes exist
+			if container.LivenessProbe == nil {
+				t.Error("expected liveness probe to be set")
+			}
+
+			if container.ReadinessProbe == nil {
+				t.Error("expected readiness probe to be set")
+			}
+
+			// Verify labels
+			labels := deployment.GetLabels()
+			if labels["control-plane"] != kubevirtDatamoverControlPlaneValue {
+				t.Errorf("control-plane label: expected '%s', got %s", kubevirtDatamoverControlPlaneValue, labels["control-plane"])
+			}
+
+			// Verify pod annotations include DPA resource version
+			podAnnotations := deployment.Spec.Template.GetAnnotations()
+			if _, exists := podAnnotations[kdmDpaResourceVersionAnnotation]; !exists {
+				t.Error("expected pod annotation with DPA resource version")
+			}
+
+			// Verify default resources are applied
+			expectedCPULimit := resource.MustParse("500m")
+			expectedMemLimit := resource.MustParse("128Mi")
+			if !container.Resources.Limits.Cpu().Equal(expectedCPULimit) {
+				t.Errorf("CPU limit: expected %s, got %s", expectedCPULimit.String(), container.Resources.Limits.Cpu().String())
+			}
+			if !container.Resources.Limits.Memory().Equal(expectedMemLimit) {
+				t.Errorf("Memory limit: expected %s, got %s", expectedMemLimit.String(), container.Resources.Limits.Memory().String())
+			}
+		})
+	}
+}

--- a/internal/controller/kubevirt_datamover_controller_test.go
+++ b/internal/controller/kubevirt_datamover_controller_test.go
@@ -39,9 +39,9 @@ func createTestKubevirtDatamoverDeployment(namespace string) *appsv1.Deployment 
 			Name:      kubevirtDatamoverObjectName,
 			Namespace: namespace,
 			Labels: map[string]string{
-				"test":                            "test",
-				"app.kubernetes.io/name":          "wrong",
-				kubevirtDatamoverControlPlaneKey:  "super-wrong",
+				"test":                           "test",
+				"app.kubernetes.io/name":         "wrong",
+				kubevirtDatamoverControlPlaneKey: "super-wrong",
 			},
 		},
 		Spec: appsv1.DeploymentSpec{

--- a/internal/controller/readiness.go
+++ b/internal/controller/readiness.go
@@ -62,6 +62,13 @@ func (r *DataProtectionApplicationReconciler) updateReadinessConditions() (bool,
 	}
 	allReady = allReady && vmfrReady
 
+	// Check KubevirtDatamover (optional - only if enabled)
+	kdmReady, err := r.updateKubevirtDatamoverReadinessCondition()
+	if err != nil {
+		return false, err
+	}
+	allReady = allReady && kdmReady
+
 	return allReady, nil
 }
 
@@ -279,6 +286,62 @@ func (r *DataProtectionApplicationReconciler) updateVMFileRestoreReadinessCondit
 			Status:  metav1.ConditionFalse,
 			Reason:  oadpv1alpha1.ReasonDeploymentNotReady,
 			Message: fmt.Sprintf("VM File Restore controller not ready: %d/%d replicas ready", deployment.Status.ReadyReplicas, replicas),
+		})
+	}
+
+	return isReady, nil
+}
+
+func (r *DataProtectionApplicationReconciler) updateKubevirtDatamoverReadinessCondition() (bool, error) {
+	// If plugin not enabled, mark as disabled (which counts as ready)
+	if !r.checkKubevirtDatamoverEnabled() {
+		apimeta.SetStatusCondition(&r.dpa.Status.Conditions, metav1.Condition{
+			Type:    oadpv1alpha1.ConditionKubevirtDatamoverReady,
+			Status:  metav1.ConditionTrue,
+			Reason:  oadpv1alpha1.ReasonComponentDisabled,
+			Message: "KubeVirt DataMover controller is disabled",
+		})
+		return true, nil
+	}
+
+	deployment := &appsv1.Deployment{}
+	err := r.Get(r.Context, types.NamespacedName{
+		Name:      kubevirtDatamoverObjectName,
+		Namespace: r.dpa.Namespace,
+	}, deployment)
+
+	if err != nil {
+		if k8serror.IsNotFound(err) {
+			apimeta.SetStatusCondition(&r.dpa.Status.Conditions, metav1.Condition{
+				Type:    oadpv1alpha1.ConditionKubevirtDatamoverReady,
+				Status:  metav1.ConditionFalse,
+				Reason:  oadpv1alpha1.ReasonComponentNotFound,
+				Message: "KubeVirt DataMover controller deployment not found",
+			})
+			return false, nil
+		}
+		return false, err
+	}
+
+	replicas := int32(1)
+	if deployment.Spec.Replicas != nil {
+		replicas = *deployment.Spec.Replicas
+	}
+	isReady := deployment.Status.ReadyReplicas >= 1 && deployment.Status.ReadyReplicas == replicas
+
+	if isReady {
+		apimeta.SetStatusCondition(&r.dpa.Status.Conditions, metav1.Condition{
+			Type:    oadpv1alpha1.ConditionKubevirtDatamoverReady,
+			Status:  metav1.ConditionTrue,
+			Reason:  oadpv1alpha1.ReasonDeploymentReady,
+			Message: fmt.Sprintf("KubeVirt DataMover controller ready: %d/%d replicas", deployment.Status.ReadyReplicas, replicas),
+		})
+	} else {
+		apimeta.SetStatusCondition(&r.dpa.Status.Conditions, metav1.Condition{
+			Type:    oadpv1alpha1.ConditionKubevirtDatamoverReady,
+			Status:  metav1.ConditionFalse,
+			Reason:  oadpv1alpha1.ReasonDeploymentNotReady,
+			Message: fmt.Sprintf("KubeVirt DataMover controller not ready: %d/%d replicas ready", deployment.Status.ReadyReplicas, replicas),
 		})
 	}
 

--- a/internal/controller/readiness_test.go
+++ b/internal/controller/readiness_test.go
@@ -94,6 +94,11 @@ var _ = ginkgo.Describe("Test Readiness Conditions", func() {
 			_ = k8sClient.Delete(ctx, vmfrDeployment)
 		}
 
+		kdmDeployment := &appsv1.Deployment{}
+		if k8sClient.Get(ctx, types.NamespacedName{Name: kubevirtDatamoverObjectName, Namespace: nsName}, kdmDeployment) == nil {
+			_ = k8sClient.Delete(ctx, kdmDeployment)
+		}
+
 		if dpa != nil {
 			_ = k8sClient.Delete(ctx, dpa)
 		}
@@ -363,6 +368,86 @@ var _ = ginkgo.Describe("Test Readiness Conditions", func() {
 		})
 	})
 
+	ginkgo.Context("KubevirtDatamover Readiness", func() {
+		ginkgo.It("should return true when kubevirt-datamover is disabled", func() {
+			namespace, dpa, r := createTestResources("readiness-kdm-1", "dpa-kdm-1")
+			defer cleanupTestResources("readiness-kdm-1", namespace, dpa)
+
+			isReady, err := r.updateKubevirtDatamoverReadinessCondition()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(isReady).To(gomega.BeTrue())
+
+			cond := findCondition(r.dpa.Status.Conditions, oadpv1alpha1.ConditionKubevirtDatamoverReady)
+			gomega.Expect(cond).NotTo(gomega.BeNil())
+			gomega.Expect(cond.Status).To(gomega.Equal(metav1.ConditionTrue))
+			gomega.Expect(cond.Reason).To(gomega.Equal(oadpv1alpha1.ReasonComponentDisabled))
+		})
+
+		ginkgo.It("should return false when kubevirt-datamover is enabled but deployment not found", func() {
+			namespace, dpa, r := createTestResources("readiness-kdm-2", "dpa-kdm-2")
+			defer cleanupTestResources("readiness-kdm-2", namespace, dpa)
+
+			r.dpa.Spec.Configuration.Velero.DefaultPlugins = []oadpv1alpha1.DefaultPlugin{
+				oadpv1alpha1.DefaultPluginKubeVirtDataMover,
+			}
+
+			isReady, err := r.updateKubevirtDatamoverReadinessCondition()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(isReady).To(gomega.BeFalse())
+
+			cond := findCondition(r.dpa.Status.Conditions, oadpv1alpha1.ConditionKubevirtDatamoverReady)
+			gomega.Expect(cond).NotTo(gomega.BeNil())
+			gomega.Expect(cond.Status).To(gomega.Equal(metav1.ConditionFalse))
+			gomega.Expect(cond.Reason).To(gomega.Equal(oadpv1alpha1.ReasonComponentNotFound))
+		})
+
+		ginkgo.It("should return false when kubevirt-datamover deployment has 0 ready replicas", func() {
+			namespace, dpa, r := createTestResources("readiness-kdm-3", "dpa-kdm-3")
+			defer cleanupTestResources("readiness-kdm-3", namespace, dpa)
+
+			r.dpa.Spec.Configuration.Velero.DefaultPlugins = []oadpv1alpha1.DefaultPlugin{
+				oadpv1alpha1.DefaultPluginKubeVirtDataMover,
+			}
+
+			deployment := createReadinessKubevirtDatamoverDeployment("readiness-kdm-3", 1, 0)
+			gomega.Expect(k8sClient.Create(ctx, deployment)).To(gomega.Succeed())
+
+			isReady, err := r.updateKubevirtDatamoverReadinessCondition()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(isReady).To(gomega.BeFalse())
+
+			cond := findCondition(r.dpa.Status.Conditions, oadpv1alpha1.ConditionKubevirtDatamoverReady)
+			gomega.Expect(cond).NotTo(gomega.BeNil())
+			gomega.Expect(cond.Status).To(gomega.Equal(metav1.ConditionFalse))
+			gomega.Expect(cond.Reason).To(gomega.Equal(oadpv1alpha1.ReasonDeploymentNotReady))
+		})
+
+		ginkgo.It("should return true when kubevirt-datamover deployment is ready", func() {
+			namespace, dpa, r := createTestResources("readiness-kdm-4", "dpa-kdm-4")
+			defer cleanupTestResources("readiness-kdm-4", namespace, dpa)
+
+			r.dpa.Spec.Configuration.Velero.DefaultPlugins = []oadpv1alpha1.DefaultPlugin{
+				oadpv1alpha1.DefaultPluginKubeVirtDataMover,
+			}
+
+			deployment := createReadinessKubevirtDatamoverDeployment("readiness-kdm-4", 1, 1)
+			gomega.Expect(k8sClient.Create(ctx, deployment)).To(gomega.Succeed())
+
+			deployment.Status.ReadyReplicas = 1
+			deployment.Status.Replicas = 1
+			gomega.Expect(k8sClient.Status().Update(ctx, deployment)).To(gomega.Succeed())
+
+			isReady, err := r.updateKubevirtDatamoverReadinessCondition()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(isReady).To(gomega.BeTrue())
+
+			cond := findCondition(r.dpa.Status.Conditions, oadpv1alpha1.ConditionKubevirtDatamoverReady)
+			gomega.Expect(cond).NotTo(gomega.BeNil())
+			gomega.Expect(cond.Status).To(gomega.Equal(metav1.ConditionTrue))
+			gomega.Expect(cond.Reason).To(gomega.Equal(oadpv1alpha1.ReasonDeploymentReady))
+		})
+	})
+
 	ginkgo.Context("Combined Readiness", func() {
 		ginkgo.It("should return false when Velero is not ready even if optional components are disabled", func() {
 			namespace, dpa, r := createTestResources("readiness-combined-1", "dpa-combined-1")
@@ -512,6 +597,38 @@ func createReadinessVMFileRestoreDeployment(namespace string) *appsv1.Deployment
 					},
 				},
 			},
+		},
+	}
+}
+
+func createReadinessKubevirtDatamoverDeployment(namespace string, replicas, readyReplicas int32) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      kubevirtDatamoverObjectName,
+			Namespace: namespace,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: ptr.To(replicas),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "kdm"},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": "kdm"},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "manager",
+							Image: "kdm:latest",
+						},
+					},
+				},
+			},
+		},
+		Status: appsv1.DeploymentStatus{
+			Replicas:      replicas,
+			ReadyReplicas: readyReplicas,
 		},
 	}
 }

--- a/internal/controller/validator.go
+++ b/internal/controller/validator.go
@@ -359,6 +359,51 @@ func (r *DataProtectionApplicationReconciler) ValidateDataProtectionCR(log logr.
 		}
 	}
 
+	// validate kubevirt-datamover plugin enable
+	if r.checkKubevirtDatamoverEnabled() {
+		// Check for cluster-wide singleton enforcement
+		dpaList := &oadpv1alpha1.DataProtectionApplicationList{}
+		err = r.ClusterWideClient.List(r.Context, dpaList)
+		if err != nil {
+			return false, err
+		}
+		for _, dpa := range dpaList.Items {
+			if dpa.Namespace != r.NamespacedName.Namespace {
+				// Check if other DPA has kubevirt-datamover enabled
+				otherReconciler := &DataProtectionApplicationReconciler{dpa: &dpa}
+				if otherReconciler.checkKubevirtDatamoverEnabled() {
+					kubevirtDatamoverDeployment := &appsv1.Deployment{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      kubevirtDatamoverObjectName,
+							Namespace: dpa.Namespace,
+						},
+					}
+					if err := r.ClusterWideClient.Get(r.Context,
+						types.NamespacedName{Name: kubevirtDatamoverDeployment.Name, Namespace: kubevirtDatamoverDeployment.Namespace},
+						kubevirtDatamoverDeployment); err == nil {
+						return false, fmt.Errorf("only a single instance of KubeVirt DataMover Controller can be installed across the entire cluster. KubeVirt DataMover controller is already configured and installed in %s namespace", dpa.Namespace)
+					}
+				}
+			}
+		}
+
+		// Warn if kubevirt plugin not also configured (soft dependency)
+		hasKubevirtPlugin := false
+		if r.dpa.Spec.Configuration.Velero.DefaultPlugins != nil {
+			for _, plugin := range r.dpa.Spec.Configuration.Velero.DefaultPlugins {
+				if plugin == oadpv1alpha1.DefaultPluginKubeVirt {
+					hasKubevirtPlugin = true
+					break
+				}
+			}
+		}
+		if !hasKubevirtPlugin {
+			log.V(-1).Info("Warning: kubevirt-datamover plugin is enabled without kubevirt plugin")
+			r.EventRecorder.Event(r.dpa, corev1.EventTypeWarning, "KubevirtDatamoverWithoutKubevirtPlugin",
+				"kubevirt-datamover plugin is enabled but kubevirt plugin is not. Consider adding 'kubevirt' to spec.configuration.velero.defaultPlugins for full VM backup/restore functionality.")
+		}
+	}
+
 	return true, nil
 }
 

--- a/internal/controller/validator_test.go
+++ b/internal/controller/validator_test.go
@@ -2584,6 +2584,129 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "Single DPA with kubevirt-datamover enabled - success",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-DPA-CR",
+					Namespace: "test-ns",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{
+							DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
+								oadpv1alpha1.DefaultPluginKubeVirtDataMover,
+							},
+							NoDefaultBackupLocation: true,
+						},
+					},
+					BackupImages: ptr.To(false),
+				},
+			},
+			objects: []client.Object{},
+			wantErr: false,
+		},
+		{
+			name: "Multiple DPAs with kubevirt-datamover in different namespaces with deployment - error",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-DPA-CR",
+					Namespace: "test-ns",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{
+							DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
+								oadpv1alpha1.DefaultPluginKubeVirtDataMover,
+							},
+							NoDefaultBackupLocation: true,
+						},
+					},
+					BackupImages: ptr.To(false),
+				},
+			},
+			objects: []client.Object{
+				&oadpv1alpha1.DataProtectionApplication{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "another-DPA-CR",
+						Namespace: "test-another-ns",
+					},
+					Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+						Configuration: &oadpv1alpha1.ApplicationConfig{
+							Velero: &oadpv1alpha1.VeleroConfig{
+								DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
+									oadpv1alpha1.DefaultPluginKubeVirtDataMover,
+								},
+							},
+						},
+					},
+				},
+				&appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "oadp-kubevirt-datamover-controller-manager",
+						Namespace: "test-another-ns",
+					},
+					Spec: appsv1.DeploymentSpec{
+						Selector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "kdm"},
+						},
+						Template: corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								Labels: map[string]string{"app": "kdm"},
+							},
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{
+									Name:  "manager",
+									Image: "kdm:latest",
+								}},
+							},
+						},
+					},
+				},
+			},
+			wantErr:    true,
+			messageErr: "only a single instance of KubeVirt DataMover Controller can be installed across the entire cluster. KubeVirt DataMover controller is already configured and installed in test-another-ns namespace",
+		},
+		{
+			name: "Multiple DPAs with kubevirt-datamover, no deployment - allowed",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-DPA-CR",
+					Namespace: "test-ns",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{
+							DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
+								oadpv1alpha1.DefaultPluginKubeVirtDataMover,
+							},
+							NoDefaultBackupLocation: true,
+						},
+					},
+					BackupImages: ptr.To(false),
+				},
+			},
+			objects: []client.Object{
+				&oadpv1alpha1.DataProtectionApplication{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "another-DPA-CR",
+						Namespace: "test-another-ns",
+					},
+					Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+						Configuration: &oadpv1alpha1.ApplicationConfig{
+							Velero: &oadpv1alpha1.VeleroConfig{
+								DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
+									oadpv1alpha1.DefaultPluginKubeVirtDataMover,
+								},
+								NoDefaultBackupLocation: true,
+							},
+						},
+						BackupImages: ptr.To(false),
+					},
+				},
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		tt.objects = append(tt.objects, tt.dpa)
@@ -3106,6 +3229,119 @@ func TestVMFileRestoreValidation(t *testing.T) {
 				}
 				if !valid {
 					t.Errorf("ValidateDataProtectionCR() = %v, want true", valid)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateDataProtectionCR_KubevirtDatamoverWarning(t *testing.T) {
+	tests := []struct {
+		name                string
+		dpa                 *oadpv1alpha1.DataProtectionApplication
+		expectWarning       bool
+		expectedEventReason string
+	}{
+		{
+			name: "Kubevirt-datamover without kubevirt plugin - warning emitted",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-DPA-CR",
+					Namespace: "test-ns",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{
+							DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
+								oadpv1alpha1.DefaultPluginAWS,
+								oadpv1alpha1.DefaultPluginKubeVirtDataMover,
+							},
+							NoDefaultBackupLocation: true,
+						},
+					},
+					BackupImages: ptr.To(false),
+				},
+			},
+			expectWarning:       true,
+			expectedEventReason: "KubevirtDatamoverWithoutKubevirtPlugin",
+		},
+		{
+			name: "Kubevirt-datamover with kubevirt plugin - no warning",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-DPA-CR",
+					Namespace: "test-ns",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{
+							DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
+								oadpv1alpha1.DefaultPluginKubeVirt,
+								oadpv1alpha1.DefaultPluginKubeVirtDataMover,
+							},
+							NoDefaultBackupLocation: true,
+						},
+					},
+					BackupImages: ptr.To(false),
+				},
+			},
+			expectWarning: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			objects := []client.Object{tt.dpa}
+			fakeClient, err := getFakeClientFromObjects(objects...)
+			if err != nil {
+				t.Fatalf("error in creating fake client: %v", err)
+			}
+
+			eventRecorder := record.NewFakeRecorder(10)
+			r := &DataProtectionApplicationReconciler{
+				Client:            fakeClient,
+				ClusterWideClient: fakeClient,
+				Scheme:            fakeClient.Scheme(),
+				Log:               logr.Discard(),
+				Context:           newContextForTest(),
+				NamespacedName: types.NamespacedName{
+					Namespace: tt.dpa.Namespace,
+					Name:      tt.dpa.Name,
+				},
+				dpa:           tt.dpa,
+				EventRecorder: eventRecorder,
+			}
+
+			_, err = r.ValidateDataProtectionCR(r.Log)
+			if err != nil {
+				t.Errorf("ValidateDataProtectionCR() unexpected error = %v", err)
+				return
+			}
+
+			// Check for warning event
+			if tt.expectWarning {
+				select {
+				case event := <-eventRecorder.Events:
+					if !strings.Contains(event, "Warning") {
+						t.Errorf("expected Warning event type, got: %s", event)
+					}
+					if !strings.Contains(event, tt.expectedEventReason) {
+						t.Errorf("expected event reason '%s', got: %s", tt.expectedEventReason, event)
+					}
+					if !strings.Contains(event, "kubevirt plugin") {
+						t.Errorf("expected event message to mention kubevirt plugin dependency, got: %s", event)
+					}
+				default:
+					t.Error("expected warning event but none was emitted")
+				}
+			} else {
+				select {
+				case event := <-eventRecorder.Events:
+					if strings.Contains(event, "KubevirtDatamoverWithoutKubevirtPlugin") {
+						t.Errorf("unexpected warning event emitted: %s", event)
+					}
+				default:
+					// No event is expected, this is correct
 				}
 			}
 		})


### PR DESCRIPTION
## Why the changes were made

Adds the controller, API, RBAC, validation code for deploying the kubevirt-datamover-controller
Builds on #2074 

## How to test the changes made

Once the quay image for kubevirt-datamover-controller is up:
1) Specify kubevirt-datamover plugin in the default plugin list

This should trigger the deployment from the kubevirt-datamover-controller