### PR TITLE
DNM, test mysql update

### DIFF
--- a/tests/e2e/sample-applications/mysql-persistent/mysql-persistent-csi.yaml
+++ b/tests/e2e/sample-applications/mysql-persistent/mysql-persistent-csi.yaml
@@ -81,7 +81,7 @@ items:
           serviceAccountName: mysql-persistent-sa
           containers:
           - name: todolist
-            image: quay.io/migtools/oadp-ci-todolist-mariadb-go-testing:testing
+            image: quay.io/migtools/oadp-ci-todolist-mariadb-go-testing:wes1
             securityContext:
               runAsGroup: 27
               runAsUser: 27

--- a/tests/e2e/sample-applications/mysql-persistent/mysql-persistent-twovol-csi.yaml
+++ b/tests/e2e/sample-applications/mysql-persistent/mysql-persistent-twovol-csi.yaml
@@ -77,7 +77,7 @@ items:
           serviceAccountName: mysql-persistent-sa
           containers:
           - name: todolist
-            image: quay.io/migtools/oadp-ci-todolist-mariadb-go-testing:testing
+            image: quay.io/migtools/oadp-ci-todolist-mariadb-go-testing:wes1
             securityContext:
               privileged: false
             env:

--- a/tests/e2e/sample-applications/mysql-persistent/mysql-persistent.yaml
+++ b/tests/e2e/sample-applications/mysql-persistent/mysql-persistent.yaml
@@ -95,7 +95,7 @@ items:
           serviceAccountName: mysql-persistent-sa
           containers:
           - name: todolist
-            image: quay.io/migtools/oadp-ci-todolist-mariadb-go-testing:testing
+            image: quay.io/migtools/oadp-ci-todolist-mariadb-go-testing:wes1
             securityContext:
               runAsUser: 27
               runAsGroup: 27


### PR DESCRIPTION
## Why the changes were made

DNM, testing  container updates
https://github.com/migtools/mig-demo-apps/pull/8

## How to test the changes made

run e2e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test environment configurations for MySQL persistent storage deployments across multiple test scenarios and deployment types, including CSI and multi-volume configurations. Updated test container versions ensure more consistent and thorough validation of data persistence, backup restoration, and recovery functionality in the testing environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->