### PR TITLE
Add oadp-cli-binaries-rhel9 to image refs for oadp-1.5

### DIFF
--- a/bundle/image-references
+++ b/bundle/image-references
@@ -43,6 +43,10 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/konveyor/kubevirt-velero-plugin:v0.7.0
+  - name: oadp-cli-binaries-rhel9
+    from:
+      kind: DockerImage
+      name: quay.io/konveyor/oadp-cli-binaries:oadp-1.5
   - name: oadp-hypershift-velero-plugin-rhel9
     from:
       kind: DockerImage


### PR DESCRIPTION
## Why the changes were made

OADP 1.5 is missing oadp-cli-binaries-rhel9 in bundle/image-references. The operator already references quay.io/konveyor/oadp-cli-binaries:oadp-1.5 in the CSV and manager config for the Console CLI download server, but the bundle image-references file does not include the CLI binaries image.

This adds the missing image-references entry so release metadata stays in sync with the rest of the OADP 1.5 image set and release-sources can validate the ImgRef column for oadp/oadp-cli-binaries-rhel9.

Tracked by migtools/oadp-cli#203.

## How to test the changes made

After merge, run release metadata check (if available):

```bash
./release-sources oadp-1.5
```
Expect oadp/oadp-cli-binaries-rhel9 to show ImgRef with a green checkmark with quay.io/konveyor/oadp-cli-binaries:oadp-1.5.
