### PR TITLE
Bump CSV metadata to v1.4.11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ TEST_UPGRADE ?= false
 
 # TOOL VERSIONS
 # All version-related variables are defined here for easy maintenance
-DEFAULT_VERSION := 1.4.10
+DEFAULT_VERSION := 1.4.11
 VERSION ?= $(DEFAULT_VERSION) # the version of the operator
 OPERATOR_SDK_VERSION ?= v1.34.2
 ENVTEST_K8S_VERSION = 1.29 # Kubernetes version from OpenShift 4.16.x
@@ -177,7 +177,7 @@ ENVTEST_K8S_VERSION = 1.29
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-DEFAULT_VERSION := 1.4.10
+DEFAULT_VERSION := 1.4.11
 VERSION ?= $(DEFAULT_VERSION)
 
 # IMAGE_TAG_BASE defines the docker.io namespace and part of the image name for remote images.

--- a/bundle/manifests/oadp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/oadp-operator.clusterserviceversion.yaml
@@ -166,7 +166,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "true"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: '>=0.0.0 <1.4.10'
+    olm.skipRange: '>=0.0.0 <1.4.11'
     operatorframework.io/suggested-namespace: openshift-adp
     operators.openshift.io/infrastructure-features: '["Disconnected"]'
     operators.openshift.io/must-gather-image: quay.io/konveyor/oadp-must-gather:oadp-1.4
@@ -181,7 +181,7 @@ metadata:
     operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
-  name: oadp-operator.v1.4.10
+  name: oadp-operator.v1.4.11
   namespace: openshift-adp
 spec:
   apiservicedefinitions: {}
@@ -1020,5 +1020,5 @@ spec:
     name: kubevirt-velero-plugin
   - image: quay.io/konveyor/oadp-must-gather:oadp-1.4
     name: mustgather
-  replaces: oadp-operator.v1.4.9
-  version: 1.4.10
+  replaces: oadp-operator.v1.4.10
+  version: 1.4.11

--- a/bundle/oadp-operator.package.yaml
+++ b/bundle/oadp-operator.package.yaml
@@ -2,5 +2,5 @@
 packageName: redhat-oadp-operator
 channels:
 - name: stable-1.4
-  currentCSV: oadp-operator.v1.4.10
+  currentCSV: oadp-operator.v1.4.11
 defaultChannel: stable-1.4

--- a/config/manifests/bases/oadp-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/oadp-operator.clusterserviceversion.yaml
@@ -20,7 +20,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "true"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: '>=0.0.0 <1.4.10'
+    olm.skipRange: '>=0.0.0 <1.4.11'
     operatorframework.io/suggested-namespace: openshift-adp
     operators.openshift.io/infrastructure-features: '["Disconnected"]'
     operators.openshift.io/must-gather-image: quay.io/konveyor/oadp-must-gather:oadp-1.4
@@ -33,7 +33,7 @@ metadata:
     operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
-  name: oadp-operator.v1.4.10
+  name: oadp-operator.v1.4.11
   namespace: openshift-adp
 spec:
   apiservicedefinitions: {}
@@ -485,5 +485,5 @@ spec:
   maturity: stable
   provider:
     name: Red Hat
-  replaces: oadp-operator.v1.4.9
-  version: 1.4.10
+  replaces: oadp-operator.v1.4.10
+  version: 1.4.11

--- a/docs/version-update.md
+++ b/docs/version-update.md
@@ -4,14 +4,14 @@ This document outlines the files and fields that need to be updated for OADP ope
 
 ## Files to Update
 
-For a patch version update (e.g., 1.4.9 → 1.4.10), update these 4 files:
+For a patch version update (e.g., 1.4.10 → 1.4.11), update these 4 files:
 
 ### 1. Makefile
 
 Update `DEFAULT_VERSION` variable:
 
 ```makefile
-DEFAULT_VERSION := 1.4.10 # was 1.4.9
+DEFAULT_VERSION := 1.4.11 # was 1.4.10
 ```
 
 ### 2. config/manifests/bases/oadp-operator.clusterserviceversion.yaml
@@ -21,11 +21,11 @@ Update 4 fields:
 ```yaml
 metadata:
   annotations:
-    olm.skipRange: '>=0.0.0 <1.4.10' # was <1.4.9
-  name: oadp-operator.v1.4.10 # was v1.4.9
+    olm.skipRange: '>=0.0.0 <1.4.11' # was <1.4.10
+  name: oadp-operator.v1.4.11 # was v1.4.10
 spec:
-  replaces: oadp-operator.v1.4.9 # was v1.4.8
-  version: 1.4.10 # was 1.4.9
+  replaces: oadp-operator.v1.4.10 # was v1.4.9
+  version: 1.4.11 # was 1.4.10
 ```
 
 ### 3. bundle/manifests/oadp-operator.clusterserviceversion.yaml
@@ -35,11 +35,11 @@ Update 4 fields (same as above):
 ```yaml
 metadata:
   annotations:
-    olm.skipRange: '>=0.0.0 <1.4.10' # was <1.4.9
-  name: oadp-operator.v1.4.10 # was v1.4.9
+    olm.skipRange: '>=0.0.0 <1.4.11' # was <1.4.10
+  name: oadp-operator.v1.4.11 # was v1.4.10
 spec:
-  replaces: oadp-operator.v1.4.9 # was v1.4.8
-  version: 1.4.10 # was 1.4.9
+  replaces: oadp-operator.v1.4.10 # was v1.4.9
+  version: 1.4.11 # was 1.4.10
 ```
 
 ### 4. bundle/oadp-operator.package.yaml
@@ -49,7 +49,7 @@ Update 1 field:
 ```yaml
 channels:
 - name: stable-1.4
-  currentCSV: oadp-operator.v1.4.10 # was v1.4.9
+  currentCSV: oadp-operator.v1.4.11 # was v1.4.10
 ```
 
 ## Summary


### PR DESCRIPTION
## Summary
- Updates the CSV metadata name from `oadp-operator.v1.4.10` to `oadp-operator.v1.4.11`
- Updates `olm.skipRange` upper bound from `<1.4.10` to `<1.4.11`
- Updates `replaces` from `oadp-operator.v1.4.9` to `oadp-operator.v1.4.10`
- Updates `version` from `1.4.10` to `1.4.11`
- Updates `currentCSV` in package.yaml to `oadp-operator.v1.4.11`

🤖 Generated with [Claude Code](https://claude.com/claude-code)