### PR TITLE
feat: add FBC catalog Dockerfile for CI without operator-sdk (cherry-pick #2204)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -399,6 +399,8 @@ undeploy-olm: login-required ## Uninstall current branch operator via OLM
 	$(OC_CLI) create namespace $(OADP_TEST_NAMESPACE) || true
 	$(OPERATOR_SDK) cleanup oadp-operator --namespace $(OADP_TEST_NAMESPACE)
 
+# Also defined in build/Dockerfile.catalog — keep in sync
+OPM_VERSION ?= v1.68.0
 .PHONY: opm
 OPM = ./bin/opm
 opm: ## Download opm locally if necessary.
@@ -408,7 +410,7 @@ ifeq (,$(shell which opm 2>/dev/null))
 	set -e ;\
 	mkdir -p $(dir $(OPM)) ;\
 	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
-	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.15.1/$${OS}-$${ARCH}-opm ;\
+	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/$(OPM_VERSION)/$${OS}-$${ARCH}-opm ;\
 	chmod +x $(OPM) ;\
 	}
 else
@@ -439,6 +441,42 @@ catalog-build: opm ## Build a catalog image.
 # opm upgrade
 catalog-build-replaces: opm ## Build a catalog image using replace mode
 	$(OPM) index add --container-tool docker --mode replaces --tag $(CATALOG_IMG) --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT)
+
+# Build a catalog image using build/Dockerfile.catalog (self-contained, used by CI).
+# Passes OPM_VERSION from this Makefile to keep the two in sync.
+#
+# Use case: test the same Dockerfile that CI uses, locally.
+#   make catalog-fbc-build BUNDLE_IMG=quay.io/konveyor/oadp-operator-bundle:latest
+#   make catalog-push
+#
+# Then install on-cluster:
+#   OLMv0 (CatalogSource + Subscription):
+#     make deploy-olm CATALOG_IMG=$(CATALOG_IMG)
+#   OLMv1 (ClusterExtension):
+#     kubectl apply -f - <<EOF
+#     apiVersion: olm.operatorframework.io/v1
+#     kind: ClusterExtension
+#     metadata:
+#       name: oadp-operator
+#     spec:
+#       source:
+#         sourceType: Catalog
+#         catalog:
+#           packageName: oadp-operator
+#       install:
+#         namespace: openshift-adp
+#         serviceAccount:
+#           name: oadp-operator-controller-manager
+#     EOF
+.PHONY: catalog-fbc-build
+catalog-fbc-build: ## Build a catalog image from build/Dockerfile.catalog.
+	docker build --load $(DOCKER_BUILD_ARGS) \
+		-f build/Dockerfile.catalog \
+		--build-arg BUNDLE_IMG=$(BUNDLE_IMG) \
+		--build-arg OPM_VERSION=$(OPM_VERSION) \
+		--build-arg VERSION=$(VERSION) \
+		--build-arg DEFAULT_CHANNEL=$(DEFAULT_CHANNEL) \
+		-t $(CATALOG_IMG) .
 
 # Push the catalog image.
 .PHONY: catalog-push

--- a/build/Dockerfile.catalog
+++ b/build/Dockerfile.catalog
@@ -1,0 +1,71 @@
+# FBC (File-Based Catalog) image for OLM operator installation.
+# Renders a bundle image into an FBC catalog with gRPC serving for OLMv0.
+# OLMv1 only needs the /configs content (no serving required).
+#
+# Usage:
+#   make catalog-fbc-build BUNDLE_IMG=<bundle-image-ref>
+#
+# Or directly:
+#   podman build -f build/Dockerfile.catalog \
+#     --build-arg BUNDLE_IMG=<bundle-image-ref> \
+#     -t <catalog-image-tag> .
+#
+# After building, push and install on-cluster:
+#   make catalog-push
+#   OLMv0: make deploy-olm CATALOG_IMG=<catalog-image-tag>
+#   OLMv1: create a ClusterExtension referencing the oadp-operator package
+#          (see Makefile catalog-fbc-build comments for full example)
+#
+# ci-operator: set BUNDLE_IMG via build_args in the ci-operator config.
+# The bundle image must be pushed to a registry accessible during the build.
+#
+# Reference: networking-incubator/coraza-kubernetes-operator catalog/Dockerfile
+
+# Keep OPM_VERSION in sync with Makefile. Override via --build-arg or `make catalog-fbc-build`.
+ARG OPM_VERSION=v1.68.0
+
+FROM quay.io/operator-framework/opm:${OPM_VERSION} AS opm
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal AS builder
+
+COPY --from=opm /bin/opm /bin/opm
+
+# Allow opm to pull bundle images from CI registries without signature verification
+RUN mkdir -p /etc/containers && \
+    echo '{"default":[{"type":"insecureAcceptAnything"}]}' > /etc/containers/policy.json
+
+ARG BUNDLE_IMG
+ARG VERSION=99.0.0
+ARG DEFAULT_CHANNEL=dev
+
+RUN test -n "${BUNDLE_IMG}" || (echo "BUNDLE_IMG build-arg is required" >&2; exit 1) && \
+    mkdir -p /configs/oadp-operator && \
+    /bin/opm render "${BUNDLE_IMG}" -o yaml > /configs/oadp-operator/index.yaml && \
+    cat >> /configs/oadp-operator/index.yaml <<EOF
+---
+schema: olm.package
+name: oadp-operator
+defaultChannel: ${DEFAULT_CHANNEL}
+---
+schema: olm.channel
+name: ${DEFAULT_CHANNEL}
+package: oadp-operator
+entries:
+  - name: oadp-operator.v${VERSION}
+EOF
+
+RUN /bin/opm validate /configs/
+
+FROM opm
+
+COPY --from=builder /configs /configs
+
+# OLMv0: pre-warm the serve cache and configure gRPC serving.
+# OLMv1 reads /configs directly from the image and does not use the serve entrypoint.
+RUN ["/bin/opm", "serve", "/configs", "--cache-dir=/tmp/cache", "--cache-only"]
+
+LABEL operators.operatorframework.io.index.configs.v1=/configs
+
+EXPOSE 50051
+ENTRYPOINT ["/bin/opm"]
+CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]

--- a/build/Dockerfile.catalog
+++ b/build/Dockerfile.catalog
@@ -35,7 +35,7 @@ RUN mkdir -p /etc/containers && \
     echo '{"default":[{"type":"insecureAcceptAnything"}]}' > /etc/containers/policy.json
 
 ARG BUNDLE_IMG
-ARG VERSION=99.0.0
+ARG VERSION=1.3.9
 ARG DEFAULT_CHANNEL=dev
 
 RUN test -n "${BUNDLE_IMG}" || (echo "BUNDLE_IMG build-arg is required" >&2; exit 1) && \


### PR DESCRIPTION
Manual cherry-pick of #2204 from `oadp-dev` to `oadp-1.3`.
Automated cherry-pick failed due to Makefile conflicts.

## Changes
- Add `build/Dockerfile.catalog` for FBC catalog image building
- Add `OPM_VERSION` variable (`v1.68.0`), replacing hardcoded `v1.15.1` in opm download URL
- Add `catalog-fbc-build` Makefile target

> [!Note]
> Responses generated with Claude