### PR TITLE
oadp-1.5: Update hypershift image ref

### DIFF
--- a/bundle/image-references
+++ b/bundle/image-references
@@ -46,4 +46,4 @@ spec:
   - name: oadp-hypershift-velero-plugin-rhel9
     from:
       kind: DockerImage
-      name: quay.io/konveyor/hypershift-oadp-plugin:oadp-1.6
+      name: quay.io/konveyor/hypershift-oadp-plugin:oadp-1.5

--- a/bundle/image-references
+++ b/bundle/image-references
@@ -46,4 +46,4 @@ spec:
   - name: oadp-hypershift-velero-plugin-rhel9
     from:
       kind: DockerImage
-      name: quay.io/redhat-user-workloads/ocp-art-tenant/oadp-hypershift-oadp-plugin-oadp-1-5:oadp-1.5
+      name: quay.io/konveyor/hypershift-oadp-plugin:oadp-1.6

--- a/bundle/manifests/oadp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/oadp-operator.clusterserviceversion.yaml
@@ -1125,7 +1125,7 @@ spec:
                 - name: RELATED_IMAGE_KUBEVIRT_VELERO_PLUGIN
                   value: quay.io/konveyor/kubevirt-velero-plugin:v0.7.0
                 - name: RELATED_IMAGE_HYPERSHIFT_VELERO_PLUGIN
-                  value: quay.io/redhat-user-workloads/ocp-art-tenant/oadp-hypershift-oadp-plugin-oadp-1-5:oadp-1.5
+                  value: quay.io/konveyor/hypershift-oadp-plugin:oadp-1.5
                 - name: RELATED_IMAGE_MUSTGATHER
                   value: quay.io/konveyor/oadp-must-gather:oadp-1.5
                 - name: RELATED_IMAGE_NON_ADMIN_CONTROLLER
@@ -1286,7 +1286,7 @@ spec:
     name: velero-plugin-for-gcp
   - image: quay.io/konveyor/kubevirt-velero-plugin:v0.7.0
     name: kubevirt-velero-plugin
-  - image: quay.io/redhat-user-workloads/ocp-art-tenant/oadp-hypershift-oadp-plugin-oadp-1-5:oadp-1.5
+  - image: quay.io/konveyor/hypershift-oadp-plugin:oadp-1.5
     name: hypershift-velero-plugin
   - image: quay.io/konveyor/oadp-must-gather:oadp-1.5
     name: mustgather

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -77,7 +77,7 @@ spec:
             - name: RELATED_IMAGE_KUBEVIRT_VELERO_PLUGIN
               value: quay.io/konveyor/kubevirt-velero-plugin:v0.7.0
             - name: RELATED_IMAGE_HYPERSHIFT_VELERO_PLUGIN
-              value: quay.io/redhat-user-workloads/ocp-art-tenant/oadp-hypershift-oadp-plugin-oadp-1-5:oadp-1.5
+              value: quay.io/konveyor/hypershift-oadp-plugin:oadp-1.5
             - name: RELATED_IMAGE_MUSTGATHER
               value: quay.io/konveyor/oadp-must-gather:oadp-1.5
             - name: RELATED_IMAGE_NON_ADMIN_CONTROLLER

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -74,7 +74,7 @@ const (
 	GCPPluginImage        = "quay.io/konveyor/velero-plugin-for-gcp:latest"
 	RegistryImage         = "quay.io/konveyor/registry:latest"
 	KubeVirtPluginImage   = "quay.io/konveyor/kubevirt-velero-plugin:v0.7.0"
-	HypershiftPluginImage = "quay.io/redhat-user-workloads/ocp-art-tenant/oadp-hypershift-oadp-plugin-oadp-1-5:oadp-1.5"
+	HypershiftPluginImage = "quay.io/konveyor/hypershift-oadp-plugin:oadp-1.5"
 )
 
 // Plugin names

--- a/pkg/credentials/credentials_test.go
+++ b/pkg/credentials/credentials_test.go
@@ -464,9 +464,9 @@ func TestCredentials_getPluginImage(t *testing.T) {
 				},
 			},
 			pluginName: oadpv1alpha1.DefaultPluginHypershift,
-			wantImage:  "quay.io/redhat-user-workloads/ocp-art-tenant/oadp-hypershift-oadp-plugin-oadp-1-5:oadp-1.5",
+			wantImage:  "quay.io/konveyor/hypershift-oadp-plugin:oadp-1.5",
 			setEnvVars: map[string]string{
-				"RELATED_IMAGE_HYPERSHIFT_VELERO_PLUGIN": "quay.io/redhat-user-workloads/ocp-art-tenant/oadp-hypershift-oadp-plugin-oadp-1-5:oadp-1.5",
+				"RELATED_IMAGE_HYPERSHIFT_VELERO_PLUGIN": "quay.io/konveyor/hypershift-oadp-plugin:oadp-1.5",
 			},
 		},
 	}

--- a/tests/e2e/lib/hcp/dpa.go
+++ b/tests/e2e/lib/hcp/dpa.go
@@ -41,7 +41,7 @@ func (h *HCHandler) AddHCPPluginToDPA(namespace, name string, overrides bool) er
 
 	if overrides {
 		dpa.Spec.UnsupportedOverrides = map[oadpv1alpha1.UnsupportedImageKey]string{
-			oadpv1alpha1.HypershiftPluginImageKey: "quay.io/redhat-user-workloads/ocp-art-tenant/oadp-hypershift-oadp-plugin-oadp-1-5:oadp-1.5",
+			oadpv1alpha1.HypershiftPluginImageKey: "quay.io/konveyor/hypershift-oadp-plugin:oadp-1.5",
 		}
 	}
 

--- a/tests/e2e/lib/hcp/dpa_test.go
+++ b/tests/e2e/lib/hcp/dpa_test.go
@@ -146,7 +146,7 @@ func TestRemoveHCPPluginFromDPA(t *testing.T) {
 						},
 					},
 					UnsupportedOverrides: map[oadpv1alpha1.UnsupportedImageKey]string{
-						oadpv1alpha1.HypershiftPluginImageKey: "quay.io/redhat-user-workloads/ocp-art-tenant/oadp-hypershift-oadp-plugin-oadp-1-5:oadp-1.5",
+						oadpv1alpha1.HypershiftPluginImageKey: "quay.io/konveyor/hypershift-oadp-plugin:oadp-1.5",
 					},
 				},
 			},


### PR DESCRIPTION
## Why the changes were made

Updates the ref to point to the newly setup images for 1.5

## How to test the changes made

oadp-operator@1.5 should now not crash since the image is present at this newly updated dest