### PR TITLE
Added oadp-cli-binaries-rhel9 to bundle/image-references for oadp-1.4

### DIFF
--- a/bundle/image-references
+++ b/bundle/image-references
@@ -43,3 +43,7 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/konveyor/velero-restore-helper:oadp-1.4
+  - name: oadp-cli-binaries-rhel9
+    from:
+      kind: DockerImage
+      name: quay.io/konveyor/oadp-cli-binaries:oadp-1.4


### PR DESCRIPTION
## Why the changes were made

OADP 1.4 is missing oadp-cli-binaries-rhel9 from bundle/image-references. Without this entry, ART cannot track the CLI binaries image for the oadp-1.4 delivery line.

This adds the missing entry so the image is tracked alongside the other OADP 1.4 component images.

## How to test the changes made

After merge, run release metadata check:

```bash
./release-sources oadp-1.4
```
ImgRef for oadp/oadp-cli-binaries-rhel9 should be green after this pr