### PR TITLE
[oadp-1.4] disable early frequent polling by default

### DIFF
--- a/api/v1alpha1/oadp_types.go
+++ b/api/v1alpha1/oadp_types.go
@@ -119,11 +119,11 @@ type VeleroConfig struct {
 	// Velero args are settings to customize velero server arguments. Overrides values in other fields.
 	// +optional
 	Args *server.Args `json:"args,omitempty"`
-	// set DisableCSISnapshotEarlyFrequentPolling to true to omit
+	// set EnableCSISnapshotEarlyFrequentPolling to true to enable
 	// the 1-second polling interval for the first 10 seconds while waiting
 	// for the snaphandle
 	// +optional
-	DisableCSISnapshotEarlyFrequentPolling bool `json:"disableCSISnapshotEarlyFrequentPolling,omitempty"`
+	EnableCSISnapshotEarlyFrequentPolling bool `json:"enableCSISnapshotEarlyFrequentPolling,omitempty"`
 }
 
 // PodConfig defines the pod configuration options

--- a/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
@@ -829,14 +829,14 @@ spec:
                         defaultVolumesToFSBackup:
                           description: Use pod volume file system backup by default for volumes
                           type: boolean
-                        disableCSISnapshotEarlyFrequentPolling:
-                          description: |-
-                            set DisableCSISnapshotEarlyFrequentPolling to true to omit
-                            the 1-second polling interval for the first 10 seconds while waiting
-                            for the snaphandle
-                          type: boolean
                         disableInformerCache:
                           description: Disable informer cache for Get calls on restore. With this enabled, it will speed up restore in cases where there are backup resources which already exist in the cluster, but for very large clusters this will increase velero memory usage. Default is false.
+                          type: boolean
+                        enableCSISnapshotEarlyFrequentPolling:
+                          description: |-
+                            set EnableCSISnapshotEarlyFrequentPolling to true to enable
+                            the 1-second polling interval for the first 10 seconds while waiting
+                            for the snaphandle
                           type: boolean
                         featureFlags:
                           description: featureFlags defines the list of features to enable for Velero instance

--- a/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
@@ -829,14 +829,14 @@ spec:
                         defaultVolumesToFSBackup:
                           description: Use pod volume file system backup by default for volumes
                           type: boolean
-                        disableCSISnapshotEarlyFrequentPolling:
-                          description: |-
-                            set DisableCSISnapshotEarlyFrequentPolling to true to omit
-                            the 1-second polling interval for the first 10 seconds while waiting
-                            for the snaphandle
-                          type: boolean
                         disableInformerCache:
                           description: Disable informer cache for Get calls on restore. With this enabled, it will speed up restore in cases where there are backup resources which already exist in the cluster, but for very large clusters this will increase velero memory usage. Default is false.
+                          type: boolean
+                        enableCSISnapshotEarlyFrequentPolling:
+                          description: |-
+                            set EnableCSISnapshotEarlyFrequentPolling to true to enable
+                            the 1-second polling interval for the first 10 seconds while waiting
+                            for the snaphandle
                           type: boolean
                         featureFlags:
                           description: featureFlags defines the list of features to enable for Velero instance

--- a/controllers/velero.go
+++ b/controllers/velero.go
@@ -552,7 +552,7 @@ func (r *DPAReconciler) customizeVeleroContainer(dpa *oadpv1alpha1.DataProtectio
 			Value: "true",
 		}})
 	}
-	if dpa.Spec.Configuration.Velero == nil || !dpa.Spec.Configuration.Velero.DisableCSISnapshotEarlyFrequentPolling {
+	if dpa.Spec.Configuration.Velero != nil && dpa.Spec.Configuration.Velero.EnableCSISnapshotEarlyFrequentPolling {
 		veleroContainer.Env = common.AppendUniqueEnvVars(veleroContainer.Env, []corev1.EnvVar{{
 			Name:  "CSI_SNAPSHOT_EARLY_FREQUENT_POLLING",
 			Value: "true",

--- a/controllers/velero_test.go
+++ b/controllers/velero_test.go
@@ -91,7 +91,6 @@ var (
 		},
 		{Name: common.LDLibraryPathEnvKey, Value: "/plugins"},
 		{Name: "OPENSHIFT_IMAGESTREAM_BACKUP", Value: "true"},
-		{Name: "CSI_SNAPSHOT_EARLY_FREQUENT_POLLING", Value: "true"},
 	}
 
 	baseVolumeMounts = []corev1.VolumeMount{


### PR DESCRIPTION
## Why the changes were made
Early frequent polling is more sensitive to other configuration parameters (parallel backups, item block worker count, qps/burst) in some environments. Disable it by default to prevent perf-related regression


<!-- Explain why this PR is important, what problems it fixes, link related issues -->

## How to test the changes made

<!-- Explain how the changes introduced by this PR can be tested and verified, with commands and pictures -->
