### PR TITLE
Remove duplicate legacy controller-gen variable and target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -400,10 +400,6 @@ build-deploy: THIS_IMAGE=ttl.sh/oadp-operator-$(shell git rev-parse --short HEAD
 build-deploy: ## Build current branch image and deploy controller to the k8s cluster specified in ~/.kube/config.
 	IMG=$(THIS_IMAGE) make docker-build docker-push deploy
 
-CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
-controller-gen: ## Download controller-gen locally if necessary.
-	$(call go-install-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.16.5)
-
 
 
 # Codecov OS String for use in download url


### PR DESCRIPTION
## Summary

Remove the duplicate legacy `CONTROLLER_GEN` variable and `controller-gen` target from the Makefile.

The old `CONTROLLER_GEN = $(shell pwd)/bin/controller-gen` assignment and its `go-install-tool` recipe conflict with the newer branch-aware `?=` pattern that uses `go-install-tool-branch` and symlinks into `bin/$(BRANCH_VERSION)/`. The `=` assignment always overrides `?=`, and the old recipe fails when it encounters the symlink created by the new target.

This aligns oadp-1.4 with oadp-1.6, which already has this cleanup.

## Changes
- Deleted 3 lines: the legacy variable assignment, target declaration, and recipe call
- No changes to the newer branch-aware pattern

## Test plan
- [ ] `make controller-gen` completes successfully and installs into `bin/$(BRANCH_VERSION)/`
- [ ] `make manifests` and `make generate` work correctly