### PR TITLE
license has to be copied by konflux.Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,5 +14,4 @@ cache
 ./*.yaml
 OWNERS
 PROJECT
-LICENSE
 Dockerfile


### PR DESCRIPTION
## Why the changes were made

to allow `podman build -f konflux.Dockerfile`
