### PR TITLE
Fix non-constant format string errors for Go 1.24

### DIFF
--- a/controllers/nodeagent_test.go
+++ b/controllers/nodeagent_test.go
@@ -2986,7 +2986,7 @@ func TestDPAReconciler_buildNodeAgentDaemonset(t *testing.T) {
 				}
 			}
 			if !reflect.DeepEqual(got, tt.want) {
-				fmt.Printf(cmp.Diff(got, tt.want))
+				fmt.Printf("%s", cmp.Diff(got, tt.want))
 				t.Errorf("DPAReconciler.buildNodeAgentDaemonset() got = %v, want %v", got, tt.want)
 			}
 		})

--- a/controllers/velero.go
+++ b/controllers/velero.go
@@ -160,7 +160,7 @@ func (r *DPAReconciler) buildVeleroDeployment(veleroDeployment *appsv1.Deploymen
 
 	_, err := r.ReconcileRestoreResourcesVersionPriority(dpa)
 	if err != nil {
-		return fmt.Errorf("error creating configmap for restore resource version priority:" + err.Error())
+		return fmt.Errorf("error creating configmap for restore resource version priority: %w", err)
 	}
 	// get resource requirements for velero deployment
 	// ignoring err here as it is checked in validator.go

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -88,7 +88,7 @@ func TestOADPE2E(t *testing.T) {
 	flag.Parse()
 	errString := LoadDpaSettingsFromJson(settings)
 	if errString != "" {
-		t.Fatalf(errString)
+		t.Fatalf("%s", errString)
 	}
 
 	RegisterFailHandler(Fail)

--- a/tests/e2e/lib/subscription_helpers.go
+++ b/tests/e2e/lib/subscription_helpers.go
@@ -86,7 +86,7 @@ func (s *Subscription) CsvIsInstalling(c client.Client) bool {
 }
 
 func (s *Subscription) CreateOrUpdate(c client.Client) error {
-	log.Printf(s.APIVersion)
+	log.Printf("%s", s.APIVersion)
 	var currentSubscription operators.Subscription
 	err := c.Get(context.Background(), types.NamespacedName{Namespace: s.Namespace, Name: s.Name}, &currentSubscription)
 	if apierrors.IsNotFound(err) {

--- a/tests/e2e/subscription_suite_test.go
+++ b/tests/e2e/subscription_suite_test.go
@@ -117,16 +117,16 @@ var _ = Describe("Subscription Config Suite Test", func() {
 					Expect(err).NotTo(HaveOccurred())
 					for _, env := range s.Spec.Config.Env {
 						for _, deployment := range vd.Items {
-							log.Printf("Checking env vars are passed to deployment " + deployment.Name)
+							log.Printf("Checking env vars are passed to deployment %s", deployment.Name)
 							for _, container := range deployment.Spec.Template.Spec.Containers {
-								log.Printf("Checking env vars are passed to container " + container.Name)
+								log.Printf("Checking env vars are passed to container %s", container.Name)
 								Expect(container.Env).To(ContainElement(env))
 							}
 						}
 						for _, daemonset := range nads.Items {
-							log.Printf("Checking env vars are passed to daemonset " + daemonset.Name)
+							log.Printf("Checking env vars are passed to daemonset %s", daemonset.Name)
 							for _, container := range daemonset.Spec.Template.Spec.Containers {
-								log.Printf("Checking env vars are passed to container " + container.Name)
+								log.Printf("Checking env vars are passed to container %s", container.Name)
 								Expect(container.Env).To(ContainElement(env))
 							}
 						}


### PR DESCRIPTION
## Summary
- Fix `go vet` errors triggered by Go 1.24's non-constant format string check (gated on `go` directive >= 1.24)
- Use `%w` / `%s` format verbs instead of string concatenation or passing variables directly as format strings
- Fixes 8 diagnostics across 5 files: `controllers/velero.go`, `controllers/nodeagent_test.go`, `tests/e2e/e2e_suite_test.go`, `tests/e2e/lib/subscription_helpers.go`, `tests/e2e/subscription_suite_test.go`

## Test plan
- [x] `go vet ./...` passes with `go 1.23` directive (current)
- [x] `go vet ./...` passes with `go 1.24` directive (simulated rebase target)
- [x] Confirmed 8 errors reproduce without the fix when `go` directive is set to 1.24

🤖 Generated with [Claude Code](https://claude.ai/claude-code)