### PR TITLE
fix(bsl): require region when s3Url is set on AWS BackupStorageLocation

### DIFF
--- a/internal/controller/bsl.go
+++ b/internal/controller/bsl.go
@@ -526,7 +526,17 @@ func (r *DataProtectionApplicationReconciler) validateAWSBackupStorageLocation(b
 		return fmt.Errorf("prefix for AWS backupstoragelocation object storage cannot be empty. It is required for backing up images")
 	}
 
-	// BSL region is required when
+	// BSL region is required when a custom s3Url is configured: the user is
+	// pointing to a non-AWS S3-compatible endpoint (IBM COS, MinIO, NooBaa,
+	// etc.) so BucketRegionIsDiscoverable cannot be trusted — it queries the
+	// AWS HeadBucket API, which either fails (validation works by accident)
+	// or returns the region for an unrelated bucket that happens to share
+	// the same name in AWS (validation passes but Velero cannot connect).
+	if bslSpec.Config != nil && len(bslSpec.Config[S3URL]) > 0 && len(bslSpec.Config[Region]) == 0 {
+		return fmt.Errorf("region is required when s3Url is set for AWS backupstoragelocation; region cannot be auto-discovered for non-AWS S3-compatible endpoints")
+	}
+
+	// BSL region is also required when
 	// - s3ForcePathStyle is true, because some velero processes requires region to be set and is not auto-discoverable when s3ForcePathStyle is true
 	//   imagestream backup in openshift-velero-plugin now uses the same method to discover region as the rest of the velero codebase
 	// - even when s3ForcePathStyle is false, some aws bucket regions may not be discoverable and the user has to set it manually


### PR DESCRIPTION
Closes #2108.

## Problem

\`validateAWSBackupStorageLocation\` in \`internal/controller/bsl.go\` accepted BSLs where \`provider: aws\`, a custom \`s3Url\` and no \`region\` were all set together. The only region check was:

\`\`\`go
if (config == nil || len(config[Region]) == 0) &&
    (config[S3ForcePathStyle] == \"true\" || !aws.BucketRegionIsDiscoverable(bucket)) {
    return ...
}
\`\`\`

Once \`s3ForcePathStyle\` stopped being required (IBM COS no longer needs it), validation fell through to \`BucketRegionIsDiscoverable\`, which queries AWS's HeadBucket API against \`s3.us-east-1.amazonaws.com\`. That's meaningless for non-AWS S3-compatible endpoints (IBM COS, MinIO, NooBaa): either discovery fails and validation works by accident, or discovery *succeeds* against an unrelated like-named AWS bucket and validation passes — but Velero can't connect to the actual backend.

## Fix

Short-circuit that path: if \`s3Url\` is set and \`region\` is not, reject the BSL before falling into the discovery branch, with the message the issue suggests:

> region is required when s3Url is set for AWS backupstoragelocation; region cannot be auto-discovered for non-AWS S3-compatible endpoints

Scoped to exactly the configuration the issue calls out (\`s3Url\` present, \`region\` absent); everything else in \`validateAWSBackupStorageLocation\` stays unchanged.

## Verification

- \`go build ./...\` — clean.
- \`go vet ./internal/controller\` — clean.
- \`go test -count=1 -run TestDPAReconciler_ValidateBackupStorageLocations ./internal/controller/...\` — ok. The envtest-based suite (\`TestAPIs\`) fails locally without the kubebuilder test assets, unrelated to this change.

I considered adding a focused unit test next to \`TestValidatePEMCertificate\`, but \`validateAWSBackupStorageLocation\` dereferences a real \`client.Client\` via \`validateProviderPluginAndSecret\` before reaching the config check, so a standalone call panics without a fake client. The existing table-driven \`TestDPAReconciler_ValidateBackupStorageLocations\` is the right place to add coverage — I'd rather wire that up as a follow-up (it's a big table and I don't want to bury this change in scaffolding noise). Happy to push that if reviewers would prefer it bundled here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated AWS Backup Storage Location validation to provide explicit error messages when S3 URL is configured without the required region setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->