### PR TITLE
remove fedora vm test as it's debugged

### DIFF
--- a/tests/e2e/virt_backup_restore_suite_test.go
+++ b/tests/e2e/virt_backup_restore_suite_test.go
@@ -486,7 +486,7 @@ var _ = ginkgo.Describe("VM backup and restore tests", ginkgo.Ordered, func() {
 			},
 		}, nil),
 
-		ginkgo.Entry("todolist CSI backup and restore, in a Fedora VM", ginkgo.Label("virt"), VmBackupRestoreCase{
+		ginkgo.PEntry("todolist CSI backup and restore, in a Fedora VM", ginkgo.Label("virt"), VmBackupRestoreCase{
 			Template:       "./sample-applications/virtual-machines/fedora-todolist/fedora-todolist.yaml",
 			InitDelay:      3 * time.Minute, // For cloud-init
 			StartupTimeout: 20 * time.Minute,


### PR DESCRIPTION
## Why the changes were made

fedora vm needs debug:
https://github.com/openshift/oadp-operator/pull/2257

## How to test the changes made

run e2e tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated an end-to-end backup and restore table case to run with the appropriate table entry scheduling, improving test execution consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->