### PR TITLE
cleanup sample app namespaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1013,6 +1013,8 @@ test-e2e-cleanup: login-required
 	$(OC_CLI) delete datadownload -n $(OADP_TEST_NAMESPACE) --all
 	$(OC_CLI) delete restore -n $(OADP_TEST_NAMESPACE) --all --wait=false
 	for restore_name in $(shell $(OC_CLI) get restore -n $(OADP_TEST_NAMESPACE) -o name);do $(OC_CLI) patch "$$restore_name" -n $(OADP_TEST_NAMESPACE) -p '{"metadata":{"finalizers":null}}' --type=merge;done
+	$(OC_CLI) delete ns mongo-persistent --ignore-not-found=true
+	$(OC_CLI) delete ns mysql-persistent --ignore-not-found=true
 	rm -rf $(SETTINGS_TMP)
 
 .PHONY: update-non-admin-manifests


### PR DESCRIPTION
## cleanup: remove persistent namespaces after e2e tests

Adds deletion of `mongo-persistent` and `mysql-persistent` namespaces in the `test-e2e-cleanup` Makefile target. These sample app namespaces were left behind after e2e test runs, causing namespace pollution in the cluster.

## Why the changes were made

E2E tests create `mongo-persistent` and `mysql-persistent` namespaces for sample application deployments but the cleanup target did not remove them. This left stale namespaces in the cluster after test runs.

## How to test the changes made

- Run `make test-e2e-cleanup` after e2e tests and verify `mongo-persistent` and `mysql-persistent` namespaces are deleted
- `--ignore-not-found=true` ensures the command succeeds even if the namespaces don't exist