### PR TITLE
[oadp-1.6] OADP-5114: Add per-StorageClass loadAffinity support to DPA

### DIFF
--- a/api/v1alpha1/dataprotectionapplication_types.go
+++ b/api/v1alpha1/dataprotectionapplication_types.go
@@ -432,6 +432,12 @@ type LoadAffinity struct {
 	// NodeSelector specifies the label selector to match nodes
 	// +optional
 	NodeSelector metav1.LabelSelector `json:"nodeSelector,omitempty"`
+
+	// StorageClass specifies the storage class to which this LoadAffinity rule applies.
+	// If empty, the affinity applies globally to all data mover operations.
+	// If set, the affinity applies only to data mover operations using this specific StorageClass.
+	// +optional
+	StorageClass string `json:"storageClass,omitempty"`
 }
 
 // Below struct should be same as:

--- a/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
@@ -343,6 +343,12 @@ spec:
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
+                              storageClass:
+                                description: |-
+                                  StorageClass specifies the storage class to which this LoadAffinity rule applies.
+                                  If empty, the affinity applies globally to all data mover operations.
+                                  If set, the affinity applies only to data mover operations using this specific StorageClass.
+                                type: string
                             type: object
                           type: array
                         loadConcurrency:
@@ -733,6 +739,12 @@ spec:
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
+                                storageClass:
+                                  description: |-
+                                    StorageClass specifies the storage class to which this LoadAffinity rule applies.
+                                    If empty, the affinity applies globally to all data mover operations.
+                                    If set, the affinity applies only to data mover operations using this specific StorageClass.
+                                  type: string
                               type: object
                             type: array
                           podResources:
@@ -1273,6 +1285,12 @@ spec:
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
+                              storageClass:
+                                description: |-
+                                  StorageClass specifies the storage class to which this LoadAffinity rule applies.
+                                  If empty, the affinity applies globally to all data mover operations.
+                                  If set, the affinity applies only to data mover operations using this specific StorageClass.
+                                type: string
                             type: object
                           type: array
                         logLevel:

--- a/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
@@ -343,6 +343,12 @@ spec:
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
+                              storageClass:
+                                description: |-
+                                  StorageClass specifies the storage class to which this LoadAffinity rule applies.
+                                  If empty, the affinity applies globally to all data mover operations.
+                                  If set, the affinity applies only to data mover operations using this specific StorageClass.
+                                type: string
                             type: object
                           type: array
                         loadConcurrency:
@@ -733,6 +739,12 @@ spec:
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
+                                storageClass:
+                                  description: |-
+                                    StorageClass specifies the storage class to which this LoadAffinity rule applies.
+                                    If empty, the affinity applies globally to all data mover operations.
+                                    If set, the affinity applies only to data mover operations using this specific StorageClass.
+                                  type: string
                               type: object
                             type: array
                           podResources:
@@ -1273,6 +1285,12 @@ spec:
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
+                              storageClass:
+                                description: |-
+                                  StorageClass specifies the storage class to which this LoadAffinity rule applies.
+                                  If empty, the affinity applies globally to all data mover operations.
+                                  If set, the affinity applies only to data mover operations using this specific StorageClass.
+                                type: string
                             type: object
                           type: array
                         logLevel:

--- a/docs/design/DPA-and-node-selectors.md
+++ b/docs/design/DPA-and-node-selectors.md
@@ -133,8 +133,10 @@ spec:
 
 #### New settings specific to the `spec.configuration.nodeAgent.loadAffinity` will be added to the nodeAgent section.
 
-The `loadAffinity` section workflow is already explained in the above paragrafs of this design document. 
+The `loadAffinity` section workflow is already explained in the above paragraphs of this design document.
 The `loadAffinity` section is also explained in the upstream Velero documentation: https://velero.io/docs/main/data-movement-backup-node-selection/
+
+Starting with OADP 1.6, each `loadAffinity` entry supports an optional `storageClass` field. When set, the affinity rule applies only to DataMover operations for volumes using that specific StorageClass. Entries without `storageClass` serve as a global fallback. This allows clusters with multiple StorageClasses to direct DataMover workloads to different nodes based on the volume's StorageClass.
 
 ```yaml
 apiVersion: oadp.openshift.io/v1alpha1
@@ -157,7 +159,10 @@ spec:
                 - node2
             - key: some-label.io/critical-workload
                 operator: DoesNotExist
-          number: 1
+          storageClass: my-storage-class
+        - nodeSelector:
+          matchLabels:
+            some-label.io/custom-node-role: cpu-2
 ```
 
 #### Repository maintenance job Node Affinity

--- a/docs/scheduling_and_node_affinity.md
+++ b/docs/scheduling_and_node_affinity.md
@@ -54,6 +54,33 @@ spec:
                   - node2
 ```
 
+### Per-StorageClass Load Affinity (New in OADP 1.6)
+
+When a cluster has multiple StorageClasses, you can configure different node affinity rules for DataMover operations depending on which StorageClass the volume uses. This is done by adding a `storageClass` field to a `loadAffinity` entry. Entries without `storageClass` act as a global fallback.
+
+```yaml
+spec:
+  configuration:
+    nodeAgent:
+      enable: true
+      loadAffinity:
+        - nodeSelector:
+            matchLabels:
+              my-custom-label.io/zone: zone-a
+          storageClass: gp3-csi
+        - nodeSelector:
+            matchLabels:
+              my-custom-label.io/zone: zone-b
+          storageClass: standard-csi
+        - nodeSelector:
+            matchLabels:
+              my-custom-label.io/role: worker
+```
+
+In this example, DataMover pods for volumes using `gp3-csi` are scheduled on nodes labeled `zone-a`, volumes using `standard-csi` on nodes labeled `zone-b`, and all other volumes fall back to nodes labeled `worker`.
+
+> **Note:** The `storageClass` field is also supported in `repositoryMaintenance` load affinity entries (see [section 2](#2-configuring-repository-maintenance-new-in-oadp-15)). It is **not** applicable to `velero.loadAffinity`, which controls Velero pod placement and is not volume-specific.
+
 #### Rules for NodeAgent Configuration
 
 - For simple node matching it is perfectly fine to use `podConfig.nodeSelector`.

--- a/internal/controller/nodeagent.go
+++ b/internal/controller/nodeagent.go
@@ -319,6 +319,7 @@ func (r *DataProtectionApplicationReconciler) ReconcileNodeAgentDaemonset(log lo
 			for i, aff := range dpa.Spec.Configuration.NodeAgent.NodeAgentConfigMapSettings.LoadAffinityConfig {
 				veleroAffinityStruct[i] = &kube.LoadAffinity{
 					NodeSelector: aff.NodeSelector,
+					StorageClass: aff.StorageClass,
 				}
 			}
 			affinity := kube.ToSystemAffinity(veleroAffinityStruct)

--- a/internal/controller/nodeagent_test.go
+++ b/internal/controller/nodeagent_test.go
@@ -1997,6 +1997,85 @@ func TestDPAReconciler_updateNodeAgentCM(t *testing.T) {
 				}`,
 			}),
 		},
+		{
+			name: "Given DPA CR instance, appropriate NodeAgent config cm is created with LoadAffinity including StorageClass",
+			nodeAgentConfigMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      common.NodeAgentConfigMapPrefix + testCmName,
+					Namespace: testCmNs,
+				},
+			},
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testCmName,
+					Namespace: testCmNs,
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{
+							DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
+								oadpv1alpha1.DefaultPluginAWS,
+							},
+						},
+						NodeAgent: &oadpv1alpha1.NodeAgentConfig{
+							NodeAgentCommonFields: oadpv1alpha1.NodeAgentCommonFields{},
+							NodeAgentConfigMapSettings: oadpv1alpha1.NodeAgentConfigMapSettings{
+								LoadAffinityConfig: []*oadpv1alpha1.LoadAffinity{
+									{
+										NodeSelector: metav1.LabelSelector{
+											MatchLabels: map[string]string{"node-type": "fast-storage"},
+										},
+										StorageClass: "gp3-csi",
+									},
+									{
+										NodeSelector: metav1.LabelSelector{
+											MatchLabels: map[string]string{"node-type": "bulk-storage"},
+										},
+										StorageClass: "standard",
+									},
+									{
+										NodeSelector: metav1.LabelSelector{
+											MatchLabels: map[string]string{"node-type": "general"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+			wantNodeAgentConfigMap: createTestBuiltNodeAgentCM(map[string]string{
+				"node-agent-config": `{
+					"loadAffinity": [
+						{
+							"nodeSelector": {
+								"matchLabels": {
+									"node-type": "fast-storage"
+								}
+							},
+							"storageClass": "gp3-csi"
+						},
+						{
+							"nodeSelector": {
+								"matchLabels": {
+									"node-type": "bulk-storage"
+								}
+							},
+							"storageClass": "standard"
+						},
+						{
+							"nodeSelector": {
+								"matchLabels": {
+									"node-type": "general"
+								}
+							}
+						}
+					],
+					"privilegedFsBackup": true
+				}`,
+			}),
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/controller/repository_maintenance_test.go
+++ b/internal/controller/repository_maintenance_test.go
@@ -89,6 +89,61 @@ func TestDataProtectionApplicationReconciler_updateRepositoryMaintenanceCM(t *te
 				},
 			},
 		},
+		{
+			name: "repository maintenance cm is updated with StorageClass in LoadAffinity",
+			cm: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "repository-maintenance-test-dpa",
+					Namespace: "test-ns",
+				},
+			},
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-dpa",
+					Namespace: "test-ns",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					BackupImages: ptr.To(false),
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{
+							NoDefaultBackupLocation: true,
+						},
+						RepositoryMaintenance: map[string]oadpv1alpha1.RepositoryMaintenanceConfig{
+							"global": {
+								LoadAffinityConfig: []*oadpv1alpha1.LoadAffinity{
+									{
+										NodeSelector: metav1.LabelSelector{
+											MatchLabels: map[string]string{"node-type": "fast"},
+										},
+										StorageClass: "gp3-csi",
+									},
+									{
+										NodeSelector: metav1.LabelSelector{
+											MatchLabels: map[string]string{"node-type": "general"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantCM: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "repository-maintenance-test-dpa",
+					Namespace: "test-ns",
+					Labels: map[string]string{
+						"app.kubernetes.io/instance":   "test-dpa",
+						"app.kubernetes.io/managed-by": "oadp-operator",
+						"app.kubernetes.io/component":  "repository-maintenance-config",
+						"openshift.io/oadp":            "True",
+					},
+				},
+				Data: map[string]string{
+					"global": `{"loadAffinity":[{"nodeSelector":{"matchLabels":{"node-type":"fast"}},"storageClass":"gp3-csi"},{"nodeSelector":{"matchLabels":{"node-type":"general"}}}]}`,
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/controller/validator_test.go
+++ b/internal/controller/validator_test.go
@@ -2529,6 +2529,43 @@ func TestDPAReconciler_ValidateDataProtectionCR(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "[valid] Only LoadAffinityConfig is set with multiple StorageClass entries",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					BackupImages: ptr.To(false),
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{
+							NoDefaultBackupLocation: true,
+						},
+						NodeAgent: &oadpv1alpha1.NodeAgentConfig{
+							NodeAgentConfigMapSettings: oadpv1alpha1.NodeAgentConfigMapSettings{
+								LoadAffinityConfig: []*oadpv1alpha1.LoadAffinity{
+									{
+										NodeSelector: metav1.LabelSelector{
+											MatchLabels: map[string]string{"node-type": "fast"},
+										},
+										StorageClass: "gp3-csi",
+									},
+									{
+										NodeSelector: metav1.LabelSelector{
+											MatchLabels: map[string]string{"node-type": "bulk"},
+										},
+										StorageClass: "standard",
+									},
+									{
+										NodeSelector: metav1.LabelSelector{
+											MatchLabels: map[string]string{"node-type": "general"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "[valid] DPA CR with deprecated PodAnnotations should pass validation but log warning",
 			dpa: &oadpv1alpha1.DataProtectionApplication{
 				ObjectMeta: metav1.ObjectMeta{

--- a/internal/controller/velero.go
+++ b/internal/controller/velero.go
@@ -285,6 +285,7 @@ func (r *DataProtectionApplicationReconciler) customizeVeleroDeployment(veleroDe
 		for i, aff := range dpa.Spec.Configuration.Velero.LoadAffinityConfig {
 			veleroAffinityStruct[i] = &kube.LoadAffinity{
 				NodeSelector: aff.NodeSelector,
+				StorageClass: aff.StorageClass,
 			}
 		}
 		affinity := kube.ToSystemAffinity(veleroAffinityStruct)

--- a/internal/controller/velero_test.go
+++ b/internal/controller/velero_test.go
@@ -1895,6 +1895,59 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 			}),
 		},
 		{
+			name: "valid DPA CR with Velero loadAffinity with StorageClass, Velero Deployment is built with loadAffinity",
+			dpa: createTestDpaWith(
+				nil,
+				oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{
+							LoadAffinityConfig: []*oadpv1alpha1.LoadAffinity{
+								{
+									NodeSelector: metav1.LabelSelector{
+										MatchLabels: map[string]string{"node-type": "fast-storage"},
+									},
+									StorageClass: "gp3-csi",
+								},
+								{
+									NodeSelector: metav1.LabelSelector{
+										MatchLabels: map[string]string{"node-type": "general"},
+									},
+								},
+							},
+						},
+					},
+				},
+			),
+			veleroDeployment: testVeleroDeployment.DeepCopy(),
+			wantVeleroDeployment: createTestBuiltVeleroDeployment(TestBuiltVeleroDeploymentOptions{
+				loadAffinity: []corev1.NodeSelectorTerm{
+					{
+						MatchExpressions: []corev1.NodeSelectorRequirement{
+							{
+								Key:      "node-type",
+								Operator: corev1.NodeSelectorOpIn,
+								Values:   []string{"fast-storage"},
+							},
+						},
+					},
+					{
+						MatchExpressions: []corev1.NodeSelectorRequirement{
+							{
+								Key:      "node-type",
+								Operator: corev1.NodeSelectorOpIn,
+								Values:   []string{"general"},
+							},
+						},
+					},
+				},
+				args: []string{
+					defaultFileSystemBackupTimeout,
+					defaultRestoreResourcePriorities,
+					defaultDisableInformerCache,
+				},
+			}),
+		},
+		{
 			name: "valid DPA CR with complex Velero loadAffinity, Velero Deployment is built with loadAffinity",
 			dpa: createTestDpaWith(
 				nil,


### PR DESCRIPTION
Fixes: [OADP-5114](https://redhat.atlassian.net/browse/OADP-5114)

Cherry-pick of https://github.com/openshift/oadp-operator/pull/2153 with a change, because we do not have in the oadp-1.6 https://github.com/openshift/oadp-operator/commit/6b2eff5a9eff593cfcacb914ab77526dc713d235

## Summary

Add per-StorageClass `loadAffinity` support to the DPA CRD, enabling users to configure different node affinity rules for DataMover operations based on the volume's StorageClass.

Previously, OADP's `LoadAffinity` struct only exposed `nodeSelector`, meaning all DataMover pods (backup and restore) used the same node affinity regardless of the underlying StorageClass. This made it impossible to direct DataMover workloads to specific nodes based on storage topology — a limitation affecting clusters with multiple StorageClasses.

Upstream Velero resolved this by adding a `StorageClass` field to `LoadAffinity` in:
- Issue: https://github.com/vmware-tanzu/velero/issues/8186
- PR (per-StorageClass field): https://github.com/vmware-tanzu/velero/pull/8949
- PR (restore path fix): https://github.com/vmware-tanzu/velero/pull/9130

This PR exposes the upstream `storageClass` field in the OADP DPA CRD and passes it through to the node-agent-config ConfigMap so Velero can apply the correct affinity per StorageClass.

## Changes

| File | Change |
|------|--------|
| `api/v1alpha1/dataprotectionapplication_types.go` | Added `StorageClass` field to `LoadAffinity` struct |
| `internal/controller/nodeagent.go` | Pass `StorageClass` when building `kube.LoadAffinity` for the node-agent-config ConfigMap |
| `internal/controller/velero.go` | Pass `StorageClass` when building `kube.LoadAffinity` for Velero deployment affinity |
| `internal/controller/nodeagent_test.go` | Added test with multiple StorageClass entries in loadAffinity |
| `internal/controller/velero_test.go` | Added test with StorageClass in Velero loadAffinity |
| `internal/controller/repository_maintenance_test.go` | Added test with StorageClass in repository maintenance loadAffinity |
| `internal/controller/validator_test.go` | Added valid DPA test with multiple StorageClass loadAffinity entries |
| `docs/scheduling_and_node_affinity.md` | Documented per-StorageClass load affinity (user-facing) |
| `docs/design/DPA-and-node-selectors.md` | Updated design doc with storageClass field |

## Backward Compatibility

The `storageClass` field uses `json:"storageClass,omitempty"`. Existing DPAs without `storageClass` produce identical JSON as before — no migration or changes required for current users.

When no `storageClass` is specified on a `loadAffinity` entry, Velero treats it as a global fallback (same behavior as before this change).

## Testing

### Prerequisites

Ensure the cluster has at least one worker node. For per-StorageClass testing, label nodes so you can distinguish affinity behavior.

```shell
oc label node <node-name> my-custom-label.io/sc-affinity=gp3
oc label node <another-node-name> my-custom-label.io/sc-affinity=standard
```

### 1. Create the DPA with per-StorageClass loadAffinity

Replace `<bucket>`, `<prefix>`, `<region>`, and credential secret name with your values.

```yaml
apiVersion: oadp.openshift.io/v1alpha1
kind: DataProtectionApplication
metadata:
  name: velero-dpa
  namespace: openshift-adp
spec:
  backupLocations:
    - velero:
        config:
          profile: default
          region: <region>
        credential:
          key: default
          name: cloud-credentials
        default: true
        objectStorage:
          bucket: <bucket>
          prefix: <prefix>
        provider: aws
  configuration:
    nodeAgent:
      enable: true
      uploaderType: kopia
      loadAffinity:
        - nodeSelector:
            matchLabels:
              my-custom-label.io/sc-affinity: gp3
          storageClass: gp3-csi
        - nodeSelector:
            matchLabels:
              my-custom-label.io/sc-affinity: standard
          storageClass: standard-csi
        - nodeSelector:
            matchLabels:
              node-role.kubernetes.io/worker: ""
    velero:
      defaultPlugins:
        - openshift
        - aws
        - csi
```

### 2. Verify the DPA is reconciled

```shell
oc get dpa velero-dpa -n openshift-adp -o jsonpath='{.status.conditions}' | python3 -m json.tool
```

Condition `Reconciled` should be `True`.

### 3. Verify the node-agent-config ConfigMap

```shell
oc get configmap node-agent-config -n openshift-adp -o yaml
```

The `loadAffinity` section in the ConfigMap JSON should contain three entries:
- One with `"storageClass":"gp3-csi"` and matching label `my-custom-label.io/sc-affinity: gp3`
- One with `"storageClass":"standard-csi"` and matching label `my-custom-label.io/sc-affinity: standard`
- One without `storageClass` (global fallback) with label `node-role.kubernetes.io/worker: ""`

### 4. Verify node-agent pods loaded the configuration

```shell
oc logs -n openshift-adp -l name=node-agent --tail=50 | grep -i "load affinity"
```

You should see log entries indicating the affinity entries were loaded.

### 5. Backward compatibility test

Apply a DPA **without** `storageClass` in any loadAffinity entry and verify the ConfigMap looks the same as before (no `storageClass` key in the JSON).

### 6. Run unit tests

```shell
go test ./internal/controller/ -run "^Test[^A]" -count=1
```

All tests should pass including the new StorageClass-specific tests.

### 7. (Optional) End-to-end validation

Create a backup of an application using a PVC with one of the configured StorageClasses, then restore it. Verify that the DataUpload/DataDownload pods are scheduled on the node matching the per-StorageClass affinity rule.
