### PR TITLE
feat: add FBC catalog Dockerfile for CI without operator-sdk (cherry-pick #2204)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,8 @@ ENVTEST_K8S_VERSION = 1.35 #refers to the version of kubebuilder assets to be do
 GOLANGCI_LINT_VERSION ?= v2.9.0
 KUSTOMIZE_VERSION ?= v5.2.1
 CONTROLLER_TOOLS_VERSION ?= v0.16.5
-OPM_VERSION ?= v1.23.0
+# Also defined in build/Dockerfile.catalog — keep in sync
+OPM_VERSION ?= v1.68.0
 BRANCH_VERSION = oadp-1.6
 PREVIOUS_CHANNEL ?= oadp-1.5
 PREVIOUS_CHANNEL_GO_VERSION ?= 1.23
@@ -416,6 +417,42 @@ catalog-build: opm ## Build a catalog image.
 	$(OPM) generate dockerfile catalog/ --binary-image=quay.io/operator-framework/opm:$(OPM_VERSION)
 	$(CONTAINER_TOOL) build --load $(DOCKER_BUILD_ARGS) -f catalog.Dockerfile -t $(CATALOG_IMG) .
 	rm -rf catalog.Dockerfile catalog/
+
+# Build a catalog image using build/Dockerfile.catalog (self-contained, used by CI).
+# Passes OPM_VERSION from this Makefile to keep the two in sync.
+#
+# Use case: test the same Dockerfile that CI uses, locally.
+#   make catalog-fbc-build BUNDLE_IMG=quay.io/konveyor/oadp-operator-bundle:latest
+#   make catalog-push
+#
+# Then install on-cluster:
+#   OLMv0 (CatalogSource + Subscription):
+#     make deploy-olm CATALOG_IMG=$(CATALOG_IMG)
+#   OLMv1 (ClusterExtension):
+#     kubectl apply -f - <<EOF
+#     apiVersion: olm.operatorframework.io/v1
+#     kind: ClusterExtension
+#     metadata:
+#       name: oadp-operator
+#     spec:
+#       source:
+#         sourceType: Catalog
+#         catalog:
+#           packageName: oadp-operator
+#       install:
+#         namespace: openshift-adp
+#         serviceAccount:
+#           name: oadp-operator-controller-manager
+#     EOF
+.PHONY: catalog-fbc-build
+catalog-fbc-build: ## Build a catalog image from build/Dockerfile.catalog.
+	$(CONTAINER_TOOL) build --load $(DOCKER_BUILD_ARGS) \
+		-f build/Dockerfile.catalog \
+		--build-arg BUNDLE_IMG=$(BUNDLE_IMG) \
+		--build-arg OPM_VERSION=$(OPM_VERSION) \
+		--build-arg VERSION=$(VERSION) \
+		--build-arg DEFAULT_CHANNEL=$(DEFAULT_CHANNEL) \
+		-t $(CATALOG_IMG) .
 
 # Push the catalog image.
 .PHONY: catalog-push

--- a/build/Dockerfile.catalog
+++ b/build/Dockerfile.catalog
@@ -1,0 +1,71 @@
+# FBC (File-Based Catalog) image for OLM operator installation.
+# Renders a bundle image into an FBC catalog with gRPC serving for OLMv0.
+# OLMv1 only needs the /configs content (no serving required).
+#
+# Usage:
+#   make catalog-fbc-build BUNDLE_IMG=<bundle-image-ref>
+#
+# Or directly:
+#   podman build -f build/Dockerfile.catalog \
+#     --build-arg BUNDLE_IMG=<bundle-image-ref> \
+#     -t <catalog-image-tag> .
+#
+# After building, push and install on-cluster:
+#   make catalog-push
+#   OLMv0: make deploy-olm CATALOG_IMG=<catalog-image-tag>
+#   OLMv1: create a ClusterExtension referencing the oadp-operator package
+#          (see Makefile catalog-fbc-build comments for full example)
+#
+# ci-operator: set BUNDLE_IMG via build_args in the ci-operator config.
+# The bundle image must be pushed to a registry accessible during the build.
+#
+# Reference: networking-incubator/coraza-kubernetes-operator catalog/Dockerfile
+
+# Keep OPM_VERSION in sync with Makefile. Override via --build-arg or `make catalog-fbc-build`.
+ARG OPM_VERSION=v1.68.0
+
+FROM quay.io/operator-framework/opm:${OPM_VERSION} AS opm
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal AS builder
+
+COPY --from=opm /bin/opm /bin/opm
+
+# Allow opm to pull bundle images from CI registries without signature verification
+RUN mkdir -p /etc/containers && \
+    echo '{"default":[{"type":"insecureAcceptAnything"}]}' > /etc/containers/policy.json
+
+ARG BUNDLE_IMG
+ARG VERSION=99.0.0
+ARG DEFAULT_CHANNEL=dev
+
+RUN test -n "${BUNDLE_IMG}" || (echo "BUNDLE_IMG build-arg is required" >&2; exit 1) && \
+    mkdir -p /configs/oadp-operator && \
+    /bin/opm render "${BUNDLE_IMG}" -o yaml > /configs/oadp-operator/index.yaml && \
+    cat >> /configs/oadp-operator/index.yaml <<EOF
+---
+schema: olm.package
+name: oadp-operator
+defaultChannel: ${DEFAULT_CHANNEL}
+---
+schema: olm.channel
+name: ${DEFAULT_CHANNEL}
+package: oadp-operator
+entries:
+  - name: oadp-operator.v${VERSION}
+EOF
+
+RUN /bin/opm validate /configs/
+
+FROM opm
+
+COPY --from=builder /configs /configs
+
+# OLMv0: pre-warm the serve cache and configure gRPC serving.
+# OLMv1 reads /configs directly from the image and does not use the serve entrypoint.
+RUN ["/bin/opm", "serve", "/configs", "--cache-dir=/tmp/cache", "--cache-only"]
+
+LABEL operators.operatorframework.io.index.configs.v1=/configs
+
+EXPOSE 50051
+ENTRYPOINT ["/bin/opm"]
+CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]

--- a/build/Dockerfile.catalog
+++ b/build/Dockerfile.catalog
@@ -35,7 +35,7 @@ RUN mkdir -p /etc/containers && \
     echo '{"default":[{"type":"insecureAcceptAnything"}]}' > /etc/containers/policy.json
 
 ARG BUNDLE_IMG
-ARG VERSION=99.0.0
+ARG VERSION=1.6.0
 ARG DEFAULT_CHANNEL=dev
 
 RUN test -n "${BUNDLE_IMG}" || (echo "BUNDLE_IMG build-arg is required" >&2; exit 1) && \


### PR DESCRIPTION
Manual cherry-pick of #2204 from `oadp-dev` to `oadp-1.6`.
Automated cherry-pick failed due to Makefile conflicts.

## Changes
- Add `build/Dockerfile.catalog` for FBC catalog image building
- Bump `OPM_VERSION` from `v1.23.0` to `v1.68.0`
- Add `catalog-fbc-build` Makefile target

> [!Note]
> Responses generated with Claude