### PR TITLE
drop OCP 4.15 from PARTNERS.md

### DIFF
--- a/PARTNERS.md
+++ b/PARTNERS.md
@@ -16,7 +16,6 @@ better stability and maintainability.
 | OpenShift Version | OADP Version | Velero Version | Estimated Release Timeline [1]|
 |-------------------|--------------|----------------|-------------------------------|
 | 4.14              | 1.3, 1.4     | v1.12, v1.14   | released                      |
-| 4.15              | 1.3, 1.4     | v1.12, v1.14   | released                      |
 | 4.16              | 1.4          | v1.14          | released                      | 
 | 4.17              | 1.4          | v1.14          | released                      |
 | 4.18              | 1.4          | v1.14          | released                      |


### PR DESCRIPTION
dropping support for OCP 4.15 per
https://access.redhat.com/support/policy/updates/openshift

## Why the changes were made

<!-- Explain why this PR is important, what problems it fixes, link related issues -->

## How to test the changes made

<!-- Explain how the changes introduced by this PR can be tested and verified, with commands and pictures -->
