### PR TITLE
Fix kubevirt-datamover controller using wrong image override key

### DIFF
--- a/api/v1alpha1/dataprotectionapplication_types.go
+++ b/api/v1alpha1/dataprotectionapplication_types.go
@@ -91,7 +91,8 @@ const OpenShiftPluginImageKey UnsupportedImageKey = "openshiftPluginImageFqin"
 const AzurePluginImageKey UnsupportedImageKey = "azurePluginImageFqin"
 const GCPPluginImageKey UnsupportedImageKey = "gcpPluginImageFqin"
 const KubeVirtPluginImageKey UnsupportedImageKey = "kubevirtPluginImageFqin"
-const KubeVirtDatamoverImageKey UnsupportedImageKey = "kubevirtDatamoverPluginImageFqin"
+const KubeVirtDatamoverPluginImageKey UnsupportedImageKey = "kubevirtDatamoverPluginImageFqin"
+const KubeVirtDatamoverControllerImageKey UnsupportedImageKey = "kubevirtDatamoverControllerImageFqin"
 const HypershiftPluginImageKey UnsupportedImageKey = "hypershiftPluginImageFqin"
 const NonAdminControllerImageKey UnsupportedImageKey = "nonAdminControllerImageFqin"
 const VMFileRestoreControllerImageKey UnsupportedImageKey = "vmFileRestoreControllerImageFqin"
@@ -907,6 +908,7 @@ type DataProtectionApplicationSpec struct {
 	//   - gcpPluginImageFqin
 	//   - kubevirtPluginImageFqin
 	//   - kubevirtDatamoverPluginImageFqin
+	//   - kubevirtDatamoverControllerImageFqin
 	//   - hypershiftPluginImageFqin
 	//   - nonAdminControllerImageFqin
 	//   - vmFileRestoreControllerImageFqin

--- a/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
@@ -2766,6 +2766,7 @@ spec:
                       - gcpPluginImageFqin
                       - kubevirtPluginImageFqin
                       - kubevirtDatamoverPluginImageFqin
+                      - kubevirtDatamoverControllerImageFqin
                       - hypershiftPluginImageFqin
                       - nonAdminControllerImageFqin
                       - vmFileRestoreControllerImageFqin

--- a/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
@@ -2766,6 +2766,7 @@ spec:
                       - gcpPluginImageFqin
                       - kubevirtPluginImageFqin
                       - kubevirtDatamoverPluginImageFqin
+                      - kubevirtDatamoverControllerImageFqin
                       - hypershiftPluginImageFqin
                       - nonAdminControllerImageFqin
                       - vmFileRestoreControllerImageFqin

--- a/internal/controller/kubevirt_datamover_controller.go
+++ b/internal/controller/kubevirt_datamover_controller.go
@@ -323,8 +323,8 @@ func (r *DataProtectionApplicationReconciler) checkKubevirtDatamoverEnabled() bo
 }
 
 func (r *DataProtectionApplicationReconciler) getKubevirtDatamoverControllerImage() string {
-	// Priority 1: UnsupportedOverrides
-	if unsupportedOverride := r.dpa.Spec.UnsupportedOverrides[oadpv1alpha1.KubeVirtDatamoverImageKey]; unsupportedOverride != "" {
+	// Priority 1: UnsupportedOverrides (controller-specific key)
+	if unsupportedOverride := r.dpa.Spec.UnsupportedOverrides[oadpv1alpha1.KubeVirtDatamoverControllerImageKey]; unsupportedOverride != "" {
 		return unsupportedOverride
 	}
 	// Priority 2: Environment variable

--- a/internal/controller/kubevirt_datamover_controller_test.go
+++ b/internal/controller/kubevirt_datamover_controller_test.go
@@ -386,7 +386,7 @@ func TestGetKubevirtDatamoverControllerImage(t *testing.T) {
 
 			if tt.overrideValue != "" {
 				dpa.Spec.UnsupportedOverrides = map[oadpv1alpha1.UnsupportedImageKey]string{
-					oadpv1alpha1.KubeVirtDatamoverImageKey: tt.overrideValue,
+					oadpv1alpha1.KubeVirtDatamoverControllerImageKey: tt.overrideValue,
 				}
 			}
 
@@ -398,6 +398,24 @@ func TestGetKubevirtDatamoverControllerImage(t *testing.T) {
 			}
 		})
 	}
+
+	// Verify plugin image override does not affect controller image
+	t.Run("Should not use plugin image override for controller", func(t *testing.T) {
+		dpa := &oadpv1alpha1.DataProtectionApplication{
+			Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+				UnsupportedOverrides: map[oadpv1alpha1.UnsupportedImageKey]string{
+					oadpv1alpha1.KubeVirtDatamoverPluginImageKey: "quay.io/some-user/plugin-image:latest",
+				},
+			},
+		}
+
+		r := &DataProtectionApplicationReconciler{dpa: dpa}
+		result := r.getKubevirtDatamoverControllerImage()
+
+		if result != defaultKubevirtDatamoverImage {
+			t.Errorf("plugin override should not affect controller image: expected %s, got %s", defaultKubevirtDatamoverImage, result)
+		}
+	})
 }
 
 func TestGetKubevirtDatamoverResources(t *testing.T) {
@@ -871,7 +889,7 @@ func TestBuildKubevirtDatamoverDeployment(t *testing.T) {
 						Velero: &oadpv1alpha1.VeleroConfig{},
 					},
 					UnsupportedOverrides: map[oadpv1alpha1.UnsupportedImageKey]string{
-						oadpv1alpha1.KubeVirtDatamoverImageKey: "custom-registry.io/kdm:v1.0",
+						oadpv1alpha1.KubeVirtDatamoverControllerImageKey: "custom-registry.io/kdm:v1.0",
 					},
 				},
 			},

--- a/pkg/credentials/credentials.go
+++ b/pkg/credentials/credentials.go
@@ -168,8 +168,8 @@ func getKubeVirtPluginImage(dpa *oadpv1alpha1.DataProtectionApplication) string 
 }
 
 func getKubeVirtDatamoverPluginImage(dpa *oadpv1alpha1.DataProtectionApplication) string {
-	if dpa.Spec.UnsupportedOverrides[oadpv1alpha1.KubeVirtDatamoverImageKey] != "" {
-		return dpa.Spec.UnsupportedOverrides[oadpv1alpha1.KubeVirtDatamoverImageKey]
+	if dpa.Spec.UnsupportedOverrides[oadpv1alpha1.KubeVirtDatamoverPluginImageKey] != "" {
+		return dpa.Spec.UnsupportedOverrides[oadpv1alpha1.KubeVirtDatamoverPluginImageKey]
 	}
 	if os.Getenv("RELATED_IMAGE_KUBEVIRT_DATAMOVER_PLUGIN") == "" {
 		return common.KubeVirtDatamoverPluginImage

--- a/pkg/credentials/credentials_test.go
+++ b/pkg/credentials/credentials_test.go
@@ -425,6 +425,96 @@ func TestCredentials_getPluginImage(t *testing.T) {
 				"RELATED_IMAGE_KUBEVIRT_VELERO_PLUGIN": "quay.io/kubevirt/kubevirt-velero-plugin:latest",
 			},
 		},
+		// KubeVirt DataMover plugin tests
+		{
+			name: "given default Velero CR without env var set, default kubevirt datamover plugin image should be returned",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-Velero-CR",
+					Namespace: "test-ns",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{
+							DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
+								oadpv1alpha1.DefaultPluginKubeVirtDataMover,
+							},
+						},
+					},
+				},
+			},
+			pluginName: oadpv1alpha1.DefaultPluginKubeVirtDataMover,
+			wantImage:  common.KubeVirtDatamoverPluginImage,
+		},
+		{
+			name: "given kubevirt datamover plugin override, custom image should be returned",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-Velero-CR",
+					Namespace: "test-ns",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{
+							DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
+								oadpv1alpha1.DefaultPluginKubeVirtDataMover,
+							},
+						},
+					},
+					UnsupportedOverrides: map[oadpv1alpha1.UnsupportedImageKey]string{
+						oadpv1alpha1.KubeVirtDatamoverPluginImageKey: "quay.io/custom/datamover-plugin:v1",
+					},
+				},
+			},
+			pluginName: oadpv1alpha1.DefaultPluginKubeVirtDataMover,
+			wantImage:  "quay.io/custom/datamover-plugin:v1",
+		},
+		{
+			name: "given kubevirt datamover plugin with env var set, image should be built via env vars",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-Velero-CR",
+					Namespace: "test-ns",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{
+							DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
+								oadpv1alpha1.DefaultPluginKubeVirtDataMover,
+							},
+						},
+					},
+				},
+			},
+			pluginName: oadpv1alpha1.DefaultPluginKubeVirtDataMover,
+			wantImage:  "quay.io/konveyor/kubevirt-datamover-plugin:latest",
+			setEnvVars: map[string]string{
+				"RELATED_IMAGE_KUBEVIRT_DATAMOVER_PLUGIN": "quay.io/konveyor/kubevirt-datamover-plugin:latest",
+			},
+		},
+		{
+			name: "given controller image override, plugin image should not be affected",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-Velero-CR",
+					Namespace: "test-ns",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{
+							DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
+								oadpv1alpha1.DefaultPluginKubeVirtDataMover,
+							},
+						},
+					},
+					UnsupportedOverrides: map[oadpv1alpha1.UnsupportedImageKey]string{
+						oadpv1alpha1.KubeVirtDatamoverControllerImageKey: "quay.io/custom/controller:v1",
+					},
+				},
+			},
+			pluginName: oadpv1alpha1.DefaultPluginKubeVirtDataMover,
+			wantImage:  common.KubeVirtDatamoverPluginImage,
+		},
 		// Hypershift tests
 		{
 			name: "given default Velero CR with no env var, default hypershift image should be returned",


### PR DESCRIPTION
## Summary
- The `kubevirtDatamoverPluginImageFqin` unsupported override was incorrectly used for both the datamover **plugin** (Velero init container) and the datamover **controller** deployment. Setting the plugin image override caused the controller pod to crash with `executable file /manager not found` because the plugin image does not contain the `/manager` binary.
- Add a separate `kubevirtDatamoverControllerImageFqin` override key for the controller deployment
- Rename Go const `KubeVirtDatamoverImageKey` to `KubeVirtDatamoverPluginImageKey` for clarity

## Test plan
- [x] Unit tests pass (`go test ./internal/controller/ -run Kubevirt`)
- [x] Plugin image tests pass (`go test ./pkg/credentials/ -run TestCredentials_getPluginImage`)
- [x] Added regression test: plugin override does not affect controller image
- [x] Added regression test: controller override does not affect plugin image
- [x] Added datamover plugin image unit tests (default, override, env var)
- [x] Lint passes (`make lint` - 0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for separately overriding the KubeVirt DataMover Controller image, enabling independent image version management from the DataMover Plugin component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->