### PR TITLE
Increase Fedora VM startup timeout to 20 minutes

### DIFF
--- a/tests/e2e/virt_backup_restore_suite_test.go
+++ b/tests/e2e/virt_backup_restore_suite_test.go
@@ -75,9 +75,10 @@ func vmPoweredOff(vmnamespace, vmname string) VerificationFunction {
 
 type VmBackupRestoreCase struct {
 	BackupRestoreCase
-	Template   string
-	InitDelay  time.Duration
-	PowerState string
+	Template       string
+	InitDelay      time.Duration
+	StartupTimeout time.Duration
+	PowerState     string
 }
 
 func runVmBackupAndRestore(brCase VmBackupRestoreCase, updateLastBRcase func(brCase VmBackupRestoreCase), v *lib.VirtOperator) {
@@ -98,7 +99,11 @@ func runVmBackupAndRestore(brCase VmBackupRestoreCase, updateLastBRcase func(brC
 	// Wait for VM to start, then give some time for cloud-init to run.
 	// Afterward, run through the standard application verification to make sure
 	// the application itself is working correctly.
-	err = wait.PollUntilContextTimeout(context.Background(), 10*time.Second, 10*time.Minute, true, func(ctx context.Context) (bool, error) {
+	startupTimeout := brCase.StartupTimeout
+	if startupTimeout == 0 {
+		startupTimeout = 10 * time.Minute
+	}
+	err = wait.PollUntilContextTimeout(context.Background(), 10*time.Second, startupTimeout, true, func(ctx context.Context) (bool, error) {
 		status, err := v.GetVmStatus(brCase.Namespace, brCase.Name)
 		return status == "Running", err
 	})
@@ -349,8 +354,9 @@ var _ = ginkgo.Describe("VM backup and restore tests", ginkgo.Ordered, func() {
 		}, nil),
 
 		ginkgo.Entry("todolist CSI backup and restore, in a Fedora VM", ginkgo.Label("virt"), VmBackupRestoreCase{
-			Template:  "./sample-applications/virtual-machines/fedora-todolist/fedora-todolist.yaml",
-			InitDelay: 3 * time.Minute, // For cloud-init
+			Template:       "./sample-applications/virtual-machines/fedora-todolist/fedora-todolist.yaml",
+			InitDelay:      3 * time.Minute, // For cloud-init
+			StartupTimeout: 20 * time.Minute,
 			BackupRestoreCase: BackupRestoreCase{
 				Namespace:         "mysql-persistent",
 				Name:              "fedora-todolist",


### PR DESCRIPTION
## Why the changes were made

Fixes https://github.com/openshift/oadp-operator/issues/2183

The Fedora todolist VM test clones a 30Gi DataVolume, which can take longer than the previous hardcoded 10-minute startup timeout. In the failing CI run, the VM reached "Running" state just 4 seconds after the timeout expired, causing a test flake.

This PR:
- Adds a configurable `StartupTimeout` field to `VmBackupRestoreCase`
- Sets 20 minutes for the Fedora todolist test (large disk)
- Defaults to 10 minutes for other tests (CirrOS, small disk)

## How to test the changes made

- Run kubevirt e2e tests: `TEST_VIRT=true make test-e2e`
- Verify Fedora todolist test passes with the increased timeout
- Verify CirrOS tests still use the default 10-minute timeout

> [!Note]
> Responses generated with Claude

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced VM backup and restore test reliability with configurable startup timeout settings per test case.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->