### PR TITLE
OADP-7882: add dpa config to disable early csi polling interval

### DIFF
--- a/api/v1alpha1/dataprotectionapplication_types.go
+++ b/api/v1alpha1/dataprotectionapplication_types.go
@@ -373,6 +373,11 @@ type VeleroConfig struct {
 	// LoadAffinityConfig is the config for data path load affinity.
 	// +optional
 	LoadAffinityConfig []*LoadAffinity `json:"loadAffinity,omitempty"`
+	// set DisableCSISnapshotEarlyFrequentPolling to true to omit
+	// the 1-second polling interval for the first 10 seconds while waiting
+	// for the snaphandle
+	// +optional
+	DisableCSISnapshotEarlyFrequentPolling bool `json:"disableCSISnapshotEarlyFrequentPolling,omitempty"`
 }
 
 // PodConfig defines the pod configuration options

--- a/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
@@ -1229,6 +1229,12 @@ spec:
                             Use pod volume file system backup by default for volumes.
                             Matches backup.spec.defaultVolumesToFsBackup in Velero API.
                           type: boolean
+                        disableCSISnapshotEarlyFrequentPolling:
+                          description: |-
+                            set DisableCSISnapshotEarlyFrequentPolling to true to omit
+                            the 1-second polling interval for the first 10 seconds while waiting
+                            for the snaphandle
+                          type: boolean
                         disableFsBackup:
                           default: false
                           description: |-

--- a/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
@@ -1229,6 +1229,12 @@ spec:
                             Use pod volume file system backup by default for volumes.
                             Matches backup.spec.defaultVolumesToFsBackup in Velero API.
                           type: boolean
+                        disableCSISnapshotEarlyFrequentPolling:
+                          description: |-
+                            set DisableCSISnapshotEarlyFrequentPolling to true to omit
+                            the 1-second polling interval for the first 10 seconds while waiting
+                            for the snaphandle
+                          type: boolean
                         disableFsBackup:
                           default: false
                           description: |-

--- a/internal/controller/velero.go
+++ b/internal/controller/velero.go
@@ -673,6 +673,12 @@ func (r *DataProtectionApplicationReconciler) customizeVeleroContainer(veleroCon
 			Value: "true",
 		}})
 	}
+	if dpa.Spec.Configuration.Velero == nil || !dpa.Spec.Configuration.Velero.DisableCSISnapshotEarlyFrequentPolling {
+		veleroContainer.Env = common.AppendUniqueEnvVars(veleroContainer.Env, []corev1.EnvVar{{
+			Name:  "CSI_SNAPSHOT_EARLY_FREQUENT_POLLING",
+			Value: "true",
+		}})
+	}
 
 	// Add Azure workload identity environment variables if using Azure STS
 	azureClientID := os.Getenv(stsflow.ClientIDEnvKey)

--- a/internal/controller/velero_test.go
+++ b/internal/controller/velero_test.go
@@ -98,6 +98,7 @@ var (
 		},
 		{Name: common.LDLibraryPathEnvKey, Value: "/plugins"},
 		{Name: "OPENSHIFT_IMAGESTREAM_BACKUP", Value: "true"},
+		{Name: "CSI_SNAPSHOT_EARLY_FREQUENT_POLLING", Value: "true"},
 	}
 
 	baseVolumeMounts = []corev1.VolumeMount{
@@ -2588,6 +2589,55 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 					},
 					{Name: common.LDLibraryPathEnvKey, Value: "/plugins"},
 					// Note: OPENSHIFT_IMAGESTREAM_BACKUP is NOT included when BackupImages is false
+					{Name: "CSI_SNAPSHOT_EARLY_FREQUENT_POLLING", Value: "true"},
+				},
+			}),
+		},
+		{
+			name: "valid DPA CR with DisableCSISnapshotEarlyFrequentPolling true, no CSI_SNAPSHOT_EARLY_FREQUENT_POLLING",
+			dpa: createTestDpaWith(
+				nil,
+				oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{
+							DisableCSISnapshotEarlyFrequentPolling: true,
+						},
+					},
+					BackupImages: ptr.To(false),
+					BackupLocations: []oadpv1alpha1.BackupLocation{
+						{
+							Velero: &velerov1.BackupStorageLocationSpec{
+								Provider: "aws",
+								StorageType: velerov1.StorageType{
+									ObjectStorage: &velerov1.ObjectStorageLocation{
+										CACert: []byte("test-ca-cert"),
+									},
+								},
+							},
+						},
+					},
+				},
+			),
+			veleroDeployment: testVeleroDeployment.DeepCopy(),
+			wantVeleroDeployment: createTestBuiltVeleroDeployment(TestBuiltVeleroDeploymentOptions{
+				args: []string{
+					defaultFileSystemBackupTimeout,
+					defaultRestoreResourcePriorities,
+					defaultDisableInformerCache,
+				},
+				// When BackupImages is false, OPENSHIFT_IMAGESTREAM_BACKUP env var is not set
+				env: []corev1.EnvVar{
+					{Name: common.VeleroScratchDirEnvKey, Value: "/scratch"},
+					{
+						Name: common.VeleroNamespaceEnvKey,
+						ValueFrom: &corev1.EnvVarSource{
+							FieldRef: &corev1.ObjectFieldSelector{
+								APIVersion: "v1",
+								FieldPath:  "metadata.namespace",
+							},
+						},
+					},
+					{Name: common.LDLibraryPathEnvKey, Value: "/plugins"},
 				},
 			}),
 		},


### PR DESCRIPTION

## Why the changes were made
Added dpa config to disable early csi polling interval
If not disabled, add env var to velero to enable early csi polling. This is needed to ensure that for windows VMs the snapshots are done within 10 seconds.

<!-- Explain why this PR is important, what problems it fixes, link related issues -->

## How to test the changes made

If the disable flag isn't set, the velero pod should have the env var CSI_SNAPSHOT_EARLY_FREQUENT_POLLING set to true, else it should not be set.
If the env var is true, then when waiting for CSI snaphandle, there should be polling logging every 1 second at first, otherwise it should be every 5 seconds.
<!-- Explain how the changes introduced by this PR can be tested and verified, with commands and pictures -->
