### PR TITLE
DNM: update golang to 1.25.3 for future CVE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM quay.io/konveyor/builder:ubi9-v1.23 AS builder
+FROM quay.io/konveyor/builder:ubi9-v1.25.3 AS builder
 
 WORKDIR /go/src/github.com/openshift/oadp-operator
 # Copy the Go Modules manifests

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/openshift/oadp-operator
 
-go 1.23.0
-
-toolchain go1.23.6
+go 1.25.3
 
 require (
 	github.com/aws/aws-sdk-go v1.44.253

--- a/must-gather/Dockerfile
+++ b/must-gather/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM quay.io/konveyor/builder:ubi9-latest AS builder
+FROM --platform=$BUILDPLATFORM quay.io/konveyor/builder:ubi9-v1.25.3 AS builder
 ARG BUILDPLATFORM
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
## Summary
- Update go.mod from go 1.23.0/toolchain go1.23.6 to go 1.25.3/toolchain go1.25.3
- Update Dockerfile builder image from `quay.io/konveyor/builder:ubi9-v1.23` to `quay.io/konveyor/builder:ubi9-v1.25.3`
- Update must-gather/Dockerfile builder image from `quay.io/konveyor/builder:ubi9-latest` to `quay.io/konveyor/builder:ubi9-v1.25.3`
- Ran `go mod tidy` to reconcile dependencies

## Test plan
- [ ] Verify `go build ./...` succeeds locally (done)
- [ ] Verify container build with `quay.io/konveyor/builder:ubi9-v1.25.3`
- [ ] Run unit tests
- [ ] Run e2e tests

Made with [Cursor](https://cursor.com)