### PR TITLE
Two utility scripts to sync aws s3 storage and cleanup kubevirt backups

### DIFF
--- a/scripts/cleanup-kubevirt-datamover-backups.sh
+++ b/scripts/cleanup-kubevirt-datamover-backups.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+# cleanup-backups.sh - Remove all OADP kubevirt-datamover backup objects from the cluster
+#
+# Removes: Velero backups, DataUploads, VirtualMachineBackups, VirtualMachineBackupTrackers,
+#          and ONLY PVCs created by the datamover (identified by name prefix and labels).
+#
+# Usage: cleanup-backups.sh [namespace]
+
+set -u
+
+NAMESPACE="${1:-openshift-adp}"
+DRY_RUN="${DRY_RUN:-true}"
+
+RED=$'\033[1;31m'
+GREEN=$'\033[1;32m'
+YELLOW=$'\033[1;33m'
+CYAN=$'\033[1;36m'
+DIM=$'\033[2m'
+RST=$'\033[0m'
+
+deleted=0
+
+run() {
+    if [[ "$DRY_RUN" == "true" ]]; then
+        echo "  ${DIM}[dry-run]${RST} $*"
+    else
+        "$@" 2>&1
+    fi
+}
+
+header() {
+    printf "\n${CYAN}== %s ==${RST}\n" "$1"
+}
+
+# Strip finalizers from a resource so delete doesn't hang
+remove_finalizers() {
+    local resource="$1" name="$2" ns="$3"
+    local finalizers
+    finalizers=$(oc get "$resource" "$name" -n "$ns" -o jsonpath='{.metadata.finalizers}' 2>/dev/null || echo "")
+    if [[ -n "$finalizers" && "$finalizers" != "[]" && "$finalizers" != "null" ]]; then
+        echo "    ${DIM}removing finalizers from $name${RST}"
+        run oc patch "$resource" "$name" -n "$ns" --type=merge -p '{"metadata":{"finalizers":[]}}' 2>/dev/null
+    fi
+}
+
+# ── Velero Backups ────────────────────────────────────────────────────────────
+header "Velero Backups"
+backups=$(oc get backup.velero.io -n "$NAMESPACE" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || echo "")
+if [[ -z "$backups" ]]; then
+    echo "  ${DIM}No backups found${RST}"
+else
+    for b in $backups; do
+        echo "  ${RED}Deleting${RST} backup ${YELLOW}$b${RST}"
+        run velero backup delete "$b" -n "$NAMESPACE" --confirm
+        (( deleted++ ))
+    done
+fi
+
+# ── VirtualMachineBackups (before DataUploads — they depend on DU) ────────────
+header "VirtualMachineBackups"
+vmbs=$(oc get virtualmachinebackup -A -o jsonpath='{range .items[*]}{.metadata.namespace}{" "}{.metadata.name}{"\n"}{end}' 2>/dev/null || echo "")
+if [[ -z "$vmbs" ]]; then
+    echo "  ${DIM}No VirtualMachineBackups found${RST}"
+else
+    while IFS=' ' read -r ns name; do
+        [[ -z "$name" ]] && continue
+        echo "  ${RED}Deleting${RST} vmb ${YELLOW}$ns/$name${RST}"
+        remove_finalizers "virtualmachinebackup" "$name" "$ns"
+        run oc delete virtualmachinebackup "$name" -n "$ns" --wait=false
+        (( deleted++ ))
+    done <<< "$vmbs"
+fi
+
+# ── VirtualMachineBackupTrackers ──────────────────────────────────────────────
+header "VirtualMachineBackupTrackers"
+vmbts=$(oc get virtualmachinebackuptracker -A -o jsonpath='{range .items[*]}{.metadata.namespace}{" "}{.metadata.name}{"\n"}{end}' 2>/dev/null || echo "")
+if [[ -z "$vmbts" ]]; then
+    echo "  ${DIM}No VirtualMachineBackupTrackers found${RST}"
+else
+    while IFS=' ' read -r ns name; do
+        [[ -z "$name" ]] && continue
+        echo "  ${RED}Deleting${RST} vmbt ${YELLOW}$ns/$name${RST}"
+        remove_finalizers "virtualmachinebackuptracker" "$name" "$ns"
+        run oc delete virtualmachinebackuptracker "$name" -n "$ns" --wait=false
+        (( deleted++ ))
+    done <<< "$vmbts"
+fi
+
+# ── DataUploads ───────────────────────────────────────────────────────────────
+header "DataUploads"
+dus=$(oc get dataupload.velero.io -n "$NAMESPACE" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || echo "")
+if [[ -z "$dus" ]]; then
+    echo "  ${DIM}No DataUploads found${RST}"
+else
+    for du in $dus; do
+        echo "  ${RED}Deleting${RST} dataupload ${YELLOW}$du${RST}"
+        remove_finalizers "dataupload.velero.io" "$du" "$NAMESPACE"
+        run oc delete dataupload.velero.io "$du" -n "$NAMESPACE" --wait=false
+        (( deleted++ ))
+    done
+fi
+
+# ── Datamover PVCs ────────────────────────────────────────────────────────────
+# ONLY delete PVCs created by the datamover, identified by:
+#   1. Name prefix: kubevirt-backup-  (temp PVCs created in VM namespace)
+#   2. Name prefix: kubevirt-dm-pvc-  (rebound PVCs created in OADP namespace)
+#   3. Label: velero.io/dataupload-name  (all datamover-created PVCs carry this)
+# This ensures we NEVER touch VM disk PVCs or any other PVCs on the cluster.
+header "Datamover PVCs (safe cleanup)"
+
+# Method 1: by label (most reliable — catches all datamover PVCs regardless of name)
+labeled_pvcs=$(oc get pvc -A -l "velero.io/dataupload-name" \
+    -o jsonpath='{range .items[*]}{.metadata.namespace}{" "}{.metadata.name}{"\n"}{end}' 2>/dev/null || echo "")
+
+# Method 2: by name prefix (fallback — catches any that might be missing the label)
+prefix_pvcs=""
+for prefix in "kubevirt-backup-" "kubevirt-dm-pvc-"; do
+    matches=$(oc get pvc -A -o jsonpath='{range .items[*]}{.metadata.namespace}{" "}{.metadata.name}{"\n"}{end}' 2>/dev/null \
+        | grep " ${prefix}" || echo "")
+    if [[ -n "$matches" ]]; then
+        prefix_pvcs="${prefix_pvcs}${matches}"$'\n'
+    fi
+done
+
+# Combine and deduplicate
+all_pvcs=$(printf '%s\n%s' "$labeled_pvcs" "$prefix_pvcs" | sort -u | grep -v '^$' || echo "")
+
+if [[ -z "$all_pvcs" ]]; then
+    echo "  ${DIM}No datamover PVCs found${RST}"
+else
+    while IFS=' ' read -r ns name; do
+        [[ -z "$name" ]] && continue
+        echo "  ${RED}Deleting${RST} pvc ${YELLOW}$ns/$name${RST}"
+        remove_finalizers "pvc" "$name" "$ns"
+        run oc delete pvc "$name" -n "$ns" --wait=false
+        (( deleted++ ))
+    done <<< "$all_pvcs"
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+printf "\n${GREEN}Done.${RST} Deleted ${YELLOW}%d${RST} resources.\n" "$deleted"
+if [[ "$DRY_RUN" == "true" ]]; then
+    printf "${DIM}(dry-run mode — nothing was actually deleted. Run with DRY_RUN=false to delete.)${RST}\n"
+fi

--- a/scripts/s3-catalog-sync.sh
+++ b/scripts/s3-catalog-sync.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+# s3-catalog-sync.sh - Sync S3 backup catalog locally using DPA configuration
+#
+# Reads BSL credentials, bucket, prefix, and region from a DataProtectionApplication
+# CR and syncs the S3 contents to a local directory. Safe to re-run — only new or
+# changed objects are downloaded.
+#
+# Usage: s3-catalog-sync.sh <local-catalog-dir> [dpa-name] [namespace]
+
+set -euo pipefail
+
+LOCAL_DIR="${1:-}"
+DPA_NAME="${2:-}"
+NAMESPACE="${3:-openshift-adp}"
+
+if [[ -z "$LOCAL_DIR" ]]; then
+    echo "Usage: $0 <local-catalog-dir> [dpa-name] [namespace]"
+    echo ""
+    echo "Arguments:"
+    echo "  local-catalog-dir Local directory to sync S3 contents into"
+    echo "  dpa-name          Name of the DPA CR (auto-detected if only one exists)"
+    echo "  namespace         Namespace of the DPA (default: openshift-adp)"
+    echo ""
+    echo "Example:"
+    echo "  $0 ./my-catalog"
+    echo "  $0 ./my-catalog dpa-test"
+    echo "  $0 /tmp/s3-catalog dpa-test openshift-adp"
+    exit 1
+fi
+
+# Auto-detect DPA name if not provided
+if [[ -z "$DPA_NAME" ]]; then
+    DPA_NAMES=$(oc get dpa -n "$NAMESPACE" -o jsonpath='{.items[*].metadata.name}')
+    DPA_COUNT=$(echo "$DPA_NAMES" | wc -w)
+
+    if [[ "$DPA_COUNT" -eq 0 ]]; then
+        echo "Error: No DataProtectionApplication found in namespace '$NAMESPACE'" >&2
+        exit 1
+    elif [[ "$DPA_COUNT" -gt 1 ]]; then
+        echo "Error: Multiple DPAs found in namespace '$NAMESPACE': $DPA_NAMES" >&2
+        echo "Please specify which one: $0 <local-catalog-dir> <dpa-name>" >&2
+        exit 1
+    fi
+
+    DPA_NAME="$DPA_NAMES"
+    echo "Auto-detected DPA: $DPA_NAME"
+fi
+
+echo "Reading DPA '$DPA_NAME' in namespace '$NAMESPACE'..."
+
+DPA_JSON=$(oc get dpa "$DPA_NAME" -n "$NAMESPACE" -o json)
+
+# Extract BSL configuration from the first backupLocation
+BUCKET=$(echo "$DPA_JSON" | jq -r '.spec.backupLocations[0].velero.objectStorage.bucket')
+PREFIX=$(echo "$DPA_JSON" | jq -r '.spec.backupLocations[0].velero.objectStorage.prefix // empty')
+REGION=$(echo "$DPA_JSON" | jq -r '.spec.backupLocations[0].velero.config.region // "us-east-1"')
+SECRET_NAME=$(echo "$DPA_JSON" | jq -r '.spec.backupLocations[0].velero.credential.name')
+SECRET_KEY=$(echo "$DPA_JSON" | jq -r '.spec.backupLocations[0].velero.credential.key')
+S3_URL=$(echo "$DPA_JSON" | jq -r '.spec.backupLocations[0].velero.config.s3Url // empty')
+
+if [[ -z "$BUCKET" || "$BUCKET" == "null" ]]; then
+    echo "Error: Could not extract bucket from DPA '$DPA_NAME'" >&2
+    exit 1
+fi
+
+if [[ -z "$SECRET_NAME" || "$SECRET_NAME" == "null" ]]; then
+    echo "Error: Could not extract credential secret name from DPA '$DPA_NAME'" >&2
+    exit 1
+fi
+
+echo "Extracting credentials from secret '$SECRET_NAME' (key: '$SECRET_KEY')..."
+
+CREDS=$(oc get secret "$SECRET_NAME" -n "$NAMESPACE" -o jsonpath="{.data.${SECRET_KEY}}" | base64 -d)
+
+export AWS_ACCESS_KEY_ID=$(echo "$CREDS" | grep aws_access_key_id | awk '{print $3}')
+export AWS_SECRET_ACCESS_KEY=$(echo "$CREDS" | grep aws_secret_access_key | awk '{print $3}')
+export AWS_DEFAULT_REGION="$REGION"
+
+if [[ -z "$AWS_ACCESS_KEY_ID" || -z "$AWS_SECRET_ACCESS_KEY" ]]; then
+    echo "Error: Could not parse AWS credentials from secret '$SECRET_NAME'" >&2
+    exit 1
+fi
+
+S3_BASE="s3://${BUCKET}"
+S3_PATH="${S3_BASE}/${PREFIX}"
+S3_PATH_DATAMOVER="${S3_BASE}/${PREFIX}-kubevirt-datamover"
+
+ENDPOINT_ARGS=()
+if [[ -n "$S3_URL" ]]; then
+    ENDPOINT_ARGS+=(--endpoint-url "$S3_URL")
+fi
+
+mkdir -p "$LOCAL_DIR"
+
+echo ""
+echo "BSL configuration:"
+echo "  Bucket:    $BUCKET"
+echo "  Prefix:    ${PREFIX:-<none>}"
+echo "  Region:    $REGION"
+echo "  S3 paths:"
+echo "    - $S3_PATH"
+echo "    - $S3_PATH_DATAMOVER"
+if [[ -n "$S3_URL" ]]; then
+    echo "  Endpoint:  $S3_URL"
+fi
+echo "  Local dir: $LOCAL_DIR"
+echo ""
+
+echo "Syncing ${PREFIX}..."
+aws s3 sync "$S3_PATH" "$LOCAL_DIR/${PREFIX}" "${ENDPOINT_ARGS[@]}" 2>&1
+
+echo ""
+echo "Syncing ${PREFIX}-kubevirt-datamover..."
+aws s3 sync "$S3_PATH_DATAMOVER" "$LOCAL_DIR/${PREFIX}-kubevirt-datamover" "${ENDPOINT_ARGS[@]}" 2>&1
+
+echo ""
+echo "Sync complete. Contents:"
+echo ""
+# Show top-level directory summary
+du -sh "$LOCAL_DIR"/*/ 2>/dev/null || echo "  (empty or flat structure)"
+echo ""
+echo "Re-run the same command to pick up new backups."


### PR DESCRIPTION
Handy scripts to run:

```shell
 # DRY_RUN is default set to true to be on a safe side

 $ DRY_RUN=true ./scripts/cleanup-kubevirt-datamover-backups.sh

 # download folder can be absent, run multiple times to sync additional data
 # s3 creds are taken from the DPA
 $ ./scripts/s3-catalog-sync.sh test-download-folder
```

Want to monitor backup? Check out the project:
https://github.com/migtools/kubevirt-datamover-monitor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a cleanup utility to remove kubevirt-datamover backup resources safely, with an opt-in execution mode that previews actions by default.
  * Added an S3 catalog synchronization tool that downloads backup catalogs to local storage, auto-detecting backup configuration and supporting custom endpoints and incremental sync.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->