### PR TITLE
OADP-4855 Add cachePVC support for Kopia cache volume

### DIFF
--- a/api/v1alpha1/dataprotectionapplication_types.go
+++ b/api/v1alpha1/dataprotectionapplication_types.go
@@ -446,8 +446,8 @@ type RuledConfigs struct {
 	Number int `json:"number"`
 }
 
-// Below struct should be same as:
-// https://github.com/openshift/velero/blob/584cf1148a746838ee67aa27e3e4e0ded1f5c069/pkg/nodeagent/node_agent.go#L90-L105
+// Below struct should mirror upstream Velero's NodeAgentConfigs.
+// Fields and JSON tags must match: https://github.com/vmware-tanzu/velero/blob/main/pkg/types/node_agent.go
 
 // NodeAgentConfigMapSettings is the config for node-agent
 type NodeAgentConfigMapSettings struct {
@@ -469,6 +469,12 @@ type NodeAgentConfigMapSettings struct {
 	// PodResources is the resource config for various types of pods launched by node-agent, i.e., data mover pods.
 	// +optional
 	PodResources *kube.PodResources `json:"podResources,omitempty"`
+	// CachePVCConfig configures a dedicated PVC for Kopia repository cache during restore operations.
+	// When set, cache data is stored on a provisioned PVC instead of the pod's root filesystem,
+	// preventing ephemeral storage exhaustion on nodes during concurrent restores.
+	// If storageClass is omitted, the cluster's default StorageClass is used.
+	// +optional
+	CachePVCConfig *types.CachePVC `json:"cachePVC,omitempty"`
 }
 
 // DeepCopyInto is a manual deepcopy function, copying the receiver, writing into out. in must be non-nil.
@@ -517,6 +523,11 @@ func (in *NodeAgentConfigMapSettings) DeepCopyInto(out *NodeAgentConfigMapSettin
 	if in.PodResources != nil {
 		in, out := &in.PodResources, &out.PodResources
 		*out = new(kube.PodResources)
+		**out = **in
+	}
+	if in.CachePVCConfig != nil {
+		in, out := &in.CachePVCConfig, &out.CachePVCConfig
+		*out = new(types.CachePVC)
 		**out = **in
 	}
 }

--- a/bundle/manifests/oadp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/oadp-operator.clusterserviceversion.yaml
@@ -1322,6 +1322,14 @@ spec:
           - update
           - watch
         - apiGroups:
+          - storage.k8s.io
+          resources:
+          - storageclasses
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
           - velero.io
           resources:
           - '*'

--- a/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
@@ -258,6 +258,21 @@ spec:
                           format: int64
                           minimum: 0
                           type: integer
+                        cachePVC:
+                          description: |-
+                            CachePVCConfig configures a dedicated PVC for Kopia repository cache during restore operations.
+                            When set, cache data is stored on a provisioned PVC instead of the pod's root filesystem,
+                            preventing ephemeral storage exhaustion on nodes during concurrent restores.
+                            If storageClass is omitted, the cluster's default StorageClass is used.
+                          properties:
+                            residentThresholdInMB:
+                              description: ResidentThresholdInMB specifies the minimum size of the backup data to create cache PVC
+                              format: int64
+                              type: integer
+                            storageClass:
+                              description: StorageClass specifies the storage class for cache PVC
+                              type: string
+                          type: object
                         dataMoverPrepareTimeout:
                           description: How long to wait for preparing a DataUpload/DataDownload. Default is 30 minutes.
                           type: string

--- a/bundle/manifests/velero.io_backupstoragelocations.yaml
+++ b/bundle/manifests/velero.io_backupstoragelocations.yaml
@@ -113,10 +113,38 @@ spec:
                     description: Bucket is the bucket to use for object storage.
                     type: string
                   caCert:
-                    description: CACert defines a CA bundle to use when verifying
-                      TLS connections to the provider.
+                    description: |-
+                      CACert defines a CA bundle to use when verifying TLS connections to the provider.
+                      Deprecated: Use CACertRef instead.
                     format: byte
                     type: string
+                  caCertRef:
+                    description: |-
+                      CACertRef is a reference to a Secret containing the CA certificate bundle to use
+                      when verifying TLS connections to the provider. The Secret must be in the same
+                      namespace as the BackupStorageLocation.
+                    properties:
+                      key:
+                        description: The key of the secret to select from.  Must be
+                          a valid secret key.
+                        type: string
+                      name:
+                        default: ""
+                        description: |-
+                          Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                      optional:
+                        description: Specify whether the Secret or its key must be
+                          defined
+                        type: boolean
+                    required:
+                    - key
+                    type: object
+                    x-kubernetes-map-type: atomic
                   prefix:
                     description: Prefix is the path inside a bucket to use for Velero
                       storage. Optional.

--- a/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
@@ -258,6 +258,21 @@ spec:
                           format: int64
                           minimum: 0
                           type: integer
+                        cachePVC:
+                          description: |-
+                            CachePVCConfig configures a dedicated PVC for Kopia repository cache during restore operations.
+                            When set, cache data is stored on a provisioned PVC instead of the pod's root filesystem,
+                            preventing ephemeral storage exhaustion on nodes during concurrent restores.
+                            If storageClass is omitted, the cluster's default StorageClass is used.
+                          properties:
+                            residentThresholdInMB:
+                              description: ResidentThresholdInMB specifies the minimum size of the backup data to create cache PVC
+                              format: int64
+                              type: integer
+                            storageClass:
+                              description: StorageClass specifies the storage class for cache PVC
+                              type: string
+                          type: object
                         dataMoverPrepareTimeout:
                           description: How long to wait for preparing a DataUpload/DataDownload. Default is 30 minutes.
                           type: string

--- a/config/crd/bases/velero.io_backupstoragelocations.yaml
+++ b/config/crd/bases/velero.io_backupstoragelocations.yaml
@@ -113,10 +113,38 @@ spec:
                     description: Bucket is the bucket to use for object storage.
                     type: string
                   caCert:
-                    description: CACert defines a CA bundle to use when verifying
-                      TLS connections to the provider.
+                    description: |-
+                      CACert defines a CA bundle to use when verifying TLS connections to the provider.
+                      Deprecated: Use CACertRef instead.
                     format: byte
                     type: string
+                  caCertRef:
+                    description: |-
+                      CACertRef is a reference to a Secret containing the CA certificate bundle to use
+                      when verifying TLS connections to the provider. The Secret must be in the same
+                      namespace as the BackupStorageLocation.
+                    properties:
+                      key:
+                        description: The key of the secret to select from.  Must be
+                          a valid secret key.
+                        type: string
+                      name:
+                        default: ""
+                        description: |-
+                          Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                      optional:
+                        description: Specify whether the Secret or its key must be
+                          defined
+                        type: boolean
+                    required:
+                    - key
+                    type: object
+                    x-kubernetes-map-type: atomic
                   prefix:
                     description: Prefix is the path inside a bucket to use for Velero
                       storage. Optional.

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -189,6 +189,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - velero.io
   resources:
   - '*'

--- a/docs/cache_volume_pvc_configuration.md
+++ b/docs/cache_volume_pvc_configuration.md
@@ -1,0 +1,129 @@
+# Cache Volume PVC Configuration for Data Movement Restore
+
+This guide describes how to configure dedicated cache volumes for Kopia repository cache storage during restore operations in OADP via the Data Protection Application (DPA) Custom Resource Definition (CRD).
+
+## Problem
+
+During data movement restore operations (DataDownload and PodVolumeRestore), Kopia stores repository cache data on the restore pod's root filesystem at `/root/.cache/kopia/`. The default cache limit is 5 GB per concurrent operation. In environments with small system disks or high restore concurrency, this can exhaust the node's ephemeral storage, causing pod evictions and restore failures.
+
+## Solution
+
+The `cachePVC` configuration enables OADP to provision dedicated PersistentVolumeClaims for Kopia cache storage during restore operations. Instead of consuming ephemeral storage on the node's root filesystem, cache data is written to dynamically provisioned PVCs that are automatically created per restore operation and cleaned up upon completion.
+
+This setting is defined under the `.spec.configuration.nodeAgent` section of the DPA CRD.
+
+## Configuration
+
+The `cachePVC` field supports the following parameters:
+
+- `storageClass` (optional) - The name of the Kubernetes StorageClass to use for provisioning cache PVCs. The StorageClass must:
+  - Support `ReadWriteOnce` access mode
+  - Support `Filesystem` volume mode
+  - Have a `Delete` reclaim policy (to ensure cache PVCs are properly cleaned up)
+
+  If this field is omitted or empty, OADP will automatically attempt to use the cluster's default StorageClass (the one annotated with `storageclass.kubernetes.io/is-default-class: "true"`). If no default StorageClass is found, cache volume creation is disabled and Kopia falls back to using the pod's root filesystem for cache storage.
+
+- `residentThresholdInMB` (optional) - The minimum size (in MB) of the backup data that triggers cache PVC creation. If the backup being restored is smaller than this threshold, no cache PVC is created and the cache remains on the root filesystem. This avoids the overhead of provisioning a PVC for small restores. If set to 0 or omitted, a cache PVC is created for all restores.
+
+## Cache PVC Size Calculation
+
+The size of each cache PVC is calculated as:
+
+```
+cacheVolumeSize = cacheLimitMB * 1.2 (rounded up to the nearest GB)
+```
+
+Where `cacheLimitMB` defaults to 5 GB (Kopia's default) but can be overridden via the `cacheLimitMB` field in the DPA. For example:
+
+- Default (no `cacheLimitMB` set): 5 GB x 1.2 = 6 GB cache PVC
+- With `cacheLimitMB: 10240`: 10 GB x 1.2 = 12 GB cache PVC
+
+## Lifecycle
+
+1. When a restore operation starts, a cache PVC is created with the calculated size
+2. The cache PVC is mounted to the restore pod
+3. Kopia uses the mounted path for local repository caching
+4. When the restore completes, the cache PVC is automatically deleted
+5. The `Delete` reclaim policy on the StorageClass ensures the underlying PersistentVolume is also cleaned up
+
+## Example Configuration
+
+### Basic configuration with cache volume (explicit StorageClass)
+
+```yaml
+apiVersion: oadp.openshift.io/v1alpha1
+kind: DataProtectionApplication
+metadata:
+  name: velero-sample
+  namespace: openshift-adp
+spec:
+  configuration:
+    nodeAgent:
+      enable: true
+      uploaderType: kopia
+      cachePVC:
+        storageClass: gp3-csi
+    velero:
+      defaultPlugins:
+        - openshift
+        - aws
+```
+
+### Basic configuration using the cluster's default StorageClass
+
+When `storageClass` is omitted, OADP resolves the cluster's default StorageClass automatically:
+
+```yaml
+apiVersion: oadp.openshift.io/v1alpha1
+kind: DataProtectionApplication
+metadata:
+  name: velero-sample
+  namespace: openshift-adp
+spec:
+  configuration:
+    nodeAgent:
+      enable: true
+      uploaderType: kopia
+      cachePVC: {}
+    velero:
+      defaultPlugins:
+        - openshift
+        - aws
+```
+
+### Configuration with resident threshold and custom cache limit
+
+This example only creates cache PVCs for restores larger than 1 GB and sets the Kopia cache limit to 10 GB:
+
+```yaml
+apiVersion: oadp.openshift.io/v1alpha1
+kind: DataProtectionApplication
+metadata:
+  name: velero-sample
+  namespace: openshift-adp
+spec:
+  configuration:
+    nodeAgent:
+      enable: true
+      uploaderType: kopia
+      cachePVC:
+        storageClass: gp3-csi
+        residentThresholdInMB: 1024
+      cacheLimitMB: 10240
+    velero:
+      defaultPlugins:
+        - openshift
+        - aws
+```
+
+## Backward Compatibility
+
+If no `cachePVC` configuration is provided, OADP and Velero fall back to the original behavior of storing cache data on the pod's root filesystem. Existing DPA configurations continue to work without modification.
+
+## Related Settings
+
+- `cacheLimitMB` - Controls the Kopia repository cache size limit. Defined in `spec.configuration.nodeAgent.cacheLimitMB`. This affects the size of cache PVCs when `cachePVC` is configured.
+- `backupPVC` - Controls intermediate PVCs for snapshot data movement (backup direction). See [Data Mover Backup PVC Configuration](data_mover_backup_pvc_configuration.md).
+- `restorePVC` - Controls intermediate PVCs for restore data movement. See [Data Mover Backup PVC Configuration](data_mover_backup_pvc_configuration.md).
+
+Please refer to the Velero documentation for more details on the cache volume feature. In the OADP project, this feature is controlled via the `nodeAgent.cachePVC` field in the DPA CRD, not through a ConfigMap. The latter is automatically created and managed by the OADP controller for you: [Cache Volume for Data Movement](https://velero.io/docs/main/data-movement-cache-volume/).

--- a/internal/controller/dataprotectionapplication_controller.go
+++ b/internal/controller/dataprotectionapplication_controller.go
@@ -75,6 +75,7 @@ var debugMode = os.Getenv("DEBUG") == "true"
 //+kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=console.openshift.io,resources=consoleclidownloads,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=storage.k8s.io,resources=storageclasses,verbs=get;list;watch
 
 // Reconcile is part of the main Kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/internal/controller/nodeagent.go
+++ b/internal/controller/nodeagent.go
@@ -14,6 +14,7 @@ import (
 	"github.com/vmware-tanzu/velero/pkg/util/kube"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -121,8 +122,26 @@ func isNodeAgentCMRequired(config oadpv1alpha1.NodeAgentConfigMapSettings, disab
 		config.RestorePVCConfig != nil ||
 		config.PodResources != nil ||
 		config.LoadAffinityConfig != nil ||
+		config.CachePVCConfig != nil ||
 		disableFsBackup == nil ||
 		!*disableFsBackup
+}
+
+// getDefaultStorageClass returns the name of the cluster's default StorageClass, if one exists.
+// A StorageClass is considered default if it has the annotation
+// "storageclass.kubernetes.io/is-default-class" set to "true".
+func (r *DataProtectionApplicationReconciler) getDefaultStorageClass() (string, error) {
+	scList := &storagev1.StorageClassList{}
+	if err := r.Client.List(r.Context, scList); err != nil {
+		return "", fmt.Errorf("failed to list storage classes: %w", err)
+	}
+	for i := range scList.Items {
+		sc := &scList.Items[i]
+		if sc.Annotations["storageclass.kubernetes.io/is-default-class"] == "true" {
+			return sc.Name, nil
+		}
+	}
+	return "", nil
 }
 
 // updateNodeAgentCM handles the creation or update of the NodeAgent ConfigMap with all required data.
@@ -140,6 +159,27 @@ func (r *DataProtectionApplicationReconciler) updateNodeAgentCM(cm *corev1.Confi
 		NodeAgentConfigMapSettings: r.dpa.Spec.Configuration.NodeAgent.NodeAgentConfigMapSettings,
 		PrivilegedFsBackup:         privilegedFsBackup,
 	}
+
+	// If CachePVCConfig is set but StorageClass is empty, resolve the cluster's default StorageClass.
+	// This prevents restore failures when local storage is limited by ensuring a StorageClass is available
+	// for cache PVC provisioning, even when the user doesn't explicitly specify one.
+	if configWithPrivileged.CachePVCConfig != nil && configWithPrivileged.CachePVCConfig.StorageClass == "" {
+		defaultSC, err := r.getDefaultStorageClass()
+		if err != nil {
+			r.Log.Info("Failed to resolve default StorageClass for cache PVC, cache volume will be disabled", "error", err)
+			configWithPrivileged.CachePVCConfig = nil
+		} else if defaultSC != "" {
+			// Create a copy to avoid modifying the DPA spec
+			cachePVCCopy := *configWithPrivileged.CachePVCConfig
+			cachePVCCopy.StorageClass = defaultSC
+			configWithPrivileged.CachePVCConfig = &cachePVCCopy
+			r.Log.Info("Resolved default StorageClass for cache PVC", "storageClass", defaultSC)
+		} else {
+			r.Log.Info("No default StorageClass found, cache volume will be disabled unless a StorageClass is specified in cachePVC config")
+			configWithPrivileged.CachePVCConfig = nil
+		}
+	}
+
 	// Convert NodeAgentConfigMapSettings to a generic map
 	configNodeAgentJSON, err := json.Marshal(configWithPrivileged)
 	if err != nil {
@@ -364,6 +404,15 @@ func (r *DataProtectionApplicationReconciler) buildNodeAgentDaemonset(ds *appsv1
 		configMapGeneration = configMap.ResourceVersion
 	}
 
+	// Determine the backup-repository-configmap name to pass to the node-agent DaemonSet
+	// so it can read Kopia repository settings (e.g. cacheLimitMB) needed for cache volume
+	// size calculations during restore operations.
+	var backupRepoConfigMapName string
+	if isBackupRepositoryCmRequired(dpa.Spec.Configuration.NodeAgent) {
+		backupRepoCmName := r.GetBackupRepositoryConfigMapName()
+		backupRepoConfigMapName = backupRepoCmName.Name
+	}
+
 	installDs := install.DaemonSet(ds.Namespace,
 		install.WithResources(nodeAgentResourceReqs),
 		install.WithImage(getVeleroImage(dpa)),
@@ -372,6 +421,7 @@ func (r *DataProtectionApplicationReconciler) buildNodeAgentDaemonset(ds *appsv1
 		install.WithServiceAccountName(common.Velero),
 		install.WithNodeAgentConfigMap(configMapName),
 		install.WithLabels(map[string]string{NodeAgentCMVersionLabel: configMapGeneration}),
+		install.WithBackupRepoConfigMap(backupRepoConfigMapName),
 	)
 	ds.TypeMeta = installDs.TypeMeta
 	var err error

--- a/internal/controller/nodeagent_test.go
+++ b/internal/controller/nodeagent_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/vmware-tanzu/velero/pkg/util/kube"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -1545,6 +1546,31 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 			}),
 		},
 		{
+			name: "valid DPA CR with KopiaRepoOptions, NodeAgent DaemonSet is built with backup-repository-configmap arg",
+			dpa: createTestDpaWith(
+				nil,
+				oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{},
+						NodeAgent: &oadpv1alpha1.NodeAgentConfig{
+							NodeAgentCommonFields: oadpv1alpha1.NodeAgentCommonFields{},
+							UploaderType:          "kopia",
+							KopiaRepoOptions: oadpv1alpha1.KopiaRepoOptions{
+								CacheLimitMB: ptr.To(int64(10240)),
+							},
+						},
+					},
+				},
+			),
+			clientObjects:      []client.Object{testGenericInfrastructure},
+			nodeAgentDaemonSet: testNodeAgentDaemonSet.DeepCopy(),
+			wantNodeAgentDaemonSet: createTestBuiltNodeAgentDaemonSet(TestBuiltNodeAgentDaemonSetOptions{
+				args: []string{
+					"--backup-repository-configmap=" + common.BackupRepoConfigMapPrefix + testDpaName,
+				},
+			}),
+		},
+		{
 			name: "valid DPA CR with Azure workload identity env vars, NodeAgent DaemonSet is built with Azure env vars",
 			dpa: createTestDpaWith(
 				nil,
@@ -1881,6 +1907,96 @@ func TestDPAReconciler_updateNodeAgentCM(t *testing.T) {
 				}`,
 			}),
 		},
+		{
+			name: "Given DPA CR instance, appropriate NodeAgent config cm is created with CachePVCConfig",
+			nodeAgentConfigMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      common.NodeAgentConfigMapPrefix + testCmName,
+					Namespace: testCmNs,
+				},
+			},
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testCmName,
+					Namespace: testCmNs,
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{
+							DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
+								oadpv1alpha1.DefaultPluginAWS,
+							},
+						},
+						NodeAgent: &oadpv1alpha1.NodeAgentConfig{
+							NodeAgentCommonFields: oadpv1alpha1.NodeAgentCommonFields{},
+							NodeAgentConfigMapSettings: oadpv1alpha1.NodeAgentConfigMapSettings{
+								CachePVCConfig: &velerotypes.CachePVC{
+									StorageClass:          "gp3-csi",
+									ResidentThresholdInMB: 1024,
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+			wantNodeAgentConfigMap: createTestBuiltNodeAgentCM(map[string]string{
+				"node-agent-config": `{
+					"cachePVC": {
+						"storageClass": "gp3-csi",
+						"residentThresholdInMB": 1024
+					},
+					"privilegedFsBackup": true
+				}`,
+			}),
+		},
+		{
+			name: "Given DPA CR instance, appropriate NodeAgent config cm is created with CachePVCConfig and other settings",
+			nodeAgentConfigMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      common.NodeAgentConfigMapPrefix + testCmName,
+					Namespace: testCmNs,
+				},
+			},
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testCmName,
+					Namespace: testCmNs,
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{
+							DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
+								oadpv1alpha1.DefaultPluginAWS,
+							},
+						},
+						NodeAgent: &oadpv1alpha1.NodeAgentConfig{
+							NodeAgentCommonFields: oadpv1alpha1.NodeAgentCommonFields{},
+							NodeAgentConfigMapSettings: oadpv1alpha1.NodeAgentConfigMapSettings{
+								LoadConcurrency: &oadpv1alpha1.LoadConcurrency{
+									GlobalConfig: 5,
+								},
+								CachePVCConfig: &velerotypes.CachePVC{
+									StorageClass: "gp3-csi",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+			wantNodeAgentConfigMap: createTestBuiltNodeAgentCM(map[string]string{
+				"node-agent-config": `{
+					"loadConcurrency": {
+						"globalConfig": 5
+					},
+					"cachePVC": {
+						"storageClass": "gp3-csi"
+					},
+					"privilegedFsBackup": true
+				}`,
+			}),
+		},
 	}
 
 	for _, tt := range tests {
@@ -1927,6 +2043,234 @@ func TestDPAReconciler_updateNodeAgentCM(t *testing.T) {
 			// Compare the unmarshalled maps
 			require.Equal(t, wantMap, gotMap, "ConfigMaps are not equal")
 
+		})
+	}
+}
+
+func Test_isNodeAgentCMRequired_CachePVCConfig(t *testing.T) {
+	tests := []struct {
+		name            string
+		config          oadpv1alpha1.NodeAgentConfigMapSettings
+		disableFsBackup *bool
+		want            bool
+	}{
+		{
+			name:            "CachePVCConfig set, fs-backup disabled, CM should be required",
+			config:          oadpv1alpha1.NodeAgentConfigMapSettings{CachePVCConfig: &velerotypes.CachePVC{StorageClass: "gp3-csi"}},
+			disableFsBackup: ptr.To(true),
+			want:            true,
+		},
+		{
+			name:            "No config set, fs-backup disabled, CM should not be required",
+			config:          oadpv1alpha1.NodeAgentConfigMapSettings{},
+			disableFsBackup: ptr.To(true),
+			want:            false,
+		},
+		{
+			name:            "CachePVCConfig set, fs-backup enabled, CM should be required",
+			config:          oadpv1alpha1.NodeAgentConfigMapSettings{CachePVCConfig: &velerotypes.CachePVC{StorageClass: "gp3-csi"}},
+			disableFsBackup: ptr.To(false),
+			want:            true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isNodeAgentCMRequired(tt.config, tt.disableFsBackup)
+			if got != tt.want {
+				t.Errorf("isNodeAgentCMRequired() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_getDefaultStorageClass(t *testing.T) {
+	tests := []struct {
+		name    string
+		objects []client.Object
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "no storage classes exist",
+			objects: nil,
+			want:    "",
+			wantErr: false,
+		},
+		{
+			name: "default storage class exists",
+			objects: []client.Object{
+				&storagev1.StorageClass{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "gp3-csi",
+						Annotations: map[string]string{
+							"storageclass.kubernetes.io/is-default-class": "true",
+						},
+					},
+				},
+				&storagev1.StorageClass{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "standard",
+					},
+				},
+			},
+			want:    "gp3-csi",
+			wantErr: false,
+		},
+		{
+			name: "no default storage class",
+			objects: []client.Object{
+				&storagev1.StorageClass{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "gp3-csi",
+					},
+				},
+			},
+			want:    "",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeClient, err := getFakeClientFromObjects(tt.objects...)
+			if err != nil {
+				t.Fatalf("error in creating fake client: %v", err)
+			}
+			r := &DataProtectionApplicationReconciler{
+				Client:  fakeClient,
+				Scheme:  fakeClient.Scheme(),
+				Log:     logr.Discard(),
+				Context: newContextForTest(),
+			}
+			got, err := r.getDefaultStorageClass()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getDefaultStorageClass() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("getDefaultStorageClass() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_updateNodeAgentCM_DefaultStorageClass(t *testing.T) {
+	testCmName := "test-dpa"
+	testCmNs := "test-ns"
+
+	tests := []struct {
+		name             string
+		storageClasses   []client.Object
+		cachePVCConfig   *velerotypes.CachePVC
+		wantStorageClass string
+	}{
+		{
+			name: "CachePVC without StorageClass, default SC exists",
+			storageClasses: []client.Object{
+				&storagev1.StorageClass{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "gp3-csi",
+						Annotations: map[string]string{
+							"storageclass.kubernetes.io/is-default-class": "true",
+						},
+					},
+				},
+			},
+			cachePVCConfig:   &velerotypes.CachePVC{},
+			wantStorageClass: "gp3-csi",
+		},
+		{
+			name:             "CachePVC without StorageClass, no default SC",
+			storageClasses:   nil,
+			cachePVCConfig:   &velerotypes.CachePVC{},
+			wantStorageClass: "",
+		},
+		{
+			name: "CachePVC with explicit StorageClass, default SC exists",
+			storageClasses: []client.Object{
+				&storagev1.StorageClass{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "gp3-csi",
+						Annotations: map[string]string{
+							"storageclass.kubernetes.io/is-default-class": "true",
+						},
+					},
+				},
+			},
+			cachePVCConfig:   &velerotypes.CachePVC{StorageClass: "my-custom-sc"},
+			wantStorageClass: "my-custom-sc",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeClient, err := getFakeClientFromObjects(tt.storageClasses...)
+			if err != nil {
+				t.Fatalf("error in creating fake client: %v", err)
+			}
+			dpa := &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testCmName,
+					Namespace: testCmNs,
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{
+							DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
+								oadpv1alpha1.DefaultPluginAWS,
+							},
+						},
+						NodeAgent: &oadpv1alpha1.NodeAgentConfig{
+							NodeAgentCommonFields: oadpv1alpha1.NodeAgentCommonFields{},
+							NodeAgentConfigMapSettings: oadpv1alpha1.NodeAgentConfigMapSettings{
+								CachePVCConfig: tt.cachePVCConfig,
+							},
+						},
+					},
+				},
+			}
+			dpa.AutoCorrect()
+
+			r := &DataProtectionApplicationReconciler{
+				Client:  fakeClient,
+				Scheme:  fakeClient.Scheme(),
+				Log:     logr.Discard(),
+				Context: newContextForTest(),
+				NamespacedName: types.NamespacedName{
+					Namespace: testCmNs,
+					Name:      testCmName,
+				},
+				EventRecorder: record.NewFakeRecorder(10),
+				dpa:           dpa,
+			}
+
+			cm := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      common.NodeAgentConfigMapPrefix + testCmName,
+					Namespace: testCmNs,
+				},
+			}
+			err = r.updateNodeAgentCM(cm)
+			require.NoError(t, err)
+
+			// Parse the ConfigMap data to verify the storageClass
+			var configMap map[string]interface{}
+			require.NoError(t, json.Unmarshal([]byte(cm.Data["node-agent-config"]), &configMap))
+
+			cachePVC, ok := configMap["cachePVC"]
+			if tt.wantStorageClass == "" && tt.cachePVCConfig.StorageClass == "" {
+				// When no default SC and no explicit SC, cachePVC should be omitted from ConfigMap
+				// so Velero falls back to root filesystem caching
+				require.False(t, ok, "cachePVC should not be present in ConfigMap when no StorageClass can be resolved")
+			} else {
+				require.True(t, ok, "cachePVC should be present in ConfigMap")
+				cachePVCMap := cachePVC.(map[string]interface{})
+				require.Equal(t, tt.wantStorageClass, cachePVCMap["storageClass"])
+			}
+
+			// Verify original DPA spec was not mutated
+			if tt.cachePVCConfig != nil && tt.cachePVCConfig.StorageClass == "" {
+				require.Empty(t, dpa.Spec.Configuration.NodeAgent.CachePVCConfig.StorageClass,
+					"DPA spec should not be mutated by default StorageClass resolution")
+			}
 		})
 	}
 }


### PR DESCRIPTION
Add cachePVC configuration to the DPA CRD under spec.configuration.nodeAgent, enabling dedicated PVC-backed cache volumes for Kopia repository cache during data movement restore operations. This prevents ephemeral storage exhaustion on nodes with limited root filesystem space during concurrent restores.

- Add CachePVCConfig field to NodeAgentConfigMapSettings using upstream types.CachePVC directly to prevent field name drift with Velero
- Serialize cachePVC config into the node-agent ConfigMap so Velero provisions per-restore cache PVCs instead of using pod root filesystem
- Add default StorageClass resolution when cachePVC is configured without explicit storageClass, falling back to the cluster's default SC
- Pass backup-repository-configmap to node-agent DaemonSet for cache volume size calculation (cacheLimitMB * 1.2)
- Add RBAC for StorageClass list/get/watch
- Add unit tests for ConfigMap assembly, default SC resolution, isNodeAgentCMRequired, and DaemonSet build with backup-repo configmap
- Add user documentation with configuration examples

## Why the changes were made

Fix [OADP-4855](https://issues.redhat.com/browse/OADP-4855)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for configuring dedicated cache volumes for Kopia repository cache during restore operations, including storage class and resident threshold settings.
  * Added CACertRef field for CA certificate references; CACert is now deprecated.

* **Documentation**
  * Added configuration guide for cache volume PVC setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->