### PR TITLE
Backport cli download 1.3

### DIFF
--- a/bundle/manifests/oadp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/oadp-operator.clusterserviceversion.yaml
@@ -735,6 +735,18 @@ spec:
           - update
           - watch
         - apiGroups:
+          - console.openshift.io
+          resources:
+          - consoleclidownloads
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
           - route.openshift.io
           resources:
           - routes
@@ -863,6 +875,8 @@ spec:
                   value: quay.io/konveyor/kubevirt-velero-plugin:v0.6.2
                 - name: RELATED_IMAGE_MUSTGATHER
                   value: quay.io/konveyor/oadp-must-gather:oadp-1.3
+                - name: RELATED_IMAGE_CONSOLE_CLI_DOWNLOAD
+                  value: quay.io/konveyor/oadp-cli-binaries:oadp-1.3
                 image: quay.io/konveyor/oadp-operator:oadp-1.3
                 imagePullPolicy: Always
                 livenessProbe:
@@ -1014,5 +1028,7 @@ spec:
     name: kubevirt-velero-plugin
   - image: quay.io/konveyor/oadp-must-gather:oadp-1.3
     name: mustgather
+  - image: quay.io/konveyor/oadp-cli-binaries:oadp-1.3
+    name: console-cli-download
   replaces: oadp-operator.v1.3.9
   version: 1.3.10

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -54,6 +54,8 @@ spec:
             value: quay.io/konveyor/kubevirt-velero-plugin:v0.6.2
           - name: RELATED_IMAGE_MUSTGATHER
             value: quay.io/konveyor/oadp-must-gather:oadp-1.3
+          - name: RELATED_IMAGE_CONSOLE_CLI_DOWNLOAD
+            value: quay.io/konveyor/oadp-cli-binaries:oadp-1.3
         args:
         - --leader-elect
         image: controller:latest

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -158,6 +158,18 @@ rules:
   - update
   - watch
 - apiGroups:
+  - console.openshift.io
+  resources:
+  - consoleclidownloads
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - route.openshift.io
   resources:
   - routes

--- a/controllers/cli_download_controller.go
+++ b/controllers/cli_download_controller.go
@@ -1,0 +1,374 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/go-logr/logr"
+	consolev1 "github.com/openshift/api/console/v1"
+	routev1 "github.com/openshift/api/route/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+const (
+	cliServerDeploymentName = "openshift-adp-oadp-cli-server"
+	cliServerServiceName    = "openshift-adp-cli-server"
+	cliServerRouteName      = "oadp-cli-server-route"
+	cliDownloadName         = "openshift-adp-oadp-cli"
+	managedByLabel          = "app.kubernetes.io/managed-by"
+	operatorName            = "oadp-operator"
+)
+
+// CLIDownloadSetup is a runnable that sets up CLI download resources when the operator starts
+type CLIDownloadSetup struct {
+	Client            client.Client
+	Namespace         string
+	OperatorName      string
+	OperatorNamespace string
+	Log               logr.Logger
+}
+
+// Start implements the Runnable interface
+func (c *CLIDownloadSetup) Start(ctx context.Context) error {
+	c.Log = ctrl.Log.WithName("cli-download-setup")
+	c.Log.Info("Starting CLI download setup")
+
+	// Get the CLI server image from environment variable
+	cliServerImage := os.Getenv("RELATED_IMAGE_CONSOLE_CLI_DOWNLOAD")
+	if cliServerImage == "" {
+		cliServerImage = "quay.io/konveyor/oadp-cli-binaries:oadp-1.3" // fallback default
+		c.Log.Info("Using default CLI server image", "image", cliServerImage)
+	}
+
+	// Get the operator deployment to use as owner for namespaced resources
+	operatorDeployment := &appsv1.Deployment{}
+	err := c.Client.Get(ctx, types.NamespacedName{
+		Name:      c.OperatorName,
+		Namespace: c.OperatorNamespace,
+	}, operatorDeployment)
+	if err != nil {
+		c.Log.Error(err, "Failed to get operator deployment")
+		return err
+	}
+
+	// Create CLI resources (idempotent - will reuse existing ConsoleCLIDownload if present)
+	if err := c.reconcileCLIResources(ctx, operatorDeployment, cliServerImage); err != nil {
+		return err
+	}
+
+	c.Log.Info("CLI download setup completed successfully")
+	return nil
+}
+
+// reconcileCLIResources creates or updates all CLI-related resources.
+// This is idempotent - it will reuse existing resources if they already exist.
+func (c *CLIDownloadSetup) reconcileCLIResources(ctx context.Context, operatorDeployment *appsv1.Deployment, cliServerImage string) error {
+	// 1. Create or update the deployment
+	deployment := &appsv1.Deployment{}
+	err := c.Client.Get(ctx, client.ObjectKey{
+		Name:      cliServerDeploymentName,
+		Namespace: c.Namespace,
+	}, deployment)
+
+	if errors.IsNotFound(err) {
+		deployment = buildCLIServerDeployment(c.Namespace, cliServerImage)
+		if err := controllerutil.SetOwnerReference(operatorDeployment, deployment, c.Client.Scheme()); err != nil {
+			return fmt.Errorf("failed to set owner reference on deployment: %w", err)
+		}
+		err = c.Client.Create(ctx, deployment)
+		if err != nil && !errors.IsAlreadyExists(err) {
+			return fmt.Errorf("failed to create CLI server deployment: %w", err)
+		}
+		c.Log.Info("Created CLI server deployment", "image", cliServerImage)
+	} else if err != nil {
+		return fmt.Errorf("failed to get CLI server deployment: %w", err)
+	}
+
+	// 2. Create or update the service
+	service := &corev1.Service{}
+	err = c.Client.Get(ctx, client.ObjectKey{
+		Name:      cliServerServiceName,
+		Namespace: c.Namespace,
+	}, service)
+
+	if errors.IsNotFound(err) {
+		service = buildCLIServerService(c.Namespace)
+		if err := controllerutil.SetOwnerReference(operatorDeployment, service, c.Client.Scheme()); err != nil {
+			return fmt.Errorf("failed to set owner reference on service: %w", err)
+		}
+		err = c.Client.Create(ctx, service)
+		if err != nil && !errors.IsAlreadyExists(err) {
+			return fmt.Errorf("failed to create CLI server service: %w", err)
+		}
+		c.Log.Info("Created CLI server service")
+	} else if err != nil {
+		return fmt.Errorf("failed to get CLI server service: %w", err)
+	}
+
+	// 3. Create or get the route
+	route := &routev1.Route{}
+	err = c.Client.Get(ctx, client.ObjectKey{
+		Name:      cliServerRouteName,
+		Namespace: c.Namespace,
+	}, route)
+
+	if errors.IsNotFound(err) {
+		route = buildCLIServerRoute(c.Namespace)
+		if err := controllerutil.SetOwnerReference(operatorDeployment, route, c.Client.Scheme()); err != nil {
+			return fmt.Errorf("failed to set owner reference on route: %w", err)
+		}
+		err = c.Client.Create(ctx, route)
+		if err != nil && !errors.IsAlreadyExists(err) {
+			return fmt.Errorf("failed to create CLI server route: %w", err)
+		}
+		c.Log.Info("Created CLI server route, waiting for hostname assignment")
+		time.Sleep(2 * time.Second)
+		if err := c.Client.Get(ctx, client.ObjectKey{
+			Name:      cliServerRouteName,
+			Namespace: c.Namespace,
+		}, route); err != nil {
+			return fmt.Errorf("failed to get route after creation: %w", err)
+		}
+	} else if err != nil {
+		return fmt.Errorf("failed to get CLI server route: %w", err)
+	}
+
+	// Retry with backoff if hostname is not yet assigned
+	hostname := route.Spec.Host
+	if hostname == "" {
+		c.Log.Info("Route hostname not yet assigned, retrying with backoff")
+		maxRetries := 5
+		backoff := 2 * time.Second
+
+		for attempt := 1; attempt <= maxRetries; attempt++ {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(backoff):
+				if err := c.Client.Get(ctx, client.ObjectKey{
+					Name:      cliServerRouteName,
+					Namespace: c.Namespace,
+				}, route); err != nil {
+					c.Log.Error(err, "Failed to get route on retry", "attempt", attempt)
+					continue
+				}
+
+				if route.Spec.Host != "" {
+					hostname = route.Spec.Host
+					c.Log.Info("Route hostname assigned", "hostname", hostname, "attempt", attempt)
+					break
+				}
+
+				c.Log.Info("Route hostname still not assigned, will retry", "attempt", attempt, "maxRetries", maxRetries)
+				backoff *= 2
+			}
+		}
+
+		if hostname == "" {
+			c.Log.Info("Route hostname not assigned after max retries, ConsoleCLIDownload will not be created. It will be created on next reconciliation when hostname becomes available.")
+			return nil
+		}
+	}
+
+	// 4. Create or update ConsoleCLIDownload (cluster-scoped)
+	downloadURL := fmt.Sprintf("https://%s/", hostname)
+
+	consoleCLIDownload := &consolev1.ConsoleCLIDownload{}
+	err = c.Client.Get(ctx, client.ObjectKey{Name: cliDownloadName}, consoleCLIDownload)
+
+	desiredSpec := consolev1.ConsoleCLIDownloadSpec{
+		Description: "OADP operator Command Line Interface (CLI)",
+		DisplayName: "oadp - OADP operator Command Line Interface (CLI)",
+		Links: []consolev1.CLIDownloadLink{
+			{
+				Href: downloadURL,
+				Text: "Download OADP CLI",
+			},
+		},
+	}
+
+	if errors.IsNotFound(err) {
+		consoleCLIDownload = &consolev1.ConsoleCLIDownload{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: cliDownloadName,
+				Labels: map[string]string{
+					managedByLabel:               operatorName,
+					"app.kubernetes.io/instance": c.OperatorNamespace,
+				},
+			},
+			Spec: desiredSpec,
+		}
+		err = c.Client.Create(ctx, consoleCLIDownload)
+		if err != nil && !errors.IsAlreadyExists(err) {
+			return fmt.Errorf("failed to create ConsoleCLIDownload: %w", err)
+		}
+		c.Log.Info("Created ConsoleCLIDownload", "url", downloadURL)
+	} else if err != nil {
+		return fmt.Errorf("failed to get ConsoleCLIDownload: %w", err)
+	} else {
+		needsUpdate := false
+
+		if consoleCLIDownload.Labels == nil {
+			consoleCLIDownload.Labels = make(map[string]string)
+		}
+		if consoleCLIDownload.Labels[managedByLabel] != operatorName {
+			consoleCLIDownload.Labels[managedByLabel] = operatorName
+			consoleCLIDownload.Labels["app.kubernetes.io/instance"] = c.OperatorNamespace
+			needsUpdate = true
+		}
+
+		if len(consoleCLIDownload.Spec.Links) == 0 || consoleCLIDownload.Spec.Links[0].Href != downloadURL {
+			consoleCLIDownload.Spec = desiredSpec
+			needsUpdate = true
+		}
+
+		if needsUpdate {
+			err = c.Client.Update(ctx, consoleCLIDownload)
+			if err != nil {
+				return fmt.Errorf("failed to update ConsoleCLIDownload: %w", err)
+			}
+			c.Log.Info("Updated ConsoleCLIDownload", "url", downloadURL)
+		} else {
+			c.Log.Info("ConsoleCLIDownload already exists and is up-to-date", "url", downloadURL)
+		}
+	}
+
+	return nil
+}
+
+func buildCLIServerDeployment(namespace, image string) *appsv1.Deployment {
+	replicas := int32(1)
+	runAsNonRoot := true
+	allowPrivilegeEscalation := false
+	readOnlyRootFilesystem := true
+
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cliServerDeploymentName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"app":          "oadp-cli",
+				managedByLabel: operatorName,
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "oadp-cli",
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": "oadp-cli",
+					},
+				},
+				Spec: corev1.PodSpec{
+					SecurityContext: &corev1.PodSecurityContext{
+						RunAsNonRoot: &runAsNonRoot,
+					},
+					Containers: []corev1.Container{
+						{
+							Name:  "oadp-cli-server",
+							Image: image,
+							Ports: []corev1.ContainerPort{
+								{
+									Name:          "http",
+									ContainerPort: 8080,
+									Protocol:      corev1.ProtocolTCP,
+								},
+							},
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("100m"),
+									corev1.ResourceMemory: resource.MustParse("64Mi"),
+								},
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("50m"),
+									corev1.ResourceMemory: resource.MustParse("32Mi"),
+								},
+							},
+							SecurityContext: &corev1.SecurityContext{
+								AllowPrivilegeEscalation: &allowPrivilegeEscalation,
+								Capabilities: &corev1.Capabilities{
+									Drop: []corev1.Capability{"ALL"},
+								},
+								ReadOnlyRootFilesystem: &readOnlyRootFilesystem,
+							},
+						},
+					},
+					TerminationGracePeriodSeconds: int64Ptr(10),
+				},
+			},
+		},
+	}
+}
+
+func buildCLIServerService(namespace string) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cliServerServiceName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"app":          "oadp-cli",
+				managedByLabel: operatorName,
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{
+				"app": "oadp-cli",
+			},
+			Ports: []corev1.ServicePort{
+				{
+					Name:       "http",
+					Port:       80,
+					TargetPort: intstr.FromInt(8080),
+					Protocol:   corev1.ProtocolTCP,
+				},
+			},
+			Type: corev1.ServiceTypeClusterIP,
+		},
+	}
+}
+
+func buildCLIServerRoute(namespace string) *routev1.Route {
+	return &routev1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cliServerRouteName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"app":          "oadp-cli",
+				managedByLabel: operatorName,
+			},
+		},
+		Spec: routev1.RouteSpec{
+			To: routev1.RouteTargetReference{
+				Kind: "Service",
+				Name: cliServerServiceName,
+			},
+			Port: &routev1.RoutePort{
+				TargetPort: intstr.FromString("http"),
+			},
+			TLS: &routev1.TLSConfig{
+				Termination:                   routev1.TLSTerminationEdge,
+				InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
+			},
+		},
+	}
+}
+
+func int64Ptr(i int64) *int64 {
+	return &i
+}

--- a/controllers/console.go
+++ b/controllers/console.go
@@ -1,0 +1,27 @@
+package controllers
+
+import (
+	"fmt"
+
+	"github.com/go-logr/logr"
+	consolev1 "github.com/openshift/api/console/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// IsConsoleCRDAvailable checks whether the ConsoleCLIDownload CRD is registered
+// with the API server. Returns false when the Console capability is not enabled
+// (e.g. SNO clusters).
+func IsConsoleCRDAvailable(mapper meta.RESTMapper, log logr.Logger) (bool, error) {
+	_, err := mapper.RESTMapping(
+		schema.GroupKind{Group: consolev1.GroupVersion.Group, Kind: "ConsoleCLIDownload"},
+	)
+	if err != nil {
+		if meta.IsNoMatchError(err) {
+			log.Info("ConsoleCLIDownload CRD not available (Console capability not enabled), skipping setup")
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to check ConsoleCLIDownload CRD availability: %w", err)
+	}
+	return true, nil
+}

--- a/controllers/console_test.go
+++ b/controllers/console_test.go
@@ -1,0 +1,50 @@
+package controllers
+
+import (
+	"testing"
+
+	consolev1 "github.com/openshift/api/console/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func TestIsConsoleCRDAvailable(t *testing.T) {
+	log := ctrl.Log.WithName("test")
+
+	tests := []struct {
+		name              string
+		includeConsoleCRD bool
+		wantAvailable     bool
+	}{
+		{
+			name:              "returns false when ConsoleCLIDownload CRD is not registered",
+			includeConsoleCRD: false,
+			wantAvailable:     false,
+		},
+		{
+			name:              "returns true when ConsoleCLIDownload CRD is registered",
+			includeConsoleCRD: true,
+			wantAvailable:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var groupVersions []schema.GroupVersion
+			if tt.includeConsoleCRD {
+				groupVersions = append(groupVersions, consolev1.GroupVersion)
+			}
+			mapper := meta.NewDefaultRESTMapper(groupVersions)
+			if tt.includeConsoleCRD {
+				mapper.Add(consolev1.GroupVersion.WithKind("ConsoleCLIDownload"), meta.RESTScopeRoot)
+			}
+
+			available, err := IsConsoleCRDAvailable(mapper, log)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantAvailable, available)
+		})
+	}
+}

--- a/controllers/dpa_controller.go
+++ b/controllers/dpa_controller.go
@@ -64,6 +64,7 @@ var debugMode = os.Getenv("DEBUG") == "true"
 //+kubebuilder:rbac:groups=velero.io,resources=backups;restores;backupstoragelocations;volumesnapshotlocations,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=oadp.openshift.io,resources=dataprotectionapplications/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=oadp.openshift.io,resources=dataprotectionapplications/finalizers,verbs=update
+//+kubebuilder:rbac:groups=console.openshift.io,resources=consoleclidownloads,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile is part of the main Kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/main.go
+++ b/main.go
@@ -38,6 +38,7 @@ import (
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
+	consolev1 "github.com/openshift/api/console/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	security "github.com/openshift/api/security/v1"
 	"github.com/openshift/oadp-operator/controllers"
@@ -199,6 +200,29 @@ func main() {
 	if err := v1.AddToScheme(mgr.GetScheme()); err != nil {
 		setupLog.Error(err, "unable to add Kubernetes API extensions to scheme")
 		os.Exit(1)
+	}
+
+	if err := consolev1.AddToScheme(mgr.GetScheme()); err != nil {
+		setupLog.Error(err, "unable to add OpenShift console API to scheme")
+		os.Exit(1)
+	}
+
+	// Add CLI download setup runnable.
+	// Skip when the ConsoleCLIDownload CRD is absent (clusters without Console capability, e.g. SNO).
+	if available, err := controllers.IsConsoleCRDAvailable(mgr.GetRESTMapper(), setupLog); !available {
+		if err != nil {
+			setupLog.Error(err, "unable to check ConsoleCLIDownload CRD availability, skipping CLI download setup")
+		}
+	} else {
+		if err := mgr.Add(&controllers.CLIDownloadSetup{
+			Client:            mgr.GetClient(),
+			Namespace:         watchNamespace,
+			OperatorName:      "openshift-adp-controller-manager",
+			OperatorNamespace: watchNamespace,
+		}); err != nil {
+			setupLog.Error(err, "unable to add CLI download setup")
+			os.Exit(1)
+		}
 	}
 
 	if err = (&controllers.DPAReconciler{


### PR DESCRIPTION
## Why the changes were made

OADP 1.6 added Console CLI download support in #1997: the operator deploys an oadp-cli download server and registers a ConsoleCLIDownload so users can install the CLI from Help → Command line tools in the OpenShift Console.

This PR backports the Console CLI download flow to oadp-1.3, with 1.3-specific adjustments:

- `RELATED_IMAGE_CONSOLE_CLI_DOWNLOAD` points at `quay.io/konveyor/oadp-cli-binaries:oadp-1.3`.
- [OADP-7868](https://redhat.atlassian.net/browse/OADP-7868): skip CLI download setup when the ConsoleCLIDownload CRD is not installed (e.g. clusters without Console capability).
- Adapted from `internal/controller/` package path (1.5/1.6) to `controllers/` for 1.3 compatibility.
- Removed `DiscoveryClient()` from `timeoutFactory` — not part of the Velero 1.12 `Factory` interface used in 1.3.
- VMDP / file-restore download from later 1.6 commits is not included — CLI download only.

## How to test the changes made

```bash
git checkout backport-cli-download-1.3
make test
```