### PR TITLE
fix: add /tmp emptyDir volume to KDM controller deployment

### DIFF
--- a/internal/controller/kubevirt_datamover_controller.go
+++ b/internal/controller/kubevirt_datamover_controller.go
@@ -259,6 +259,12 @@ func ensureKubevirtDatamoverRequiredSpecs(
 			},
 		},
 		Resources: resources,
+		VolumeMounts: []corev1.VolumeMount{
+			{
+				Name:      "tmp",
+				MountPath: "/tmp",
+			},
+		},
 		SecurityContext: &corev1.SecurityContext{
 			AllowPrivilegeEscalation: ptr.To(false),
 			Capabilities: &corev1.Capabilities{
@@ -316,6 +322,14 @@ func ensureKubevirtDatamoverRequiredSpecs(
 		return fmt.Errorf("could not find kubevirt-datamover container in Deployment")
 	}
 
+	deploymentObject.Spec.Template.Spec.Volumes = []corev1.Volume{
+		{
+			Name: "tmp",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+	}
 	deploymentObject.Spec.Template.Spec.RestartPolicy = corev1.RestartPolicyAlways
 	deploymentObject.Spec.Template.Spec.ServiceAccountName = kubevirtDatamoverObjectName
 	return nil

--- a/internal/controller/kubevirt_datamover_controller_test.go
+++ b/internal/controller/kubevirt_datamover_controller_test.go
@@ -936,6 +936,33 @@ func TestEnsureKubevirtDatamoverRequiredSpecs(t *testing.T) {
 				}
 			}
 
+			// Verify /tmp emptyDir volume is present on pod spec
+			volumes := deployment.Spec.Template.Spec.Volumes
+			hasTmpVolume := false
+			for _, v := range volumes {
+				if v.Name == "tmp" && v.VolumeSource.EmptyDir != nil {
+					hasTmpVolume = true
+					break
+				}
+			}
+			if !hasTmpVolume {
+				t.Error("expected /tmp emptyDir volume on pod spec")
+			}
+
+			// Verify /tmp volume mount on container (only for new containers)
+			if len(tt.existingContainers) == 0 {
+				hasTmpMount := false
+				for _, vm := range container.VolumeMounts {
+					if vm.Name == "tmp" && vm.MountPath == "/tmp" {
+						hasTmpMount = true
+						break
+					}
+				}
+				if !hasTmpMount {
+					t.Error("expected /tmp volumeMount on container")
+				}
+			}
+
 			// Verify template labels include control-plane
 			if deployment.Spec.Template.Labels == nil {
 				t.Error("expected template labels to be set")
@@ -1174,6 +1201,29 @@ func TestBuildKubevirtDatamoverDeployment(t *testing.T) {
 
 			if container.ReadinessProbe == nil {
 				t.Error("expected readiness probe to be set")
+			}
+
+			// Verify /tmp emptyDir volume and mount
+			hasTmpVolume := false
+			for _, v := range deployment.Spec.Template.Spec.Volumes {
+				if v.Name == "tmp" && v.VolumeSource.EmptyDir != nil {
+					hasTmpVolume = true
+					break
+				}
+			}
+			if !hasTmpVolume {
+				t.Error("expected /tmp emptyDir volume on pod spec")
+			}
+
+			hasTmpMount := false
+			for _, vm := range container.VolumeMounts {
+				if vm.Name == "tmp" && vm.MountPath == "/tmp" {
+					hasTmpMount = true
+					break
+				}
+			}
+			if !hasTmpMount {
+				t.Error("expected /tmp volumeMount on container")
 			}
 
 			// Verify labels


### PR DESCRIPTION
## Summary

- Adds a `/tmp` emptyDir volume and mount to the KDM controller deployment spec
- Required because the container runs with `readOnlyRootFilesystem: true` and the credential parsing fix ([migtools/kubevirt-datamover-controller#22](https://github.com/migtools/kubevirt-datamover-controller/issues/22)) uses `os.CreateTemp` to write in-memory BSL credentials for the AWS SDK
- Without this, the controller's credential path fails with permission denied on clusters enforcing read-only root filesystems

Companion PR: [migtools/kubevirt-datamover-controller#66](https://github.com/migtools/kubevirt-datamover-controller/pull/66)

## Test plan

- [x] OADP operator unit tests pass (`go test ./internal/controller/`)
- [x] Live cluster tested with both unquoted and quoted BSL credentials -- backups completed successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * kubevirt-datamover deployment now includes a temporary in-memory filesystem mounted at /tmp for container temporary file operations.
* **Tests**
  * Added/updated tests to verify the presence of the temporary volume and that it is mounted at /tmp in the pod spec.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->