### PR TITLE
Fix CLI E2E tests missing ReadyToStart backup/restore phase

### DIFF
--- a/tests/e2e/lib/backup.go
+++ b/tests/e2e/lib/backup.go
@@ -62,6 +62,29 @@ func GetBackup(c client.Client, namespace string, name string) (*velero.Backup, 
 	return &backup, nil
 }
 
+// backupPhasesNotDone is the shared list of backup phases that indicate a backup is still in progress.
+var backupPhasesNotDone = []velero.BackupPhase{
+	velero.BackupPhaseNew,
+	velero.BackupPhaseQueued,
+	velero.BackupPhaseReadyToStart,
+	velero.BackupPhaseInProgress,
+	velero.BackupPhaseWaitingForPluginOperations,
+	velero.BackupPhaseWaitingForPluginOperationsPartiallyFailed,
+	velero.BackupPhaseFinalizing,
+	velero.BackupPhaseFinalizingPartiallyFailed,
+	"",
+}
+
+// IsBackupPhaseNotDone returns true if the given phase string represents a backup still in progress.
+func IsBackupPhaseNotDone(phase string) bool {
+	for _, notDonePhase := range backupPhasesNotDone {
+		if phase == string(notDonePhase) {
+			return true
+		}
+	}
+	return false
+}
+
 func IsBackupDone(ocClient client.Client, veleroNamespace, name string) wait.ConditionFunc {
 	return func() (bool, error) {
 		backup, err := GetBackup(ocClient, veleroNamespace, name)
@@ -71,23 +94,7 @@ func IsBackupDone(ocClient client.Client, veleroNamespace, name string) wait.Con
 		if len(backup.Status.Phase) > 0 {
 			log.Printf("backup phase: %s", backup.Status.Phase)
 		}
-		var phasesNotDone = []velero.BackupPhase{
-			velero.BackupPhaseNew,
-			velero.BackupPhaseQueued,
-			velero.BackupPhaseReadyToStart,
-			velero.BackupPhaseInProgress,
-			velero.BackupPhaseWaitingForPluginOperations,
-			velero.BackupPhaseWaitingForPluginOperationsPartiallyFailed,
-			velero.BackupPhaseFinalizing,
-			velero.BackupPhaseFinalizingPartiallyFailed,
-			"",
-		}
-		for _, notDonePhase := range phasesNotDone {
-			if backup.Status.Phase == notDonePhase {
-				return false, nil
-			}
-		}
-		return true, nil
+		return !IsBackupPhaseNotDone(string(backup.Status.Phase)), nil
 	}
 }
 

--- a/tests/e2e/lib/backup_cli.go
+++ b/tests/e2e/lib/backup_cli.go
@@ -121,7 +121,6 @@ func GetBackupViaCLI(name string) (*velero.Backup, error) {
 // IsBackupDoneViaCLI checks if backup is done using the OADP CLI
 func IsBackupDoneViaCLI(name string) wait.ConditionFunc {
 	return func() (bool, error) {
-		// Use CLI to get backup status
 		cmd := &CLICommand{
 			Resource: "backup",
 			Action:   "get",
@@ -133,29 +132,13 @@ func IsBackupDoneViaCLI(name string) wait.ConditionFunc {
 			return false, fmt.Errorf("failed to get backup status via CLI: %v", err)
 		}
 
-		// Parse phase from YAML output
 		phase := ParsePhaseFromYAML(string(output))
 
 		if len(phase) > 0 {
 			log.Printf("backup phase: %s", phase)
 		}
 
-		var phasesNotDone = []string{
-			string(velero.BackupPhaseNew),
-			string(velero.BackupPhaseInProgress),
-			string(velero.BackupPhaseWaitingForPluginOperations),
-			string(velero.BackupPhaseWaitingForPluginOperationsPartiallyFailed),
-			string(velero.BackupPhaseFinalizing),
-			string(velero.BackupPhaseFinalizingPartiallyFailed),
-			"",
-		}
-
-		for _, notDonePhase := range phasesNotDone {
-			if phase == notDonePhase {
-				return false, nil
-			}
-		}
-		return true, nil
+		return !IsBackupPhaseNotDone(phase), nil
 	}
 }
 

--- a/tests/e2e/lib/restore.go
+++ b/tests/e2e/lib/restore.go
@@ -66,6 +66,28 @@ func GetRestore(c client.Client, namespace string, name string) (*velero.Restore
 	return &restore, nil
 }
 
+// restorePhasesNotDone is the shared list of restore phases that indicate a restore is still in progress.
+var restorePhasesNotDone = []velero.RestorePhase{
+	velero.RestorePhaseNew,
+	"ReadyToStart",
+	velero.RestorePhaseInProgress,
+	velero.RestorePhaseWaitingForPluginOperations,
+	velero.RestorePhaseWaitingForPluginOperationsPartiallyFailed,
+	velero.RestorePhaseFinalizing,
+	velero.RestorePhaseFinalizingPartiallyFailed,
+	"",
+}
+
+// IsRestorePhaseNotDone returns true if the given phase string represents a restore still in progress.
+func IsRestorePhaseNotDone(phase string) bool {
+	for _, notDonePhase := range restorePhasesNotDone {
+		if phase == string(notDonePhase) {
+			return true
+		}
+	}
+	return false
+}
+
 func IsRestoreDone(ocClient client.Client, veleroNamespace, name string) wait.ConditionFunc {
 	return func() (bool, error) {
 		restore, err := GetRestore(ocClient, veleroNamespace, name)
@@ -75,21 +97,7 @@ func IsRestoreDone(ocClient client.Client, veleroNamespace, name string) wait.Co
 		if len(restore.Status.Phase) > 0 {
 			log.Printf("restore phase: %s", restore.Status.Phase)
 		}
-		var phasesNotDone = []velero.RestorePhase{
-			velero.RestorePhaseNew,
-			velero.RestorePhaseInProgress,
-			velero.RestorePhaseWaitingForPluginOperations,
-			velero.RestorePhaseWaitingForPluginOperationsPartiallyFailed,
-			velero.RestorePhaseFinalizing,
-			velero.RestorePhaseFinalizingPartiallyFailed,
-			"",
-		}
-		for _, notDonePhase := range phasesNotDone {
-			if restore.Status.Phase == notDonePhase {
-				return false, nil
-			}
-		}
-		return true, nil
+		return !IsRestorePhaseNotDone(string(restore.Status.Phase)), nil
 
 	}
 }

--- a/tests/e2e/lib/restore_cli.go
+++ b/tests/e2e/lib/restore_cli.go
@@ -96,7 +96,6 @@ func GetRestoreViaCLI(name string) (*velero.Restore, error) {
 // IsRestoreDoneViaCLI checks if restore is done using the OADP CLI
 func IsRestoreDoneViaCLI(name string) wait.ConditionFunc {
 	return func() (bool, error) {
-		// Use CLI to get restore status
 		cmd := &CLICommand{
 			Resource: "restore",
 			Action:   "get",
@@ -108,29 +107,13 @@ func IsRestoreDoneViaCLI(name string) wait.ConditionFunc {
 			return false, fmt.Errorf("failed to get restore status via CLI: %v", err)
 		}
 
-		// Parse phase from YAML output
 		phase := ParsePhaseFromYAML(string(output))
 
 		if len(phase) > 0 {
 			log.Printf("restore phase: %s", phase)
 		}
 
-		var phasesNotDone = []string{
-			string(velero.RestorePhaseNew),
-			string(velero.RestorePhaseInProgress),
-			string(velero.RestorePhaseWaitingForPluginOperations),
-			string(velero.RestorePhaseWaitingForPluginOperationsPartiallyFailed),
-			string(velero.RestorePhaseFinalizing),
-			string(velero.RestorePhaseFinalizingPartiallyFailed),
-			"",
-		}
-
-		for _, notDonePhase := range phasesNotDone {
-			if phase == notDonePhase {
-				return false, nil
-			}
-		}
-		return true, nil
+		return !IsRestorePhaseNotDone(phase), nil
 	}
 }
 


### PR DESCRIPTION
## Why the changes were made

The CLI backup and restore "done" checks were missing the ReadyToStart phase, causing tests to incorrectly treat backups/restores as completed before they had started. This led to false PartiallyFailed results.

Extract shared phase lists and helpers (IsBackupPhaseNotDone, IsRestorePhaseNotDone) to eliminate duplication between CLI and non-CLI code paths and prevent future phase drift.

## How to test the changes made

The CLI tests should run without any issues