### PR TITLE
Fix kubevirt velero image tag

### DIFF
--- a/bundle/manifests/oadp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/oadp-operator.clusterserviceversion.yaml
@@ -1458,7 +1458,7 @@ spec:
                 - name: RELATED_IMAGE_VELERO_PLUGIN_FOR_GCP
                   value: quay.io/konveyor/velero-plugin-for-gcp:oadp-1.6
                 - name: RELATED_IMAGE_KUBEVIRT_VELERO_PLUGIN
-                  value: quay.io/konveyor/kubevirt-velero-plugin:latest
+                  value: quay.io/konveyor/kubevirt-velero-plugin:oadp-1.6
                 - name: RELATED_IMAGE_HYPERSHIFT_VELERO_PLUGIN
                   value: quay.io/konveyor/hypershift-oadp-plugin:oadp-1.6
                 - name: RELATED_IMAGE_MUSTGATHER
@@ -1699,7 +1699,7 @@ spec:
     name: velero-plugin-for-microsoft-azure
   - image: quay.io/konveyor/velero-plugin-for-gcp:oadp-1.6
     name: velero-plugin-for-gcp
-  - image: quay.io/konveyor/kubevirt-velero-plugin:latest
+  - image: quay.io/konveyor/kubevirt-velero-plugin:oadp-1.6
     name: kubevirt-velero-plugin
   - image: quay.io/konveyor/hypershift-oadp-plugin:oadp-1.6
     name: hypershift-velero-plugin

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -81,7 +81,7 @@ spec:
             - name: RELATED_IMAGE_VELERO_PLUGIN_FOR_GCP
               value: quay.io/konveyor/velero-plugin-for-gcp:oadp-1.6
             - name: RELATED_IMAGE_KUBEVIRT_VELERO_PLUGIN
-              value: quay.io/konveyor/kubevirt-velero-plugin:latest
+              value: quay.io/konveyor/kubevirt-velero-plugin:oadp-1.6
             - name: RELATED_IMAGE_HYPERSHIFT_VELERO_PLUGIN
               value: quay.io/konveyor/hypershift-oadp-plugin:oadp-1.6
             - name: RELATED_IMAGE_MUSTGATHER


### PR DESCRIPTION
## Why the changes were made

Fix the kubevirt-velero-plugin image tag from `:latest` to `:oadp-1.6` so that it matches the convention used by all other images in the bundle and manager configuration.

## How to test the changes made

String match

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>