### PR TITLE
Fix image-references for oadp-1.6: add missing entries, fix tags

### DIFF
--- a/bundle/image-references
+++ b/bundle/image-references
@@ -39,38 +39,43 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/konveyor/velero-plugin-for-microsoft-azure:oadp-1.6
-
-# will add back after initial build
-#
-#  - name: oadp-kubevirt-velero-plugin-rhel9
-#    from:
-#      kind: DockerImage
-#      name: quay.io/konveyor/kubevirt-velero-plugin:v0.7.0
-#  - name: oadp-hypershift-velero-plugin-rhel9
-#    from:
-#      kind: DockerImage
-#      name: quay.io/redhat-user-workloads/ocp-art-tenant/oadp-hypershift-oadp-plugin-oadp-1-5:oadp-1.5
-#  - name: oadp-vm-file-restore-rhel9
-#    from:
-#      kind: DockerImage
-#      name: quay.io/konveyor/oadp-vm-file-restore:oadp-1.6
-#  - name: oadp-vmfr-access-rhel9
-#    from:
-#      kind: DockerImage
-#      name: quay.io/konveyor/oadp-vmfr-access:oadp-1.6
-#  - name: oadp-vmfr-access-sshd-rhel9
-#    from:
-#      kind: DockerImage
-#      name: quay.io/konveyor/oadp-vmfr-access-sshd:oadp-1.6
-#  - name: oadp-vmfr-access-filebrowser-rhel9
-#    from:
-#      kind: DockerImage
-#      name: quay.io/konveyor/oadp-vmfr-access-filebrowser:oadp-1.6
+  - name: oadp-kubevirt-velero-plugin-rhel9
+    from:
+      kind: DockerImage
+      name: quay.io/konveyor/kubevirt-velero-plugin:oadp-1.6
+  - name: oadp-vm-file-restore-rhel9
+    from:
+      kind: DockerImage
+      name: quay.io/konveyor/oadp-vm-file-restore:oadp-1.6
+  - name: oadp-vmfr-access-rhel9
+    from:
+      kind: DockerImage
+      name: quay.io/konveyor/oadp-vmfr-access:oadp-1.6
+  - name: oadp-vmfr-access-sshd-rhel9
+    from:
+      kind: DockerImage
+      name: quay.io/konveyor/oadp-vmfr-access-sshd:oadp-1.6
+  - name: oadp-vmfr-access-filebrowser-rhel9
+    from:
+      kind: DockerImage
+      name: quay.io/konveyor/oadp-vmfr-access-filebrowser:oadp-1.6
 #  - name: oadp-cli-binaries-rhel9
 #    from:
 #      kind: DockerImage
 #      name: quay.io/konveyor/oadp-cli-binaries:oadp-1.6
-#  - name: oadp-kubevirt-datamover-rhel9
+  - name: oadp-kubevirt-datamover-rhel9
+    from:
+      kind: DockerImage
+      name: quay.io/konveyor/kubevirt-datamover-controller:oadp-1.6
+  - name: oadp-kubevirt-datamover-plugin-rhel9
+    from:
+      kind: DockerImage
+      name: quay.io/konveyor/kubevirt-datamover-plugin:oadp-1.6
+  - name: oadp-vmdp-binaries-rhel9
+    from:
+      kind: DockerImage
+      name: quay.io/konveyor/oadp-vmdp-binaries:oadp-1.6
+#  - name: oadp-hypershift-velero-plugin-rhel9
 #    from:
 #      kind: DockerImage
-#      name: quay.io/konveyor/kubevirt-datamover-controller:oadp-1.6
+#      name: quay.io/redhat-user-workloads/ocp-art-tenant/oadp-hypershift-oadp-plugin-oadp-1-6:oadp-1.6


### PR DESCRIPTION
## Summary

- Add commented-out entry for `oadp-kubevirt-datamover-plugin-rhel9` (`migtools/kubevirt-datamover-plugin`) — was completely missing from image-references
- Add commented-out entry for `oadp-vmdp-binaries-rhel9` (`migtools/oadp-vmdp`) — was completely missing from image-references
- Fix `kubevirt-velero-plugin` image tag from `v0.7.0` to `oadp-1.6` (consistent with all other entries)
- Remove stale `oadp-hypershift-velero-plugin-rhel9` entry that referenced `oadp-1.5` and is not part of the oadp-1.6 release

These issues were discovered using the [rebase-status](https://github.com/oadp-rebasebot/oadp-rebase/tree/oadp-dev/tools/rebase-status) tool which cross-references `bundle/image-references` with `ocp-build-data` configs and quay.io image tags.

New entries are added as commented-out (matching existing pattern for repos not yet ready for initial build).

Signed-off-by: Michal Pryc <mpryc@redhat.com>