### PR TITLE
disable early frequent polling by default

### DIFF
--- a/api/v1alpha1/dataprotectionapplication_types.go
+++ b/api/v1alpha1/dataprotectionapplication_types.go
@@ -373,11 +373,11 @@ type VeleroConfig struct {
 	// LoadAffinityConfig is the config for data path load affinity.
 	// +optional
 	LoadAffinityConfig []*LoadAffinity `json:"loadAffinity,omitempty"`
-	// set DisableCSISnapshotEarlyFrequentPolling to true to omit
+	// set EnableCSISnapshotEarlyFrequentPolling to true to enable
 	// the 1-second polling interval for the first 10 seconds while waiting
 	// for the snaphandle
 	// +optional
-	DisableCSISnapshotEarlyFrequentPolling bool `json:"disableCSISnapshotEarlyFrequentPolling,omitempty"`
+	EnableCSISnapshotEarlyFrequentPolling bool `json:"enableCSISnapshotEarlyFrequentPolling,omitempty"`
 }
 
 // PodConfig defines the pod configuration options

--- a/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
@@ -1258,12 +1258,6 @@ spec:
                             Use pod volume file system backup by default for volumes.
                             Matches backup.spec.defaultVolumesToFsBackup in Velero API.
                           type: boolean
-                        disableCSISnapshotEarlyFrequentPolling:
-                          description: |-
-                            set DisableCSISnapshotEarlyFrequentPolling to true to omit
-                            the 1-second polling interval for the first 10 seconds while waiting
-                            for the snaphandle
-                          type: boolean
                         disableFsBackup:
                           default: false
                           description: |-
@@ -1273,6 +1267,12 @@ spec:
                           type: boolean
                         disableInformerCache:
                           description: Disable informer cache for Get calls on restore. With this enabled, it will speed up restore in cases where there are backup resources which already exist in the cluster, but for very large clusters this will increase velero memory usage. Default is false.
+                          type: boolean
+                        enableCSISnapshotEarlyFrequentPolling:
+                          description: |-
+                            set EnableCSISnapshotEarlyFrequentPolling to true to enable
+                            the 1-second polling interval for the first 10 seconds while waiting
+                            for the snaphandle
                           type: boolean
                         featureFlags:
                           description: featureFlags defines the list of features to enable for Velero instance

--- a/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
@@ -1258,12 +1258,6 @@ spec:
                             Use pod volume file system backup by default for volumes.
                             Matches backup.spec.defaultVolumesToFsBackup in Velero API.
                           type: boolean
-                        disableCSISnapshotEarlyFrequentPolling:
-                          description: |-
-                            set DisableCSISnapshotEarlyFrequentPolling to true to omit
-                            the 1-second polling interval for the first 10 seconds while waiting
-                            for the snaphandle
-                          type: boolean
                         disableFsBackup:
                           default: false
                           description: |-
@@ -1273,6 +1267,12 @@ spec:
                           type: boolean
                         disableInformerCache:
                           description: Disable informer cache for Get calls on restore. With this enabled, it will speed up restore in cases where there are backup resources which already exist in the cluster, but for very large clusters this will increase velero memory usage. Default is false.
+                          type: boolean
+                        enableCSISnapshotEarlyFrequentPolling:
+                          description: |-
+                            set EnableCSISnapshotEarlyFrequentPolling to true to enable
+                            the 1-second polling interval for the first 10 seconds while waiting
+                            for the snaphandle
                           type: boolean
                         featureFlags:
                           description: featureFlags defines the list of features to enable for Velero instance

--- a/internal/controller/velero.go
+++ b/internal/controller/velero.go
@@ -673,7 +673,7 @@ func (r *DataProtectionApplicationReconciler) customizeVeleroContainer(veleroCon
 			Value: "true",
 		}})
 	}
-	if dpa.Spec.Configuration.Velero == nil || !dpa.Spec.Configuration.Velero.DisableCSISnapshotEarlyFrequentPolling {
+	if dpa.Spec.Configuration.Velero != nil && dpa.Spec.Configuration.Velero.EnableCSISnapshotEarlyFrequentPolling {
 		veleroContainer.Env = common.AppendUniqueEnvVars(veleroContainer.Env, []corev1.EnvVar{{
 			Name:  "CSI_SNAPSHOT_EARLY_FREQUENT_POLLING",
 			Value: "true",

--- a/internal/controller/velero_test.go
+++ b/internal/controller/velero_test.go
@@ -98,7 +98,6 @@ var (
 		},
 		{Name: common.LDLibraryPathEnvKey, Value: "/plugins"},
 		{Name: "OPENSHIFT_IMAGESTREAM_BACKUP", Value: "true"},
-		{Name: "CSI_SNAPSHOT_EARLY_FREQUENT_POLLING", Value: "true"},
 	}
 
 	baseVolumeMounts = []corev1.VolumeMount{
@@ -2575,18 +2574,17 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 					},
 					{Name: common.LDLibraryPathEnvKey, Value: "/plugins"},
 					// Note: OPENSHIFT_IMAGESTREAM_BACKUP is NOT included when BackupImages is false
-					{Name: "CSI_SNAPSHOT_EARLY_FREQUENT_POLLING", Value: "true"},
 				},
 			}),
 		},
 		{
-			name: "valid DPA CR with DisableCSISnapshotEarlyFrequentPolling true, no CSI_SNAPSHOT_EARLY_FREQUENT_POLLING",
+			name: "valid DPA CR with EnableCSISnapshotEarlyFrequentPolling true, adds CSI_SNAPSHOT_EARLY_FREQUENT_POLLING",
 			dpa: createTestDpaWith(
 				nil,
 				oadpv1alpha1.DataProtectionApplicationSpec{
 					Configuration: &oadpv1alpha1.ApplicationConfig{
 						Velero: &oadpv1alpha1.VeleroConfig{
-							DisableCSISnapshotEarlyFrequentPolling: true,
+							EnableCSISnapshotEarlyFrequentPolling: true,
 						},
 					},
 					BackupImages: ptr.To(false),
@@ -2624,6 +2622,7 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 						},
 					},
 					{Name: common.LDLibraryPathEnvKey, Value: "/plugins"},
+					{Name: "CSI_SNAPSHOT_EARLY_FREQUENT_POLLING", Value: "true"},
 				},
 			}),
 		},


### PR DESCRIPTION
## Why the changes were made

Early frequent polling is more sensitive to other configuration parameters (parallel backups, item block worker count, qps/burst) in some environments. Disable it by default to prevent perf-related regression

<!-- Explain why this PR is important, what problems it fixes, link related issues -->

## How to test the changes made

Confirm that by default, the `CSI_SNAPSHOT_EARLY_FREQUENT_POLLING` env var is not set on the velero container and that if dpa.spec.disableCSISnapshotEarlyFrequentPolling is true, then `disableCSISnapshotEarlyFrequentPolling` is also set to true.
<!-- Explain how the changes introduced by this PR can be tested and verified, with commands and pictures -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Changes**
  * Updated the DataProtectionApplication specification by replacing `DisableCSISnapshotEarlyFrequentPolling` with `EnableCSISnapshotEarlyFrequentPolling`. CSI snapshot polling is now disabled by default and requires explicit enablement in your configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->