### PR TITLE
Align DPA defaultVolumesToFsBackup with Velero backup spec

### DIFF
--- a/api/v1alpha1/dataprotectionapplication_types.go
+++ b/api/v1alpha1/dataprotectionapplication_types.go
@@ -327,7 +327,11 @@ type VeleroConfig struct {
 	// How long to wait on asynchronous BackupItemActions and RestoreItemActions to complete before timing out. Default value is 1h.
 	// +optional
 	DefaultItemOperationTimeout string `json:"defaultItemOperationTimeout,omitempty"`
-	// Use pod volume file system backup by default for volumes
+	// Use pod volume file system backup by default for volumes.
+	// Matches backup.spec.defaultVolumesToFsBackup in Velero API.
+	// +optional
+	DefaultVolumesToFsBackup *bool `json:"defaultVolumesToFsBackup,omitempty"`
+	// Deprecated: Use defaultVolumesToFsBackup instead (matches Velero backup spec).
 	// +optional
 	DefaultVolumesToFSBackup *bool `json:"defaultVolumesToFSBackup,omitempty"`
 	// DisableFsBackup determines whether the NodeAgent should disable file system backup.

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -1326,6 +1326,11 @@ func (in *VeleroConfig) DeepCopyInto(out *VeleroConfig) {
 		*out = new(PodConfig)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.DefaultVolumesToFsBackup != nil {
+		in, out := &in.DefaultVolumesToFsBackup, &out.DefaultVolumesToFsBackup
+		*out = new(bool)
+		**out = **in
+	}
 	if in.DefaultVolumesToFSBackup != nil {
 		in, out := &in.DefaultVolumesToFSBackup, &out.DefaultVolumesToFSBackup
 		*out = new(bool)

--- a/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
@@ -1181,7 +1181,12 @@ spec:
                           description: Specify whether CSI snapshot data should be moved to backup storage by default
                           type: boolean
                         defaultVolumesToFSBackup:
-                          description: Use pod volume file system backup by default for volumes
+                          description: 'Deprecated: Use defaultVolumesToFsBackup instead (matches Velero backup spec).'
+                          type: boolean
+                        defaultVolumesToFsBackup:
+                          description: |-
+                            Use pod volume file system backup by default for volumes.
+                            Matches backup.spec.defaultVolumesToFsBackup in Velero API.
                           type: boolean
                         disableFsBackup:
                           default: false

--- a/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
@@ -1181,7 +1181,12 @@ spec:
                           description: Specify whether CSI snapshot data should be moved to backup storage by default
                           type: boolean
                         defaultVolumesToFSBackup:
-                          description: Use pod volume file system backup by default for volumes
+                          description: 'Deprecated: Use defaultVolumesToFsBackup instead (matches Velero backup spec).'
+                          type: boolean
+                        defaultVolumesToFsBackup:
+                          description: |-
+                            Use pod volume file system backup by default for volumes.
+                            Matches backup.spec.defaultVolumesToFsBackup in Velero API.
                           type: boolean
                         disableFsBackup:
                           default: false

--- a/internal/controller/velero.go
+++ b/internal/controller/velero.go
@@ -411,7 +411,7 @@ func (r *DataProtectionApplicationReconciler) customizeVeleroDeployment(veleroDe
 	// check for default-snapshot-move-data parameter
 	defaultSnapshotMoveData := getDefaultSnapshotMoveDataValue(dpa)
 	// check for default-volumes-to-fs-backup
-	defaultVolumesToFSBackup := getDefaultVolumesToFSBackup(dpa)
+	defaultVolumesToFsBackup := getDefaultVolumesToFsBackup(dpa)
 
 	// check for default-snapshot-move-data
 	if len(defaultSnapshotMoveData) > 0 {
@@ -419,8 +419,8 @@ func (r *DataProtectionApplicationReconciler) customizeVeleroDeployment(veleroDe
 	}
 
 	// check for default-volumes-to-fs-backup
-	if len(defaultVolumesToFSBackup) > 0 {
-		veleroContainer.Args = append(veleroContainer.Args, fmt.Sprintf("--default-volumes-to-fs-backup=%s", defaultVolumesToFSBackup))
+	if len(defaultVolumesToFsBackup) > 0 {
+		veleroContainer.Args = append(veleroContainer.Args, fmt.Sprintf("--default-volumes-to-fs-backup=%s", defaultVolumesToFsBackup))
 	}
 
 	// check for disable-informer-cache flag
@@ -726,15 +726,22 @@ func getDefaultSnapshotMoveDataValue(dpa *oadpv1alpha1.DataProtectionApplication
 	return ""
 }
 
-func getDefaultVolumesToFSBackup(dpa *oadpv1alpha1.DataProtectionApplication) string {
-	if dpa.Spec.Configuration.Velero != nil && boolptr.IsSetToTrue(dpa.Spec.Configuration.Velero.DefaultVolumesToFSBackup) {
+func getDefaultVolumesToFsBackup(dpa *oadpv1alpha1.DataProtectionApplication) string {
+	velero := dpa.Spec.Configuration.Velero
+	if velero == nil {
+		return ""
+	}
+	// Prefer new field (matches Velero backup.spec.defaultVolumesToFsBackup), fall back to deprecated field
+	val := velero.DefaultVolumesToFsBackup
+	if val == nil {
+		val = velero.DefaultVolumesToFSBackup
+	}
+	if boolptr.IsSetToTrue(val) {
 		return TrueVal
 	}
-
-	if dpa.Spec.Configuration.Velero != nil && boolptr.IsSetToFalse(dpa.Spec.Configuration.Velero.DefaultVolumesToFSBackup) {
+	if boolptr.IsSetToFalse(val) {
 		return FalseVal
 	}
-
 	return ""
 }
 

--- a/internal/controller/velero_test.go
+++ b/internal/controller/velero_test.go
@@ -1210,7 +1210,7 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 							DefaultItemOperationTimeout: "2h",
 							DefaultSnapshotMoveData:     ptr.To(false),
 							NoDefaultBackupLocation:     true,
-							DefaultVolumesToFSBackup:    ptr.To(true),
+							DefaultVolumesToFsBackup:    ptr.To(true),
 							DefaultPlugins:              []oadpv1alpha1.DefaultPlugin{oadpv1alpha1.DefaultPluginCSI},
 						},
 					},
@@ -1278,7 +1278,29 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 			}),
 		},
 		{
-			name: "valid DPA CR with DefaultVolumesToFSBackup true, Velero Deployment is built with DefaultVolumesToFSBackup true",
+			name: "valid DPA CR with DefaultVolumesToFsBackup true (new field), Velero Deployment is built with default-volumes-to-fs-backup true",
+			dpa: createTestDpaWith(
+				nil,
+				oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{
+							DefaultVolumesToFsBackup: ptr.To(true),
+						},
+					},
+				},
+			),
+			veleroDeployment: testVeleroDeployment.DeepCopy(),
+			wantVeleroDeployment: createTestBuiltVeleroDeployment(TestBuiltVeleroDeploymentOptions{
+				args: []string{
+					defaultFileSystemBackupTimeout,
+					defaultRestoreResourcePriorities,
+					"--default-volumes-to-fs-backup=true",
+					defaultDisableInformerCache,
+				},
+			}),
+		},
+		{
+			name: "valid DPA CR with DefaultVolumesToFSBackup true (deprecated field, backwards compat), Velero Deployment is built with default-volumes-to-fs-backup true",
 			dpa: createTestDpaWith(
 				nil,
 				oadpv1alpha1.DataProtectionApplicationSpec{
@@ -1295,6 +1317,29 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 					defaultFileSystemBackupTimeout,
 					defaultRestoreResourcePriorities,
 					"--default-volumes-to-fs-backup=true",
+					defaultDisableInformerCache,
+				},
+			}),
+		},
+		{
+			name: "valid DPA CR with both DefaultVolumesToFsBackup and DefaultVolumesToFSBackup set, new field takes precedence",
+			dpa: createTestDpaWith(
+				nil,
+				oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{
+							DefaultVolumesToFsBackup: ptr.To(false),
+							DefaultVolumesToFSBackup: ptr.To(true), // deprecated, should be ignored
+						},
+					},
+				},
+			),
+			veleroDeployment: testVeleroDeployment.DeepCopy(),
+			wantVeleroDeployment: createTestBuiltVeleroDeployment(TestBuiltVeleroDeploymentOptions{
+				args: []string{
+					defaultFileSystemBackupTimeout,
+					defaultRestoreResourcePriorities,
+					"--default-volumes-to-fs-backup=false",
 					defaultDisableInformerCache,
 				},
 			}),


### PR DESCRIPTION
- Add defaultVolumesToFsBackup field (matches backup.spec.defaultVolumesToFsBackup)
- Deprecate defaultVolumesToFSBackup, keep for backwards compatibility
- Controller prefers new field, falls back to deprecated field when unset
- Add tests for new field, backwards compat, and precedence

## Why the changes were made

Dpa.spec.configuration flag **defaultVolumesToFSBackup** is not identical to the one used by the backup spec **defaultVolumesToFsBackup**, which can be confusing for some users.  Make these flags identical to each other. 

$ oc explain dpa.spec.configuration.velero.defaultVolumesToFSBackup
KIND:     DataProtectionApplication
VERSION:  oadp.openshift.io/v1alpha1
FIELD:    defaultVolumesToFSBackup <boolean>
DESCRIPTION:
     Use pod volume file system backup by default for volumes

$ oc explain backup.spec.defaultVolumesToFsBackup
KIND:     Backup
VERSION:  velero.io/v1

DESCRIPTION:
     DefaultVolumesToFsBackup specifies whether pod volume file system backup
     should be used for all volumes by default. 




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new standardized configuration field for specifying default volume-to-filesystem backup behavior in Velero operations.

* **Deprecations**
  * Marked previous volume-backup configuration field as deprecated. Existing configurations continue to work with full backwards compatibility maintained while users transition to the new field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->