### PR TITLE
controllers: use DPAReconciler.Log instead of passing logger to ReconcileFunc

### DIFF
--- a/internal/controller/backup_repository.go
+++ b/internal/controller/backup_repository.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -65,7 +64,7 @@ func (r *DataProtectionApplicationReconciler) GetBackupRepositoryConfigMapName()
 }
 
 // ReconcileBackupRepositoryConfigMap handles creation, update, and deletion of the BackupRepository ConfigMap.
-func (r *DataProtectionApplicationReconciler) ReconcileBackupRepositoryConfigMap(log logr.Logger) (bool, error) {
+func (r *DataProtectionApplicationReconciler) ReconcileBackupRepositoryConfigMap() (bool, error) {
 	dpa := r.dpa
 	cmName := r.GetBackupRepositoryConfigMapName()
 	configMap := corev1.ConfigMap{

--- a/internal/controller/bsl.go
+++ b/internal/controller/bsl.go
@@ -10,7 +10,6 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/go-logr/logr"
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -165,7 +164,7 @@ func (r *DataProtectionApplicationReconciler) ValidateBackupStorageLocations() (
 	return true, nil
 }
 
-func (r *DataProtectionApplicationReconciler) ReconcileBackupStorageLocations(log logr.Logger) (bool, error) {
+func (r *DataProtectionApplicationReconciler) ReconcileBackupStorageLocations() (bool, error) {
 	dpa := r.dpa
 	dpaBSLNames := []string{}
 

--- a/internal/controller/bsl_test.go
+++ b/internal/controller/bsl_test.go
@@ -2663,7 +2663,7 @@ func TestDPAReconciler_ReconcileBackupStorageLocations(t *testing.T) {
 					}},
 				},
 			}
-			got, err := r.ReconcileBackupStorageLocations(r.Log)
+			got, err := r.ReconcileBackupStorageLocations()
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ReconcileBackupStorageLocations() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -3490,7 +3490,7 @@ func TestDPAReconciler_ReconcileBackupStorageLocations(t *testing.T) {
 				dpa:           tt.objects[0].(*oadpv1alpha1.DataProtectionApplication),
 			}
 
-			got, err := r.ReconcileBackupStorageLocations(r.Log)
+			got, err := r.ReconcileBackupStorageLocations()
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ReconcileBackupStorageLocations() error =%v, wantErr %v", err, tt.wantErr)
 				return
@@ -3579,7 +3579,7 @@ func TestDPAReconciler_ReconcileBackupStorageLocations(t *testing.T) {
 		}
 
 		// First reconciliation - should create BSL
-		success, err := r.ReconcileBackupStorageLocations(r.Log)
+		success, err := r.ReconcileBackupStorageLocations()
 		if err != nil {
 			t.Fatalf("first ReconcileBackupStorageLocations() failed: %v", err)
 		}
@@ -3612,7 +3612,7 @@ func TestDPAReconciler_ReconcileBackupStorageLocations(t *testing.T) {
 		}
 
 		// Second reconciliation - should not update BSL if nothing changed
-		success, err = r.ReconcileBackupStorageLocations(r.Log)
+		success, err = r.ReconcileBackupStorageLocations()
 		if err != nil {
 			t.Fatalf("second ReconcileBackupStorageLocations() failed: %v", err)
 		}
@@ -3641,7 +3641,7 @@ func TestDPAReconciler_ReconcileBackupStorageLocations(t *testing.T) {
 		}
 
 		// Third reconciliation - verify it still doesn't change
-		success, err = r.ReconcileBackupStorageLocations(r.Log)
+		success, err = r.ReconcileBackupStorageLocations()
 		if err != nil {
 			t.Fatalf("third ReconcileBackupStorageLocations() failed: %v", err)
 		}
@@ -3731,7 +3731,7 @@ func TestDPAReconciler_ReconcileBackupStorageLocations(t *testing.T) {
 		}
 
 		// First reconciliation - should create BSL
-		success, err := r.ReconcileBackupStorageLocations(r.Log)
+		success, err := r.ReconcileBackupStorageLocations()
 		if err != nil {
 			t.Fatalf("first ReconcileBackupStorageLocations() failed: %v", err)
 		}
@@ -3787,7 +3787,7 @@ func TestDPAReconciler_ReconcileBackupStorageLocations(t *testing.T) {
 
 		// Perform 5 reconciliations to ensure no loops occur
 		for i := 2; i <= 5; i++ {
-			success, err = r.ReconcileBackupStorageLocations(r.Log)
+			success, err = r.ReconcileBackupStorageLocations()
 			if err != nil {
 				t.Fatalf("reconciliation %d failed: %v", i, err)
 			}
@@ -5665,7 +5665,7 @@ func TestDPAReconciler_ensureBSLPreservesDefaultField(t *testing.T) {
 			}
 
 			// Call the BSL reconciliation
-			_, err := r.ReconcileBackupStorageLocations(r.Log)
+			_, err := r.ReconcileBackupStorageLocations()
 			assert.NoError(t, err)
 
 			// Verify the BSL was created/updated correctly

--- a/internal/controller/cloudstorage_providers_integration_test.go
+++ b/internal/controller/cloudstorage_providers_integration_test.go
@@ -227,7 +227,7 @@ web_identity_token_file = /var/run/secrets/openshift/serviceaccount/token`),
 			r.dpa = tt.dpa
 
 			// Create BSL from DPA spec
-			_, err = r.ReconcileBackupStorageLocations(log.Log)
+			_, err = r.ReconcileBackupStorageLocations()
 			assert.NoError(t, err)
 
 			// Verify BSL was created
@@ -475,7 +475,7 @@ func TestCloudStorageRefIntegrationGCP(t *testing.T) {
 			r.dpa = tt.dpa
 
 			// Create BSL from DPA spec
-			_, err = r.ReconcileBackupStorageLocations(log.Log)
+			_, err = r.ReconcileBackupStorageLocations()
 			assert.NoError(t, err)
 
 			// Verify BSL was created
@@ -714,7 +714,7 @@ AZURE_SUBSCRIPTION_ID=87654321-4321-4321-4321-210987654321`),
 			r.dpa = tt.dpa
 
 			// Create BSL from DPA spec
-			_, err = r.ReconcileBackupStorageLocations(log.Log)
+			_, err = r.ReconcileBackupStorageLocations()
 			assert.NoError(t, err)
 
 			// Verify BSL was created
@@ -836,7 +836,7 @@ func TestCloudStorageRefUpdateScenarios(t *testing.T) {
 			r.dpa = tt.dpa
 
 			// Create initial BSL
-			_, err = r.ReconcileBackupStorageLocations(log.Log)
+			_, err = r.ReconcileBackupStorageLocations()
 			assert.NoError(t, err)
 
 			// Get the current CloudStorage to ensure we have the latest resource version
@@ -853,7 +853,7 @@ func TestCloudStorageRefUpdateScenarios(t *testing.T) {
 			assert.NoError(t, err)
 
 			// Rebuild BSL after CloudStorage update
-			_, err = r.ReconcileBackupStorageLocations(log.Log)
+			_, err = r.ReconcileBackupStorageLocations()
 			assert.NoError(t, err)
 
 			// Verify BSL update
@@ -1234,7 +1234,7 @@ func TestCloudStorageRefBackupSyncPeriod(t *testing.T) {
 			r.dpa = tt.dpa
 
 			// Create BSL from DPA spec
-			_, err = r.ReconcileBackupStorageLocations(log.Log)
+			_, err = r.ReconcileBackupStorageLocations()
 			assert.NoError(t, err)
 
 			// List BSLs to verify creation

--- a/internal/controller/dataprotectionapplication_controller.go
+++ b/internal/controller/dataprotectionapplication_controller.go
@@ -252,8 +252,9 @@ type ReconcileFunc func(logr.Logger) (bool, error)
 
 // reconcileBatch steps through a list of reconcile functions until one returns
 // false or an error.
+// Note: The logger is passed explicitly to each function for clarity and testability.
+// This follows the Go best practice of dependency injection.
 func ReconcileBatch(l logr.Logger, reconcileFuncs ...ReconcileFunc) (bool, error) {
-	// TODO: #1127 DPAReconciler already have a logger, use it instead of passing to each reconcile functions
 	for _, f := range reconcileFuncs {
 		if cont, err := f(l); !cont || err != nil {
 			return cont, err

--- a/internal/controller/dataprotectionapplication_controller.go
+++ b/internal/controller/dataprotectionapplication_controller.go
@@ -250,10 +250,10 @@ func (l *labelHandler) Generic(ctx context.Context, evt event.TypedGenericEvent[
 
 type ReconcileFunc func(logr.Logger) (bool, error)
 
-// reconcileBatch steps through a list of reconcile functions until one returns
+// ReconcileBatch steps through a list of reconcile functions until one returns
 // false or an error.
-// Note: The logger is passed explicitly to each function for clarity and testability.
-// This follows the Go best practice of dependency injection.
+// The logger is passed explicitly to each function for clarity and testability,
+// following the Go dependency-injection pattern.
 func ReconcileBatch(l logr.Logger, reconcileFuncs ...ReconcileFunc) (bool, error) {
 	for _, f := range reconcileFuncs {
 		if cont, err := f(l); !cont || err != nil {

--- a/internal/controller/dataprotectionapplication_controller.go
+++ b/internal/controller/dataprotectionapplication_controller.go
@@ -95,7 +95,7 @@ func (r *DataProtectionApplicationReconciler) Reconcile(ctx context.Context, req
 	// set client to pkg/client for use in non-reconcile functions
 	oadpclient.SetClient(r.Client)
 
-	_, err := ReconcileBatch(r.Log,
+	_, err := ReconcileBatch(
 		r.ValidateDataProtectionCR,
 		r.ReconcileFsRestoreHelperConfig,
 		r.ReconcileBackupStorageLocations,
@@ -248,15 +248,13 @@ func (l *labelHandler) Generic(ctx context.Context, evt event.TypedGenericEvent[
 
 }
 
-type ReconcileFunc func(logr.Logger) (bool, error)
+type ReconcileFunc func() (bool, error)
 
 // ReconcileBatch steps through a list of reconcile functions until one returns
 // false or an error.
-// The logger is passed explicitly to each function for clarity and testability,
-// following the Go dependency-injection pattern.
-func ReconcileBatch(l logr.Logger, reconcileFuncs ...ReconcileFunc) (bool, error) {
+func ReconcileBatch(reconcileFuncs ...ReconcileFunc) (bool, error) {
 	for _, f := range reconcileFuncs {
-		if cont, err := f(l); !cont || err != nil {
+		if cont, err := f(); !cont || err != nil {
 			return cont, err
 		}
 	}

--- a/internal/controller/kubevirt_datamover_controller.go
+++ b/internal/controller/kubevirt_datamover_controller.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/go-logr/logr"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/exp/maps"
 	appsv1 "k8s.io/api/apps/v1"
@@ -48,7 +47,7 @@ var (
 )
 
 // ReconcileKubevirtDatamoverController manages the kubevirt-datamover controller deployment
-func (r *DataProtectionApplicationReconciler) ReconcileKubevirtDatamoverController(log logr.Logger) (bool, error) {
+func (r *DataProtectionApplicationReconciler) ReconcileKubevirtDatamoverController() (bool, error) {
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      kubevirtDatamoverObjectName,

--- a/internal/controller/kubevirt_datamover_controller_test.go
+++ b/internal/controller/kubevirt_datamover_controller_test.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/go-logr/logr"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
@@ -123,7 +122,7 @@ func runReconcileKubevirtDatamoverControllerTest(
 		EventRecorder: event,
 		dpa:           dpa,
 	}
-	result, err := r.ReconcileKubevirtDatamoverController(logr.Discard())
+	result, err := r.ReconcileKubevirtDatamoverController()
 
 	if len(scenario.errMessage) == 0 {
 		gomega.Expect(result).To(gomega.BeTrue())

--- a/internal/controller/monitor.go
+++ b/internal/controller/monitor.go
@@ -3,14 +3,13 @@ package controller
 import (
 	"fmt"
 
-	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-func (r *DataProtectionApplicationReconciler) ReconcileVeleroMetricsSVC(log logr.Logger) (bool, error) {
+func (r *DataProtectionApplicationReconciler) ReconcileVeleroMetricsSVC() (bool, error) {
 	svc := corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "openshift-adp-velero-metrics-svc",

--- a/internal/controller/nodeagent.go
+++ b/internal/controller/nodeagent.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"reflect"
 
-	"github.com/go-logr/logr"
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/operator-framework/operator-lib/proxy"
 	"github.com/vmware-tanzu/velero/pkg/install"
@@ -170,7 +169,7 @@ func (r *DataProtectionApplicationReconciler) updateNodeAgentCM(cm *corev1.Confi
 }
 
 // ReconcileNodeAgentConfigMap handles creation, update, and deletion of the NodeAgent ConfigMap.
-func (r *DataProtectionApplicationReconciler) ReconcileNodeAgentConfigMap(log logr.Logger) (bool, error) {
+func (r *DataProtectionApplicationReconciler) ReconcileNodeAgentConfigMap() (bool, error) {
 	dpa := r.dpa
 	cmName := types.NamespacedName{Name: common.NodeAgentConfigMapPrefix + dpa.Name, Namespace: r.NamespacedName.Namespace}
 	configMap := corev1.ConfigMap{
@@ -215,7 +214,7 @@ func (r *DataProtectionApplicationReconciler) ReconcileNodeAgentConfigMap(log lo
 	return true, nil
 }
 
-func (r *DataProtectionApplicationReconciler) ReconcileNodeAgentDaemonset(log logr.Logger) (bool, error) {
+func (r *DataProtectionApplicationReconciler) ReconcileNodeAgentDaemonset() (bool, error) {
 	dpa := r.dpa
 	// Define "static" portion of daemonset
 	ds := &appsv1.DaemonSet{
@@ -293,12 +292,12 @@ func (r *DataProtectionApplicationReconciler) ReconcileNodeAgentDaemonset(log lo
 			if isStatusCause && cause.Field == "spec.selector" {
 				// recreate deployment
 				// TODO: check for in-progress backup/restore to wait for it to finish
-				log.Info("Found immutable selector from previous daemonset, recreating NodeAgent daemonset")
+				r.Log.Info("Found immutable selector from previous daemonset, recreating NodeAgent daemonset")
 				err := r.Delete(r.Context, ds)
 				if err != nil {
 					return false, err
 				}
-				return r.ReconcileNodeAgentDaemonset(log)
+				return r.ReconcileNodeAgentDaemonset()
 			}
 		}
 		return false, err
@@ -688,7 +687,7 @@ func (r *DataProtectionApplicationReconciler) customizeNodeAgentDaemonset(ds *ap
 }
 
 // This is needed to remove fsRestoreHelperCM added in OADP 1.4 and earlier.
-func (r *DataProtectionApplicationReconciler) ReconcileFsRestoreHelperConfig(log logr.Logger) (bool, error) {
+func (r *DataProtectionApplicationReconciler) ReconcileFsRestoreHelperConfig() (bool, error) {
 	cmName := types.NamespacedName{Name: FsRestoreHelperCM, Namespace: r.NamespacedName.Namespace}
 	fsRestoreHelperCM := corev1.ConfigMap{}
 	err := r.Get(r.Context, cmName, &fsRestoreHelperCM)

--- a/internal/controller/nodeagent_test.go
+++ b/internal/controller/nodeagent_test.go
@@ -170,7 +170,7 @@ var _ = ginkgo.Describe("Test ReconcileNodeAgentDaemonSet function", func() {
 				EventRecorder: event,
 				dpa:           dpa,
 			}
-			result, err := r.ReconcileNodeAgentDaemonset(logr.Discard())
+			result, err := r.ReconcileNodeAgentDaemonset()
 
 			gomega.Expect(result).To(gomega.BeTrue())
 			gomega.Expect(err).To(gomega.Not(gomega.HaveOccurred()))

--- a/internal/controller/nonadmin_controller.go
+++ b/internal/controller/nonadmin_controller.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/go-logr/logr"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/exp/maps"
 	appsv1 "k8s.io/api/apps/v1"
@@ -48,7 +47,7 @@ var (
 	previousDefaultBSLSyncPeriod  *time.Duration         = nil
 )
 
-func (r *DataProtectionApplicationReconciler) ReconcileNonAdminController(log logr.Logger) (bool, error) {
+func (r *DataProtectionApplicationReconciler) ReconcileNonAdminController() (bool, error) {
 	nonAdminDeployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      nonAdminObjectName,

--- a/internal/controller/nonadmin_controller_test.go
+++ b/internal/controller/nonadmin_controller_test.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
@@ -106,6 +107,7 @@ func runReconcileNonAdminControllerTest(
 	r := &DataProtectionApplicationReconciler{
 		Client:  k8sClient,
 		Scheme:  testEnv.Scheme,
+		Log:     logr.Discard(),
 		Context: ctx,
 		NamespacedName: types.NamespacedName{
 			Name:      scenario.dpa,

--- a/internal/controller/nonadmin_controller_test.go
+++ b/internal/controller/nonadmin_controller_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
-	v1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	"github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/internal/controller/nonadmin_controller_test.go
+++ b/internal/controller/nonadmin_controller_test.go
@@ -6,11 +6,10 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/go-logr/logr"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
-	"github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	v1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -115,7 +114,7 @@ func runReconcileNonAdminControllerTest(
 		EventRecorder: event,
 		dpa:           dpa,
 	}
-	result, err := r.ReconcileNonAdminController(logr.Discard())
+	result, err := r.ReconcileNonAdminController()
 
 	if len(scenario.errMessage) == 0 {
 		gomega.Expect(result).To(gomega.BeTrue())

--- a/internal/controller/registry.go
+++ b/internal/controller/registry.go
@@ -158,7 +158,7 @@ type azureCredentials struct {
 	strorageAccountKey string
 }
 
-func (r *DataProtectionApplicationReconciler) ReconcileRegistries(log logr.Logger) (bool, error) {
+func (r *DataProtectionApplicationReconciler) ReconcileRegistries() (bool, error) {
 	bslLabels := map[string]string{
 		"app.kubernetes.io/name":       common.OADPOperatorVelero,
 		"app.kubernetes.io/managed-by": common.OADPOperator,
@@ -540,7 +540,7 @@ func (r *DataProtectionApplicationReconciler) getMatchedKeyValue(key string, s s
 	return s, nil
 }
 
-func (r *DataProtectionApplicationReconciler) ReconcileRegistrySVCs(log logr.Logger) (bool, error) {
+func (r *DataProtectionApplicationReconciler) ReconcileRegistrySVCs() (bool, error) {
 	// fetch the bsl instances
 	bslList := velerov1.BackupStorageLocationList{}
 	if err := r.List(r.Context, &bslList, &client.ListOptions{
@@ -583,7 +583,7 @@ func (r *DataProtectionApplicationReconciler) ReconcileRegistrySVCs(log logr.Log
 	return true, nil
 }
 
-func (r *DataProtectionApplicationReconciler) ReconcileRegistryRoutes(log logr.Logger) (bool, error) {
+func (r *DataProtectionApplicationReconciler) ReconcileRegistryRoutes() (bool, error) {
 	// fetch the bsl instances
 	bslList := velerov1.BackupStorageLocationList{}
 	if err := r.List(r.Context, &bslList, &client.ListOptions{
@@ -634,7 +634,7 @@ func (r *DataProtectionApplicationReconciler) ReconcileRegistryRoutes(log logr.L
 	return true, nil
 }
 
-func (r *DataProtectionApplicationReconciler) ReconcileRegistryRouteConfigs(log logr.Logger) (bool, error) {
+func (r *DataProtectionApplicationReconciler) ReconcileRegistryRouteConfigs() (bool, error) {
 	// Now for each of these bsl instances, create a registry route cm for each of them
 	registryRouteCM := corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -665,7 +665,7 @@ func (r *DataProtectionApplicationReconciler) ReconcileRegistryRouteConfigs(log 
 }
 
 // Create secret for registry to be parsed by openshift-velero-plugin
-func (r *DataProtectionApplicationReconciler) ReconcileRegistrySecrets(log logr.Logger) (bool, error) {
+func (r *DataProtectionApplicationReconciler) ReconcileRegistrySecrets() (bool, error) {
 	dpa := r.dpa
 	// fetch the bsl instances
 	bslList := velerov1.BackupStorageLocationList{}

--- a/internal/controller/repository_maintenance.go
+++ b/internal/controller/repository_maintenance.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -68,7 +67,7 @@ func (r *DataProtectionApplicationReconciler) GetRepositoryMaintenanceConfigMapN
 }
 
 // ReconcileRepositoryMaintenanceConfigMap handles creation, update, and deletion of the RepositoryMaintenance ConfigMap.
-func (r *DataProtectionApplicationReconciler) ReconcileRepositoryMaintenanceConfigMap(log logr.Logger) (bool, error) {
+func (r *DataProtectionApplicationReconciler) ReconcileRepositoryMaintenanceConfigMap() (bool, error) {
 	dpa := r.dpa
 	cmName := r.GetRepositoryMaintenanceConfigMapName()
 	configMap := corev1.ConfigMap{

--- a/internal/controller/stsflow.go
+++ b/internal/controller/stsflow.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -28,7 +27,7 @@ import (
 //
 // The secret created here is injected into both Velero and NodeAgent pods via envFrom,
 // eliminating the need for temporary credential files as used by AWS/GCP providers.
-func (r *DataProtectionApplicationReconciler) ReconcileAzureWorkloadIdentitySecret(log logr.Logger) (bool, error) {
+func (r *DataProtectionApplicationReconciler) ReconcileAzureWorkloadIdentitySecret() (bool, error) {
 	dpa := r.dpa
 	azureClientID := os.Getenv(stsflow.ClientIDEnvKey)
 
@@ -65,7 +64,7 @@ func (r *DataProtectionApplicationReconciler) ReconcileAzureWorkloadIdentitySecr
 	})
 
 	if err != nil {
-		log.Error(err, "Error reconciling Azure workload identity secret")
+		r.Log.Error(err, "Error reconciling Azure workload identity secret")
 		return false, err
 	}
 

--- a/internal/controller/stsflow_test.go
+++ b/internal/controller/stsflow_test.go
@@ -125,7 +125,7 @@ func TestDPAReconciler_ReconcileAzureWorkloadIdentitySecret(t *testing.T) {
 			}
 
 			// Call the function
-			result, err := r.ReconcileAzureWorkloadIdentitySecret(logr.Discard())
+			result, err := r.ReconcileAzureWorkloadIdentitySecret()
 
 			// Check error
 			if (err != nil) != tt.wantError {

--- a/internal/controller/validator.go
+++ b/internal/controller/validator.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	mapset "github.com/deckarep/golang-set/v2"
-	"github.com/go-logr/logr"
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -24,7 +23,7 @@ const NACNonEnforceableErr = "DPA %s is non-enforceable by admins"
 
 // ValidateDataProtectionCR function validates the DPA CR, returns true if valid, false otherwise
 // it calls other validation functions to validate the DPA CR
-func (r *DataProtectionApplicationReconciler) ValidateDataProtectionCR(log logr.Logger) (bool, error) {
+func (r *DataProtectionApplicationReconciler) ValidateDataProtectionCR() (bool, error) {
 	dpaList := &oadpv1alpha1.DataProtectionApplicationList{}
 	err := r.List(r.Context, dpaList, &client.ListOptions{Namespace: r.NamespacedName.Namespace})
 	if err != nil {
@@ -44,7 +43,7 @@ func (r *DataProtectionApplicationReconciler) ValidateDataProtectionCR(log logr.
 			"Please migrate to 'configuration.velero.podConfig.annotations' for Velero pods " +
 			"and 'configuration.nodeAgent.podConfig.annotations' for NodeAgent pods."
 		// V(-1) corresponds to the warn level
-		log.V(-1).Info(deprecationWarning)
+		r.Log.V(-1).Info(deprecationWarning)
 		r.EventRecorder.Event(r.dpa, corev1.EventTypeWarning, "DeprecationPodAnnotations", deprecationWarning)
 	}
 
@@ -398,7 +397,7 @@ func (r *DataProtectionApplicationReconciler) ValidateDataProtectionCR(log logr.
 			}
 		}
 		if !hasKubevirtPlugin {
-			log.V(-1).Info("Warning: kubevirt-datamover plugin is enabled without kubevirt plugin")
+			r.Log.V(-1).Info("Warning: kubevirt-datamover plugin is enabled without kubevirt plugin")
 			r.EventRecorder.Event(r.dpa, corev1.EventTypeWarning, "KubevirtDatamoverWithoutKubevirtPlugin",
 				"kubevirt-datamover plugin is enabled but kubevirt plugin is not. Consider adding 'kubevirt' to spec.configuration.velero.defaultPlugins for full VM backup/restore functionality.")
 		}

--- a/internal/controller/validator_test.go
+++ b/internal/controller/validator_test.go
@@ -2728,7 +2728,7 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 			EventRecorder: record.NewFakeRecorder(10),
 		}
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := r.ValidateDataProtectionCR(r.Log)
+			got, err := r.ValidateDataProtectionCR()
 			if err != nil && !tt.wantErr {
 				t.Errorf("ValidateDataProtectionCR() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -2825,7 +2825,7 @@ func TestDPAReconciler_ValidateDataProtectionCR_PodAnnotationsDeprecationWarning
 	}
 
 	// Run validation
-	valid, err := r.ValidateDataProtectionCR(testLogger)
+	valid, err := r.ValidateDataProtectionCR()
 	if err != nil {
 		t.Errorf("ValidateDataProtectionCR() unexpected error = %v", err)
 		return
@@ -2927,7 +2927,7 @@ func TestDPAReconciler_ValidateDataProtectionCR_NoPodAnnotationsNoWarning(t *tes
 	}
 
 	// Run validation
-	valid, err := r.ValidateDataProtectionCR(testLogger)
+	valid, err := r.ValidateDataProtectionCR()
 	if err != nil {
 		t.Errorf("ValidateDataProtectionCR() unexpected error = %v", err)
 		return
@@ -3209,7 +3209,7 @@ func TestVMFileRestoreValidation(t *testing.T) {
 			}
 
 			// Run validation
-			valid, err := r.ValidateDataProtectionCR(logr.Discard())
+			valid, err := r.ValidateDataProtectionCR()
 
 			if tt.wantErr {
 				if err == nil {
@@ -3312,7 +3312,7 @@ func TestValidateDataProtectionCR_KubevirtDatamoverWarning(t *testing.T) {
 				EventRecorder: eventRecorder,
 			}
 
-			_, err = r.ValidateDataProtectionCR(r.Log)
+			_, err = r.ValidateDataProtectionCR()
 			if err != nil {
 				t.Errorf("ValidateDataProtectionCR() unexpected error = %v", err)
 				return

--- a/internal/controller/velero.go
+++ b/internal/controller/velero.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
 	"github.com/operator-framework/operator-lib/proxy"
 	"github.com/sirupsen/logrus"
@@ -75,7 +74,7 @@ var (
 	}
 )
 
-func (r *DataProtectionApplicationReconciler) ReconcileVeleroDeployment(log logr.Logger) (bool, error) {
+func (r *DataProtectionApplicationReconciler) ReconcileVeleroDeployment() (bool, error) {
 
 	dpa := r.dpa
 
@@ -116,12 +115,12 @@ func (r *DataProtectionApplicationReconciler) ReconcileVeleroDeployment(log logr
 			if isStatusCause && cause.Field == "spec.selector" {
 				// recreate deployment
 				// TODO: check for in-progress backup/restore to wait for it to finish
-				log.Info("Found immutable selector from previous deployment, recreating Velero Deployment")
+				r.Log.Info("Found immutable selector from previous deployment, recreating Velero Deployment")
 				err := r.Delete(r.Context, veleroDeployment)
 				if err != nil {
 					return false, err
 				}
-				return r.ReconcileVeleroDeployment(log)
+				return r.ReconcileVeleroDeployment()
 			}
 		}
 

--- a/internal/controller/velero_test.go
+++ b/internal/controller/velero_test.go
@@ -271,7 +271,7 @@ var _ = ginkgo.Describe("Test ReconcileVeleroDeployment function", func() {
 				EventRecorder: event,
 				dpa:           dpa,
 			}
-			result, err := r.ReconcileVeleroDeployment(logr.Discard())
+			result, err := r.ReconcileVeleroDeployment()
 
 			gomega.Expect(result).To(gomega.BeTrue())
 			gomega.Expect(err).To(gomega.Not(gomega.HaveOccurred()))

--- a/internal/controller/vmfilerestore_controller.go
+++ b/internal/controller/vmfilerestore_controller.go
@@ -6,7 +6,6 @@ import (
 	"reflect"
 	"strconv"
 
-	"github.com/go-logr/logr"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/exp/maps"
 	appsv1 "k8s.io/api/apps/v1"
@@ -49,7 +48,7 @@ var (
 )
 
 // ReconcileVMFileRestoreController manages the VM file restore controller deployment
-func (r *DataProtectionApplicationReconciler) ReconcileVMFileRestoreController(log logr.Logger) (bool, error) {
+func (r *DataProtectionApplicationReconciler) ReconcileVMFileRestoreController() (bool, error) {
 	vmFileRestoreDeployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      vmFileRestoreObjectName,

--- a/internal/controller/vmfilerestore_controller_test.go
+++ b/internal/controller/vmfilerestore_controller_test.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/go-logr/logr"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
@@ -125,7 +124,7 @@ func runReconcileVMFileRestoreControllerTest(
 		EventRecorder: event,
 		dpa:           dpa,
 	}
-	result, err := r.ReconcileVMFileRestoreController(logr.Discard())
+	result, err := r.ReconcileVMFileRestoreController()
 
 	if len(scenario.errMessage) == 0 {
 		gomega.Expect(result).To(gomega.BeTrue())

--- a/internal/controller/vsl.go
+++ b/internal/controller/vsl.go
@@ -6,7 +6,6 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/go-logr/logr"
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -51,7 +50,7 @@ var validAzureKeys = map[string]bool{
 	AzureResourceGroup:  true,
 }
 
-func (r *DataProtectionApplicationReconciler) LabelVSLSecrets(log logr.Logger) (bool, error) {
+func (r *DataProtectionApplicationReconciler) LabelVSLSecrets() (bool, error) {
 	dpa := r.dpa
 	for _, vsl := range dpa.Spec.SnapshotLocations {
 		provider := strings.TrimPrefix(vsl.Velero.Provider, veleroIOPrefix)
@@ -183,7 +182,7 @@ func (r *DataProtectionApplicationReconciler) ValidateVolumeSnapshotLocations() 
 	return true, nil
 }
 
-func (r *DataProtectionApplicationReconciler) ReconcileVolumeSnapshotLocations(log logr.Logger) (bool, error) {
+func (r *DataProtectionApplicationReconciler) ReconcileVolumeSnapshotLocations() (bool, error) {
 	dpa := r.dpa
 	dpaVSLNames := []string{}
 	// Loop through all configured VSLs

--- a/internal/controller/vsl_test.go
+++ b/internal/controller/vsl_test.go
@@ -777,7 +777,7 @@ func TestDPAReconciler_ReconcileVolumeSnapshotLocations(t *testing.T) {
 					}},
 				},
 			}
-			got, err := r.ReconcileVolumeSnapshotLocations(r.Log)
+			got, err := r.ReconcileVolumeSnapshotLocations()
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ReconcileVolumeSnapshotLocations() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
## Summary

Remove the explicit `logr.Logger` parameter from `ReconcileFunc` and all reconcile functions. Each function now uses `r.Log` directly from the `DPAReconciler` struct, which is already set from the context logger in the `Reconcile` method.

Closes #1127

## Changes

- `ReconcileFunc` type: `func(logr.Logger) (bool, error)` → `func() (bool, error)`
- `ReconcileBatch`: removed the `logr.Logger` parameter
- Updated all 20 reconcile function signatures to remove `log logr.Logger`
- Replaced `log.` usages with `r.Log.` in functions that used the parameter
- Cleaned up unused `logr` imports
- Updated all test call sites

## Testing

- `go build ./internal/controller/...` passes
- `go vet ./internal/controller/...` passes
- No logic changes — only the source of the logger changes (struct field instead of parameter)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed external logger parameters across reconciler methods and unified logging to the reconciler's internal logger.
  * Simplified batch reconcile behavior so the batch runner reports success when all steps complete without short-circuiting or errors.

* **Tests**
  * Updated unit and integration tests to invoke reconciler methods without supplying an external logger.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->