### PR TITLE
update oadp builds to oadp-1.5.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # TOOL VERSIONS
 # All version-related variables are defined here for easy maintenance
-DEFAULT_VERSION := 1.5.7
+DEFAULT_VERSION := 1.5.8
 VERSION ?= $(DEFAULT_VERSION)
 OPERATOR_SDK_VERSION ?= v1.34.2
 ENVTEST_K8S_VERSION = 1.32 #refers to the version of kubebuilder assets to be downloaded by envtest binary # Kubernetes version from OpenShift 4.19.x

--- a/bundle/manifests/oadp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/oadp-operator.clusterserviceversion.yaml
@@ -281,7 +281,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "true"
     features.operators.openshift.io/token-auth-azure: "true"
     features.operators.openshift.io/token-auth-gcp: "true"
-    olm.skipRange: '>=1.4.0 <1.5.7'
+    olm.skipRange: '>=1.4.0 <1.5.8'
     operatorframework.io/suggested-namespace: openshift-adp
     operators.openshift.io/infrastructure-features: '["Disconnected"]'
     operators.openshift.io/must-gather-image: quay.io/konveyor/oadp-must-gather:oadp-1.5
@@ -296,7 +296,7 @@ metadata:
     operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
-  name: oadp-operator.v1.5.7
+  name: oadp-operator.v1.5.8
   namespace: openshift-adp
 spec:
   apiservicedefinitions: {}
@@ -1308,5 +1308,5 @@ spec:
     name: non-admin-controller
   - image: quay.io/konveyor/oadp-cli-binaries:oadp-1.5
     name: console-cli-download
-  replaces: oadp-operator.v1.5.6
-  version: 1.5.7
+  replaces: oadp-operator.v1.5.7
+  version: 1.5.8

--- a/bundle/oadp-operator.package.yaml
+++ b/bundle/oadp-operator.package.yaml
@@ -2,5 +2,5 @@
 packageName: redhat-oadp-operator
 channels:
 - name: stable
-  currentCSV: oadp-operator.v1.5.7
+  currentCSV: oadp-operator.v1.5.8
 defaultChannel: stable

--- a/config/manifests/bases/oadp-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/oadp-operator.clusterserviceversion.yaml
@@ -20,7 +20,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "true"
     features.operators.openshift.io/token-auth-azure: "true"
     features.operators.openshift.io/token-auth-gcp: "true"
-    olm.skipRange: '>=1.4.0 <1.5.7'
+    olm.skipRange: '>=1.4.0 <1.5.8'
     operatorframework.io/suggested-namespace: openshift-adp
     operators.openshift.io/infrastructure-features: '["Disconnected"]'
     operators.openshift.io/must-gather-image: quay.io/konveyor/oadp-must-gather:oadp-1.5
@@ -33,7 +33,7 @@ metadata:
     operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
-  name: oadp-operator.v1.5.7
+  name: oadp-operator.v1.5.8
   namespace: openshift-adp
 spec:
   apiservicedefinitions: {}
@@ -516,5 +516,5 @@ spec:
   maturity: stable
   provider:
     name: Red Hat
-  replaces: oadp-operator.v1.5.6
-  version: 1.5.7
+  replaces: oadp-operator.v1.5.7
+  version: 1.5.8

--- a/docs/version-update.md
+++ b/docs/version-update.md
@@ -4,14 +4,14 @@ This document outlines the files and fields that need to be updated for OADP ope
 
 ## Files to Update
 
-For a patch version update (e.g., 1.5.6 → 1.5.7), update these 4 files:
+For a patch version update (e.g., 1.5.7 → 1.5.8), update these 4 files:
 
 ### 1. Makefile
 
 Update `DEFAULT_VERSION` variable:
 
 ```makefile
-DEFAULT_VERSION := 1.5.7  # was 1.5.6
+DEFAULT_VERSION := 1.5.8  # was 1.5.7
 ```
 
 ### 2. config/manifests/bases/oadp-operator.clusterserviceversion.yaml
@@ -21,11 +21,11 @@ Update 4 fields:
 ```yaml
 metadata:
   annotations:
-    olm.skipRange: '>=1.4.0 <1.5.7'  # was <1.5.6
-  name: oadp-operator.v1.5.7  # was v1.5.6
+    olm.skipRange: '>=1.4.0 <1.5.8'  # was <1.5.7
+  name: oadp-operator.v1.5.8  # was v1.5.7
 spec:
-  replaces: oadp-operator.v1.5.6  # was v1.5.5
-  version: 1.5.7  # was 1.5.6
+  replaces: oadp-operator.v1.5.7  # was v1.5.6
+  version: 1.5.8  # was 1.5.7
 ```
 
 ### 3. bundle/manifests/oadp-operator.clusterserviceversion.yaml
@@ -35,11 +35,11 @@ Update 4 fields (same as above):
 ```yaml
 metadata:
   annotations:
-    olm.skipRange: '>=1.4.0 <1.5.7'  # was <1.5.6
-  name: oadp-operator.v1.5.7  # was v1.5.6
+    olm.skipRange: '>=1.4.0 <1.5.8'  # was <1.5.7
+  name: oadp-operator.v1.5.8  # was v1.5.7
 spec:
-  replaces: oadp-operator.v1.5.6  # was v1.5.5
-  version: 1.5.7  # was 1.5.6
+  replaces: oadp-operator.v1.5.7  # was v1.5.6
+  version: 1.5.8  # was 1.5.7
 ```
 
 ### 4. bundle/oadp-operator.package.yaml
@@ -49,7 +49,7 @@ Update 1 field:
 ```yaml
 channels:
 - name: stable
-  currentCSV: oadp-operator.v1.5.7  # was v1.5.6
+  currentCSV: oadp-operator.v1.5.8  # was v1.5.7
 ```
 
 ## Summary


### PR DESCRIPTION
## Why the changes were made

start building oadp 1.5.8
downstream builds will use golang 1.26 FYI
https://github.com/openshift-eng/ocp-build-data/pull/11343

## How to test the changes made

make deploy-olm

Made with [Cursor](https://cursor.com)