### PR TITLE
public velero ref 1.18.1 to match openshift/velero replace

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/kubernetes-csi/external-snapshotter/client/v6 v6.3.0
 	github.com/stretchr/testify v1.11.1
-	github.com/vmware-tanzu/velero v1.14.0
+	github.com/vmware-tanzu/velero v1.18.1
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
 	google.golang.org/api v0.277.0
 	k8s.io/klog/v2 v2.130.1


### PR DESCRIPTION
## Why the changes were made

The replace is pointing to the Openshift fork of Velero 1.18.1 but the advertised dependency is Velero 1.14.

This causes all downstream use to need a replace statement to use the appropriate api versions.

## How to test the changes made

Changes only to go.mod and there is a replace in go.mod. Code and unit tests should be unaffected. Build should be enough test this along with using the branch as a go import.
