### PR TITLE
DNM, first pass at kubevirt-datamover e2e test

### DIFF
--- a/build/ci-Dockerfile
+++ b/build/ci-Dockerfile
@@ -14,6 +14,12 @@ RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/s
     chmod +x kubectl && \
     mv kubectl /usr/local/bin/
 
+# Install virtctl for KubeVirt VM operations in E2E tests
+RUN export KV_VERSION=$(curl -s https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirt/stable.txt) && \
+    curl -L -o virtctl "https://github.com/kubevirt/kubevirt/releases/download/${KV_VERSION}/virtctl-${KV_VERSION}-linux-${TARGETARCH}" && \
+    chmod +x virtctl && \
+    mv virtctl /usr/local/bin/
+
 # Install Claude CLI (native binary, no Node.js dependency)
 # Installer places binary at ~/.local/bin/claude
 RUN curl -fsSL https://claude.ai/install.sh | bash && \

--- a/docs/design/specs/2026-04-21-kubevirt-datamover-e2e-test-design.md
+++ b/docs/design/specs/2026-04-21-kubevirt-datamover-e2e-test-design.md
@@ -1,0 +1,277 @@
+# Kubevirt Datamover E2E Test Design
+
+## Summary
+
+Add a basic E2E test to `virt_backup_restore_suite_test.go` that validates the kubevirt-datamover backup path: enabling CBT on a CirrOS VM via HCO configuration and VM labels, deploying OADP with the `kubevirt-datamover` plugin, triggering a Velero backup with `SnapshotMoveData=true`, and verifying that a `VirtualMachineBackupTracker` is created (proving the kubevirt-datamover controller processed the backup).
+
+## Approach
+
+Extend the existing HCO/OLM-based virt test infrastructure. No new KubeVirt install paths.
+
+## Prerequisites
+
+- HCO version with KubeVirt >= v1.7 (CBT support, released Nov 2025)
+- kubevirt-datamover-controller deployed (handled by OADP operator when `kubevirt-datamover` plugin is enabled)
+- kubevirt-datamover-plugin image available (Velero init container, configured via DPA `DefaultPluginKubeVirtDataMover`)
+
+---
+
+## Existing KubeVirt Installation Flow (No Changes)
+
+The existing virt test suite installs KubeVirt via the HyperConverged Cluster Operator (HCO) through OLM. This flow is in `tests/e2e/lib/virt_helpers.go` and is driven by the `BeforeAll` in `virt_backup_restore_suite_test.go`. The test does NOT install raw upstream KubeVirt; it always uses HCO.
+
+### Step-by-step existing flow
+
+1. **`GetVirtOperator(client, clientset, dynamicClient, useUpstreamHco)`** (line 65)
+   - Selects namespace and OLM package based on `upstream` flag:
+     - OpenShift (default): namespace `openshift-cnv`, PackageManifest `kubevirt-hyperconverged`, catalog `redhat-operators`
+     - Upstream (`HCO_UPSTREAM=true`): namespace `kubevirt-hyperconverged`, PackageManifest `community-kubevirt-hyperconverged`, catalog `community-operators`
+   - Reads the `stable` channel from the PackageManifest to get the current CSV name and version
+
+2. **`EnsureVirtInstallation()`** (line 732) — only runs if HCO is not already present
+   - `EnsureNamespace(v.Namespace)` — creates `openshift-cnv` or `kubevirt-hyperconverged`
+   - `ensureOperatorGroup()` — creates OperatorGroup (upstream uses empty `TargetNamespaces`)
+   - `ensureSubscription()` — creates OLM Subscription pointing to the catalog/channel/CSV
+   - `ensureCsv(5min)` — waits for the ClusterServiceVersion to be ready
+   - `ensureHco(5min)` — creates the `HyperConverged` CR and waits for health
+
+3. **`installHco()`** (line 339) — creates the HyperConverged CR with **empty spec**:
+   ```yaml
+   apiVersion: hco.kubevirt.io/v1beta1
+   kind: HyperConverged
+   metadata:
+     name: kubevirt-hyperconverged
+     namespace: <v.Namespace>
+   spec: {}
+   ```
+   HCO then creates and manages the KubeVirt CR, CDI, and other operands.
+
+4. **Optional: KVM emulation** (`EnsureEmulation()`, line 686)
+   - Only when `kvmEmulation=true` (cloud clusters without nested virt)
+   - Patches the HCO CR's **annotation** `kubevirt.kubevirt.io/jsonpatch` with:
+     ```json
+     [{"op": "add", "path": "/spec/configuration/developerConfiguration", "value": {"useEmulation": true}}]
+     ```
+   - HCO applies this JSON patch to the KubeVirt CR it manages
+
+5. **CirrOS boot image setup**
+   - Downloads latest CirrOS image URL
+   - Creates DataVolume `cirros` in `openshift-virtualization-os-images` namespace
+   - Creates DataSource from the PVC
+
+6. **DPA plugin configuration**
+   - Appends `DefaultPluginKubeVirt` to `dpaCR.VeleroDefaultPlugins`
+
+7. **Storage classes and RBAC**
+   - Creates `test-sc-immediate` and `test-sc-wffc` StorageClasses
+   - Installs `cirros-rbac.yaml`
+
+### Key point: HCO annotations propagate to KubeVirt CR
+
+HCO manages the KubeVirt CR. Direct edits to the KubeVirt CR are overwritten by HCO. To inject KubeVirt-level configuration that HCO doesn't directly expose, the pattern is to use the `kubevirt.kubevirt.io/jsonpatch` annotation on the HCO CR. This is already used for KVM emulation (step 4 above).
+
+---
+
+## CBT Enablement: Two Separate Configurations Required
+
+Enabling ChangedBlockTracking on a VM requires two distinct cluster-level configurations plus a per-VM label.
+
+**Note:** An older setup procedure used three `kubevirt.kubevirt.io/jsonpatch` operations to inject `IncrementalBackup` and `UtilityVolumes` feature gates plus the label selector. That is **no longer necessary** — HCO now exposes `incrementalBackup` as a first-class feature gate, and enabling it automatically enables `UtilityVolumes`. Only the label selector still requires the jsonpatch annotation.
+
+### Configuration 1: HCO Feature Gate (`incrementalBackup`)
+
+The HCO CR has a feature gate `spec.featureGates.incrementalBackup` (default: `false`). Setting this to `true`:
+- Enables the `IncrementalBackup` feature gate in the KubeVirt CR
+- Automatically enables the `UtilityVolumes` feature gate (required for backup output storage)
+- This is a Tech Preview feature (Alpha graduation)
+
+**What to set on HCO:**
+```yaml
+apiVersion: hco.kubevirt.io/v1beta1
+kind: HyperConverged
+metadata:
+  name: kubevirt-hyperconverged
+spec:
+  featureGates:
+    incrementalBackup: true
+```
+
+This is a direct field on the HCO spec, so it can be set via a standard merge patch on the HCO resource (no annotation needed).
+
+### Configuration 2: KubeVirt Label Selector (`changedBlockTrackingLabelSelectors`)
+
+The KubeVirt CR has a configuration field `spec.configuration.changedBlockTrackingLabelSelectors` that tells KubeVirt which VMs should have CBT enabled, using label selectors. This field is on the **KubeVirt CR**, not directly exposed by HCO.
+
+**What to set on KubeVirt CR:**
+```yaml
+apiVersion: kubevirt.io/v1
+kind: KubeVirt
+spec:
+  configuration:
+    changedBlockTrackingLabelSelectors:
+      virtualMachineLabelSelector:
+        matchLabels:
+          changedBlockTracking: "true"
+```
+
+Since HCO manages the KubeVirt CR and overwrites direct edits, this must be injected via the `kubevirt.kubevirt.io/jsonpatch` annotation on the HCO CR (same mechanism as KVM emulation):
+
+```json
+[{"op": "add", "path": "/spec/configuration/changedBlockTrackingLabelSelectors", "value": {"virtualMachineLabelSelector": {"matchLabels": {"changedBlockTracking": "true"}}}}]
+```
+
+**Important:** The `kubevirt.kubevirt.io/jsonpatch` annotation is a single annotation holding a JSON array of patch operations. If KVM emulation is also enabled, both patches must be combined into one annotation value:
+```json
+[
+  {"op": "add", "path": "/spec/configuration/developerConfiguration", "value": {"useEmulation": true}},
+  {"op": "add", "path": "/spec/configuration/changedBlockTrackingLabelSelectors", "value": {"virtualMachineLabelSelector": {"matchLabels": {"changedBlockTracking": "true"}}}}
+]
+```
+
+### Configuration 3: VM Label
+
+The VM itself must carry the matching label. This is baked into the VM manifest:
+```yaml
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  labels:
+    changedBlockTracking: "true"
+```
+
+### VM Restart Required
+
+Even with the label present from VM creation, a restart cycle is required for KubeVirt to:
+1. Create a backend storage PVC
+2. Create a qcow2 overlay on top of the raw disk
+3. Update the VM's domain XML
+
+After restart, the VM's `status.ChangedBlockTracking.State` transitions to `Enabled`.
+
+### Full CBT activation sequence in the test
+
+```
+1. EnsureVirtInstallation()          — existing flow, installs HCO with empty spec
+2. EnableCBTFeatureGate()            — patch HCO: spec.featureGates.incrementalBackup = true
+3. EnableCBTLabelSelector()          — patch HCO annotation: jsonpatch to set changedBlockTrackingLabelSelectors on KubeVirt CR
+4. Deploy CirrOS VM with label       — template has changedBlockTracking: "true"
+5. Wait for VM Running
+6. Restart VM (stop + start)         — required for qcow2 overlay creation
+7. Wait for VM Running again
+8. Wait for status.ChangedBlockTracking.State == "Enabled"
+9. Proceed with backup
+```
+
+Steps 2 and 3 are idempotent and can be placed in `BeforeAll` so they run once for the entire suite.
+
+---
+
+## Changes
+
+### 1. New CirrOS VM template with CBT label
+
+**File:** `tests/e2e/sample-applications/virtual-machines/cirros-test/cirros-test-cbt.yaml`
+
+Based on existing `cirros-test.yaml`, with the addition of:
+- `metadata.labels.changedBlockTracking: "true"` on the VirtualMachine
+- Same CirrOS boot image, same storage class, same resource requests
+
+### 2. New VirtOperator methods in `tests/e2e/lib/virt_helpers.go`
+
+#### `EnableCBTFeatureGate() error`
+
+Patches the HCO CR to set `spec.featureGates.incrementalBackup: true`. Uses the dynamic client to get the HCO, set the nested field, and update. Follows the same retry-on-conflict pattern as `EnsureEmulation`.
+
+#### `EnableCBTLabelSelector() error`
+
+Patches the HCO CR's `kubevirt.kubevirt.io/jsonpatch` annotation to inject `changedBlockTrackingLabelSelectors` into the KubeVirt CR. Must handle the case where:
+- The annotation doesn't exist yet (create it with just the CBT patch)
+- The annotation already has patches (e.g. emulation) — parse the existing JSON array, append the CBT patch if not already present, write back
+
+#### `StartVm(namespace, name string) error`
+
+REST call to the KubeVirt subresource API:
+```
+PUT /apis/subresources.kubevirt.io/v1/namespaces/{namespace}/virtualmachines/{name}/start
+```
+Mirrors the existing `StopVm` method.
+
+#### `RestartVmAndWaitRunning(namespace, name string, timeout time.Duration) error`
+
+Stops the VM, waits for Stopped status, starts it, and waits for Running status.
+
+#### `WaitForCBTEnabled(namespace, name string, timeout time.Duration) error`
+
+Polls the VM's `status.changedBlockTracking.state` via the dynamic client until it equals `"Enabled"` or times out.
+
+### 3. DPA configuration in `virt_backup_restore_suite_test.go`
+
+In `BeforeAll`, add `DefaultPluginKubeVirtDataMover` to `dpaCR.VeleroDefaultPlugins` alongside the existing `DefaultPluginKubeVirt`. This causes the OADP operator to:
+- Add the kubevirt-datamover-plugin as a Velero init container
+- Deploy the kubevirt-datamover-controller Deployment
+
+### 4. New test entry in `virt_backup_restore_suite_test.go`
+
+A new `ginkgo.Entry` in the existing `DescribeTable` with label `"virt"`:
+
+**"no-application kubevirt-datamover backup, CirrOS VM with CBT"**
+
+Uses a modified `runVmBackupAndRestore` flow or a dedicated run function that:
+
+1. Creates DPA (via `prepareBackupAndRestore`)
+2. Creates namespace, installs the CBT CirrOS VM template
+3. Waits for VM Running
+4. Calls `v.EnableCBTFeatureGate()` and `v.EnableCBTLabelSelector()` (idempotent, can also be in BeforeAll)
+5. Restarts the VM (`v.RestartVmAndWaitRunning`)
+6. Waits for `status.ChangedBlockTracking.State == Enabled` (`v.WaitForCBTEnabled`)
+7. Triggers Velero backup (via existing `runBackup` with `CSIDataMover` type for `SnapshotMoveData=true`)
+8. **Post-backup verification**: Checks that a `VirtualMachineBackupTracker` CR (`backup.kubevirt.io/v1alpha1`) was created in the VM's namespace. This is the definitive signal that the kubevirt-datamover-controller received and started processing the DataUpload — it creates the VMBT during the Accepted phase before creating the VMB for the actual qcow2 backup.
+9. Deletes VM and namespace
+10. Runs restore
+11. **Post-restore verification**: VM comes back running (restore path is best-effort since the kubevirt-datamover-controller doesn't implement DataDownload reconciliation yet)
+
+### 5. Verification helper
+
+**`verifyVMBackupTrackerExists(dynamicClient, vmNamespace string)`**
+
+Uses the dynamic client to list `VirtualMachineBackupTracker` resources (`backup.kubevirt.io/v1alpha1`) in the VM namespace and asserts at least one exists. This proves the full chain worked: BIA plugin created a DataUpload with `dataMover: kubevirt`, and the kubevirt-datamover-controller reconciled it and created the VMBT.
+
+## Files Changed
+
+| File | Type | Description |
+|------|------|-------------|
+| `tests/e2e/sample-applications/virtual-machines/cirros-test/cirros-test-cbt.yaml` | New | CirrOS VM template with `changedBlockTracking: "true"` label |
+| `tests/e2e/lib/virt_helpers.go` | Modified | Add `EnableCBTFeatureGate`, `EnableCBTLabelSelector`, `StartVm`, `RestartVmAndWaitRunning`, `WaitForCBTEnabled` |
+| `tests/e2e/virt_backup_restore_suite_test.go` | Modified | Add `DefaultPluginKubeVirtDataMover` to plugins, add CBT test entry, add VMBT verification |
+
+## Test Labels and Execution
+
+The test entry uses the `"virt"` label (same as existing VM tests), gated by `TEST_VIRT=true`. If the HCO version doesn't support the `incrementalBackup` feature gate or CBT, the enablement steps will fail with a clear error.
+
+## Volume Policy: `custom` Action Type
+
+As of Velero 1.18.1, the upstream `custom` action type for volume policies has been merged ([velero-io/velero#9678](https://github.com/velero-io/velero/pull/9678), fixing [#9505](https://github.com/velero-io/velero/issues/9505)). This allows volume policies to specify a `custom` action with an action parameters map, which the kubevirt-datamover-plugin can inspect to determine if a PVC should use the kubevirt datamover path.
+
+The plugin currently approximates this by checking for PVCs with "skip" policy (no snapshot), but the `custom` action type is the intended long-term mechanism. The E2E test should use a volume policy ConfigMap with the `custom` action type if the Velero version supports it. If the test environment uses Velero < 1.18.1, the existing skip-based fallback in the plugin still works.
+
+Example volume policy with custom action (for future use):
+```yaml
+version: v1
+volumePolicies:
+  - conditions:
+      pvcLabels:
+        changedBlockTracking: "true"
+    action:
+      type: custom
+      parameters:
+        provider: kubevirt
+```
+
+For the initial E2E test, this is noted as a future enhancement — the test will rely on the plugin's current skip-based volume policy detection.
+
+## Out of Scope
+
+- Restore via kubevirt-datamover (DataDownload controller not implemented)
+- Raw upstream KubeVirt daily build installation
+- New BackupRestoreType for kubevirt-datamover (reuses `CSIDataMover` for `SnapshotMoveData=true`)
+- Implementing `custom` volume policy in the E2E test (plugin's skip-based fallback is sufficient for initial test; `custom` action integration tracked in [kubevirt-datamover-plugin#4](https://github.com/migtools/kubevirt-datamover-plugin/issues/4))

--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/kubernetes-csi/external-snapshotter/client/v6 v6.3.0
 	github.com/stretchr/testify v1.11.1
 	github.com/vmware-tanzu/velero v1.14.0
+	golang.org/x/crypto v0.45.0
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
 	google.golang.org/api v0.256.0
 	k8s.io/klog/v2 v2.130.1
@@ -176,7 +177,6 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.1 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
-	golang.org/x/crypto v0.45.0 // indirect
 	golang.org/x/net v0.47.0 // indirect
 	golang.org/x/oauth2 v0.33.0 // indirect
 	golang.org/x/sync v0.18.0 // indirect

--- a/tests/e2e/lib/virt_helpers.go
+++ b/tests/e2e/lib/virt_helpers.go
@@ -2,6 +2,7 @@ package lib
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
@@ -26,6 +27,9 @@ const (
 	emulationAnnotation = "kubevirt.kubevirt.io/jsonpatch"
 	useEmulation        = `[{"op": "add", "path": "/spec/configuration/developerConfiguration", "value": {"useEmulation": true}}]`
 	stopVmPath          = "/apis/subresources.kubevirt.io/v1/namespaces/%s/virtualmachines/%s/stop"
+	startVmPath         = "/apis/subresources.kubevirt.io/v1/namespaces/%s/virtualmachines/%s/start"
+
+	cbtJsonPatchPath = "/spec/configuration/changedBlockTrackingLabelSelectors"
 )
 
 var packageManifestsGvr = schema.GroupVersionResource{
@@ -49,6 +53,18 @@ var virtualMachineGvr = schema.GroupVersionResource{
 var csvGvr = schema.GroupVersionResource{
 	Group:    "operators.coreos.com",
 	Resource: "clusterserviceversion",
+	Version:  "v1alpha1",
+}
+
+var virtualMachineInstanceGvr = schema.GroupVersionResource{
+	Group:    "kubevirt.io",
+	Resource: "virtualmachineinstances",
+	Version:  "v1",
+}
+
+var virtualMachineBackupTrackerGvr = schema.GroupVersionResource{
+	Group:    "backup.kubevirt.io",
+	Resource: "virtualmachinebackuptrackers",
 	Version:  "v1alpha1",
 }
 
@@ -640,6 +656,31 @@ func (v *VirtOperator) GetVmStatus(namespace, name string) (string, error) {
 	return GetVmStatus(v.Dynamic, namespace, name)
 }
 
+func (v *VirtOperator) WaitForVMReady(namespace, name string, timeout time.Duration) error {
+	log.Printf("Waiting for VMI %s/%s Ready condition", namespace, name)
+	return wait.PollUntilContextTimeout(context.Background(), 10*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		vmi, err := v.Dynamic.Resource(virtualMachineInstanceGvr).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return false, nil
+		}
+		conditions, found, err := unstructured.NestedSlice(vmi.UnstructuredContent(), "status", "conditions")
+		if err != nil || !found {
+			return false, nil
+		}
+		for _, c := range conditions {
+			cond, ok := c.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if cond["type"] == "Ready" && cond["status"] == "True" {
+				log.Printf("VMI %s/%s is Ready", namespace, name)
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+}
+
 // StopVm stops a VM with a REST call to "stop". This is needed because a
 // poweroff from inside the VM results in KubeVirt restarting it.
 // From the KubeVirt API reference:
@@ -809,4 +850,200 @@ func (v *VirtOperator) EnsureVirtRemoval() error {
 func (v *VirtOperator) RemoveVm(namespace, name string, timeout time.Duration) error {
 	log.Printf("Removing virtual machine %s/%s", namespace, name)
 	return v.ensureVmRemoval(namespace, name, timeout)
+}
+
+// StartVm starts a VM with a REST call to "start".
+func (v *VirtOperator) StartVm(namespace, name string) error {
+	path := fmt.Sprintf(startVmPath, namespace, name)
+	return v.Clientset.RESTClient().Put().AbsPath(path).Do(context.Background()).Error()
+}
+
+// RestartVmAndWaitRunning stops a VM, waits for it to stop, starts it, and
+// waits for it to be running again.
+func (v *VirtOperator) RestartVmAndWaitRunning(namespace, name string, timeout time.Duration) error {
+	log.Printf("Restarting VM %s/%s", namespace, name)
+
+	if err := v.StopVm(namespace, name); err != nil {
+		return fmt.Errorf("failed to stop VM %s/%s: %w", namespace, name, err)
+	}
+
+	halfTimeout := timeout / 2
+	err := wait.PollUntilContextTimeout(context.Background(), 10*time.Second, halfTimeout, true, func(ctx context.Context) (bool, error) {
+		status, err := v.GetVmStatus(namespace, name)
+		if err != nil {
+			return false, nil
+		}
+		return status == "Stopped", nil
+	})
+	if err != nil {
+		return fmt.Errorf("timed out waiting for VM %s/%s to stop: %w", namespace, name, err)
+	}
+	log.Printf("VM %s/%s stopped, starting again", namespace, name)
+
+	if err := v.StartVm(namespace, name); err != nil {
+		return fmt.Errorf("failed to start VM %s/%s: %w", namespace, name, err)
+	}
+
+	err = wait.PollUntilContextTimeout(context.Background(), 10*time.Second, halfTimeout, true, func(ctx context.Context) (bool, error) {
+		status, err := v.GetVmStatus(namespace, name)
+		if err != nil {
+			return false, nil
+		}
+		return status == "Running", nil
+	})
+	if err != nil {
+		return fmt.Errorf("timed out waiting for VM %s/%s to start: %w", namespace, name, err)
+	}
+	log.Printf("VM %s/%s restarted successfully", namespace, name)
+
+	return nil
+}
+
+// EnableCBTFeatureGate patches the HyperConverged CR to set
+// spec.featureGates.incrementalBackup = true. This enables CBT and
+// UtilityVolumes feature gates in the KubeVirt CR.
+func (v *VirtOperator) EnableCBTFeatureGate(timeout time.Duration) error {
+	log.Printf("Enabling incrementalBackup feature gate on HCO")
+
+	err := wait.PollUntilContextTimeout(context.Background(), 5*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		hco, err := v.Dynamic.Resource(hyperConvergedGvr).Namespace(v.Namespace).Get(ctx, "kubevirt-hyperconverged", metav1.GetOptions{})
+		if err != nil {
+			return false, fmt.Errorf("failed to get HCO: %w", err)
+		}
+
+		if err := unstructured.SetNestedField(hco.UnstructuredContent(), true, "spec", "featureGates", "incrementalBackup"); err != nil {
+			return false, fmt.Errorf("failed to set incrementalBackup feature gate: %w", err)
+		}
+
+		_, err = v.Dynamic.Resource(hyperConvergedGvr).Namespace(v.Namespace).Update(ctx, hco, metav1.UpdateOptions{})
+		if err != nil {
+			if apierrors.IsConflict(err) {
+				log.Printf("HCO modification conflict setting incrementalBackup, retrying...")
+				return false, nil
+			}
+			return false, err
+		}
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to enable CBT feature gate: %w", err)
+	}
+
+	log.Printf("incrementalBackup feature gate enabled on HCO")
+	return nil
+}
+
+// EnableCBTLabelSelector patches the HCO's kubevirt.kubevirt.io/jsonpatch
+// annotation to inject changedBlockTrackingLabelSelectors into the KubeVirt CR.
+// If the annotation already contains patches (e.g. emulation), the CBT patch
+// is appended to the existing array.
+func (v *VirtOperator) EnableCBTLabelSelector(timeout time.Duration) error {
+	log.Printf("Enabling CBT label selector via HCO jsonpatch annotation")
+
+	cbtPatch := map[string]interface{}{
+		"op":   "add",
+		"path": cbtJsonPatchPath,
+		"value": map[string]interface{}{
+			"virtualMachineLabelSelector": map[string]interface{}{
+				"matchLabels": map[string]interface{}{
+					"changedBlockTracking": "true",
+				},
+			},
+		},
+	}
+
+	err := wait.PollUntilContextTimeout(context.Background(), 5*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		hco, err := v.Dynamic.Resource(hyperConvergedGvr).Namespace(v.Namespace).Get(ctx, "kubevirt-hyperconverged", metav1.GetOptions{})
+		if err != nil {
+			return false, fmt.Errorf("failed to get HCO: %w", err)
+		}
+
+		annotations, _, _ := unstructured.NestedMap(hco.UnstructuredContent(), "metadata", "annotations")
+		if annotations == nil {
+			annotations = make(map[string]interface{})
+		}
+
+		var patches []interface{}
+		if existing, ok := annotations[emulationAnnotation]; ok {
+			existingStr, isStr := existing.(string)
+			if isStr && existingStr != "" {
+				if err := json.Unmarshal([]byte(existingStr), &patches); err != nil {
+					return false, fmt.Errorf("failed to parse existing jsonpatch annotation: %w", err)
+				}
+				for _, p := range patches {
+					patchMap, ok := p.(map[string]interface{})
+					if ok && patchMap["path"] == cbtJsonPatchPath {
+						log.Printf("CBT label selector patch already present in annotation")
+						return true, nil
+					}
+				}
+			}
+		}
+
+		patches = append(patches, cbtPatch)
+		patchBytes, err := json.Marshal(patches)
+		if err != nil {
+			return false, fmt.Errorf("failed to marshal jsonpatch: %w", err)
+		}
+		annotations[emulationAnnotation] = string(patchBytes)
+
+		if err := unstructured.SetNestedMap(hco.UnstructuredContent(), annotations, "metadata", "annotations"); err != nil {
+			return false, err
+		}
+
+		_, err = v.Dynamic.Resource(hyperConvergedGvr).Namespace(v.Namespace).Update(ctx, hco, metav1.UpdateOptions{})
+		if err != nil {
+			if apierrors.IsConflict(err) {
+				log.Printf("HCO modification conflict setting CBT label selector, retrying...")
+				return false, nil
+			}
+			return false, err
+		}
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to enable CBT label selector: %w", err)
+	}
+
+	log.Printf("CBT label selector enabled via HCO jsonpatch annotation")
+	return nil
+}
+
+// WaitForCBTEnabled polls the VM's status.changedBlockTracking.state until it
+// equals "Enabled" or the timeout is reached.
+func (v *VirtOperator) WaitForCBTEnabled(namespace, name string, timeout time.Duration) error {
+	log.Printf("Waiting for CBT to be enabled on VM %s/%s", namespace, name)
+
+	err := wait.PollUntilContextTimeout(context.Background(), 10*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		vm, err := v.Dynamic.Resource(virtualMachineGvr).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			log.Printf("Error getting VM %s/%s: %v", namespace, name, err)
+			return false, nil
+		}
+
+		state, ok, err := unstructured.NestedString(vm.UnstructuredContent(), "status", "changedBlockTracking", "state")
+		if err != nil || !ok {
+			log.Printf("CBT state not yet available on VM %s/%s", namespace, name)
+			return false, nil
+		}
+
+		log.Printf("VM %s/%s CBT state: %s", namespace, name, state)
+		return state == "Enabled", nil
+	})
+	if err != nil {
+		return fmt.Errorf("timed out waiting for CBT to be enabled on VM %s/%s: %w", namespace, name, err)
+	}
+
+	log.Printf("CBT is enabled on VM %s/%s", namespace, name)
+	return nil
+}
+
+// CheckVMBackupTrackerExists checks if any VirtualMachineBackupTracker resources
+// exist in the given namespace. Returns true if at least one VMBT is found.
+func (v *VirtOperator) CheckVMBackupTrackerExists(namespace string) (bool, error) {
+	list, err := v.Dynamic.Resource(virtualMachineBackupTrackerGvr).Namespace(namespace).List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return false, fmt.Errorf("failed to list VirtualMachineBackupTrackers in %s: %w", namespace, err)
+	}
+	return len(list.Items) > 0, nil
 }

--- a/tests/e2e/lib/virt_storage_helpers.go
+++ b/tests/e2e/lib/virt_storage_helpers.go
@@ -297,6 +297,9 @@ func (v *VirtOperator) CreateWaitForFirstConsumerStorageClass(name string) error
 	wffcStorageClass.Annotations["storageclass.kubernetes.io/is-default-class"] = "false"
 
 	_, err = v.Clientset.StorageV1().StorageClasses().Create(context.Background(), wffcStorageClass, metav1.CreateOptions{})
+	if apierrors.IsAlreadyExists(err) {
+		return nil
+	}
 	return err
 }
 

--- a/tests/e2e/sample-applications/virtual-machines/cirros-test/cirros-test-cbt.yaml
+++ b/tests/e2e/sample-applications/virtual-machines/cirros-test/cirros-test-cbt.yaml
@@ -1,0 +1,55 @@
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: kubevirt.io/v1
+    kind: VirtualMachine
+    metadata:
+      labels:
+        app: cirros-test
+        changedBlockTracking: "true"
+      name: cirros-test
+      namespace: cirros-test
+    spec:
+      dataVolumeTemplates:
+      - metadata:
+          annotations:
+            cdi.kubevirt.io/storage.deleteAfterCompletion: "false"
+          name: cirros-test-disk
+        spec:
+          pvc:
+            accessModes:
+            - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Mi
+            volumeMode: Block
+          source:
+            registry:
+              pullMethod: node
+              url: docker://quay.io/kubevirt/cirros-container-disk-demo
+      running: true
+      template:
+        metadata:
+          name: cirros-test
+        spec:
+          domain:
+            devices:
+              disks:
+              - disk:
+                  bus: virtio
+                name: volume0
+              interfaces:
+              - masquerade: {}
+                name: default
+              rng: {}
+            resources:
+              requests:
+                memory: 256M
+          networks:
+          - name: default
+            pod: {}
+          terminationGracePeriodSeconds: 0
+          volumes:
+          - dataVolume:
+              name: cirros-test-disk
+            name: volume0

--- a/tests/e2e/virt_backup_restore_suite_test.go
+++ b/tests/e2e/virt_backup_restore_suite_test.go
@@ -104,11 +104,8 @@ func runVmBackupAndRestore(brCase VmBackupRestoreCase, updateLastBRcase func(brC
 	})
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-	// TODO: find a better way to check for clout-init completion
-	if brCase.InitDelay > 0*time.Second {
-		log.Printf("Sleeping to wait for cloud-init to be ready...")
-		time.Sleep(brCase.InitDelay)
-	}
+	err = v.WaitForVMReady(brCase.Namespace, brCase.Name, 5*time.Minute)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 	// Check if this VM should be running or stopped for this test.
 	// Depend on pre-backup verification function to poll state.
@@ -148,6 +145,55 @@ func runVmBackupAndRestore(brCase VmBackupRestoreCase, updateLastBRcase func(brC
 	// avoid finalizers in namespace deletion
 	err = v.RemoveVm(brCase.Namespace, brCase.Name, 5*time.Minute)
 	gomega.Expect(err).To(gomega.BeNil())
+}
+
+
+func runCBTVmBackup(brCase VmBackupRestoreCase, updateLastBRcase func(brCase VmBackupRestoreCase), v *lib.VirtOperator) {
+	updateLastBRcase(brCase)
+
+	backupName, _ := prepareBackupAndRestore(brCase.BackupRestoreCase, func() {})
+
+	gomega.Eventually(lib.IsNamespaceDeleted(kubernetesClientForSuiteRun, brCase.Namespace), time.Minute*2, time.Second*5).Should(gomega.BeTrue())
+	err := lib.CreateNamespace(v.Clientset, brCase.Namespace)
+	gomega.Expect(err).To(gomega.BeNil())
+
+	err = lib.InstallApplication(v.Client, brCase.Template)
+	if err != nil {
+		fmt.Printf("Failed to install VM template %s: %v", brCase.Template, err)
+	}
+	gomega.Expect(err).To(gomega.BeNil())
+
+	err = wait.PollUntilContextTimeout(context.Background(), 10*time.Second, 10*time.Minute, true, func(ctx context.Context) (bool, error) {
+		status, err := v.GetVmStatus(brCase.Namespace, brCase.Name)
+		if err != nil {
+			log.Printf("VM %s/%s not yet available: %v", brCase.Namespace, brCase.Name, err)
+			return false, nil
+		}
+		return status == "Running", nil
+	})
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+	err = v.WaitForVMReady(brCase.Namespace, brCase.Name, 5*time.Minute)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+	log.Printf("Restarting VM to activate CBT qcow2 overlay")
+	err = v.RestartVmAndWaitRunning(brCase.Namespace, brCase.Name, 10*time.Minute)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+	err = v.WaitForVMReady(brCase.Namespace, brCase.Name, 5*time.Minute)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+	log.Printf("Waiting for CBT to be enabled on VM")
+	err = v.WaitForCBTEnabled(brCase.Namespace, brCase.Name, 5*time.Minute)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+	runBackup(brCase.BackupRestoreCase, backupName)
+
+	err = v.RemoveVm(brCase.Namespace, brCase.Name, 5*time.Minute)
+	gomega.Expect(err).To(gomega.BeNil())
+	err = lib.DeleteNamespace(v.Clientset, brCase.Namespace)
+	gomega.Expect(err).To(gomega.BeNil())
+	gomega.Eventually(lib.IsNamespaceDeleted(kubernetesClientForSuiteRun, brCase.Namespace), time.Minute*5, time.Second*5).Should(gomega.BeTrue())
 }
 
 var _ = ginkgo.Describe("VM backup and restore tests", ginkgo.Ordered, func() {
@@ -194,6 +240,7 @@ var _ = ginkgo.Describe("VM backup and restore tests", ginkgo.Ordered, func() {
 			cirrosDownloadedFromTest = true
 		}
 		dpaCR.VeleroDefaultPlugins = append(dpaCR.VeleroDefaultPlugins, v1alpha1.DefaultPluginKubeVirt)
+		dpaCR.VeleroDefaultPlugins = append(dpaCR.VeleroDefaultPlugins, v1alpha1.DefaultPluginKubeVirtDataMover)
 
 		err = v.CreateImmediateModeStorageClass("test-sc-immediate")
 		gomega.Expect(err).To(gomega.BeNil())
@@ -211,6 +258,12 @@ var _ = ginkgo.Describe("VM backup and restore tests", ginkgo.Ordered, func() {
 			err = v.CreateTargetDataSourceFromPvc(pvcNamespace, "openshift-virtualization-os-images", pvcName, "fedora")
 			gomega.Expect(err).To(gomega.BeNil())
 		}
+
+		log.Printf("Enabling CBT feature gate and label selector for kubevirt-datamover tests")
+		err = v.EnableCBTFeatureGate(30 * time.Second)
+		gomega.Expect(err).To(gomega.BeNil())
+		err = v.EnableCBTLabelSelector(30 * time.Second)
+		gomega.Expect(err).To(gomega.BeNil())
 
 	})
 
@@ -359,6 +412,23 @@ var _ = ginkgo.Describe("VM backup and restore tests", ginkgo.Ordered, func() {
 				PreBackupVerify:   vmTodoListReady(true, false, "mysql"),
 				PostRestoreVerify: vmTodoListReady(false, false, "mysql"),
 				BackupTimeout:     45 * time.Minute,
+			},
+		}, nil),
+	)
+
+	ginkgo.DescribeTable("Kubevirt datamover backup with CBT",
+		func(brCase VmBackupRestoreCase, expectedError error) {
+			runCBTVmBackup(brCase, updateLastBRcase, v)
+		},
+
+		ginkgo.Entry("no-application kubevirt-datamover backup, CirrOS VM with CBT", ginkgo.Label("virt"), VmBackupRestoreCase{
+			Template: "./sample-applications/virtual-machines/cirros-test/cirros-test-cbt.yaml",
+			BackupRestoreCase: BackupRestoreCase{
+				Namespace:         "cirros-test",
+				Name:              "cirros-test",
+				SkipVerifyLogs:    true,
+				BackupRestoreType: lib.CSIDataMover,
+				BackupTimeout:     20 * time.Minute,
 			},
 		}, nil),
 	)


### PR DESCRIPTION
## Why the changes were made

need to test kubevirt-dm sooner than we thought.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added E2E testing for KubeVirt datamover with Changed Block Tracking (CBT) capability.
  * Introduced VM lifecycle operations including start and restart functionality.
  * Added CBT enablement and validation for virtual machines.

* **Tests**
  * Added CBT-enabled backup and restore test scenarios.

* **Bug Fixes**
  * Improved storage class creation error handling.

* **Chores**
  * Updated Docker build to include KubeVirt tooling.

* **Documentation**
  * Added comprehensive E2E test design specification for datamover functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->