### PR TITLE
Add HCP skip flake to oadp-1.5

### DIFF
--- a/tests/e2e/lib/flakes.go
+++ b/tests/e2e/lib/flakes.go
@@ -21,6 +21,7 @@ var errorIgnorePatterns = []string{
 	// https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_oadp-operator/1126/pull-ci-openshift-oadp-operator-master-4.10-operator-e2e-aws/1690109468546699264#1:build-log.txt%3A686
 	"level=error msg=\"error patch for managed fields ",
 	"VolumeSnapshot has a temporary error Failed to create snapshot: error updating status for volume snapshot content snapcontent-",
+	"Skipping hypershift plugin execution",
 }
 
 type FlakePattern struct {

--- a/tests/e2e/lib/flakes.go
+++ b/tests/e2e/lib/flakes.go
@@ -21,7 +21,7 @@ var errorIgnorePatterns = []string{
 	// https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_oadp-operator/1126/pull-ci-openshift-oadp-operator-master-4.10-operator-e2e-aws/1690109468546699264#1:build-log.txt%3A686
 	"level=error msg=\"error patch for managed fields ",
 	"VolumeSnapshot has a temporary error Failed to create snapshot: error updating status for volume snapshot content snapcontent-",
-	"Skipping hypershift plugin execution",
+	"Skipping hypershift plugin execution - not a hypershift backup: error checking for HostedControlPlane CRD",
 }
 
 type FlakePattern struct {


### PR DESCRIPTION
## Why the changes were made

oadp-1.5 did not get the flake text commit for HCP plugin execution skip.

## How to test the changes made

Tests should run without failing.