### PR TITLE
fix: handle not-found error in nodeagent DaemonSet deletion

### DIFF
--- a/internal/controller/nodeagent.go
+++ b/internal/controller/nodeagent.go
@@ -276,6 +276,9 @@ func (r *DataProtectionApplicationReconciler) ReconcileNodeAgentDaemonset(log lo
 		// no errors means there is already an existing DaemonSet.
 		// TODO: Check if NodeAgent is in use, a backup is running, so don't blindly delete NodeAgent.
 		if err := r.Delete(deleteContext, ds, &client.DeleteOptions{PropagationPolicy: ptr.To(metav1.DeletePropagationForeground)}); err != nil {
+			if errors.IsNotFound(err) {
+				return true, nil
+			}
 			// TODO: Come back and fix event recording to be consistent
 			r.EventRecorder.Event(ds, corev1.EventTypeNormal, "DeleteDaemonSetFailed", "Got DaemonSet to delete but could not delete err:"+err.Error())
 			return false, err


### PR DESCRIPTION
## Summary
- Fix TOCTOU race condition in `ReconcileNodeAgentDaemonset` when NodeAgent is disabled
- Treat "not found" errors during DaemonSet deletion as success, since the desired state (DaemonSet absent) is already achieved
- Matches the pattern already used by other Delete calls in the same file (ConfigMap deletion at lines 232 and 770)
Fixes flakes from https://github.com/openshift/oadp-operator/pull/2160

## Problem
When NodeAgent is disabled, concurrent reconciliation loops can race between `Get()` and `Delete()`:
1. Loop A checks DaemonSet exists via `Get()` → found
2. Loop B deletes the DaemonSet
3. Loop A calls `Delete()` → fails with "not found"
4. Error causes DPA to transition to `Reconciled=False`

## Test plan
- [ ] Existing unit tests pass
- [ ] E2E tests pass with NodeAgent disable/enable scenarios
- [ ] Verify `Reconciled=True` remains stable when disabling NodeAgent under concurrent reconciliation

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when disabling NodeAgent to gracefully handle scenarios where underlying system components don't exist, enhancing overall reliability during cleanup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->