### PR TITLE
Update e2e and kubevirt-dm design to use custom volume policy

### DIFF
--- a/docs/design/kubevirt-datamover.md
+++ b/docs/design/kubevirt-datamover.md
@@ -43,18 +43,18 @@ Taking a VolumeSnapshot and then using kopia to process the entire volume and co
 ## High-Level design
 
 ### Upstream velero changes
-- Update velero volume policy model to allow unrecognized volume policy actions. Velero would treat unrecognized actions as "skip" (i.e. no snapshot or fs-backup), but the kubevirt datamover could only act if the policy action is "kubevirt".
+- Update velero volume policy model to allow custom volume policy actions. Velero would treat custom actions as "skip" (i.e. no snapshot or fs-backup), but the kubevirt datamover could only act if the policy action is "custom" with "datamover: kubevirt" in "parameters".
 - In `pkg/restore/actions/dataupload_retrieve_action.go` and in `DataDownload` we need to add SnapshotType.
 
 ### BackupItemAction/RestoreItemAction plugins
 - VirtualMachine BIA plugin
   - The plugin will check whether the VirtualMachine's `status.ChangedBlockTracking` is `Enabled`
   - The plugin must also determine whether the VM is running, since offline backup is not supported in the initial release.
-    - If QEMU backup is enabled, the next question is whether the user wants to use the kubevirt datamover for this VM's volumes. We will use volume policies for this, although it's a bit more complicated since a VM could have multiple PVCs. If at least one PVC for the VM has the "kubevirt" policy action specified, and no PVCs in this VM have other non-skip policies (i.e. "snapshot", etc.) then we'll use the kubevirt datamover
-	- In addition, SnapshotMoveData must be true
+    - If QEMU backup is enabled, the next question is whether the user wants to use the kubevirt datamover for this VM's volumes. We will use volume policies for this, although it's a bit more complicated since a VM could have multiple PVCs. If at least one PVC for the VM has the "custom" policy action with "datamover=kubevirt" parameter specified, and no PVCs in this VM have other non-skip policies (i.e. "snapshot", etc.) then we'll use the kubevirt datamover
+    - In addition, SnapshotMoveData must be true
     - Iterate over all PVCs for the VM
-    - If any PVC has an action other than "kubevirt" or "skip", exit without action
-    - If at least one PVC has an action of "kubevirt", then use the kubevirt datamover
+    - If any PVC has an action other than "custom" or "skip", exit without action
+    - If at least one PVC has an action of "custom" with parameter "datamover=kubevirt", then use the kubevirt datamover
   - This plugin will create a DataUpload with `Spec.SnapshotType` set to "kubevirt" and `Spec.DataMover` set to "kubevirt"
     - Note that unlike the built-in datamover, this DataUpload is tied to a VM (which could include multiple PVCs) rather than to a single PVC.
   - An annotation will be added to the DataUpload identifying the VirtualMachine we're backing up.

--- a/tests/e2e/lib/backup.go
+++ b/tests/e2e/lib/backup.go
@@ -62,8 +62,9 @@ const kubevirtVolumePolicyData = `version: v1
 volumePolicies:
   - conditions: {}
     action:
-      type: skip
-`
+      type: custom
+      parameters:
+        datamover: kubevirt`
 
 // EnsureKubevirtVolumePolicy creates (or updates) the volume policy ConfigMap
 // that tells Velero to skip CSI snapshots for CBT-labeled PVCs, allowing the

--- a/tests/e2e/sample-applications/virtual-machines/kubevirt-dm/volume-policy.yaml
+++ b/tests/e2e/sample-applications/virtual-machines/kubevirt-dm/volume-policy.yaml
@@ -9,4 +9,6 @@ data:
     volumePolicies:
       - conditions: {}
         action:
-          type: skip
+          type: custom
+          parameters:
+            datamover: kubevirt


### PR DESCRIPTION
## Why the changes were made

Updates e2e tests to use custom volume policy instead of skip. Currently, this PR breaks tests, but once https://github.com/migtools/kubevirt-datamover-plugin/pull/23 merges, this PR will be needed to fix tests.

With the plugin change, instead of a skip policy action, the following is needed in the matching volume policy to trigger kubevirt-dm backups:
```
      action:
        type: custom
        parameters:
          datamover: kubevirt
```
<!-- Explain why this PR is important, what problems it fixes, link related issues -->

## How to test the changes made

<!-- Explain how the changes introduced by this PR can be tested and verified, with commands and pictures -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced volume policy handling so kubevirt datamover activation is driven by a **custom** policy action with parameter `datamover: kubevirt`.
  * Tightened policy eligibility: datamover selection occurs only when matching PVCs are present and no PVCs use unsupported actions.

* **Documentation**
  * Updated incremental kubevirt datamover design notes to reflect the revised volume policy and activation rules.

* **Tests**
  * Updated end-to-end sample and backup policy data to use `action.type: custom` and include `parameters.datamover: kubevirt`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->