### PR TITLE
oadp-1.5.5 is the current 1.5 version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # TOOL VERSIONS
 # All version-related variables are defined here for easy maintenance
-DEFAULT_VERSION := 1.5.4
+DEFAULT_VERSION := 1.5.5
 VERSION ?= $(DEFAULT_VERSION)
 OPERATOR_SDK_VERSION ?= v1.34.2
 ENVTEST_K8S_VERSION = 1.32 #refers to the version of kubebuilder assets to be downloaded by envtest binary # Kubernetes version from OpenShift 4.19.x

--- a/bundle/manifests/oadp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/oadp-operator.clusterserviceversion.yaml
@@ -281,7 +281,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "true"
     features.operators.openshift.io/token-auth-azure: "true"
     features.operators.openshift.io/token-auth-gcp: "true"
-    olm.skipRange: '>=1.4.0 <1.5.4'
+    olm.skipRange: '>=1.4.0 <1.5.5'
     operatorframework.io/suggested-namespace: openshift-adp
     operators.openshift.io/infrastructure-features: '["Disconnected"]'
     operators.openshift.io/must-gather-image: quay.io/konveyor/oadp-must-gather:oadp-1.5
@@ -296,7 +296,7 @@ metadata:
     operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
-  name: oadp-operator.v1.5.4
+  name: oadp-operator.v1.5.5
   namespace: openshift-adp
 spec:
   apiservicedefinitions: {}
@@ -1292,5 +1292,5 @@ spec:
     name: mustgather
   - image: quay.io/konveyor/oadp-non-admin:oadp-1.5
     name: non-admin-controller
-  replaces: oadp-operator.v1.5.3
-  version: 1.5.4
+  replaces: oadp-operator.v1.5.4
+  version: 1.5.5

--- a/bundle/oadp-operator.package.yaml
+++ b/bundle/oadp-operator.package.yaml
@@ -2,5 +2,5 @@
 packageName: redhat-oadp-operator
 channels:
 - name: stable
-  currentCSV: oadp-operator.v1.5.4
+  currentCSV: oadp-operator.v1.5.5
 defaultChannel: stable

--- a/config/manifests/bases/oadp-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/oadp-operator.clusterserviceversion.yaml
@@ -20,7 +20,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "true"
     features.operators.openshift.io/token-auth-azure: "true"
     features.operators.openshift.io/token-auth-gcp: "true"
-    olm.skipRange: '>=1.4.0 <1.5.4'
+    olm.skipRange: '>=1.4.0 <1.5.5'
     operatorframework.io/suggested-namespace: openshift-adp
     operators.openshift.io/infrastructure-features: '["Disconnected"]'
     operators.openshift.io/must-gather-image: quay.io/konveyor/oadp-must-gather:oadp-1.5
@@ -33,7 +33,7 @@ metadata:
     operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
-  name: oadp-operator.v1.5.4
+  name: oadp-operator.v1.5.5
   namespace: openshift-adp
 spec:
   apiservicedefinitions: {}
@@ -516,5 +516,5 @@ spec:
   maturity: stable
   provider:
     name: Red Hat
-  replaces: oadp-operator.v1.5.3
-  version: 1.5.4
+  replaces: oadp-operator.v1.5.4
+  version: 1.5.5

--- a/docs/version-update.md
+++ b/docs/version-update.md
@@ -4,14 +4,14 @@ This document outlines the files and fields that need to be updated for OADP ope
 
 ## Files to Update
 
-For a patch version update (e.g., 1.5.3 → 1.5.4), update these 4 files:
+For a patch version update (e.g., 1.5.4 → 1.5.5), update these 4 files:
 
 ### 1. Makefile
 
 Update `DEFAULT_VERSION` variable:
 
 ```makefile
-DEFAULT_VERSION := 1.5.4  # was 1.5.3
+DEFAULT_VERSION := 1.5.5  # was 1.5.4
 ```
 
 ### 2. config/manifests/bases/oadp-operator.clusterserviceversion.yaml
@@ -21,11 +21,11 @@ Update 4 fields:
 ```yaml
 metadata:
   annotations:
-    olm.skipRange: '>=1.4.0 <1.5.4'  # was <1.5.3
-  name: oadp-operator.v1.5.4  # was v1.5.3
+    olm.skipRange: '>=1.4.0 <1.5.5'  # was <1.5.4
+  name: oadp-operator.v1.5.5  # was v1.5.4
 spec:
-  replaces: oadp-operator.v1.5.3  # was v1.5.2
-  version: 1.5.4  # was 1.5.3
+  replaces: oadp-operator.v1.5.4  # was v1.5.3
+  version: 1.5.5  # was 1.5.4
 ```
 
 ### 3. bundle/manifests/oadp-operator.clusterserviceversion.yaml
@@ -35,11 +35,11 @@ Update 4 fields (same as above):
 ```yaml
 metadata:
   annotations:
-    olm.skipRange: '>=1.4.0 <1.5.4'  # was <1.5.3
-  name: oadp-operator.v1.5.4  # was v1.5.3
+    olm.skipRange: '>=1.4.0 <1.5.5'  # was <1.5.4
+  name: oadp-operator.v1.5.5  # was v1.5.4
 spec:
-  replaces: oadp-operator.v1.5.3  # was v1.5.2
-  version: 1.5.4  # was 1.5.3
+  replaces: oadp-operator.v1.5.4  # was v1.5.3
+  version: 1.5.5  # was 1.5.4
 ```
 
 ### 4. bundle/oadp-operator.package.yaml
@@ -49,7 +49,7 @@ Update 1 field:
 ```yaml
 channels:
 - name: stable
-  currentCSV: oadp-operator.v1.5.4  # was v1.5.3
+  currentCSV: oadp-operator.v1.5.5  # was v1.5.4
 ```
 
 ## Summary


### PR DESCRIPTION
Update DEFAULT_VERSION, olm.skipRange, CSV name, replaces, and version fields across Makefile, bundle CSV, config CSV, and version-update docs.

## Why the changes were made

Need those builds :)

## How to test the changes made

the usual automated tests