### PR TITLE
OADP-7665: Pass --log-level to NodeAgent DaemonSet container args

### DIFF
--- a/internal/controller/nodeagent.go
+++ b/internal/controller/nodeagent.go
@@ -709,6 +709,10 @@ func (r *DataProtectionApplicationReconciler) customizeNodeAgentDaemonset(ds *ap
 				nodeAgentContainer.Args = append(nodeAgentContainer.Args, fmt.Sprintf("--log-format=%s", dpa.Spec.LogFormat))
 			}
 
+			if dpa.Spec.Configuration.Velero.LogLevel != "" {
+				nodeAgentContainer.Args = append(nodeAgentContainer.Args, fmt.Sprintf("--log-level=%s", dpa.Spec.Configuration.Velero.LogLevel))
+			}
+
 			if len(dpa.Spec.Configuration.NodeAgent.ExtraArgs) > 0 {
 				nodeAgentContainer.Args = common.MergeExtraArgs(nodeAgentContainer.Args, dpa.Spec.Configuration.NodeAgent.ExtraArgs)
 			}

--- a/internal/controller/nodeagent_test.go
+++ b/internal/controller/nodeagent_test.go
@@ -253,6 +253,7 @@ type TestBuiltNodeAgentDaemonSetOptions struct {
 	dataMoverPrepareTimeout *string
 	resourceTimeout         *string
 	logFormat               *string
+	logLevel                *string
 	toleration              []corev1.Toleration
 	nodeSelector            map[string]string
 	disableFsBackup         *bool
@@ -583,6 +584,9 @@ func createTestBuiltNodeAgentDaemonSet(options TestBuiltNodeAgentDaemonSetOption
 	if len(options.priorityClassName) > 0 {
 		testBuiltNodeAgentDaemonSet.Spec.Template.Spec.PriorityClassName = options.priorityClassName
 	}
+	if options.logLevel != nil {
+		testBuiltNodeAgentDaemonSet.Spec.Template.Spec.Containers[0].Args = append(testBuiltNodeAgentDaemonSet.Spec.Template.Spec.Containers[0].Args, fmt.Sprintf("--log-level=%s", *options.logLevel))
+	}
 
 	return testBuiltNodeAgentDaemonSet
 }
@@ -843,6 +847,25 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 			nodeAgentDaemonSet: testNodeAgentDaemonSet.DeepCopy(),
 			wantNodeAgentDaemonSet: createTestBuiltNodeAgentDaemonSet(TestBuiltNodeAgentDaemonSetOptions{
 				logFormat: ptr.To("text"),
+			}),
+		},
+		{
+			name: "valid DPA CR with LogLevel set to debug, NodeAgent DaemonSet is built with LogLevel set to debug",
+			dpa: createTestDpaWith(
+				nil,
+				oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{
+							LogLevel: "debug",
+						},
+						NodeAgent: &oadpv1alpha1.NodeAgentConfig{},
+					},
+				},
+			),
+			clientObjects:      []client.Object{testGenericInfrastructure},
+			nodeAgentDaemonSet: testNodeAgentDaemonSet.DeepCopy(),
+			wantNodeAgentDaemonSet: createTestBuiltNodeAgentDaemonSet(TestBuiltNodeAgentDaemonSetOptions{
+				logLevel: ptr.To("debug"),
 			}),
 		},
 		{


### PR DESCRIPTION
## Summary
- Pass `--log-level` from `dpa.Spec.Configuration.Velero.LogLevel` to NodeAgent DaemonSet container args
- This allows the Velero exposer to inherit log level for data mover pods (via `getInheritedPodInfo` in `pkg/exposer/image.go`)
- Previously, LogLevel was only passed to the Velero server deployment but not to NodeAgent

Request: https://redhat-internal.slack.com/archives/C0144ECKUJ0/p1772820634393599

## Test plan
- [x] Unit test added for LogLevel=debug in NodeAgent DaemonSet build
- [x] `go test ./internal/controller/ -run TestDPAReconciler_buildNodeAgentDaemonset` passes
- [ ] E2E: set `logLevel: debug` in DPA and verify node-agent pod has `--log-level=debug` in args
- [ ] E2E: verify data mover pods spawned during backup/restore inherit the log level

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - NodeAgent resource labels and annotations are now applied consistently to ConfigMaps, DaemonSets, and pod templates.
  - Additional NodeAgent arguments and Velero log-level settings are supported with predictable precedence.
  - Load affinity now supports storage-class constraints.
- **Bug Fixes**
  - Unbounded pod resource values are normalized before configuration serialization.
  - DaemonSet cleanup succeeds when the resource is already absent.
  - Pod labels and annotations now require the appropriate NodeAgent ConfigMap configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->