### PR TITLE
Update manifests after kubevirt datamover phase 4.

### DIFF
--- a/bundle/manifests/oadp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/oadp-operator.clusterserviceversion.yaml
@@ -884,6 +884,35 @@ spec:
           - update
           - watch
         - apiGroups:
+          - ""
+          resources:
+          - persistentvolumes
+          verbs:
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
           - backup.kubevirt.io
           resources:
           - virtualmachinebackups
@@ -900,13 +929,28 @@ spec:
           - backup.kubevirt.io
           resources:
           - virtualmachinebackups/status
+          verbs:
+          - get
+        - apiGroups:
+          - backup.kubevirt.io
+          resources:
           - virtualmachinebackuptrackers/status
           verbs:
           - get
+          - patch
+          - update
         - apiGroups:
           - kubevirt.io
           resources:
           - virtualmachines
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - velero.io
+          resources:
+          - backupstoragelocations
           verbs:
           - get
           - list
@@ -1303,6 +1347,15 @@ spec:
           - create
         serviceAccountName: openshift-adp-controller-manager
       - rules:
+        - apiGroups:
+          - backup.kubevirt.io
+          resources:
+          - virtualmachinebackups
+          - virtualmachinebackuptrackers
+          verbs:
+          - get
+          - list
+          - delete
         - apiGroups:
           - build.openshift.io
           - migration.openshift.io

--- a/config/kubevirt-datamover-controller_rbac/datamover_role.yaml
+++ b/config/kubevirt-datamover-controller_rbac/datamover_role.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: datamover-kubevirt-reader
+rules:
+- apiGroups: ["backup.kubevirt.io"]
+  resources: ["virtualmachinebackups", "virtualmachinebackuptrackers"]
+  verbs: ["get", "list", "delete"]

--- a/config/kubevirt-datamover-controller_rbac/datamover_role_binding.yaml
+++ b/config/kubevirt-datamover-controller_rbac/datamover_role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: datamover-kubevirt-reader-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datamover-kubevirt-reader
+subjects:
+- kind: ServiceAccount
+  name: velero
+  namespace: system

--- a/config/kubevirt-datamover-controller_rbac/kustomization.yaml
+++ b/config/kubevirt-datamover-controller_rbac/kustomization.yaml
@@ -19,3 +19,6 @@ resources:
 - metrics_auth_role.yaml
 - metrics_auth_role_binding.yaml
 - metrics_reader_role.yaml
+# RBAC for the datamover pod (velero SA) to read KubeVirt backup CRDs
+- datamover_role.yaml
+- datamover_role_binding.yaml

--- a/config/kubevirt-datamover-controller_rbac/role.yaml
+++ b/config/kubevirt-datamover-controller_rbac/role.yaml
@@ -17,6 +17,35 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - backup.kubevirt.io
   resources:
   - virtualmachinebackups
@@ -33,13 +62,28 @@ rules:
   - backup.kubevirt.io
   resources:
   - virtualmachinebackups/status
+  verbs:
+  - get
+- apiGroups:
+  - backup.kubevirt.io
+  resources:
   - virtualmachinebackuptrackers/status
   verbs:
   - get
+  - patch
+  - update
 - apiGroups:
   - kubevirt.io
   resources:
   - virtualmachines
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - velero.io
+  resources:
+  - backupstoragelocations
   verbs:
   - get
   - list


### PR DESCRIPTION
Required after the following PR got merged:
  https://github.com/migtools/kubevirt-datamover-controller/pull/13



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced RBAC configuration to support KubeVirt virtual machine backup and restore operations.
  * Expanded access permissions for backup storage management and data protection workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->