### PR TITLE
Enable hypershift OADP plugin build with quay.io/konveyor registry

### DIFF
--- a/bundle/image-references
+++ b/bundle/image-references
@@ -75,7 +75,7 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/konveyor/oadp-vmdp-binaries:oadp-1.6
-#  - name: oadp-hypershift-velero-plugin-rhel9
-#    from:
-#      kind: DockerImage
-#      name: quay.io/redhat-user-workloads/ocp-art-tenant/oadp-hypershift-oadp-plugin-oadp-1-6:oadp-1.6
+  - name: oadp-hypershift-velero-plugin-rhel9
+    from:
+      kind: DockerImage
+      name: quay.io/konveyor/hypershift-oadp-plugin:oadp-1.6

--- a/bundle/manifests/oadp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/oadp-operator.clusterserviceversion.yaml
@@ -1460,7 +1460,7 @@ spec:
                 - name: RELATED_IMAGE_KUBEVIRT_VELERO_PLUGIN
                   value: quay.io/konveyor/kubevirt-velero-plugin:latest
                 - name: RELATED_IMAGE_HYPERSHIFT_VELERO_PLUGIN
-                  value: quay.io/redhat-user-workloads/ocp-art-tenant/oadp-hypershift-oadp-plugin-main:main
+                  value: quay.io/konveyor/hypershift-oadp-plugin:oadp-1.6
                 - name: RELATED_IMAGE_MUSTGATHER
                   value: quay.io/konveyor/oadp-must-gather:oadp-1.6
                 - name: RELATED_IMAGE_NON_ADMIN_CONTROLLER
@@ -1701,7 +1701,7 @@ spec:
     name: velero-plugin-for-gcp
   - image: quay.io/konveyor/kubevirt-velero-plugin:latest
     name: kubevirt-velero-plugin
-  - image: quay.io/redhat-user-workloads/ocp-art-tenant/oadp-hypershift-oadp-plugin-main:main
+  - image: quay.io/konveyor/hypershift-oadp-plugin:oadp-1.6
     name: hypershift-velero-plugin
   - image: quay.io/konveyor/oadp-must-gather:oadp-1.6
     name: mustgather

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -83,7 +83,7 @@ spec:
             - name: RELATED_IMAGE_KUBEVIRT_VELERO_PLUGIN
               value: quay.io/konveyor/kubevirt-velero-plugin:latest
             - name: RELATED_IMAGE_HYPERSHIFT_VELERO_PLUGIN
-              value: quay.io/redhat-user-workloads/ocp-art-tenant/oadp-hypershift-oadp-plugin-main:main
+              value: quay.io/konveyor/hypershift-oadp-plugin:oadp-1.6
             - name: RELATED_IMAGE_MUSTGATHER
               value: quay.io/konveyor/oadp-must-gather:oadp-1.6
             - name: RELATED_IMAGE_NON_ADMIN_CONTROLLER

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -75,7 +75,7 @@ const (
 	RegistryImage                = "quay.io/konveyor/registry:latest"
 	KubeVirtPluginImage          = "quay.io/konveyor/kubevirt-velero-plugin:latest"
 	KubeVirtDatamoverPluginImage = "quay.io/konveyor/kubevirt-datamover-plugin:oadp-1.6"
-	HypershiftPluginImage        = "quay.io/redhat-user-workloads/ocp-art-tenant/oadp-hypershift-oadp-plugin-main:main"
+	HypershiftPluginImage        = "quay.io/konveyor/hypershift-oadp-plugin:oadp-1.6"
 )
 
 // Plugin names

--- a/pkg/credentials/credentials_test.go
+++ b/pkg/credentials/credentials_test.go
@@ -464,9 +464,9 @@ func TestCredentials_getPluginImage(t *testing.T) {
 				},
 			},
 			pluginName: oadpv1alpha1.DefaultPluginHypershift,
-			wantImage:  "quay.io/redhat-user-workloads/ocp-art-tenant/oadp-hypershift-oadp-plugin-main:main",
+			wantImage:  "quay.io/konveyor/hypershift-oadp-plugin:oadp-1.6",
 			setEnvVars: map[string]string{
-				"RELATED_IMAGE_HYPERSHIFT_VELERO_PLUGIN": "quay.io/redhat-user-workloads/ocp-art-tenant/oadp-hypershift-oadp-plugin-main:main",
+				"RELATED_IMAGE_HYPERSHIFT_VELERO_PLUGIN": "quay.io/konveyor/hypershift-oadp-plugin:oadp-1.6",
 			},
 		},
 	}

--- a/tests/e2e/lib/hcp/dpa.go
+++ b/tests/e2e/lib/hcp/dpa.go
@@ -41,7 +41,7 @@ func (h *HCHandler) AddHCPPluginToDPA(namespace, name string, overrides bool) er
 
 	if overrides {
 		dpa.Spec.UnsupportedOverrides = map[oadpv1alpha1.UnsupportedImageKey]string{
-			oadpv1alpha1.HypershiftPluginImageKey: "quay.io/redhat-user-workloads/ocp-art-tenant/oadp-hypershift-oadp-plugin-main:main",
+			oadpv1alpha1.HypershiftPluginImageKey: "quay.io/konveyor/hypershift-oadp-plugin:oadp-1.6",
 		}
 	}
 

--- a/tests/e2e/lib/hcp/dpa_test.go
+++ b/tests/e2e/lib/hcp/dpa_test.go
@@ -146,7 +146,7 @@ func TestRemoveHCPPluginFromDPA(t *testing.T) {
 						},
 					},
 					UnsupportedOverrides: map[oadpv1alpha1.UnsupportedImageKey]string{
-						oadpv1alpha1.HypershiftPluginImageKey: "quay.io/redhat-user-workloads/ocp-art-tenant/oadp-hypershift-oadp-plugin-main:main",
+						oadpv1alpha1.HypershiftPluginImageKey: "quay.io/konveyor/hypershift-oadp-plugin:oadp-1.6",
 					},
 				},
 			},


### PR DESCRIPTION
## Summary

- Switch the hypershift-oadp-plugin image from the ART/Konflux registry (`quay.io/redhat-user-workloads/ocp-art-tenant`) to the konveyor registry (`quay.io/konveyor/hypershift-oadp-plugin:oadp-1.6`), aligning with all other plugin images on the oadp-1.6 branch.
- Uncomment the hypershift entry in `bundle/image-references` to enable the build in ART.
- Update all references across operator config, CSV, default image constants, and test fixtures.

## Test plan

- [ ] Verify `make test` passes with updated image references
- [ ] Deploy with `make deploy-olm` and confirm the hypershift plugin init container uses the correct image
- [ ] Run HCP E2E tests to validate backup/restore with the new plugin image

🤖 Generated with [Claude Code](https://claude.com/claude-code)