### PR TITLE
Enable oadp-cli-binaries image reference for oadp-1.6

### DIFF
--- a/bundle/image-references
+++ b/bundle/image-references
@@ -59,10 +59,10 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/konveyor/oadp-vmfr-access-filebrowser:oadp-1.6
-#  - name: oadp-cli-binaries-rhel9
-#    from:
-#      kind: DockerImage
-#      name: quay.io/konveyor/oadp-cli-binaries:oadp-1.6
+  - name: oadp-cli-binaries-rhel9
+    from:
+      kind: DockerImage
+      name: quay.io/konveyor/oadp-cli-binaries:oadp-1.6
   - name: oadp-kubevirt-datamover-rhel9
     from:
       kind: DockerImage


### PR DESCRIPTION
## Summary
- Uncomments the `oadp-cli-binaries-rhel9` entry in `bundle/image-references` to include CLI binaries in the 1.6 release

## Test plan
- [ ] Verify bundle builds successfully with the enabled image reference
- [ ] Confirm `oadp-cli-binaries-rhel9` image is pulled and included in the release payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)