### PR TITLE
OADP-5777: Require region in BSL validation when s3Url is set, fix nil config skipping region auto-detection

### DIFF
--- a/internal/controller/bsl.go
+++ b/internal/controller/bsl.go
@@ -413,7 +413,7 @@ func (r *DataProtectionApplicationReconciler) updateBSLFromSpec(bsl *velerov1.Ba
 	}
 
 	// Update BSL spec and registry-deployment label
-	if err := common.UpdateBackupStorageLocation(bsl, bslSpec); err != nil {
+	if err := common.UpdateBackupStorageLocation(bsl, bslSpec, r.Log); err != nil {
 		return err
 	}
 

--- a/internal/controller/bsl.go
+++ b/internal/controller/bsl.go
@@ -527,12 +527,16 @@ func (r *DataProtectionApplicationReconciler) validateAWSBackupStorageLocation(b
 	}
 
 	// BSL region is required when
+	// - s3Url is set, because the user is pointing to a non-AWS S3-compatible service
+	//   where region auto-discovery via AWS API is not valid
 	// - s3ForcePathStyle is true, because some velero processes requires region to be set and is not auto-discoverable when s3ForcePathStyle is true
 	//   imagestream backup in openshift-velero-plugin now uses the same method to discover region as the rest of the velero codebase
 	// - even when s3ForcePathStyle is false, some aws bucket regions may not be discoverable and the user has to set it manually
 	if (bslSpec.Config == nil || len(bslSpec.Config[Region]) == 0) &&
-		(bslSpec.Config != nil && bslSpec.Config[S3ForcePathStyle] == "true" || !aws.BucketRegionIsDiscoverable(bslSpec.ObjectStorage.Bucket)) {
-		return fmt.Errorf("region for AWS backupstoragelocation not automatically discoverable. Please set the region in the backupstoragelocation config")
+		(bslSpec.Config != nil && len(bslSpec.Config[S3URL]) > 0 ||
+			bslSpec.Config != nil && bslSpec.Config[S3ForcePathStyle] == "true" ||
+			!aws.BucketRegionIsDiscoverable(bslSpec.ObjectStorage.Bucket)) {
+		return fmt.Errorf("region for AWS backupstoragelocation is required. Please set the region in the backupstoragelocation config")
 	}
 
 	//TODO: Add minio, noobaa, local storage validations

--- a/internal/controller/bsl.go
+++ b/internal/controller/bsl.go
@@ -532,11 +532,15 @@ func (r *DataProtectionApplicationReconciler) validateAWSBackupStorageLocation(b
 	// - s3ForcePathStyle is true, because some velero processes requires region to be set and is not auto-discoverable when s3ForcePathStyle is true
 	//   imagestream backup in openshift-velero-plugin now uses the same method to discover region as the rest of the velero codebase
 	// - even when s3ForcePathStyle is false, some aws bucket regions may not be discoverable and the user has to set it manually
-	if (bslSpec.Config == nil || len(bslSpec.Config[Region]) == 0) &&
-		(bslSpec.Config != nil && len(bslSpec.Config[S3URL]) > 0 ||
-			bslSpec.Config != nil && bslSpec.Config[S3ForcePathStyle] == "true" ||
-			!aws.BucketRegionIsDiscoverable(bslSpec.ObjectStorage.Bucket)) {
-		return fmt.Errorf("region for AWS backupstoragelocation is required. Please set the region in the backupstoragelocation config")
+	if bslSpec.Config == nil || len(bslSpec.Config[Region]) == 0 {
+		switch {
+		case bslSpec.Config != nil && len(bslSpec.Config[S3URL]) > 0:
+			return fmt.Errorf("region for AWS backupstoragelocation is required when s3Url is configured. Please set the region in the backupstoragelocation config")
+		case bslSpec.Config != nil && bslSpec.Config[S3ForcePathStyle] == "true":
+			return fmt.Errorf("region for AWS backupstoragelocation is required when s3ForcePathStyle is true. Please set the region in the backupstoragelocation config")
+		case !aws.BucketRegionIsDiscoverable(bslSpec.ObjectStorage.Bucket):
+			return fmt.Errorf("region for AWS backupstoragelocation not automatically discoverable. Please set the region in the backupstoragelocation config")
+		}
 	}
 
 	//TODO: Add minio, noobaa, local storage validations

--- a/internal/controller/bsl_test.go
+++ b/internal/controller/bsl_test.go
@@ -1460,6 +1460,131 @@ func TestDPAReconciler_ValidateBackupStorageLocations(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "BSL with s3Url and no region expect to fail",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "test-ns",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{},
+					},
+					BackupImages: ptr.To(false),
+					BackupLocations: []oadpv1alpha1.BackupLocation{
+						{
+							Velero: &velerov1.BackupStorageLocationSpec{
+								Provider: "aws",
+								Config: map[string]string{
+									S3URL: "https://s3.us-south.cloud-object-storage.appdomain.cloud",
+								},
+								StorageType: velerov1.StorageType{
+									ObjectStorage: &velerov1.ObjectStorageLocation{
+										Bucket: DiscoverableBucket,
+										Prefix: "prefix",
+									},
+								},
+								Default: true,
+							},
+						},
+					},
+				},
+			},
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cloud-credentials",
+					Namespace: "test-ns",
+				},
+				Data: map[string][]byte{"cloud": []byte("[default]\naws_access_key_id=AKIAIOSFODNN7EXAMPLE\naws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")},
+			},
+			want:    false,
+			wantErr: true,
+		},
+		{
+			name: "BSL with s3Url and region set expect to succeed",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "test-ns",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{},
+					},
+					BackupImages: ptr.To(false),
+					BackupLocations: []oadpv1alpha1.BackupLocation{
+						{
+							Velero: &velerov1.BackupStorageLocationSpec{
+								Provider: "aws",
+								Config: map[string]string{
+									S3URL:  "https://s3.us-south.cloud-object-storage.appdomain.cloud",
+									Region: "us-south",
+								},
+								StorageType: velerov1.StorageType{
+									ObjectStorage: &velerov1.ObjectStorageLocation{
+										Bucket: "ibm-cos-bucket",
+										Prefix: "prefix",
+									},
+								},
+								Default: true,
+							},
+						},
+					},
+				},
+			},
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cloud-credentials",
+					Namespace: "test-ns",
+				},
+				Data: map[string][]byte{"cloud": []byte("[default]\naws_access_key_id=AKIAIOSFODNN7EXAMPLE\naws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")},
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "BSL with s3Url and s3ForcePathStyle but no region expect to fail",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "test-ns",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{},
+					},
+					BackupImages: ptr.To(false),
+					BackupLocations: []oadpv1alpha1.BackupLocation{
+						{
+							Velero: &velerov1.BackupStorageLocationSpec{
+								Provider: "aws",
+								Config: map[string]string{
+									S3URL:            "https://s3.us-south.cloud-object-storage.appdomain.cloud",
+									S3ForcePathStyle: "true",
+								},
+								StorageType: velerov1.StorageType{
+									ObjectStorage: &velerov1.ObjectStorageLocation{
+										Bucket: "ibm-cos-bucket",
+										Prefix: "prefix",
+									},
+								},
+								Default: true,
+							},
+						},
+					},
+				},
+			},
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cloud-credentials",
+					Namespace: "test-ns",
+				},
+				Data: map[string][]byte{"cloud": []byte("[default]\naws_access_key_id=AKIAIOSFODNN7EXAMPLE\naws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")},
+			},
+			want:    false,
+			wantErr: true,
+		},
+		{
 			name: "CloudStorage with different providers - AWS",
 			dpa: &oadpv1alpha1.DataProtectionApplication{
 				ObjectMeta: metav1.ObjectMeta{

--- a/internal/controller/bsl_test.go
+++ b/internal/controller/bsl_test.go
@@ -2083,6 +2083,12 @@ func newContextForTest() context.Context {
 }
 
 func TestDPAReconciler_updateBSLFromSpec(t *testing.T) {
+	originalGetBucketRegionFunc := aws.GetBucketRegionFunc
+	aws.GetBucketRegionFunc = func(bucket string) (string, error) {
+		return "", fmt.Errorf("bucket region not discoverable")
+	}
+	defer func() { aws.GetBucketRegionFunc = originalGetBucketRegionFunc }()
+
 	tests := []struct {
 		name    string
 		bsl     *velerov1.BackupStorageLocation
@@ -2174,7 +2180,7 @@ func TestDPAReconciler_updateBSLFromSpec(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "BSL spec config is nil, no BSL spec update",
+			name: "BSL spec config is nil, config initialized with checksumAlgorithm",
 			bsl: &velerov1.BackupStorageLocation{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo-1",
@@ -2232,6 +2238,9 @@ func TestDPAReconciler_updateBSLFromSpec(t *testing.T) {
 				},
 				Spec: velerov1.BackupStorageLocationSpec{
 					Provider: "aws",
+					Config: map[string]string{
+						"checksumAlgorithm": "",
+					},
 					StorageType: velerov1.StorageType{
 						ObjectStorage: &velerov1.ObjectStorageLocation{
 							Bucket: "test-aws-bucket",

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/go-logr/logr"
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	"github.com/vmware-tanzu/velero/pkg/types"
 	corev1 "k8s.io/api/core/v1"
@@ -303,7 +304,7 @@ func ApplyUnsupportedServerArgsOverride(container *corev1.Container, unsupported
 // UpdateBackupStorageLocation updates the BackupStorageLocation spec and config.
 //
 //nolint:unparam // Keeping error return type for making the public function flexible for future usage
-func UpdateBackupStorageLocation(bsl *velerov1.BackupStorageLocation, bslSpec velerov1.BackupStorageLocationSpec) error {
+func UpdateBackupStorageLocation(bsl *velerov1.BackupStorageLocation, bslSpec velerov1.BackupStorageLocationSpec, logger logr.Logger) error {
 	if bsl.ObjectMeta.Labels == nil {
 		bsl.ObjectMeta.Labels = make(map[string]string)
 	}
@@ -350,13 +351,13 @@ func UpdateBackupStorageLocation(bsl *velerov1.BackupStorageLocation, bslSpec ve
 						// Attempt to auto-detect the bucket's region
 						// AWS Security confirmed that GetBucketRegion works with anonymous credentials
 						// for both public and private buckets (Engagement ID: CACenGS4Mha_KeJ=e3jBSLD6rPZ2iNtfuJUv9QJViaCOt7GVNDg)
-						if detectedRegion, err := aws.GetBucketRegion(bslSpec.ObjectStorage.Bucket); err == nil && detectedRegion != "" {
+						detectedRegion, err := aws.GetBucketRegion(bslSpec.ObjectStorage.Bucket)
+						if err != nil {
+							logger.Error(err, "Failed to auto-detect AWS bucket region", "bucket", bslSpec.ObjectStorage.Bucket)
+						} else if detectedRegion != "" {
+							logger.Info("Auto-detected AWS bucket region", "bucket", bslSpec.ObjectStorage.Bucket, "region", detectedRegion)
 							bslSpec.Config["region"] = detectedRegion
-							// Note: We successfully auto-detected the region. This is logged at a higher level
-							// to avoid importing logging dependencies here.
 						}
-						// If auto-detection fails, we continue without setting the region.
-						// The user can still manually specify it if needed.
 					}
 				}
 			}

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -347,14 +347,15 @@ func UpdateBackupStorageLocation(bsl *velerov1.BackupStorageLocation, bslSpec ve
 			// Auto-detect region for actual AWS S3 buckets (not S3-compatible storage)
 			// This only applies when:
 			// 1. No custom s3Url is configured (meaning it's real AWS S3)
-			// 2. No region is already specified in the config
-			// 3. A bucket name is provided in ObjectStorage
+			// 2. No region is already specified in the DPA spec config
+			// 3. No region was previously auto-detected (stored in existing BSL)
+			// 4. A bucket name is provided in ObjectStorage
+			// If the bucket is recreated in a different region, delete the BSL to trigger re-detection.
 			if _, hasS3Url := bslSpec.Config["s3Url"]; !hasS3Url {
 				if _, hasRegion := bslSpec.Config["region"]; !hasRegion {
-					if bslSpec.ObjectStorage != nil && bslSpec.ObjectStorage.Bucket != "" {
-						// Attempt to auto-detect the bucket's region
-						// AWS Security confirmed that GetBucketRegion works with anonymous credentials
-						// for both public and private buckets (Engagement ID: CACenGS4Mha_KeJ=e3jBSLD6rPZ2iNtfuJUv9QJViaCOt7GVNDg)
+					if existingRegion := bsl.Spec.Config["region"]; existingRegion != "" {
+						bslSpec.Config["region"] = existingRegion
+					} else if bslSpec.ObjectStorage != nil && bslSpec.ObjectStorage.Bucket != "" {
 						detectedRegion, err := aws.GetBucketRegion(bslSpec.ObjectStorage.Bucket)
 						if err != nil {
 							logger.Error(err, "Failed to auto-detect AWS bucket region", "bucket", bslSpec.ObjectStorage.Bucket)

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -311,7 +311,11 @@ func UpdateBackupStorageLocation(bsl *velerov1.BackupStorageLocation, bslSpec ve
 
 	bsl.ObjectMeta.Labels[RegistryDeploymentLabel] = "True"
 
-	if bslSpec.Config != nil {
+	if bslSpec.Config == nil {
+		bslSpec.Config = make(map[string]string)
+	}
+
+	{
 		// While using Service Principal as Azure credentials, `storageAccountKeyEnvVar` value is not required to be set.
 		// However, the registry deployment fails without a valid storage account key.
 		// This logic prevents the registry pods from being deployed if Azure SP is used as an auth mechanism.

--- a/pkg/common/common_test.go
+++ b/pkg/common/common_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/go-logr/logr"
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -580,7 +581,7 @@ func TestUpdateBackupStorageLocation(t *testing.T) {
 			bslCopy := tt.bsl.DeepCopy()
 			bslSpecCopy := tt.bslSpec.DeepCopy()
 
-			UpdateBackupStorageLocation(bslCopy, *bslSpecCopy)
+			UpdateBackupStorageLocation(bslCopy, *bslSpecCopy, logr.Discard())
 
 			if !reflect.DeepEqual(bslCopy, tt.expectedBsl) {
 				t.Errorf("UpdateBackupStorageLocation() = %v, want %v", bslCopy, tt.expectedBsl)

--- a/pkg/common/common_test.go
+++ b/pkg/common/common_test.go
@@ -3,9 +3,11 @@ package common
 import (
 	"errors"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/funcr"
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -648,5 +650,113 @@ func TestUpdateBackupStorageLocation(t *testing.T) {
 				t.Errorf("UpdateBackupStorageLocation() = %v, want %v", bslCopy, tt.expectedBsl)
 			}
 		})
+	}
+}
+
+func TestUpdateBackupStorageLocation_ExistingRegionSkipsAutoDetect(t *testing.T) {
+	originalGetBucketRegionFunc := aws.GetBucketRegionFunc
+	defer func() { aws.GetBucketRegionFunc = originalGetBucketRegionFunc }()
+
+	callCount := 0
+	aws.GetBucketRegionFunc = func(bucket string) (string, error) {
+		callCount++
+		return "us-east-1", nil
+	}
+
+	bsl := &velerov1.BackupStorageLocation{
+		Spec: velerov1.BackupStorageLocationSpec{
+			Provider: "aws",
+			Config: map[string]string{
+				"region":            "us-east-1",
+				"checksumAlgorithm": "",
+			},
+			StorageType: velerov1.StorageType{
+				ObjectStorage: &velerov1.ObjectStorageLocation{
+					Bucket: "my-bucket",
+				},
+			},
+		},
+	}
+
+	bslSpec := velerov1.BackupStorageLocationSpec{
+		Provider: "aws",
+		StorageType: velerov1.StorageType{
+			ObjectStorage: &velerov1.ObjectStorageLocation{
+				Bucket: "my-bucket",
+			},
+		},
+	}
+
+	UpdateBackupStorageLocation(bsl, bslSpec, logr.Discard())
+
+	if callCount != 0 {
+		t.Errorf("GetBucketRegion called %d times, expected 0 (should reuse existing BSL region)", callCount)
+	}
+	if bsl.Spec.Config["region"] != "us-east-1" {
+		t.Errorf("region = %q, want %q", bsl.Spec.Config["region"], "us-east-1")
+	}
+}
+
+func TestUpdateBackupStorageLocation_ReconcileLoopPrevention(t *testing.T) {
+	originalGetBucketRegionFunc := aws.GetBucketRegionFunc
+	defer func() { aws.GetBucketRegionFunc = originalGetBucketRegionFunc }()
+
+	callCount := 0
+	aws.GetBucketRegionFunc = func(bucket string) (string, error) {
+		callCount++
+		return "us-west-2", nil
+	}
+
+	var logMessages []string
+	logger := funcr.NewJSON(func(obj string) {
+		logMessages = append(logMessages, obj)
+	}, funcr.Options{})
+
+	bsl := &velerov1.BackupStorageLocation{}
+
+	bslSpec := velerov1.BackupStorageLocationSpec{
+		Provider: "aws",
+		StorageType: velerov1.StorageType{
+			ObjectStorage: &velerov1.ObjectStorageLocation{
+				Bucket: "my-bucket",
+			},
+		},
+	}
+
+	// First reconcile: auto-detect should fire
+	UpdateBackupStorageLocation(bsl, *bslSpec.DeepCopy(), logger)
+
+	if callCount != 1 {
+		t.Fatalf("first reconcile: GetBucketRegion called %d times, expected 1", callCount)
+	}
+	if bsl.Spec.Config["region"] != "us-west-2" {
+		t.Fatalf("first reconcile: region = %q, want %q", bsl.Spec.Config["region"], "us-west-2")
+	}
+
+	autoDetectLogs := 0
+	for _, msg := range logMessages {
+		if strings.Contains(msg, "Auto-detected AWS bucket region") {
+			autoDetectLogs++
+		}
+	}
+	if autoDetectLogs != 1 {
+		t.Fatalf("first reconcile: expected 1 auto-detect log, got %d", autoDetectLogs)
+	}
+
+	// Second reconcile: BSL now has region, DPA spec still has none
+	logMessages = nil
+	UpdateBackupStorageLocation(bsl, *bslSpec.DeepCopy(), logger)
+
+	if callCount != 1 {
+		t.Errorf("second reconcile: GetBucketRegion called %d total times, expected still 1", callCount)
+	}
+	if bsl.Spec.Config["region"] != "us-west-2" {
+		t.Errorf("second reconcile: region = %q, want %q", bsl.Spec.Config["region"], "us-west-2")
+	}
+
+	for _, msg := range logMessages {
+		if strings.Contains(msg, "Auto-detected AWS bucket region") {
+			t.Errorf("second reconcile: unexpected auto-detect log emitted: %s", msg)
+		}
 	}
 }

--- a/pkg/common/common_test.go
+++ b/pkg/common/common_test.go
@@ -533,6 +533,67 @@ func TestUpdateBackupStorageLocation(t *testing.T) {
 			},
 		},
 		{
+			name: "AWS region auto-detection - nil config with discoverable bucket",
+			bsl:  &velerov1.BackupStorageLocation{},
+			bslSpec: velerov1.BackupStorageLocationSpec{
+				Provider: "aws",
+				StorageType: velerov1.StorageType{
+					ObjectStorage: &velerov1.ObjectStorageLocation{
+						Bucket: "openshift-velero-plugin-s3-auto-region-test-1",
+					},
+				},
+			},
+			expectedBsl: &velerov1.BackupStorageLocation{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						RegistryDeploymentLabel: "True",
+					},
+				},
+				Spec: velerov1.BackupStorageLocationSpec{
+					Provider: "aws",
+					Config: map[string]string{
+						"region":            "us-east-1",
+						"checksumAlgorithm": "",
+					},
+					StorageType: velerov1.StorageType{
+						ObjectStorage: &velerov1.ObjectStorageLocation{
+							Bucket: "openshift-velero-plugin-s3-auto-region-test-1",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "AWS region auto-detection - nil config with undiscoverable bucket",
+			bsl:  &velerov1.BackupStorageLocation{},
+			bslSpec: velerov1.BackupStorageLocationSpec{
+				Provider: "aws",
+				StorageType: velerov1.StorageType{
+					ObjectStorage: &velerov1.ObjectStorageLocation{
+						Bucket: "some-nonexistent-bucket",
+					},
+				},
+			},
+			expectedBsl: &velerov1.BackupStorageLocation{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						RegistryDeploymentLabel: "True",
+					},
+				},
+				Spec: velerov1.BackupStorageLocationSpec{
+					Provider: "aws",
+					Config: map[string]string{
+						"checksumAlgorithm": "",
+					},
+					StorageType: velerov1.StorageType{
+						ObjectStorage: &velerov1.ObjectStorageLocation{
+							Bucket: "some-nonexistent-bucket",
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "AWS region auto-detection - real bucket (openshift-velero-plugin-s3-auto-region-test-1)",
 			bsl:  &velerov1.BackupStorageLocation{},
 			bslSpec: velerov1.BackupStorageLocationSpec{

--- a/tests/e2e/dpa_deployment_suite_test.go
+++ b/tests/e2e/dpa_deployment_suite_test.go
@@ -377,7 +377,7 @@ var _ = ginkgo.Describe("Configuration testing for DPA Custom Resource", func() 
 				NoRegion:         true,
 				s3ForcePathStyle: true,
 			}),
-		}, "region for AWS backupstoragelocation not automatically discoverable. Please set the region in the backupstoragelocation config"),
+		}, "region for AWS backupstoragelocation is required. Please set the region in the backupstoragelocation config"),
 		ginkgo.Entry("DPA CR with restic config enabled", InstallCase{
 			DpaSpec: createTestDPASpec(TestDPASpec{
 				BSLSecretName: bslSecretName,

--- a/tests/e2e/dpa_deployment_suite_test.go
+++ b/tests/e2e/dpa_deployment_suite_test.go
@@ -377,7 +377,7 @@ var _ = ginkgo.Describe("Configuration testing for DPA Custom Resource", func() 
 				NoRegion:         true,
 				s3ForcePathStyle: true,
 			}),
-		}, "region for AWS backupstoragelocation is required. Please set the region in the backupstoragelocation config"),
+		}, "region for AWS backupstoragelocation is required when s3ForcePathStyle is true. Please set the region in the backupstoragelocation config"),
 		ginkgo.Entry("DPA CR with restic config enabled", InstallCase{
 			DpaSpec: createTestDPASpec(TestDPASpec{
 				BSLSecretName: bslSecretName,


### PR DESCRIPTION
## Why the changes were made

This PR addresses two related issues with AWS BSL region handling:

### 1. Fix nil config skipping region auto-detection ([OADP-5777](https://redhat.atlassian.net/browse/OADP-5777))

**Root cause**: When DPA `backupLocations` has no `config:` section, `bslSpec.Config` is nil. The `UpdateBackupStorageLocation` function guarded all AWS-specific logic (region auto-detection, checksumAlgorithm defaults) behind `if bslSpec.Config != nil`, so when config was omitted entirely, none of that logic ran.

This is why PR #1740's auto-detection fix didn't work in practice — the nil config guard skipped it. Verified by reproducing Tareq's exact scenario (DPA with AWS provider, no config section, no region) on a live cluster.

**Fix**: Initialize `bslSpec.Config` to an empty map when nil, so AWS logic runs regardless of whether user specifies a config section.

### 2. Require region when s3Url is set

When a custom `s3Url` is configured, the BSL points to a non-AWS S3-compatible service (e.g. IBM Cloud Object Storage, MinIO) where region auto-discovery via AWS HeadBucket API is not valid. Previously, region was only enforced when `s3ForcePathStyle` was true or AWS discovery failed.

**Fix**: Validate that region is specified at DPA validation time when `s3Url` is set, with context-specific error messages.

### 3. Add logging to region auto-detection

Added `logr.Logger` parameter to `UpdateBackupStorageLocation` so auto-detection success/failure is visible in operator logs instead of silently falling through.

Fixes: https://issues.redhat.com/browse/OADP-5777
Fixes: https://github.com/openshift/oadp-operator/issues/2108

## How to test the changes made

### Unit tests
```bash
go test -v ./pkg/common/... -run TestUpdateBackupStorageLocation
go test -v ./internal/controller/... -run TestValidateBackupStorageLocations
```

### Manual verification (nil config fix)
1. Create DPA with AWS provider, **no config section**, no region:
```yaml
spec:
  backupLocations:
  - velero:
      credential:
        key: cloud
        name: cloud-credentials
      default: true
      objectStorage:
        bucket: <your-bucket>
        prefix: velero
      provider: aws
```
2. Check operator logs — should see: `Auto-detected AWS bucket region {"bucket": "...", "region": "..."}`
3. Check BSL — should have `config.region` and `config.checksumAlgorithm` set

### Verified on cluster
- OCP 4.22 ARM64 cluster on AWS
- DPA with no config section, bucket `tkaovila-sts-oadp`
- Before fix: BSL had no config at all (nil config guard skipped everything)
- After fix: BSL has `region: us-east-1` and `checksumAlgorithm: ""` auto-populated

> [!Note]
> Responses generated with Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Validation now requires an explicit region when an S3 URL is provided, when s3ForcePathStyle is true, or when bucket-region discovery fails; error messages were clarified to indicate the specific missing-region reason and guide users to set the region in the backup storage location configuration.
* **Tests**
  * Added/updated tests covering S3 URL, s3ForcePathStyle, and region presence scenarios and expected error messages.
* **Chores**
  * Improved logging around bucket-region auto-detection to surface detection failures and reported regions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->