### PR TITLE
Update non-admin CRDs to include ReadyToStart backup phase

### DIFF
--- a/bundle/manifests/oadp.openshift.io_nonadminbackups.yaml
+++ b/bundle/manifests/oadp.openshift.io_nonadminbackups.yaml
@@ -523,6 +523,10 @@ spec:
                           uploads to perform when using the uploader.
                         type: integer
                     type: object
+                  volumeGroupSnapshotLabelKey:
+                    description: VolumeGroupSnapshotLabelKey specifies the label key
+                      to group PVCs under a VGS.
+                    type: string
                   volumeSnapshotLocations:
                     description: VolumeSnapshotLocations is a list containing names
                       of VolumeSnapshotLocations associated with this backup.
@@ -1174,6 +1178,10 @@ spec:
                               parallel uploads to perform when using the uploader.
                             type: integer
                         type: object
+                      volumeGroupSnapshotLabelKey:
+                        description: VolumeGroupSnapshotLabelKey specifies the label
+                          key to group PVCs under a VGS.
+                        type: string
                       volumeSnapshotLocations:
                         description: VolumeSnapshotLocations is a list containing
                           names of VolumeSnapshotLocations associated with this backup.
@@ -1259,6 +1267,8 @@ spec:
                         description: Phase is the current state of the Backup.
                         enum:
                         - New
+                        - Queued
+                        - ReadyToStart
                         - FailedValidation
                         - InProgress
                         - WaitingForPluginOperations
@@ -1290,6 +1300,11 @@ spec:
                               filters that happen as items are processed.
                             type: integer
                         type: object
+                      queuePosition:
+                        description: |-
+                          QueuePosition is the position of the backup in the queue.
+                          Only relevant when Phase is "Queued"
+                        type: integer
                       startTimestamp:
                         description: |-
                           StartTimestamp records the time a backup was started.

--- a/config/crd/bases/oadp.openshift.io_nonadminbackups.yaml
+++ b/config/crd/bases/oadp.openshift.io_nonadminbackups.yaml
@@ -523,6 +523,10 @@ spec:
                           uploads to perform when using the uploader.
                         type: integer
                     type: object
+                  volumeGroupSnapshotLabelKey:
+                    description: VolumeGroupSnapshotLabelKey specifies the label key
+                      to group PVCs under a VGS.
+                    type: string
                   volumeSnapshotLocations:
                     description: VolumeSnapshotLocations is a list containing names
                       of VolumeSnapshotLocations associated with this backup.
@@ -1174,6 +1178,10 @@ spec:
                               parallel uploads to perform when using the uploader.
                             type: integer
                         type: object
+                      volumeGroupSnapshotLabelKey:
+                        description: VolumeGroupSnapshotLabelKey specifies the label
+                          key to group PVCs under a VGS.
+                        type: string
                       volumeSnapshotLocations:
                         description: VolumeSnapshotLocations is a list containing
                           names of VolumeSnapshotLocations associated with this backup.
@@ -1259,6 +1267,8 @@ spec:
                         description: Phase is the current state of the Backup.
                         enum:
                         - New
+                        - Queued
+                        - ReadyToStart
                         - FailedValidation
                         - InProgress
                         - WaitingForPluginOperations
@@ -1290,6 +1300,11 @@ spec:
                               filters that happen as items are processed.
                             type: integer
                         type: object
+                      queuePosition:
+                        description: |-
+                          QueuePosition is the position of the backup in the queue.
+                          Only relevant when Phase is "Queued"
+                        type: integer
                       startTimestamp:
                         description: |-
                           StartTimestamp records the time a backup was started.


### PR DESCRIPTION
## Why the changes were made

The NonAdminBackup CRD was missing the `ReadyToStart` phase in its
validation enum. Velero added this phase but `make update-non-admin-manifests`
was never run to sync the latest CRDs from the `oadp-non-admin` repo,
causing validation errors when backups transitioned through this phase.

## How to test the changes made

- `make test`
- Deploy OADP with non-admin enabled
- Create a NonAdminBackup and verify no validation errors for ReadyToStart phase
- `make bundle-isupdated`

🤖 Generated with [Claude Code](https://claude.ai/code)