### PR TITLE
OADP-7882: add dpa config to disable early csi polling interval

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -310,7 +310,7 @@ check-envtest-arch:
 	fi
 
 $(ENVTEST): check-envtest-arch ## Download envtest-setup locally if necessary.
-	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@latest)
+	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20250308055145-5fe7bb3edc86)
 
 .PHONY: envtest
 envtest: $(ENVTEST)

--- a/api/v1alpha1/oadp_types.go
+++ b/api/v1alpha1/oadp_types.go
@@ -119,6 +119,11 @@ type VeleroConfig struct {
 	// Velero args are settings to customize velero server arguments. Overrides values in other fields.
 	// +optional
 	Args *server.Args `json:"args,omitempty"`
+	// set DisableCSISnapshotEarlyFrequentPolling to true to omit
+	// the 1-second polling interval for the first 10 seconds while waiting
+	// for the snaphandle
+	// +optional
+	DisableCSISnapshotEarlyFrequentPolling bool `json:"disableCSISnapshotEarlyFrequentPolling,omitempty"`
 }
 
 // PodConfig defines the pod configuration options

--- a/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
@@ -829,6 +829,12 @@ spec:
                         defaultVolumesToFSBackup:
                           description: Use pod volume file system backup by default for volumes
                           type: boolean
+                        disableCSISnapshotEarlyFrequentPolling:
+                          description: |-
+                            set DisableCSISnapshotEarlyFrequentPolling to true to omit
+                            the 1-second polling interval for the first 10 seconds while waiting
+                            for the snaphandle
+                          type: boolean
                         disableInformerCache:
                           description: Disable informer cache for Get calls on restore. With this enabled, it will speed up restore in cases where there are backup resources which already exist in the cluster, but for very large clusters this will increase velero memory usage. Default is false.
                           type: boolean

--- a/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
@@ -829,6 +829,12 @@ spec:
                         defaultVolumesToFSBackup:
                           description: Use pod volume file system backup by default for volumes
                           type: boolean
+                        disableCSISnapshotEarlyFrequentPolling:
+                          description: |-
+                            set DisableCSISnapshotEarlyFrequentPolling to true to omit
+                            the 1-second polling interval for the first 10 seconds while waiting
+                            for the snaphandle
+                          type: boolean
                         disableInformerCache:
                           description: Disable informer cache for Get calls on restore. With this enabled, it will speed up restore in cases where there are backup resources which already exist in the cluster, but for very large clusters this will increase velero memory usage. Default is false.
                           type: boolean

--- a/controllers/velero.go
+++ b/controllers/velero.go
@@ -552,6 +552,12 @@ func (r *DPAReconciler) customizeVeleroContainer(dpa *oadpv1alpha1.DataProtectio
 			Value: "true",
 		}})
 	}
+	if dpa.Spec.Configuration.Velero == nil || !dpa.Spec.Configuration.Velero.DisableCSISnapshotEarlyFrequentPolling {
+		veleroContainer.Env = common.AppendUniqueEnvVars(veleroContainer.Env, []corev1.EnvVar{{
+			Name:  "CSI_SNAPSHOT_EARLY_FREQUENT_POLLING",
+			Value: "true",
+		}})
+	}
 
 	// Enable user to specify --fs-backup-timeout (defaults to 4h)
 	// Append FS timeout option manually. Not configurable via install package, missing from podTemplateConfig struct. See: https://github.com/vmware-tanzu/velero/blob/8d57215ded1aa91cdea2cf091d60e072ce3f340f/pkg/install/deployment.go#L34-L45

--- a/controllers/velero_test.go
+++ b/controllers/velero_test.go
@@ -91,6 +91,7 @@ var (
 		},
 		{Name: common.LDLibraryPathEnvKey, Value: "/plugins"},
 		{Name: "OPENSHIFT_IMAGESTREAM_BACKUP", Value: "true"},
+		{Name: "CSI_SNAPSHOT_EARLY_FREQUENT_POLLING", Value: "true"},
 	}
 
 	baseVolumeMounts = []corev1.VolumeMount{


### PR DESCRIPTION
If not disabled, add env var to velero to enable early csi polling

## Why the changes were made

<!-- Explain why this PR is important, what problems it fixes, link related issues -->

## How to test the changes made

<!-- Explain how the changes introduced by this PR can be tested and verified, with commands and pictures -->
