### PR TITLE
OADP-4817, OADP-1945, OADP-641: Add AWS_CA_BUNDLE support for custom CA certificates in BSLs

### DIFF
--- a/controllers/bsl.go
+++ b/controllers/bsl.go
@@ -487,3 +487,69 @@ func (r *DPAReconciler) ensureSecretDataExists(dpa *oadpv1alpha1.DataProtectionA
 	}
 	return nil
 }
+
+// processCACertForBSLs creates a ConfigMap containing CA certificates from BackupStorageLocations.
+// Returns the ConfigMap name if certificates were found, empty string otherwise.
+func (r *DPAReconciler) processCACertForBSLs(dpa *oadpv1alpha1.DataProtectionApplication) (string, error) {
+	var caCertData []byte
+
+	for _, bslSpec := range dpa.Spec.BackupLocations {
+		var caCert []byte
+
+		if bslSpec.Velero != nil && bslSpec.Velero.ObjectStorage != nil {
+			caCert = bslSpec.Velero.ObjectStorage.CACert
+		}
+		if bslSpec.CloudStorage != nil {
+			caCert = bslSpec.CloudStorage.CACert
+		}
+
+		if len(caCert) > 0 {
+			caCertData = append(caCertData, caCert...)
+			caCertData = append(caCertData, '\n')
+		}
+	}
+
+	if len(caCertData) == 0 {
+		return "", nil
+	}
+
+	configMapName := caBundleConfigMapName
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configMapName,
+			Namespace: dpa.Namespace,
+		},
+	}
+
+	op, err := controllerutil.CreateOrPatch(r.Context, r.Client, configMap, func() error {
+		if configMap.Labels == nil {
+			configMap.Labels = make(map[string]string)
+		}
+		configMap.Labels["app.kubernetes.io/name"] = common.Velero
+		configMap.Labels["app.kubernetes.io/managed-by"] = common.OADPOperator
+		configMap.Labels["app.kubernetes.io/component"] = "ca-bundle"
+		configMap.Labels[oadpv1alpha1.OadpOperatorLabel] = "True"
+
+		if configMap.Data == nil {
+			configMap.Data = make(map[string]string)
+		}
+		configMap.Data[caBundleFileName] = string(caCertData)
+
+		return nil
+	})
+
+	if err != nil {
+		return "", fmt.Errorf("failed to create/update CA bundle ConfigMap: %w", err)
+	}
+
+	if op == controllerutil.OperationResultCreated || op == controllerutil.OperationResultUpdated {
+		r.Log.Info("CA certificate ConfigMap processed", "configMap", configMapName, "operation", op)
+		r.EventRecorder.Event(configMap,
+			corev1.EventTypeNormal,
+			"CACertificateConfigMapReconciled",
+			fmt.Sprintf("performed %s on CA certificate ConfigMap %s/%s", op, configMap.Namespace, configMap.Name),
+		)
+	}
+
+	return configMapName, nil
+}

--- a/controllers/bsl_test.go
+++ b/controllers/bsl_test.go
@@ -2591,3 +2591,146 @@ func TestDPAReconciler_ReconcileBackupStorageLocations(t *testing.T) {
 		})
 	}
 }
+
+func TestProcessCACertForBSLs(t *testing.T) {
+	testCACertPEM := `-----BEGIN CERTIFICATE-----
+MIIDNzCCAh+gAwIBAgIJAJ7qAHESwpNwMA0GCSqGSIb3DQEBCwUAMDMxMTAvBgNV
+BAMMKGVjMi01NC0yMTEtOC0yNDguY29tcHV0ZS0xLmFtYXpvbmF3cy5jb20wHhcN
+MjUwMTI0MTcxNjQyWhcNMjYwMTI0MTcxNjQyWjAzMTEwLwYDVQQDDChlYzItNTQt
+-----END CERTIFICATE-----`
+
+	tests := []struct {
+		name              string
+		backupLocations   []oadpv1alpha1.BackupLocation
+		wantConfigMapName string
+		wantError         bool
+	}{
+		{
+			name: "BSL with Velero CA certificate",
+			backupLocations: []oadpv1alpha1.BackupLocation{
+				{
+					Velero: &velerov1.BackupStorageLocationSpec{
+						Provider: "aws",
+						StorageType: velerov1.StorageType{
+							ObjectStorage: &velerov1.ObjectStorageLocation{
+								Bucket: "test-bucket",
+								CACert: []byte(testCACertPEM),
+							},
+						},
+					},
+				},
+			},
+			wantConfigMapName: caBundleConfigMapName,
+			wantError:         false,
+		},
+		{
+			name: "BSL with CloudStorage CA certificate",
+			backupLocations: []oadpv1alpha1.BackupLocation{
+				{
+					CloudStorage: &oadpv1alpha1.CloudStorageLocation{
+						CloudStorageRef: corev1.LocalObjectReference{Name: "test-bucket"},
+						CACert:          []byte(testCACertPEM),
+					},
+				},
+			},
+			wantConfigMapName: caBundleConfigMapName,
+			wantError:         false,
+		},
+		{
+			name: "BSL without CA certificate",
+			backupLocations: []oadpv1alpha1.BackupLocation{
+				{
+					Velero: &velerov1.BackupStorageLocationSpec{
+						Provider: "aws",
+						StorageType: velerov1.StorageType{
+							ObjectStorage: &velerov1.ObjectStorageLocation{
+								Bucket: "test-bucket",
+							},
+						},
+					},
+				},
+			},
+			wantConfigMapName: "",
+			wantError:         false,
+		},
+		{
+			name:              "No backup locations",
+			backupLocations:   []oadpv1alpha1.BackupLocation{},
+			wantConfigMapName: "",
+			wantError:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dpa := &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-dpa",
+					Namespace: "test-ns",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					BackupLocations: tt.backupLocations,
+				},
+			}
+
+			fakeClient, err := getFakeClientFromObjects(dpa)
+			if err != nil {
+				t.Fatalf("error creating fake client: %v", err)
+			}
+
+			r := &DPAReconciler{
+				Client:        fakeClient,
+				Scheme:        fakeClient.Scheme(),
+				Log:           logr.Discard(),
+				Context:       context.Background(),
+				EventRecorder: record.NewFakeRecorder(10),
+				NamespacedName: types.NamespacedName{
+					Name:      dpa.Name,
+					Namespace: dpa.Namespace,
+				},
+			}
+
+			gotConfigMapName, err := r.processCACertForBSLs(dpa)
+
+			if tt.wantError {
+				if err == nil {
+					t.Errorf("expected error but got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if gotConfigMapName != tt.wantConfigMapName {
+				t.Errorf("expected ConfigMap name %q, got %q", tt.wantConfigMapName, gotConfigMapName)
+			}
+
+			if tt.wantConfigMapName != "" {
+				configMap := &corev1.ConfigMap{}
+				err := fakeClient.Get(context.Background(), types.NamespacedName{
+					Name:      tt.wantConfigMapName,
+					Namespace: dpa.Namespace,
+				}, configMap)
+				if err != nil {
+					t.Fatalf("expected ConfigMap to exist: %v", err)
+				}
+
+				if _, ok := configMap.Data[caBundleFileName]; !ok {
+					t.Error("ConfigMap missing ca-bundle.pem data key")
+				}
+
+				if configMap.Labels["app.kubernetes.io/name"] != "velero" {
+					t.Errorf("expected label app.kubernetes.io/name=velero, got %s", configMap.Labels["app.kubernetes.io/name"])
+				}
+				if configMap.Labels["app.kubernetes.io/component"] != "ca-bundle" {
+					t.Errorf("expected label app.kubernetes.io/component=ca-bundle, got %s", configMap.Labels["app.kubernetes.io/component"])
+				}
+				if configMap.Labels[oadpv1alpha1.OadpOperatorLabel] != "True" {
+					t.Errorf("expected OADP operator label to be True")
+				}
+			}
+		})
+	}
+}

--- a/controllers/velero.go
+++ b/controllers/velero.go
@@ -46,6 +46,12 @@ const (
 
 	TrueVal  = "true"
 	FalseVal = "false"
+
+	// CA certificate related constants
+	caCertVolumeName      = "ca-certificate-bundle"
+	caCertMountPath       = "/etc/velero/ca-certs"
+	caBundleFileName      = "ca-bundle.pem"
+	caBundleConfigMapName = "velero-ca-bundle"
 )
 
 var (
@@ -406,6 +412,11 @@ func (r *DPAReconciler) customizeVeleroDeployment(dpa *oadpv1alpha1.DataProtecti
 				return err
 			}
 		}
+	}
+
+	// Process CA certificates from BackupStorageLocations
+	if err := r.processCACertificatesForVelero(dpa, veleroDeployment, veleroContainer); err != nil {
+		return fmt.Errorf("failed to process CA certificates: %w", err)
 	}
 
 	return nil
@@ -815,4 +826,46 @@ func (r DPAReconciler) noDefaultCredentials(dpa oadpv1alpha1.DataProtectionAppli
 
 	return providerNeedsDefaultCreds, hasCloudStorage, nil
 
+}
+
+// processCACertificatesForVelero processes CA certificates from BSLs and configures Velero deployment
+func (r *DPAReconciler) processCACertificatesForVelero(dpa *oadpv1alpha1.DataProtectionApplication, veleroDeployment *appsv1.Deployment, veleroContainer *corev1.Container) error {
+	configMapName, err := r.processCACertForBSLs(dpa)
+	if err != nil {
+		return fmt.Errorf("failed to process CA certificates from BSLs: %w", err)
+	}
+
+	if configMapName == "" {
+		return nil
+	}
+
+	caCertVolume := corev1.Volume{
+		Name: caCertVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: configMapName,
+				},
+			},
+		},
+	}
+	veleroDeployment.Spec.Template.Spec.Volumes = append(veleroDeployment.Spec.Template.Spec.Volumes, caCertVolume)
+
+	caCertVolumeMount := corev1.VolumeMount{
+		Name:      caCertVolumeName,
+		MountPath: caCertMountPath,
+		ReadOnly:  true,
+	}
+	veleroContainer.VolumeMounts = append(veleroContainer.VolumeMounts, caCertVolumeMount)
+
+	// AWS_CA_BUNDLE is a standard AWS SDK environment variable that specifies a custom CA bundle
+	// for TLS certificate validation. When set, the AWS SDK for Go automatically uses this bundle
+	// for all S3 API calls, enabling imagestream backup in air-gapped environments with custom CAs.
+	awsCABundleEnv := corev1.EnvVar{
+		Name:  "AWS_CA_BUNDLE",
+		Value: caCertMountPath + "/" + caBundleFileName,
+	}
+	veleroContainer.Env = common.AppendUniqueEnvVars(veleroContainer.Env, []corev1.EnvVar{awsCABundleEnv})
+
+	return nil
 }

--- a/controllers/velero_test.go
+++ b/controllers/velero_test.go
@@ -2163,3 +2163,213 @@ func TestDPAReconciler_VeleroDebugEnvironment(t *testing.T) {
 		})
 	}
 }
+
+func TestDPAReconciler_processCACertificatesForVelero(t *testing.T) {
+	tests := []struct {
+		name            string
+		dpa             *oadpv1alpha1.DataProtectionApplication
+		configMapName   string
+		wantErr         bool
+		wantVolume      bool
+		wantVolumeMount bool
+		wantEnvVar      bool
+	}{
+		{
+			name: "should mount CA certificate ConfigMap and set AWS_CA_BUNDLE when certificates exist",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-dpa",
+					Namespace: "test-ns",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					BackupLocations: []oadpv1alpha1.BackupLocation{
+						{
+							Velero: &velerov1.BackupStorageLocationSpec{
+								Provider: "aws",
+								StorageType: velerov1.StorageType{
+									ObjectStorage: &velerov1.ObjectStorageLocation{
+										CACert: []byte("test-ca-cert"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			configMapName:   caBundleConfigMapName,
+			wantErr:         false,
+			wantVolume:      true,
+			wantVolumeMount: true,
+			wantEnvVar:      true,
+		},
+		{
+			name: "should not mount or set environment variables when no CA certificates exist",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-dpa",
+					Namespace: "test-ns",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					BackupLocations: []oadpv1alpha1.BackupLocation{
+						{
+							Velero: &velerov1.BackupStorageLocationSpec{
+								Provider: "aws",
+								StorageType: velerov1.StorageType{
+									ObjectStorage: &velerov1.ObjectStorageLocation{
+										Bucket: "test-bucket",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			configMapName:   "",
+			wantErr:         false,
+			wantVolume:      false,
+			wantVolumeMount: false,
+			wantEnvVar:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create fake client with DPA and optional ConfigMap
+			objs := []client.Object{tt.dpa}
+			if tt.configMapName != "" {
+				configMap := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      tt.configMapName,
+						Namespace: tt.dpa.Namespace,
+					},
+					Data: map[string]string{
+						caBundleFileName: "test-ca-cert",
+					},
+				}
+				objs = append(objs, configMap)
+			}
+
+			fakeClient, err := getFakeClientFromObjects(objs...)
+			if err != nil {
+				t.Fatalf("error creating fake client: %v", err)
+			}
+
+			r := &DPAReconciler{
+				Client:        fakeClient,
+				Scheme:        fakeClient.Scheme(),
+				Log:           logr.Discard(),
+				Context:       context.Background(),
+				EventRecorder: record.NewFakeRecorder(10),
+				NamespacedName: types.NamespacedName{
+					Name:      tt.dpa.Name,
+					Namespace: tt.dpa.Namespace,
+				},
+			}
+
+			veleroDeployment := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "velero",
+					Namespace: tt.dpa.Namespace,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: common.Velero,
+								},
+							},
+						},
+					},
+				},
+			}
+
+			veleroContainer := &veleroDeployment.Spec.Template.Spec.Containers[0]
+			originalVolumeCount := len(veleroDeployment.Spec.Template.Spec.Volumes)
+			originalVolumeMountCount := len(veleroContainer.VolumeMounts)
+			originalEnvCount := len(veleroContainer.Env)
+
+			err = r.processCACertificatesForVelero(tt.dpa, veleroDeployment, veleroContainer)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("processCACertificatesForVelero() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.wantVolume {
+				if len(veleroDeployment.Spec.Template.Spec.Volumes) != originalVolumeCount+1 {
+					t.Errorf("Expected volume count to increase by 1, got %d", len(veleroDeployment.Spec.Template.Spec.Volumes))
+				}
+				foundVolume := false
+				for _, volume := range veleroDeployment.Spec.Template.Spec.Volumes {
+					if volume.Name == caCertVolumeName {
+						foundVolume = true
+						if volume.ConfigMap == nil {
+							t.Error("Expected ConfigMap volume source")
+						} else if volume.ConfigMap.Name != tt.configMapName {
+							t.Errorf("Expected ConfigMap name %s, got %s", tt.configMapName, volume.ConfigMap.Name)
+						}
+						break
+					}
+				}
+				if !foundVolume {
+					t.Errorf("Expected volume '%s' to be added", caCertVolumeName)
+				}
+			} else {
+				if len(veleroDeployment.Spec.Template.Spec.Volumes) != originalVolumeCount {
+					t.Errorf("Expected no volume changes, got %d, want %d", len(veleroDeployment.Spec.Template.Spec.Volumes), originalVolumeCount)
+				}
+			}
+
+			if tt.wantVolumeMount {
+				if len(veleroContainer.VolumeMounts) != originalVolumeMountCount+1 {
+					t.Errorf("Expected volume mount count to increase by 1, got %d", len(veleroContainer.VolumeMounts))
+				}
+				foundVolumeMount := false
+				for _, vm := range veleroContainer.VolumeMounts {
+					if vm.Name == caCertVolumeName {
+						foundVolumeMount = true
+						if vm.MountPath != caCertMountPath {
+							t.Errorf("Expected mount path %s, got %s", caCertMountPath, vm.MountPath)
+						}
+						if !vm.ReadOnly {
+							t.Error("Expected volume mount to be read-only")
+						}
+						break
+					}
+				}
+				if !foundVolumeMount {
+					t.Errorf("Expected volume mount '%s' to be added", caCertVolumeName)
+				}
+			} else {
+				if len(veleroContainer.VolumeMounts) != originalVolumeMountCount {
+					t.Errorf("Expected no volume mount changes, got %d, want %d", len(veleroContainer.VolumeMounts), originalVolumeMountCount)
+				}
+			}
+
+			if tt.wantEnvVar {
+				if len(veleroContainer.Env) != originalEnvCount+1 {
+					t.Errorf("Expected env var count to increase by 1, got %d", len(veleroContainer.Env))
+				}
+				foundEnv := false
+				for _, env := range veleroContainer.Env {
+					if env.Name == "AWS_CA_BUNDLE" {
+						foundEnv = true
+						expectedValue := caCertMountPath + "/" + caBundleFileName
+						if env.Value != expectedValue {
+							t.Errorf("Expected AWS_CA_BUNDLE value %s, got %s", expectedValue, env.Value)
+						}
+						break
+					}
+				}
+				if !foundEnv {
+					t.Error("Expected AWS_CA_BUNDLE environment variable to be set")
+				}
+			} else {
+				if len(veleroContainer.Env) != originalEnvCount {
+					t.Errorf("Expected no env var changes, got %d, want %d", len(veleroContainer.Env), originalEnvCount)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Cherry-pick of #1930 (master) / #1943 (oadp-1.5) adapted for oadp-1.4 branch structure.

## Summary

- Add `processCACertForBSLs()` to extract CA certificates from BSL configurations and create `velero-ca-bundle` ConfigMap
- Add `processCACertificatesForVelero()` to mount the ConfigMap and set `AWS_CA_BUNDLE` environment variable in the Velero deployment
- `AWS_CA_BUNDLE` triggers AWS SDK native CA certificate functionality for S3 operations, enabling imagestream backup in air-gapped environments with custom CAs
- Comprehensive unit tests for both functions (6 test cases)

## Adaptation notes

oadp-1.4 uses `controllers/` package with `DPAReconciler` (master uses `internal/controller/` with `DataProtectionApplicationReconciler`). DPA is passed as a function parameter since oadp-1.4's reconciler has no `r.dpa` field.

## Known limitation

If any BSL has `caCert`, the `AWS_CA_BUNDLE` env var applies to all BSLs' imagestream S3 client (env var is container-wide).

## Related

- Master: #1930
- oadp-1.5: #1943
- Jira: [OADP-1945](https://issues.redhat.com/browse/OADP-1945), [OADP-4817](https://issues.redhat.com/browse/OADP-4817), [OADP-641](https://issues.redhat.com/browse/OADP-641)

## Corresponding openshift-velero-plugin PRs (already merged to oadp-1.4)

- [openshift-velero-plugin#290](https://github.com/openshift/openshift-velero-plugin/pull/290) — docker-distribution fix (master)
- [openshift-velero-plugin#293](https://github.com/openshift/openshift-velero-plugin/pull/293) — oadp-1.4 backport of pr 290
- [openshift-velero-plugin#375](https://github.com/openshift/openshift-velero-plugin/pull/375) — updated udist for oadp-1.4 (replacement for #293)