### PR TITLE
OADP-7869: Fix stale resourceAnnotations/resourceLabels after DPA patch

### DIFF
--- a/internal/controller/backup_repository.go
+++ b/internal/controller/backup_repository.go
@@ -42,10 +42,8 @@ func (r *DataProtectionApplicationReconciler) updateBackupRepositoryCM(cm *corev
 		oadpv1alpha1.OadpOperatorLabel: "True",
 	}
 
-	// Apply user-provided resource labels (protected labels are filtered)
-	cm.Labels = applyResourceLabels(r.dpa, cm.Labels)
-
-	// Apply user-provided resource annotations
+	// Apply user-provided resource labels and annotations
+	cm.Labels, cm.Annotations = applyResourceLabels(r.dpa, cm.Labels, cm.Annotations)
 	cm.Annotations = applyResourceAnnotations(r.dpa, cm.Annotations)
 
 	if cm.Data == nil {

--- a/internal/controller/bsl.go
+++ b/internal/controller/bsl.go
@@ -425,10 +425,8 @@ func (r *DataProtectionApplicationReconciler) updateBSLFromSpec(bsl *velerov1.Ba
 	bsl.Labels["app.kubernetes.io/component"] = "bsl"
 	bsl.Labels[oadpv1alpha1.OadpOperatorLabel] = "True"
 
-	// Apply user-provided resource labels (protected labels are filtered)
-	bsl.Labels = applyResourceLabels(r.dpa, bsl.Labels)
-
-	// Apply user-provided resource annotations
+	// Apply user-provided resource labels and annotations
+	bsl.Labels, bsl.Annotations = applyResourceLabels(r.dpa, bsl.Labels, bsl.Annotations)
 	bsl.Annotations = applyResourceAnnotations(r.dpa, bsl.Annotations)
 
 	return nil

--- a/internal/controller/kubevirt_datamover_controller.go
+++ b/internal/controller/kubevirt_datamover_controller.go
@@ -103,10 +103,10 @@ func (r *DataProtectionApplicationReconciler) buildKubevirtDatamoverDeployment(d
 		return err
 	}
 
-	// Apply user-provided resource labels (protected labels are filtered)
+	// Apply user-provided resource labels and annotations
 	// Note: NOT applied to Spec.Selector.MatchLabels as those are immutable after creation
-	deploymentObject.Labels = applyResourceLabels(r.dpa, deploymentObject.Labels)
-	deploymentObject.Spec.Template.Labels = applyResourceLabels(r.dpa, deploymentObject.Spec.Template.Labels)
+	deploymentObject.Labels, deploymentObject.Annotations = applyResourceLabels(r.dpa, deploymentObject.Labels, deploymentObject.Annotations)
+	deploymentObject.Spec.Template.Labels, deploymentObject.Spec.Template.Annotations = applyResourceLabels(r.dpa, deploymentObject.Spec.Template.Labels, deploymentObject.Spec.Template.Annotations)
 
 	// Re-assert selector labels to ensure template labels match selector
 	// This prevents user resourceLabels from overriding selector-critical labels
@@ -119,7 +119,6 @@ func (r *DataProtectionApplicationReconciler) buildKubevirtDatamoverDeployment(d
 		}
 	}
 
-	// Apply user-provided resource annotations to both deployment and pod template
 	deploymentObject.Annotations = applyResourceAnnotations(r.dpa, deploymentObject.Annotations)
 	deploymentObject.Spec.Template.Annotations = applyResourceAnnotations(r.dpa, deploymentObject.Spec.Template.Annotations)
 

--- a/internal/controller/monitor.go
+++ b/internal/controller/monitor.go
@@ -64,10 +64,8 @@ func (r *DataProtectionApplicationReconciler) updateVeleroMetricsSVC(svc *corev1
 
 	svc.Labels = getDpaAppLabels(r.dpa)
 
-	// Apply user-provided resource labels (protected labels are filtered)
-	svc.Labels = applyResourceLabels(r.dpa, svc.Labels)
-
-	// Apply user-provided resource annotations
+	// Apply user-provided resource labels and annotations
+	svc.Labels, svc.Annotations = applyResourceLabels(r.dpa, svc.Labels, svc.Annotations)
 	svc.Annotations = applyResourceAnnotations(r.dpa, svc.Annotations)
 
 	return nil

--- a/internal/controller/nodeagent.go
+++ b/internal/controller/nodeagent.go
@@ -195,10 +195,8 @@ func (r *DataProtectionApplicationReconciler) updateNodeAgentCM(cm *corev1.Confi
 		oadpv1alpha1.OadpOperatorLabel: "True",
 	}
 
-	// Apply user-provided resource labels (protected labels are filtered)
-	cm.Labels = applyResourceLabels(r.dpa, cm.Labels)
-
-	// Apply user-provided resource annotations
+	// Apply user-provided resource labels and annotations
+	cm.Labels, cm.Annotations = applyResourceLabels(r.dpa, cm.Labels, cm.Annotations)
 	cm.Annotations = applyResourceAnnotations(r.dpa, cm.Annotations)
 
 	if cm.Data == nil {
@@ -571,10 +569,10 @@ func (r *DataProtectionApplicationReconciler) customizeNodeAgentDaemonset(ds *ap
 		}
 	}
 
-	// Apply user-provided resource labels (protected labels are filtered)
+	// Apply user-provided resource labels and annotations
 	// Note: NOT applied to Spec.Selector.MatchLabels as those are immutable after creation
-	ds.Labels = applyResourceLabels(dpa, ds.Labels)
-	ds.Spec.Template.Labels = applyResourceLabels(dpa, ds.Spec.Template.Labels)
+	ds.Labels, ds.Annotations = applyResourceLabels(dpa, ds.Labels, ds.Annotations)
+	ds.Spec.Template.Labels, ds.Spec.Template.Annotations = applyResourceLabels(dpa, ds.Spec.Template.Labels, ds.Spec.Template.Annotations)
 
 	// Re-assert selector labels to ensure template labels match selector
 	// This prevents user resourceLabels from overriding selector-critical labels
@@ -587,7 +585,6 @@ func (r *DataProtectionApplicationReconciler) customizeNodeAgentDaemonset(ds *ap
 		}
 	}
 
-	// Apply user-provided resource annotations to both daemonset and pod template
 	ds.Annotations = applyResourceAnnotations(dpa, ds.Annotations)
 	ds.Spec.Template.Annotations = applyResourceAnnotations(dpa, ds.Spec.Template.Annotations)
 

--- a/internal/controller/nonadmin_controller.go
+++ b/internal/controller/nonadmin_controller.go
@@ -135,10 +135,10 @@ func (r *DataProtectionApplicationReconciler) buildNonAdminDeployment(deployment
 		return err
 	}
 
-	// Apply user-provided resource labels (protected labels are filtered)
+	// Apply user-provided resource labels and annotations
 	// Note: NOT applied to Spec.Selector.MatchLabels as those are immutable after creation
-	deploymentObject.Labels = applyResourceLabels(r.dpa, deploymentObject.Labels)
-	deploymentObject.Spec.Template.Labels = applyResourceLabels(r.dpa, deploymentObject.Spec.Template.Labels)
+	deploymentObject.Labels, deploymentObject.Annotations = applyResourceLabels(r.dpa, deploymentObject.Labels, deploymentObject.Annotations)
+	deploymentObject.Spec.Template.Labels, deploymentObject.Spec.Template.Annotations = applyResourceLabels(r.dpa, deploymentObject.Spec.Template.Labels, deploymentObject.Spec.Template.Annotations)
 
 	// Re-assert selector labels to ensure template labels match selector
 	// This prevents user resourceLabels from overriding selector-critical labels
@@ -151,7 +151,6 @@ func (r *DataProtectionApplicationReconciler) buildNonAdminDeployment(deployment
 		}
 	}
 
-	// Apply user-provided resource annotations to both deployment and pod template
 	deploymentObject.Annotations = applyResourceAnnotations(r.dpa, deploymentObject.Annotations)
 	deploymentObject.Spec.Template.Annotations = applyResourceAnnotations(r.dpa, deploymentObject.Spec.Template.Annotations)
 

--- a/internal/controller/registry.go
+++ b/internal/controller/registry.go
@@ -746,10 +746,8 @@ func (r *DataProtectionApplicationReconciler) patchRegistrySecret(secret *corev1
 		return err
 	}
 
-	// Apply user-provided resource labels (protected labels are filtered)
-	secret.Labels = applyResourceLabels(r.dpa, secret.Labels)
-
-	// Apply user-provided resource annotations
+	// Apply user-provided resource labels and annotations
+	secret.Labels, secret.Annotations = applyResourceLabels(r.dpa, secret.Labels, secret.Annotations)
 	secret.Annotations = applyResourceAnnotations(r.dpa, secret.Annotations)
 
 	// when updating the spec fields we update each field individually

--- a/internal/controller/repository_maintenance.go
+++ b/internal/controller/repository_maintenance.go
@@ -36,10 +36,8 @@ func (r *DataProtectionApplicationReconciler) updateRepositoryMaintenanceCM(cm *
 		oadpv1alpha1.OadpOperatorLabel: "True",
 	}
 
-	// Apply user-provided resource labels (protected labels are filtered)
-	cm.Labels = applyResourceLabels(r.dpa, cm.Labels)
-
-	// Apply user-provided resource annotations
+	// Apply user-provided resource labels and annotations
+	cm.Labels, cm.Annotations = applyResourceLabels(r.dpa, cm.Labels, cm.Annotations)
 	cm.Annotations = applyResourceAnnotations(r.dpa, cm.Annotations)
 
 	if cm.Data == nil {

--- a/internal/controller/velero.go
+++ b/internal/controller/velero.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -51,6 +52,9 @@ const (
 	caCertMountPath       = "/etc/velero/ca-certs"
 	caBundleFileName      = "ca-bundle.pem"
 	caBundleConfigMapName = "velero-ca-bundle"
+
+	managedAnnotationKeysAnnotation = "oadp.openshift.io/managed-resource-annotation-keys"
+	managedLabelKeysAnnotation      = "oadp.openshift.io/managed-resource-label-keys"
 )
 
 var (
@@ -171,14 +175,9 @@ func (r *DataProtectionApplicationReconciler) buildVeleroDeployment(veleroDeploy
 	// get resource requirements for velero deployment
 	// ignoring err here as it is checked in validator.go
 	veleroResourceReqs, _ := r.getVeleroResourceReqs()
-	veleroAnnotations := make(map[string]string)
+	var podAnnotations map[string]string
 	if dpa.Spec.Configuration != nil && dpa.Spec.Configuration.Velero != nil && dpa.Spec.Configuration.Velero.PodConfig != nil {
-		veleroAnnotations = dpa.Spec.Configuration.Velero.PodConfig.Annotations
-	}
-
-	podAnnotations, err := common.AppendUniqueKeyTOfTMaps(veleroAnnotations, veleroDeployment.Annotations)
-	if err != nil {
-		return fmt.Errorf("error appending pod annotations: %v", err)
+		podAnnotations = dpa.Spec.Configuration.Velero.PodConfig.Annotations
 	}
 
 	uploaderType := ""
@@ -188,7 +187,7 @@ func (r *DataProtectionApplicationReconciler) buildVeleroDeployment(veleroDeploy
 
 	// Filter out resourceLabels before passing to install.Deployment
 	// This ensures matchLabels don't contain resourceLabels (which would cause immutable selector errors on reconcile)
-	labelsForInstall := filterOutResourceLabels(dpa, veleroDeployment.Labels)
+	labelsForInstall := filterOutResourceLabels(dpa, veleroDeployment.Labels, veleroDeployment.Annotations)
 
 	installDeployment := install.Deployment(veleroDeployment.Namespace,
 		install.WithResources(veleroResourceReqs),
@@ -244,7 +243,7 @@ func (r *DataProtectionApplicationReconciler) customizeVeleroDeployment(veleroDe
 	}
 	// Filter out resourceLabels from veleroDeployment.Labels before adding to matchLabels
 	// matchLabels are immutable, so we must not include resourceLabels which are user-configurable
-	labelsForMatchLabels := filterOutResourceLabels(dpa, veleroDeployment.Labels)
+	labelsForMatchLabels := filterOutResourceLabels(dpa, veleroDeployment.Labels, veleroDeployment.Annotations)
 	veleroDeployment.Spec.Selector.MatchLabels, err = common.AppendUniqueKeyTOfTMaps(veleroDeployment.Spec.Selector.MatchLabels, labelsForMatchLabels, getDpaAppLabels(dpa))
 	if err != nil {
 		return fmt.Errorf("velero deployment selector label: %v", err)
@@ -263,8 +262,8 @@ func (r *DataProtectionApplicationReconciler) customizeVeleroDeployment(veleroDe
 
 	// Apply user-provided resource labels (protected labels are filtered)
 	// Note: NOT applied to Spec.Selector.MatchLabels as those are immutable after creation
-	veleroDeployment.Labels = applyResourceLabels(dpa, veleroDeployment.Labels)
-	veleroDeployment.Spec.Template.Labels = applyResourceLabels(dpa, veleroDeployment.Spec.Template.Labels)
+	veleroDeployment.Labels, veleroDeployment.Annotations = applyResourceLabels(dpa, veleroDeployment.Labels, veleroDeployment.Annotations)
+	veleroDeployment.Spec.Template.Labels, veleroDeployment.Spec.Template.Annotations = applyResourceLabels(dpa, veleroDeployment.Spec.Template.Labels, veleroDeployment.Spec.Template.Annotations)
 
 	// Apply user-provided resource annotations to both deployment and pod template
 	veleroDeployment.Annotations = applyResourceAnnotations(dpa, veleroDeployment.Annotations)
@@ -840,33 +839,59 @@ func isProtectedLabel(key string) bool {
 	return false
 }
 
-// applyResourceLabels merges DPA resourceLabels with core labels.
-// Core labels take precedence - protected labels from user input are filtered out.
-// Returns a new map containing core labels plus non-protected user labels.
-func applyResourceLabels(dpa *oadpv1alpha1.DataProtectionApplication, coreLabels map[string]string) map[string]string {
-	if dpa == nil || dpa.Spec.ResourceLabels == nil {
-		return coreLabels
-	}
-
-	// Start with core labels
-	result := make(map[string]string)
+// applyResourceLabels applies DPA resourceLabels to a resource's labels,
+// using a tracking annotation to clean up stale keys when labels are removed from the DPA spec.
+// Returns updated labels and annotations (annotations carry the tracking key).
+func applyResourceLabels(dpa *oadpv1alpha1.DataProtectionApplication, coreLabels map[string]string, annotations map[string]string) (map[string]string, map[string]string) {
+	labelResult := make(map[string]string)
 	for k, v := range coreLabels {
-		result[k] = v
+		labelResult[k] = v
 	}
 
-	// Add user labels, skipping protected ones
-	for k, v := range dpa.Spec.ResourceLabels {
-		if !isProtectedLabel(k) {
-			result[k] = v
+	if tracked, ok := annotations[managedLabelKeysAnnotation]; ok {
+		for _, k := range strings.Split(tracked, ",") {
+			if k = strings.TrimSpace(k); k != "" && !isProtectedLabel(k) {
+				delete(labelResult, k)
+			}
+		}
+		if annotations != nil {
+			annCopy := make(map[string]string)
+			for k, v := range annotations {
+				annCopy[k] = v
+			}
+			delete(annCopy, managedLabelKeysAnnotation)
+			annotations = annCopy
 		}
 	}
 
-	return result
+	if dpa == nil || len(dpa.Spec.ResourceLabels) == 0 {
+		return labelResult, annotations
+	}
+
+	var keys []string
+	for k, v := range dpa.Spec.ResourceLabels {
+		if !isProtectedLabel(k) {
+			labelResult[k] = v
+			keys = append(keys, k)
+		}
+	}
+
+	if len(keys) > 0 {
+		annResult := make(map[string]string)
+		for k, v := range annotations {
+			annResult[k] = v
+		}
+		slices.Sort(keys)
+		annResult[managedLabelKeysAnnotation] = strings.Join(keys, ",")
+		return labelResult, annResult
+	}
+
+	return labelResult, annotations
 }
 
-// filterOutResourceLabels removes resourceLabels from the given labels map.
-// This is used to get labels that are safe for matchLabels (which are immutable).
-func filterOutResourceLabels(dpa *oadpv1alpha1.DataProtectionApplication, labels map[string]string) map[string]string {
+// filterOutResourceLabels removes resourceLabels (current and previously-tracked) from the given
+// labels map. This is used to get labels that are safe for matchLabels (which are immutable).
+func filterOutResourceLabels(dpa *oadpv1alpha1.DataProtectionApplication, labels map[string]string, annotations map[string]string) map[string]string {
 	if labels == nil {
 		return nil
 	}
@@ -876,8 +901,6 @@ func filterOutResourceLabels(dpa *oadpv1alpha1.DataProtectionApplication, labels
 		result[k] = v
 	}
 
-	// Remove resourceLabels if present, but skip protected labels
-	// Protected labels should always be preserved in matchLabels
 	if dpa != nil && dpa.Spec.ResourceLabels != nil {
 		for k := range dpa.Spec.ResourceLabels {
 			if !isProtectedLabel(k) {
@@ -886,14 +909,24 @@ func filterOutResourceLabels(dpa *oadpv1alpha1.DataProtectionApplication, labels
 		}
 	}
 
+	if tracked, ok := annotations[managedLabelKeysAnnotation]; ok {
+		for _, k := range strings.Split(tracked, ",") {
+			if k = strings.TrimSpace(k); k != "" && !isProtectedLabel(k) {
+				delete(result, k)
+			}
+		}
+	}
+
 	return result
 }
 
-// applyResourceAnnotations merges DPA resourceAnnotations with existing annotations.
-// User-provided annotations are added to existing annotations. User annotations take precedence
-// for any conflicting keys.
+// applyResourceAnnotations applies DPA resourceAnnotations to a resource's annotations,
+// using a tracking annotation to clean up stale keys when annotations are removed from the DPA spec.
 func applyResourceAnnotations(dpa *oadpv1alpha1.DataProtectionApplication, existingAnnotations map[string]string) map[string]string {
-	if dpa == nil || dpa.Spec.ResourceAnnotations == nil {
+	_, hasTracking := existingAnnotations[managedAnnotationKeysAnnotation]
+	hasNewAnnotations := dpa != nil && len(dpa.Spec.ResourceAnnotations) > 0
+
+	if !hasTracking && !hasNewAnnotations {
 		return existingAnnotations
 	}
 
@@ -902,8 +935,31 @@ func applyResourceAnnotations(dpa *oadpv1alpha1.DataProtectionApplication, exist
 		result[k] = v
 	}
 
+	if tracked, ok := result[managedAnnotationKeysAnnotation]; ok {
+		for _, k := range strings.Split(tracked, ",") {
+			if k = strings.TrimSpace(k); k != "" {
+				delete(result, k)
+			}
+		}
+		delete(result, managedAnnotationKeysAnnotation)
+	}
+
+	if !hasNewAnnotations {
+		return result
+	}
+
+	var keys []string
 	for k, v := range dpa.Spec.ResourceAnnotations {
+		if k == managedAnnotationKeysAnnotation || k == managedLabelKeysAnnotation {
+			continue
+		}
 		result[k] = v
+		keys = append(keys, k)
+	}
+
+	if len(keys) > 0 {
+		slices.Sort(keys)
+		result[managedAnnotationKeysAnnotation] = strings.Join(keys, ",")
 	}
 
 	return result

--- a/internal/controller/velero_test.go
+++ b/internal/controller/velero_test.go
@@ -3614,10 +3614,12 @@ func TestIsProtectedLabel(t *testing.T) {
 
 func TestApplyResourceLabels(t *testing.T) {
 	tests := []struct {
-		name           string
-		dpa            *oadpv1alpha1.DataProtectionApplication
-		coreLabels     map[string]string
-		expectedLabels map[string]string
+		name                string
+		dpa                 *oadpv1alpha1.DataProtectionApplication
+		coreLabels          map[string]string
+		annotations         map[string]string
+		expectedLabels      map[string]string
+		expectedAnnotations map[string]string
 	}{
 		{
 			name: "nil DPA returns core labels",
@@ -3625,9 +3627,9 @@ func TestApplyResourceLabels(t *testing.T) {
 			coreLabels: map[string]string{
 				"app.kubernetes.io/name": "velero",
 			},
-			expectedLabels: map[string]string{
-				"app.kubernetes.io/name": "velero",
-			},
+			annotations:         nil,
+			expectedLabels:      map[string]string{"app.kubernetes.io/name": "velero"},
+			expectedAnnotations: nil,
 		},
 		{
 			name: "nil resourceLabels returns core labels",
@@ -3639,9 +3641,9 @@ func TestApplyResourceLabels(t *testing.T) {
 			coreLabels: map[string]string{
 				"app.kubernetes.io/name": "velero",
 			},
-			expectedLabels: map[string]string{
-				"app.kubernetes.io/name": "velero",
-			},
+			annotations:         nil,
+			expectedLabels:      map[string]string{"app.kubernetes.io/name": "velero"},
+			expectedAnnotations: nil,
 		},
 		{
 			name: "user labels are merged with core labels",
@@ -3656,10 +3658,14 @@ func TestApplyResourceLabels(t *testing.T) {
 			coreLabels: map[string]string{
 				"app.kubernetes.io/name": "velero",
 			},
+			annotations: nil,
 			expectedLabels: map[string]string{
 				"app.kubernetes.io/name": "velero",
 				"custom-label":           "custom-value",
 				"team":                   "backup",
+			},
+			expectedAnnotations: map[string]string{
+				managedLabelKeysAnnotation: "custom-label,team",
 			},
 		},
 		{
@@ -3667,9 +3673,9 @@ func TestApplyResourceLabels(t *testing.T) {
 			dpa: &oadpv1alpha1.DataProtectionApplication{
 				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
 					ResourceLabels: map[string]string{
-						"app.kubernetes.io/name":       "user-override", // should be ignored
-						"app.kubernetes.io/managed-by": "user-manager",  // should be ignored
-						"custom-label":                 "custom-value",  // should be included
+						"app.kubernetes.io/name":       "user-override",
+						"app.kubernetes.io/managed-by": "user-manager",
+						"custom-label":                 "custom-value",
 					},
 				},
 			},
@@ -3677,10 +3683,14 @@ func TestApplyResourceLabels(t *testing.T) {
 				"app.kubernetes.io/name":       "velero",
 				"app.kubernetes.io/managed-by": common.OADPOperator,
 			},
+			annotations: nil,
 			expectedLabels: map[string]string{
-				"app.kubernetes.io/name":       "velero",            // core label preserved
-				"app.kubernetes.io/managed-by": common.OADPOperator, // core label preserved
-				"custom-label":                 "custom-value",      // user label added
+				"app.kubernetes.io/name":       "velero",
+				"app.kubernetes.io/managed-by": common.OADPOperator,
+				"custom-label":                 "custom-value",
+			},
+			expectedAnnotations: map[string]string{
+				managedLabelKeysAnnotation: "custom-label",
 			},
 		},
 		{
@@ -3695,18 +3705,217 @@ func TestApplyResourceLabels(t *testing.T) {
 			coreLabels: map[string]string{
 				"app.kubernetes.io/name": "velero",
 			},
+			annotations: nil,
 			expectedLabels: map[string]string{
 				"app.kubernetes.io/name":          "velero",
 				"argocd.argoproj.io/sync-options": "ServerSideApply=true",
+			},
+			expectedAnnotations: map[string]string{
+				managedLabelKeysAnnotation: "argocd.argoproj.io/sync-options",
+			},
+		},
+		{
+			name: "stale labels removed when resourceLabels cleared",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					ResourceLabels: nil,
+				},
+			},
+			coreLabels: map[string]string{
+				"app.kubernetes.io/name": "velero",
+				"stale-label":            "old-value",
+			},
+			annotations: map[string]string{
+				managedLabelKeysAnnotation: "stale-label",
+			},
+			expectedLabels: map[string]string{
+				"app.kubernetes.io/name": "velero",
+			},
+			expectedAnnotations: map[string]string{},
+		},
+		{
+			name: "stale label key removed when key removed from resourceLabels",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					ResourceLabels: map[string]string{
+						"keep-this": "val1",
+					},
+				},
+			},
+			coreLabels: map[string]string{
+				"app.kubernetes.io/name": "velero",
+				"keep-this":              "val1",
+				"remove-this":            "val2",
+			},
+			annotations: map[string]string{
+				managedLabelKeysAnnotation: "keep-this,remove-this",
+			},
+			expectedLabels: map[string]string{
+				"app.kubernetes.io/name": "velero",
+				"keep-this":              "val1",
+			},
+			expectedAnnotations: map[string]string{
+				managedLabelKeysAnnotation: "keep-this",
+			},
+		},
+		{
+			name: "tracking annotation keys are sorted",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					ResourceLabels: map[string]string{
+						"zebra": "z",
+						"alpha": "a",
+					},
+				},
+			},
+			coreLabels: map[string]string{
+				"app.kubernetes.io/name": "velero",
+			},
+			annotations: nil,
+			expectedLabels: map[string]string{
+				"app.kubernetes.io/name": "velero",
+				"zebra":                  "z",
+				"alpha":                  "a",
+			},
+			expectedAnnotations: map[string]string{
+				managedLabelKeysAnnotation: "alpha,zebra",
+			},
+		},
+		{
+			name: "protected labels are not tracked",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					ResourceLabels: map[string]string{
+						"app.kubernetes.io/name": "override",
+						"custom":                 "value",
+					},
+				},
+			},
+			coreLabels: map[string]string{
+				"app.kubernetes.io/name": "velero",
+			},
+			annotations: nil,
+			expectedLabels: map[string]string{
+				"app.kubernetes.io/name": "velero",
+				"custom":                 "value",
+			},
+			expectedAnnotations: map[string]string{
+				managedLabelKeysAnnotation: "custom",
+			},
+		},
+		{
+			name: "empty resourceLabels behaves like nil",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					ResourceLabels: map[string]string{},
+				},
+			},
+			coreLabels: map[string]string{
+				"app.kubernetes.io/name": "velero",
+				"stale":                  "old",
+			},
+			annotations: map[string]string{
+				managedLabelKeysAnnotation: "stale",
+			},
+			expectedLabels: map[string]string{
+				"app.kubernetes.io/name": "velero",
+			},
+			expectedAnnotations: map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resultLabels, resultAnnotations := applyResourceLabels(tt.dpa, tt.coreLabels, tt.annotations)
+			if !reflect.DeepEqual(resultLabels, tt.expectedLabels) {
+				t.Errorf("applyResourceLabels() labels = %v, expected %v", resultLabels, tt.expectedLabels)
+			}
+			if !reflect.DeepEqual(resultAnnotations, tt.expectedAnnotations) {
+				t.Errorf("applyResourceLabels() annotations = %v, expected %v", resultAnnotations, tt.expectedAnnotations)
+			}
+		})
+	}
+}
+
+func TestFilterOutResourceLabels(t *testing.T) {
+	tests := []struct {
+		name           string
+		dpa            *oadpv1alpha1.DataProtectionApplication
+		labels         map[string]string
+		annotations    map[string]string
+		expectedLabels map[string]string
+	}{
+		{
+			name: "filters current resourceLabels",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					ResourceLabels: map[string]string{
+						"custom": "value",
+					},
+				},
+			},
+			labels: map[string]string{
+				"app.kubernetes.io/name": "velero",
+				"custom":                 "value",
+			},
+			annotations: nil,
+			expectedLabels: map[string]string{
+				"app.kubernetes.io/name": "velero",
+			},
+		},
+		{
+			name: "filters previously tracked stale labels",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					ResourceLabels: nil,
+				},
+			},
+			labels: map[string]string{
+				"app.kubernetes.io/name": "velero",
+				"stale":                  "old-value",
+			},
+			annotations: map[string]string{
+				managedLabelKeysAnnotation: "stale",
+			},
+			expectedLabels: map[string]string{
+				"app.kubernetes.io/name": "velero",
+			},
+		},
+		{
+			name:           "nil labels returns nil",
+			dpa:            nil,
+			labels:         nil,
+			annotations:    nil,
+			expectedLabels: nil,
+		},
+		{
+			name: "filters both current and previously tracked labels",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					ResourceLabels: map[string]string{
+						"current": "value",
+					},
+				},
+			},
+			labels: map[string]string{
+				"app.kubernetes.io/name": "velero",
+				"current":                "value",
+				"stale":                  "old",
+			},
+			annotations: map[string]string{
+				managedLabelKeysAnnotation: "stale",
+			},
+			expectedLabels: map[string]string{
+				"app.kubernetes.io/name": "velero",
 			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := applyResourceLabels(tt.dpa, tt.coreLabels)
+			result := filterOutResourceLabels(tt.dpa, tt.labels, tt.annotations)
 			if !reflect.DeepEqual(result, tt.expectedLabels) {
-				t.Errorf("applyResourceLabels() = %v, expected %v", result, tt.expectedLabels)
+				t.Errorf("filterOutResourceLabels() = %v, expected %v", result, tt.expectedLabels)
 			}
 		})
 	}
@@ -3720,7 +3929,7 @@ func TestApplyResourceAnnotations(t *testing.T) {
 		expectedAnnotations map[string]string
 	}{
 		{
-			name: "nil DPA returns existing annotations",
+			name: "nil DPA returns existing annotations without stale keys",
 			dpa:  nil,
 			existingAnnotations: map[string]string{
 				"existing": "annotation",
@@ -3730,7 +3939,7 @@ func TestApplyResourceAnnotations(t *testing.T) {
 			},
 		},
 		{
-			name: "nil resourceAnnotations returns existing annotations",
+			name: "nil resourceAnnotations returns existing annotations without stale keys",
 			dpa: &oadpv1alpha1.DataProtectionApplication{
 				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
 					ResourceAnnotations: nil,
@@ -3744,7 +3953,7 @@ func TestApplyResourceAnnotations(t *testing.T) {
 			},
 		},
 		{
-			name: "user annotations are merged with existing",
+			name: "user annotations are merged with existing and tracking annotation set",
 			dpa: &oadpv1alpha1.DataProtectionApplication{
 				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
 					ResourceAnnotations: map[string]string{
@@ -3756,8 +3965,9 @@ func TestApplyResourceAnnotations(t *testing.T) {
 				"existing": "annotation",
 			},
 			expectedAnnotations: map[string]string{
-				"existing":          "annotation",
-				"custom-annotation": "custom-value",
+				"existing":                      "annotation",
+				"custom-annotation":             "custom-value",
+				managedAnnotationKeysAnnotation: "custom-annotation",
 			},
 		},
 		{
@@ -3773,7 +3983,8 @@ func TestApplyResourceAnnotations(t *testing.T) {
 				"existing": "annotation",
 			},
 			expectedAnnotations: map[string]string{
-				"existing": "user-value", // user value wins
+				"existing":                      "user-value",
+				managedAnnotationKeysAnnotation: "existing",
 			},
 		},
 		{
@@ -3791,10 +4002,11 @@ func TestApplyResourceAnnotations(t *testing.T) {
 			expectedAnnotations: map[string]string{
 				"prometheus.io/scrape":                       "true",
 				"argocd.argoproj.io/ignore-resource-updates": "true",
+				managedAnnotationKeysAnnotation:              "argocd.argoproj.io/ignore-resource-updates",
 			},
 		},
 		{
-			name: "nil existing annotations",
+			name: "nil existing annotations with resourceAnnotations",
 			dpa: &oadpv1alpha1.DataProtectionApplication{
 				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
 					ResourceAnnotations: map[string]string{
@@ -3804,7 +4016,116 @@ func TestApplyResourceAnnotations(t *testing.T) {
 			},
 			existingAnnotations: nil,
 			expectedAnnotations: map[string]string{
-				"custom": "value",
+				"custom":                        "value",
+				managedAnnotationKeysAnnotation: "custom",
+			},
+		},
+		{
+			name: "stale annotations removed when resourceAnnotations cleared",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					ResourceAnnotations: nil,
+				},
+			},
+			existingAnnotations: map[string]string{
+				"existing":                      "annotation",
+				"stale-from-dpa":                "old-value",
+				managedAnnotationKeysAnnotation: "stale-from-dpa",
+			},
+			expectedAnnotations: map[string]string{
+				"existing": "annotation",
+			},
+		},
+		{
+			name: "stale annotation key removed when key removed from resourceAnnotations",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					ResourceAnnotations: map[string]string{
+						"keep-this": "val1",
+					},
+				},
+			},
+			existingAnnotations: map[string]string{
+				"existing":                      "annotation",
+				"keep-this":                     "val1",
+				"remove-this":                   "val2",
+				managedAnnotationKeysAnnotation: "keep-this,remove-this",
+			},
+			expectedAnnotations: map[string]string{
+				"existing":                      "annotation",
+				"keep-this":                     "val1",
+				managedAnnotationKeysAnnotation: "keep-this",
+			},
+		},
+		{
+			name: "tracking annotation keys are sorted",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					ResourceAnnotations: map[string]string{
+						"zebra": "z",
+						"alpha": "a",
+						"beta":  "b",
+					},
+				},
+			},
+			existingAnnotations: nil,
+			expectedAnnotations: map[string]string{
+				"zebra":                         "z",
+				"alpha":                         "a",
+				"beta":                          "b",
+				managedAnnotationKeysAnnotation: "alpha,beta,zebra",
+			},
+		},
+		{
+			name: "reserved tracking keys in resourceAnnotations are skipped",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					ResourceAnnotations: map[string]string{
+						managedAnnotationKeysAnnotation: "hacker",
+						"legit":                         "value",
+					},
+				},
+			},
+			existingAnnotations: nil,
+			expectedAnnotations: map[string]string{
+				"legit":                         "value",
+				managedAnnotationKeysAnnotation: "legit",
+			},
+		},
+		{
+			name: "empty resourceAnnotations cleans up stale keys",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					ResourceAnnotations: map[string]string{},
+				},
+			},
+			existingAnnotations: map[string]string{
+				"existing":                      "annotation",
+				"stale":                         "old",
+				managedAnnotationKeysAnnotation: "stale",
+			},
+			expectedAnnotations: map[string]string{
+				"existing": "annotation",
+			},
+		},
+		{
+			name: "idempotent when called twice with same input",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					ResourceAnnotations: map[string]string{
+						"custom": "value",
+					},
+				},
+			},
+			existingAnnotations: map[string]string{
+				"existing":                      "annotation",
+				"custom":                        "value",
+				managedAnnotationKeysAnnotation: "custom",
+			},
+			expectedAnnotations: map[string]string{
+				"existing":                      "annotation",
+				"custom":                        "value",
+				managedAnnotationKeysAnnotation: "custom",
 			},
 		},
 	}

--- a/internal/controller/vmfilerestore_controller.go
+++ b/internal/controller/vmfilerestore_controller.go
@@ -136,10 +136,10 @@ func (r *DataProtectionApplicationReconciler) buildVMFileRestoreDeployment(deplo
 		return err
 	}
 
-	// Apply user-provided resource labels (protected labels are filtered)
+	// Apply user-provided resource labels and annotations
 	// Note: NOT applied to Spec.Selector.MatchLabels as those are immutable after creation
-	deploymentObject.Labels = applyResourceLabels(r.dpa, deploymentObject.Labels)
-	deploymentObject.Spec.Template.Labels = applyResourceLabels(r.dpa, deploymentObject.Spec.Template.Labels)
+	deploymentObject.Labels, deploymentObject.Annotations = applyResourceLabels(r.dpa, deploymentObject.Labels, deploymentObject.Annotations)
+	deploymentObject.Spec.Template.Labels, deploymentObject.Spec.Template.Annotations = applyResourceLabels(r.dpa, deploymentObject.Spec.Template.Labels, deploymentObject.Spec.Template.Annotations)
 
 	// Re-assert selector labels to ensure template labels match selector
 	// This prevents user resourceLabels from overriding selector-critical labels
@@ -152,7 +152,6 @@ func (r *DataProtectionApplicationReconciler) buildVMFileRestoreDeployment(deplo
 		}
 	}
 
-	// Apply user-provided resource annotations to both deployment and pod template
 	deploymentObject.Annotations = applyResourceAnnotations(r.dpa, deploymentObject.Annotations)
 	deploymentObject.Spec.Template.Annotations = applyResourceAnnotations(r.dpa, deploymentObject.Spec.Template.Annotations)
 

--- a/internal/controller/vsl.go
+++ b/internal/controller/vsl.go
@@ -227,10 +227,8 @@ func (r *DataProtectionApplicationReconciler) ReconcileVolumeSnapshotLocations(l
 				oadpv1alpha1.OadpOperatorLabel: "True",
 			}
 
-			// Apply user-provided resource labels (protected labels are filtered)
-			vsl.Labels = applyResourceLabels(dpa, vsl.Labels)
-
-			// Apply user-provided resource annotations
+			// Apply user-provided resource labels and annotations
+			vsl.Labels, vsl.Annotations = applyResourceLabels(dpa, vsl.Labels, vsl.Annotations)
 			vsl.Annotations = applyResourceAnnotations(dpa, vsl.Annotations)
 
 			vsl.Spec = *vslSpec.Velero


### PR DESCRIPTION
## Summary

- Fix stale `resourceAnnotations` and `resourceLabels` not being removed from managed resources when cleared from the DPA spec
- Introduce tracking annotations (`oadp.openshift.io/managed-resource-annotation-keys`, `oadp.openshift.io/managed-resource-label-keys`) to record which keys were applied, enabling cleanup on subsequent reconciles
- Fix Velero deployment incorrectly merging metadata annotations into the pod template via `AppendUniqueKeyTOfTMaps`, aligning with the node-agent pattern of passing only PodConfig annotations to the install library

## Details

### Problem
When `resourceAnnotations` or `resourceLabels` were removed from the DPA spec, stale values persisted on all managed resources (Velero deployment, node-agent DaemonSet, BSL, ConfigMaps, Services, etc.). The `applyResourceAnnotations()` and `applyResourceLabels()` functions only merged values in and never removed previously-applied keys.

Additionally, the node-agent DaemonSet appeared unaffected at the pod level because its spec was rebuilt from scratch each reconcile, but its object metadata annotations were also stale. The Velero deployment pod template was affected because metadata annotations leaked into the pod template through an incorrect merge.

### Fix
- **Tracking annotations**: Each managed resource now carries a tracking annotation that records which annotation/label keys were applied via `resourceAnnotations`/`resourceLabels`. On each reconcile, previously-tracked keys are removed before applying the current set. This follows the same pattern used by `kubectl apply` (`kubectl.kubernetes.io/last-applied-configuration`).
- **Pod template annotation leak**: Removed the merge of deployment metadata annotations into pod template annotations for the Velero deployment, matching the existing node-agent pattern.

### Affected resources
All resources using `applyResourceAnnotations`/`applyResourceLabels` (12 call sites across 10 files): Velero Deployment, Node-Agent DaemonSet, Node-Agent ConfigMap, BSL, VSL, Monitor Service, Registry Secret, Backup Repository ConfigMap, Repository Maintenance ConfigMap, NonAdmin Controller, KubeVirt DataMover, VMFileRestore Controller.

Fixes: [OADP-7869](https://redhat.atlassian.net/browse/OADP-7869)

## Test plan

- [x] Unit tests: 27 test cases covering annotations, labels, and filterOutResourceLabels (nil/empty inputs, stale key cleanup, partial removal, sorted tracking keys, protected label filtering, reserved key protection, idempotency)
- [x] `make test` passes (unit tests + lint + go vet + api-isupdated)
- [x] Live cluster verification: deployed fix, added `resourceAnnotations`/`resourceLabels` to DPA, verified they appeared on all managed resources, removed them, verified all stale values were cleaned up across Deployment metadata, DaemonSet metadata, pod templates, BSL, and ConfigMaps
- [x] CI/Prow E2E tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated resource label and annotation application logic to operate as single combined steps across multiple resource types and hierarchy levels.
  * Enhanced lifecycle management with tracking of user-provided label and annotation keys for cleanup of stale entries.
  * Streamlined annotation processing by removing redundant separate operations.

* **Tests**
  * Extended test coverage for combined label and annotation handling scenarios.
  * Added validation for tracking and removal of stale label and annotation keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->