### PR TITLE
Rename to kubevirt-datamover-controller

### DIFF
--- a/bundle/image-references
+++ b/bundle/image-references
@@ -63,7 +63,7 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/konveyor/oadp-cli-binaries:oadp-1.6
-  - name: oadp-kubevirt-datamover-rhel9
+  - name: oadp-kubevirt-datamover-controller-rhel9
     from:
       kind: DockerImage
       name: quay.io/konveyor/kubevirt-datamover-controller:oadp-1.6


### PR DESCRIPTION
## Why the changes were made

Fix kubevirt-datamover-controller name. Should match [ocp-build-data 1.6 image file spec](https://github.com/openshift-eng/ocp-build-data/tree/oadp-1.6/images)

## How to test the changes made

[This](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/rhtap-releng-tenant/applications/oadp-1-6/taskruns/managed-4fqwz-publish-pyxis-repository/logs) should pass after this and ocp-build-data rename fix goes in