### PR TITLE
DNM: Test: disable pod restart workaround after file-system restore

### DIFF
--- a/tests/e2e/backup_restore_cli_suite_test.go
+++ b/tests/e2e/backup_restore_cli_suite_test.go
@@ -1,7 +1,6 @@
 package e2e_test
 
 import (
-	"context"
 	"fmt"
 	"log"
 	"strings"
@@ -9,7 +8,6 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/openshift/oadp-operator/tests/e2e/lib"
 )

--- a/tests/e2e/backup_restore_cli_suite_test.go
+++ b/tests/e2e/backup_restore_cli_suite_test.go
@@ -175,20 +175,23 @@ func runApplicationBackupAndRestoreViaCLI(brCase ApplicationBackupRestoreCase, u
 	// run restore via CLI
 	runRestoreViaCLI(brCase.BackupRestoreCase, backupName, restoreName, nsRequiredResticDCWorkaround)
 
+	// TODO: Testing whether this workaround is still needed. Remove if
+	// file-system restore tests pass without it.
+	//
 	// For file-system backup restores (KOPIA/restic), the restored pods may have
 	// broken networking because OVN-Kubernetes doesn't fully wire the network
 	// namespace for pods recreated by Velero with a restore-wait init container.
 	// Deleting the pods lets the deployment controller create fresh ones with
 	// proper networking while preserving the restored PVC data.
-	if brCase.BackupRestoreType == lib.KOPIA {
-		log.Printf("Restarting pods in namespace %s to ensure proper networking after file-system restore", brCase.Namespace)
-		err = kubernetesClientForSuiteRun.CoreV1().Pods(brCase.Namespace).DeleteCollection(
-			context.Background(),
-			metav1.DeleteOptions{},
-			metav1.ListOptions{LabelSelector: "e2e-app=true"},
-		)
-		gomega.Expect(err).ToNot(gomega.HaveOccurred())
-	}
+	// if brCase.BackupRestoreType == lib.KOPIA {
+	// 	log.Printf("Restarting pods in namespace %s to ensure proper networking after file-system restore", brCase.Namespace)
+	// 	err = kubernetesClientForSuiteRun.CoreV1().Pods(brCase.Namespace).DeleteCollection(
+	// 		context.Background(),
+	// 		metav1.DeleteOptions{},
+	// 		metav1.ListOptions{LabelSelector: "e2e-app=true"},
+	// 	)
+	// 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	// }
 
 	// Run optional custom verification
 	if brCase.PostRestoreVerify != nil {

--- a/tests/e2e/backup_restore_suite_test.go
+++ b/tests/e2e/backup_restore_suite_test.go
@@ -266,20 +266,23 @@ func runApplicationBackupAndRestore(brCase ApplicationBackupRestoreCase, updateL
 	// run restore
 	runRestore(brCase.BackupRestoreCase, backupName, restoreName, nsRequiredResticDCWorkaround)
 
+	// TODO: Testing whether this workaround is still needed. Remove if
+	// file-system restore tests pass without it.
+	//
 	// For file-system backup restores (KOPIA/restic), the restored pods may have
 	// broken networking because OVN-Kubernetes doesn't fully wire the network
 	// namespace for pods recreated by Velero with a restore-wait init container.
 	// Deleting the pods lets the deployment controller create fresh ones with
 	// proper networking while preserving the restored PVC data.
-	if brCase.BackupRestoreType == lib.KOPIA {
-		log.Printf("Restarting pods in namespace %s to ensure proper networking after file-system restore", brCase.Namespace)
-		err = kubernetesClientForSuiteRun.CoreV1().Pods(brCase.Namespace).DeleteCollection(
-			context.Background(),
-			metav1.DeleteOptions{},
-			metav1.ListOptions{LabelSelector: "e2e-app=true"},
-		)
-		gomega.Expect(err).ToNot(gomega.HaveOccurred())
-	}
+	// if brCase.BackupRestoreType == lib.KOPIA {
+	// 	log.Printf("Restarting pods in namespace %s to ensure proper networking after file-system restore", brCase.Namespace)
+	// 	err = kubernetesClientForSuiteRun.CoreV1().Pods(brCase.Namespace).DeleteCollection(
+	// 		context.Background(),
+	// 		metav1.DeleteOptions{},
+	// 		metav1.ListOptions{LabelSelector: "e2e-app=true"},
+	// 	)
+	// 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	// }
 
 	// Run optional custom verification
 	if brCase.PostRestoreVerify != nil {


### PR DESCRIPTION
## Summary
- Comments out the post-restore pod deletion workaround for KOPIA (file-system) backups in both `backup_restore_suite_test.go` and `backup_restore_cli_suite_test.go`
- This workaround was added because OVN-Kubernetes didn't fully wire the network namespace for pods recreated by Velero with a restore-wait init container
- Goal: determine whether this workaround is still needed by running E2E tests without it

## Test plan
- [ ] KOPIA backup/restore E2E tests pass without the pod restart workaround
- [ ] CLI KOPIA backup/restore E2E tests pass without the pod restart workaround
- [ ] If tests fail with networking issues, revert this change and keep the workaround


Made with [Cursor](https://cursor.com)