### PR TITLE
Add pods/log RBAC for kubevirt datamover controller

### DIFF
--- a/bundle/manifests/oadp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/oadp-operator.clusterserviceversion.yaml
@@ -908,6 +908,12 @@ spec:
         - apiGroups:
           - ""
           resources:
+          - pods/log
+          verbs:
+          - get
+        - apiGroups:
+          - ""
+          resources:
           - secrets
           verbs:
           - get

--- a/config/kubevirt-datamover-controller_rbac/role.yaml
+++ b/config/kubevirt-datamover-controller_rbac/role.yaml
@@ -40,6 +40,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods/log
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - get


### PR DESCRIPTION
## Summary
- Add `pods/log` `get` permission to the kubevirt datamover controller's ClusterRole
- The controller now collects pod logs from terminated datamover pods to surface error details in controller logs (migtools/kubevirt-datamover-controller#52)

## Details

Without this permission, the controller's log collection fails with a 403:

```
Warning: failed to collect datamover pod logs
"error": "pods \"...\" is forbidden: User \"system:serviceaccount:openshift-adp:oadp-kubevirt-datamover-controller-manager\" cannot get resource \"pods/log\" in API group \"\" in the namespace \"openshift-adp\""
```

The controller handles the RBAC failure gracefully (warns and continues), but the logs are lost.

Synced from `migtools/kubevirt-datamover-controller` `config/rbac/role.yaml` via `make update-kubevirt-datamover-manifests`, with unwanted RBAC changes from `make bundle` manually reverted per standard practice.

## Test plan

- [x] Verified controller logs show 403 without this permission
- [x] `make bundle` generates the correct CSV entry
- [x] Deploy operator with this change, run a kubevirt datamover backup, verify pod logs appear in controller logs

Related: migtools/kubevirt-datamover-controller#107

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved controller access to pod logs, supporting more reliable monitoring and troubleshooting of managed workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->