### PR TITLE
OADP-7541: fix non-deterministic matchExpressions ordering causing node-agent restarts

### DIFF
--- a/internal/controller/nodeagent.go
+++ b/internal/controller/nodeagent.go
@@ -324,6 +324,7 @@ func (r *DataProtectionApplicationReconciler) ReconcileNodeAgentDaemonset(log lo
 					terms = append(terms, a.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms...)
 				}
 			}
+			common.SortNodeSelectorTerms(terms)
 			if len(terms) > 0 {
 				ds.Spec.Template.Spec.Affinity = &corev1.Affinity{
 					NodeAffinity: &corev1.NodeAffinity{

--- a/internal/controller/nodeagent_test.go
+++ b/internal/controller/nodeagent_test.go
@@ -2771,3 +2771,69 @@ func TestDPAReconciler_buildNodeAgentDaemonsetWithAzureWorkloadIdentity(t *testi
 		})
 	}
 }
+
+// TestNodeAgentAffinityMatchExpressionsDeterministicOrder verifies that
+// matchExpressions built from a multi-label NodeSelector are always sorted
+// by key, preventing non-deterministic DaemonSet spec changes that cause
+// unnecessary node-agent pod restarts. See OADP-7541.
+func TestNodeAgentAffinityMatchExpressionsDeterministicOrder(t *testing.T) {
+	tests := []struct {
+		name        string
+		matchLabels map[string]string
+		wantKeys    []string
+	}{
+		{
+			name: "two labels matching customer config from OADP-7541",
+			matchLabels: map[string]string{
+				"network":                        "int",
+				"node-role.kubernetes.io/infra":   "",
+			},
+			wantKeys: []string{"network", "node-role.kubernetes.io/infra"},
+		},
+		{
+			name: "three labels to verify sorting with more keys",
+			matchLabels: map[string]string{
+				"zone":                           "us-east-1a",
+				"disk-type":                      "ssd",
+				"node-role.kubernetes.io/worker":  "",
+			},
+			wantKeys: []string{"disk-type", "node-role.kubernetes.io/worker", "zone"},
+		},
+		{
+			name: "single label is trivially stable",
+			matchLabels: map[string]string{
+				"node-role.kubernetes.io/infra": "",
+			},
+			wantKeys: []string{"node-role.kubernetes.io/infra"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for i := 0; i < 100; i++ {
+				la := &kube.LoadAffinity{
+					NodeSelector: metav1.LabelSelector{
+						MatchLabels: tt.matchLabels,
+					},
+				}
+				affinity := kube.ToSystemAffinity(la, nil)
+				require.NotNil(t, affinity, "iteration %d: affinity should not be nil", i)
+
+				terms := affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+				require.Len(t, terms, 1, "iteration %d: expected 1 NodeSelectorTerm", i)
+
+				common.SortNodeSelectorTerms(terms)
+
+				exprs := terms[0].MatchExpressions
+				require.Len(t, exprs, len(tt.wantKeys), "iteration %d: wrong number of matchExpressions", i)
+
+				gotKeys := make([]string, len(exprs))
+				for j, expr := range exprs {
+					gotKeys[j] = expr.Key
+				}
+				require.Equal(t, tt.wantKeys, gotKeys,
+					"iteration %d: matchExpressions keys not in sorted order", i)
+			}
+		})
+	}
+}

--- a/internal/controller/nodeagent_test.go
+++ b/internal/controller/nodeagent_test.go
@@ -2785,8 +2785,8 @@ func TestNodeAgentAffinityMatchExpressionsDeterministicOrder(t *testing.T) {
 		{
 			name: "two labels matching customer config from OADP-7541",
 			matchLabels: map[string]string{
-				"network":                        "int",
-				"node-role.kubernetes.io/infra":   "",
+				"network":                       "int",
+				"node-role.kubernetes.io/infra": "",
 			},
 			wantKeys: []string{"network", "node-role.kubernetes.io/infra"},
 		},
@@ -2795,7 +2795,7 @@ func TestNodeAgentAffinityMatchExpressionsDeterministicOrder(t *testing.T) {
 			matchLabels: map[string]string{
 				"zone":                           "us-east-1a",
 				"disk-type":                      "ssd",
-				"node-role.kubernetes.io/worker":  "",
+				"node-role.kubernetes.io/worker": "",
 			},
 			wantKeys: []string{"disk-type", "node-role.kubernetes.io/worker", "zone"},
 		},

--- a/internal/controller/velero.go
+++ b/internal/controller/velero.go
@@ -295,6 +295,7 @@ func (r *DataProtectionApplicationReconciler) customizeVeleroDeployment(veleroDe
 				terms = append(terms, a.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms...)
 			}
 		}
+		common.SortNodeSelectorTerms(terms)
 		if len(terms) > 0 {
 			veleroDeployment.Spec.Template.Spec.Affinity = &corev1.Affinity{
 				NodeAffinity: &corev1.NodeAffinity{

--- a/internal/controller/velero_test.go
+++ b/internal/controller/velero_test.go
@@ -23,7 +23,9 @@ import (
 	"github.com/onsi/gomega"
 	"github.com/operator-framework/operator-lib/proxy"
 	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	"github.com/vmware-tanzu/velero/pkg/util/kube"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -4186,5 +4188,41 @@ func TestApplyResourceAnnotations(t *testing.T) {
 				t.Errorf("applyResourceAnnotations() = %v, expected %v", result, tt.expectedAnnotations)
 			}
 		})
+	}
+}
+
+// TestVeleroAffinityMatchExpressionsDeterministicOrder verifies that
+// matchExpressions built from a multi-label NodeSelector are always sorted
+// by key, preventing non-deterministic Deployment spec changes. See OADP-7541.
+func TestVeleroAffinityMatchExpressionsDeterministicOrder(t *testing.T) {
+	matchLabels := map[string]string{
+		"network":                      "int",
+		"node-role.kubernetes.io/infra": "",
+	}
+	wantKeys := []string{"network", "node-role.kubernetes.io/infra"}
+
+	for i := 0; i < 100; i++ {
+		la := &kube.LoadAffinity{
+			NodeSelector: metav1.LabelSelector{
+				MatchLabels: matchLabels,
+			},
+		}
+		affinity := kube.ToSystemAffinity(la, nil)
+		require.NotNil(t, affinity, "iteration %d: affinity should not be nil", i)
+
+		terms := affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+		require.Len(t, terms, 1, "iteration %d: expected 1 NodeSelectorTerm", i)
+
+		common.SortNodeSelectorTerms(terms)
+
+		exprs := terms[0].MatchExpressions
+		require.Len(t, exprs, len(wantKeys), "iteration %d: wrong number of matchExpressions", i)
+
+		gotKeys := make([]string, len(exprs))
+		for j, expr := range exprs {
+			gotKeys[j] = expr.Key
+		}
+		require.Equal(t, wantKeys, gotKeys,
+			"iteration %d: matchExpressions keys not in sorted order", i)
 	}
 }

--- a/internal/controller/velero_test.go
+++ b/internal/controller/velero_test.go
@@ -4196,7 +4196,7 @@ func TestApplyResourceAnnotations(t *testing.T) {
 // by key, preventing non-deterministic Deployment spec changes. See OADP-7541.
 func TestVeleroAffinityMatchExpressionsDeterministicOrder(t *testing.T) {
 	matchLabels := map[string]string{
-		"network":                      "int",
+		"network":                       "int",
 		"node-role.kubernetes.io/infra": "",
 	}
 	wantKeys := []string{"network", "node-role.kubernetes.io/infra"}

--- a/internal/controller/velero_test.go
+++ b/internal/controller/velero_test.go
@@ -2098,11 +2098,6 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 					{
 						MatchExpressions: []corev1.NodeSelectorRequirement{
 							{
-								Key:      "zone",
-								Operator: corev1.NodeSelectorOpIn,
-								Values:   []string{"east"},
-							},
-							{
 								Key:      "disk-type",
 								Operator: corev1.NodeSelectorOpIn,
 								Values:   []string{"ssd", "nvme"},
@@ -2111,19 +2106,24 @@ func TestDPAReconciler_buildVeleroDeployment(t *testing.T) {
 								Key:      "gpu",
 								Operator: corev1.NodeSelectorOpDoesNotExist,
 							},
+							{
+								Key:      "zone",
+								Operator: corev1.NodeSelectorOpIn,
+								Values:   []string{"east"},
+							},
 						},
 					},
 					{
 						MatchExpressions: []corev1.NodeSelectorRequirement{
 							{
-								Key:      "instance-type",
-								Operator: corev1.NodeSelectorOpIn,
-								Values:   []string{"m5.large", "m5.xlarge"},
-							},
-							{
 								Key:      "environment",
 								Operator: corev1.NodeSelectorOpNotIn,
 								Values:   []string{"dev"},
+							},
+							{
+								Key:      "instance-type",
+								Operator: corev1.NodeSelectorOpIn,
+								Values:   []string{"m5.large", "m5.xlarge"},
 							},
 						},
 					},

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -1,8 +1,10 @@
 package common
 
 import (
+	"cmp"
 	"fmt"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 
@@ -373,4 +375,17 @@ func UpdateBackupStorageLocation(bsl *velerov1.BackupStorageLocation, bslSpec ve
 	bsl.Spec = bslSpec
 
 	return nil
+}
+
+// SortNodeSelectorTerms sorts MatchExpressions by key within each
+// NodeSelectorTerm to ensure deterministic ordering. Without this,
+// Go map iteration randomness in upstream kube.ToSystemAffinity
+// produces non-deterministic matchExpressions order, which Kubernetes
+// treats as a spec change and triggers unnecessary DaemonSet rollouts.
+func SortNodeSelectorTerms(terms []corev1.NodeSelectorTerm) {
+	for i := range terms {
+		slices.SortFunc(terms[i].MatchExpressions, func(a, b corev1.NodeSelectorRequirement) int {
+			return cmp.Compare(a.Key, b.Key)
+		})
+	}
 }

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -377,15 +377,17 @@ func UpdateBackupStorageLocation(bsl *velerov1.BackupStorageLocation, bslSpec ve
 	return nil
 }
 
-// SortNodeSelectorTerms sorts MatchExpressions by key within each
-// NodeSelectorTerm to ensure deterministic ordering. Without this,
-// Go map iteration randomness in upstream kube.ToSystemAffinity
-// produces non-deterministic matchExpressions order, which Kubernetes
-// treats as a spec change and triggers unnecessary DaemonSet rollouts.
+// SortNodeSelectorTerms sorts MatchExpressions and MatchFields by key
+// within each NodeSelectorTerm to ensure deterministic ordering. Without
+// this, Go map iteration randomness in upstream kube.ToSystemAffinity
+// produces non-deterministic ordering, which Kubernetes treats as a spec
+// change and triggers unnecessary DaemonSet rollouts.
 func SortNodeSelectorTerms(terms []corev1.NodeSelectorTerm) {
+	cmpKey := func(a, b corev1.NodeSelectorRequirement) int {
+		return cmp.Compare(a.Key, b.Key)
+	}
 	for i := range terms {
-		slices.SortFunc(terms[i].MatchExpressions, func(a, b corev1.NodeSelectorRequirement) int {
-			return cmp.Compare(a.Key, b.Key)
-		})
+		slices.SortFunc(terms[i].MatchExpressions, cmpKey)
+		slices.SortFunc(terms[i].MatchFields, cmpKey)
 	}
 }


### PR DESCRIPTION
## Summary
- When a DPA configures `nodeAgent.podConfig.nodeSelector` with multiple labels, `kube.ToSystemAffinity()` iterates Go maps in random order to build `matchExpressions`. Kubernetes treats arrays as ordered, so each order flip registers as a spec change, triggering DaemonSet rollouts every reconciliation (~30s). Customer observed generation **13858** on node-agent while velero deployment stayed at **2**.
- Adds `common.SortNodeSelectorTerms()` helper that sorts `MatchExpressions` by key within each `NodeSelectorTerm`
- Applied to both node-agent DaemonSet and Velero Deployment code paths
- Unit tests run 100 iterations with multi-label selectors to verify deterministic ordering

## Test plan
- [x] New unit tests pass: `TestNodeAgentAffinityMatchExpressionsDeterministicOrder` (3 sub-cases × 100 iterations)
- [x] New unit tests pass: `TestVeleroAffinityMatchExpressionsDeterministicOrder` (100 iterations)
- [x] Tests run with `-count=5` for additional confidence
- [x] All files compile cleanly
- [ ] E2E: deploy with multi-label nodeSelector, verify node-agent generation stays stable

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Node affinity match expressions for NodeAgent and Velero are now deterministically ordered, preventing non-deterministic pod/deployment spec diffs and ensuring consistent scheduling.

* **Tests**
  * Added unit tests that repeatedly validate deterministic ordering of node affinity match expressions across multi-label scenarios to guard against nondeterminism.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->