### PR TITLE
OADP-8446: add namesapce resource policy for oadp

### DIFF
--- a/bundle/manifests/oadp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/oadp-operator.clusterserviceversion.yaml
@@ -298,7 +298,7 @@ metadata:
       Cloud Provider,Developer Tools,Modernization & Migration,OpenShift Optional,Storage
     certified: "false"
     containerImage: quay.io/konveyor/oadp-operator:latest
-    createdAt: "2025-02-28T20:03:54Z"
+    createdAt: "2026-07-16T15:56:44Z"
     description: OADP (OpenShift API for Data Protection) operator sets up and installs
       Data Protection Applications on the OpenShift platform.
     features.operators.openshift.io/cnf: "false"
@@ -1168,6 +1168,15 @@ spec:
           - list
           - patch
           - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - resourcequotas
+          verbs:
+          - create
+          - get
+          - list
           - watch
         - apiGroups:
           - apps

--- a/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/bundle/manifests/oadp.openshift.io_dataprotectionapplications.yaml
@@ -12,727 +12,434 @@ spec:
     listKind: DataProtectionApplicationList
     plural: dataprotectionapplications
     shortNames:
-      - dpa
+    - dpa
     singular: dataprotectionapplication
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - description: DataProtectionApplication Reconciled Status
-          jsonPath: .status.conditions[?(@.type=='Reconciled')].status
-          name: Reconciled
-          type: string
-        - description: DataProtectionApplication creation timestamp
-          jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: |-
-            DataProtectionApplication represents configuration to install a data protection
-            application to safely backup and restore, perform disaster recovery and migrate
-            Kubernetes cluster resources and persistent volumes.
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-              type: string
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: DataProtectionApplicationSpec defines the desired state of Velero
-              properties:
-                backupImages:
-                  description: backupImages is used to specify whether you want to deploy a registry for enabling backup and restore of images
-                  type: boolean
-                backupLocations:
-                  description: backupLocations defines the list of desired configuration to use for BackupStorageLocations
-                  items:
-                    description: BackupLocation defines the configuration for the DPA backup storage
-                    properties:
-                      bucket:
-                        description: CloudStorageLocation defines BackupStorageLocation using bucket referenced by CloudStorage CR.
-                        properties:
-                          backupSyncPeriod:
-                            description: backupSyncPeriod defines how frequently to sync backup API objects from object storage. A value of 0 disables sync.
-                            nullable: true
-                            type: string
-                          caCert:
-                            description: CACert defines a CA bundle to use when verifying TLS connections to the provider.
-                            format: byte
-                            type: string
-                          cloudStorageRef:
-                            description: |-
-                              LocalObjectReference contains enough information to let you locate the
-                              referenced object inside the same namespace.
-                            properties:
-                              name:
-                                default: ""
-                                description: |-
-                                  Name of the referent.
-                                  This field is effectively required, but due to backwards compatibility is
-                                  allowed to be empty. Instances of this type with an empty value here are
-                                  almost certainly wrong.
-                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                type: string
-                            type: object
-                            x-kubernetes-map-type: atomic
-                          config:
-                            additionalProperties:
-                              type: string
-                            description: config is for provider-specific configuration fields.
-                            type: object
-                          credential:
-                            description: credential contains the credential information intended to be used with this location
-                            properties:
-                              key:
-                                description: The key of the secret to select from.  Must be a valid secret key.
-                                type: string
-                              name:
-                                default: ""
-                                description: |-
-                                  Name of the referent.
-                                  This field is effectively required, but due to backwards compatibility is
-                                  allowed to be empty. Instances of this type with an empty value here are
-                                  almost certainly wrong.
-                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                type: string
-                              optional:
-                                description: Specify whether the Secret or its key must be defined
-                                type: boolean
-                            required:
-                              - key
-                            type: object
-                            x-kubernetes-map-type: atomic
-                          default:
-                            description: default indicates this location is the default backup storage location.
-                            type: boolean
-                          prefix:
-                            description: Prefix is the path inside a bucket to use for Velero storage. Optional.
-                            type: string
-                        required:
-                          - cloudStorageRef
-                        type: object
-                      name:
-                        type: string
-                      velero:
-                        description: BackupStorageLocationSpec defines the desired state of a Velero BackupStorageLocation
-                        properties:
-                          accessMode:
-                            description: AccessMode defines the permissions for the backup storage location.
-                            enum:
-                              - ReadOnly
-                              - ReadWrite
-                            type: string
-                          backupSyncPeriod:
-                            description: BackupSyncPeriod defines how frequently to sync backup API objects from object storage. A value of 0 disables sync.
-                            nullable: true
-                            type: string
-                          config:
-                            additionalProperties:
-                              type: string
-                            description: Config is for provider-specific configuration fields.
-                            type: object
-                          credential:
-                            description: Credential contains the credential information intended to be used with this location
-                            properties:
-                              key:
-                                description: The key of the secret to select from.  Must be a valid secret key.
-                                type: string
-                              name:
-                                default: ""
-                                description: |-
-                                  Name of the referent.
-                                  This field is effectively required, but due to backwards compatibility is
-                                  allowed to be empty. Instances of this type with an empty value here are
-                                  almost certainly wrong.
-                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                type: string
-                              optional:
-                                description: Specify whether the Secret or its key must be defined
-                                type: boolean
-                            required:
-                              - key
-                            type: object
-                            x-kubernetes-map-type: atomic
-                          default:
-                            description: Default indicates this location is the default backup storage location.
-                            type: boolean
-                          objectStorage:
-                            description: ObjectStorageLocation specifies the settings necessary to connect to a provider's object storage.
-                            properties:
-                              bucket:
-                                description: Bucket is the bucket to use for object storage.
-                                type: string
-                              caCert:
-                                description: |-
-                                  CACert defines a CA bundle to use when verifying TLS connections to the provider.
-                                  Deprecated: Use CACertRef instead.
-                                format: byte
-                                type: string
-                              caCertRef:
-                                description: |-
-                                  CACertRef is a reference to a Secret containing the CA certificate bundle to use
-                                  when verifying TLS connections to the provider. The Secret must be in the same
-                                  namespace as the BackupStorageLocation.
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.  Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    default: ""
-                                    description: |-
-                                      Name of the referent.
-                                      This field is effectively required, but due to backwards compatibility is
-                                      allowed to be empty. Instances of this type with an empty value here are
-                                      almost certainly wrong.
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    type: string
-                                  optional:
-                                    description: Specify whether the Secret or its key must be defined
-                                    type: boolean
-                                required:
-                                  - key
-                                type: object
-                                x-kubernetes-map-type: atomic
-                              prefix:
-                                description: Prefix is the path inside a bucket to use for Velero storage. Optional.
-                                type: string
-                            required:
-                              - bucket
-                            type: object
-                          provider:
-                            description: Provider is the provider of the backup storage.
-                            type: string
-                          validationFrequency:
-                            description: ValidationFrequency defines how frequently to validate the corresponding object storage. A value of 0 disables validation.
-                            nullable: true
-                            type: string
-                        required:
-                          - objectStorage
-                          - provider
-                        type: object
-                    type: object
-                  type: array
-                configuration:
-                  description: configuration is used to configure the data protection application's server config
+  - additionalPrinterColumns:
+    - description: DataProtectionApplication Reconciled Status
+      jsonPath: .status.conditions[?(@.type=='Reconciled')].status
+      name: Reconciled
+      type: string
+    - description: DataProtectionApplication creation timestamp
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          DataProtectionApplication represents configuration to install a data protection
+          application to safely backup and restore, perform disaster recovery and migrate
+          Kubernetes cluster resources and persistent volumes.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DataProtectionApplicationSpec defines the desired state of
+              Velero
+            properties:
+              backupImages:
+                description: backupImages is used to specify whether you want to deploy
+                  a registry for enabling backup and restore of images
+                type: boolean
+              backupLocations:
+                description: backupLocations defines the list of desired configuration
+                  to use for BackupStorageLocations
+                items:
+                  description: BackupLocation defines the configuration for the DPA
+                    backup storage
                   properties:
-                    kubevirtDatamover:
-                      description: KubevirtDatamover configures the kubevirt-datamover-controller for VM backup/restore.
+                    bucket:
+                      description: CloudStorageLocation defines BackupStorageLocation
+                        using bucket referenced by CloudStorage CR.
                       properties:
-                        maxIncrementalBackups:
+                        backupSyncPeriod:
+                          description: backupSyncPeriod defines how frequently to
+                            sync backup API objects from object storage. A value of
+                            0 disables sync.
+                          nullable: true
+                          type: string
+                        caCert:
+                          description: CACert defines a CA bundle to use when verifying
+                            TLS connections to the provider.
+                          format: byte
+                          type: string
+                        cloudStorageRef:
                           description: |-
-                            MaxIncrementalBackups is the maximum number of incremental backups per VM
-                            before forcing a full backup. 0 means unlimited (default behavior).
-                            Can be overridden per-VM via the kubevirt-datamover.io/max-incremental-backups
-                            annotation on the VirtualMachine CR.
-                          format: int32
-                          minimum: 0
-                          type: integer
-                      type: object
-                    nodeAgent:
-                      description: NodeAgent is needed to allow selection between kopia or restic
-                      properties:
-                        backupPVC:
-                          additionalProperties:
-                            properties:
-                              annotations:
-                                additionalProperties:
-                                  type: string
-                                description: Annotations permits setting annotations for the backupPVC
-                                type: object
-                              readOnly:
-                                description: ReadOnly sets the backupPVC's access mode as read only
-                                type: boolean
-                              spcNoRelabeling:
-                                description: |-
-                                  SPCNoRelabeling sets Spec.SecurityContext.SELinux.Type to "spc_t" for the pod mounting the backupPVC
-                                  ignored if ReadOnly is false
-                                type: boolean
-                              storageClass:
-                                description: StorageClass is the name of storage class to be used by the backupPVC
-                                type: string
-                            type: object
-                          description: BackupPVCConfig is the config for backupPVC (intermediate PVC) of snapshot data movement
-                          type: object
-                        cacheLimitMB:
-                          description: CacheLimitMB specifies the size limit(in MB) for the local data cache
-                          format: int64
-                          minimum: 0
-                          type: integer
-                        cachePVC:
-                          description: |-
-                            CachePVCConfig configures a dedicated PVC for Kopia repository cache during restore operations.
-                            When set, cache data is stored on a provisioned PVC instead of the pod's root filesystem,
-                            preventing ephemeral storage exhaustion on nodes during concurrent restores.
-                            If storageClass is omitted, the cluster's default StorageClass is used.
+                            LocalObjectReference contains enough information to let you locate the
+                            referenced object inside the same namespace.
                           properties:
-                            residentThresholdInMB:
-                              description: ResidentThresholdInMB specifies the minimum size of the backup data to create cache PVC
-                              format: int64
-                              type: integer
-                            storageClass:
-                              description: StorageClass specifies the storage class for cache PVC
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                               type: string
                           type: object
-                        dataMoverPrepareTimeout:
-                          description: How long to wait for preparing a DataUpload/DataDownload. Default is 30 minutes.
-                          type: string
-                        enable:
-                          description: |-
-                            enable defines a boolean pointer whether we want the daemonset to
-                            exist or not
-                          type: boolean
-                        fullMaintenanceInterval:
-                          description: |-
-                            fullMaintenanceInterval determines the time between kopia full maintenance operations.
-                            normalGC: 24 hours
-                            fastGC: 12 hours
-                            eagerGC: 6 hours
-                          enum:
-                            - normalGC
-                            - fastGC
-                            - eagerGC
-                          type: string
-                        loadAffinity:
-                          description: LoadAffinity is the config for data path load affinity.
-                          items:
-                            description: |-
-                              LoadAffinity is the config for data path load affinity.
-                              Used by the Node-Agent, that needs to match the DataMover and the RepositoryMaintenance pods.
-                            properties:
-                              nodeSelector:
-                                description: NodeSelector specifies the label selector to match nodes
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                    items:
-                                      description: |-
-                                        A label selector requirement is a selector that contains values, a key, and an operator that
-                                        relates the key and values.
-                                      properties:
-                                        key:
-                                          description: key is the label key that the selector applies to.
-                                          type: string
-                                        operator:
-                                          description: |-
-                                            operator represents a key's relationship to a set of values.
-                                            Valid operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: |-
-                                            values is an array of string values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                            the values array must be empty. This array is replaced during a strategic
-                                            merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                          x-kubernetes-list-type: atomic
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                    x-kubernetes-list-type: atomic
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    description: |-
-                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                    type: object
-                                type: object
-                                x-kubernetes-map-type: atomic
-                              storageClass:
-                                description: |-
-                                  StorageClass specifies the storage class to which this LoadAffinity rule applies.
-                                  If empty, the affinity applies globally to all data mover operations.
-                                  If set, the affinity applies only to data mover operations using this specific StorageClass.
-                                type: string
-                            type: object
-                          type: array
-                        loadConcurrency:
-                          description: LoadConcurrency is the config for data path load concurrency per node.
-                          properties:
-                            globalConfig:
-                              description: GlobalConfig specifies the concurrency number to all nodes for which per-node config is not specified
-                              type: integer
-                            perNodeConfig:
-                              description: PerNodeConfig specifies the concurrency number to nodes matched by rules
-                              items:
-                                description: RuledConfigs is the config for data path load concurrency per node.
-                                properties:
-                                  nodeSelector:
-                                    description: NodeSelector specifies the label selector to match nodes
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                        items:
-                                          description: |-
-                                            A label selector requirement is a selector that contains values, a key, and an operator that
-                                            relates the key and values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: |-
-                                                operator represents a key's relationship to a set of values.
-                                                Valid operators are In, NotIn, Exists and DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: |-
-                                                values is an array of string values. If the operator is In or NotIn,
-                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                              x-kubernetes-list-type: atomic
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                        x-kubernetes-list-type: atomic
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: |-
-                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                    x-kubernetes-map-type: atomic
-                                  number:
-                                    description: Number specifies the number value associated to the matched nodes
-                                    type: integer
-                                required:
-                                  - nodeSelector
-                                  - number
-                                type: object
-                              type: array
-                            prepareQueueLength:
-                              description: PrepareQueueLength specifies the max number of loads that are under expose
-                              type: integer
-                          type: object
-                        podAnnotations:
+                          x-kubernetes-map-type: atomic
+                        config:
                           additionalProperties:
                             type: string
-                          description: PodAnnotations are annotations to be added to pods created by node-agent, i.e., data mover pods.
+                          description: config is for provider-specific configuration
+                            fields.
                           type: object
-                        podConfig:
-                          description: Pod specific configuration
+                        credential:
+                          description: credential contains the credential information
+                            intended to be used with this location
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        default:
+                          description: default indicates this location is the default
+                            backup storage location.
+                          type: boolean
+                        prefix:
+                          description: Prefix is the path inside a bucket to use for
+                            Velero storage. Optional.
+                          type: string
+                      required:
+                      - cloudStorageRef
+                      type: object
+                    name:
+                      type: string
+                    velero:
+                      description: BackupStorageLocationSpec defines the desired state
+                        of a Velero BackupStorageLocation
+                      properties:
+                        accessMode:
+                          description: AccessMode defines the permissions for the
+                            backup storage location.
+                          enum:
+                          - ReadOnly
+                          - ReadWrite
+                          type: string
+                        backupSyncPeriod:
+                          description: BackupSyncPeriod defines how frequently to
+                            sync backup API objects from object storage. A value of
+                            0 disables sync.
+                          nullable: true
+                          type: string
+                        config:
+                          additionalProperties:
+                            type: string
+                          description: Config is for provider-specific configuration
+                            fields.
+                          type: object
+                        credential:
+                          description: Credential contains the credential information
+                            intended to be used with this location
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        default:
+                          description: Default indicates this location is the default
+                            backup storage location.
+                          type: boolean
+                        objectStorage:
+                          description: ObjectStorageLocation specifies the settings
+                            necessary to connect to a provider's object storage.
+                          properties:
+                            bucket:
+                              description: Bucket is the bucket to use for object
+                                storage.
+                              type: string
+                            caCert:
+                              description: |-
+                                CACert defines a CA bundle to use when verifying TLS connections to the provider.
+                                Deprecated: Use CACertRef instead.
+                              format: byte
+                              type: string
+                            caCertRef:
+                              description: |-
+                                CACertRef is a reference to a Secret containing the CA certificate bundle to use
+                                when verifying TLS connections to the provider. The Secret must be in the same
+                                namespace as the BackupStorageLocation.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            prefix:
+                              description: Prefix is the path inside a bucket to use
+                                for Velero storage. Optional.
+                              type: string
+                          required:
+                          - bucket
+                          type: object
+                        provider:
+                          description: Provider is the provider of the backup storage.
+                          type: string
+                        validationFrequency:
+                          description: ValidationFrequency defines how frequently
+                            to validate the corresponding object storage. A value
+                            of 0 disables validation.
+                          nullable: true
+                          type: string
+                      required:
+                      - objectStorage
+                      - provider
+                      type: object
+                  type: object
+                type: array
+              configuration:
+                description: configuration is used to configure the data protection
+                  application's server config
+                properties:
+                  kubevirtDatamover:
+                    description: KubevirtDatamover configures the kubevirt-datamover-controller
+                      for VM backup/restore.
+                    properties:
+                      maxIncrementalBackups:
+                        description: |-
+                          MaxIncrementalBackups is the maximum number of incremental backups per VM
+                          before forcing a full backup. 0 means unlimited (default behavior).
+                          Can be overridden per-VM via the kubevirt-datamover.io/max-incremental-backups
+                          annotation on the VirtualMachine CR.
+                        format: int32
+                        minimum: 0
+                        type: integer
+                    type: object
+                  nodeAgent:
+                    description: NodeAgent is needed to allow selection between kopia
+                      or restic
+                    properties:
+                      backupPVC:
+                        additionalProperties:
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
-                              description: annotations to add to pods
+                              description: Annotations permits setting annotations
+                                for the backupPVC
                               type: object
-                            env:
-                              description: env defines the list of environment variables to be supplied to podSpec
-                              items:
-                                description: EnvVar represents an environment variable present in a Container.
-                                properties:
-                                  name:
-                                    description: Name of the environment variable. Must be a C_IDENTIFIER.
-                                    type: string
-                                  value:
-                                    description: |-
-                                      Variable references $(VAR_NAME) are expanded
-                                      using the previously defined environment variables in the container and
-                                      any service environment variables. If a variable cannot be resolved,
-                                      the reference in the input string will be unchanged. Double $$ are reduced
-                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                                      "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                                      Escaped references will never be expanded, regardless of whether the variable
-                                      exists or not.
-                                      Defaults to "".
-                                    type: string
-                                  valueFrom:
-                                    description: Source for the environment variable's value. Cannot be used if value is not empty.
-                                    properties:
-                                      configMapKeyRef:
-                                        description: Selects a key of a ConfigMap.
-                                        properties:
-                                          key:
-                                            description: The key to select.
-                                            type: string
-                                          name:
-                                            default: ""
-                                            description: |-
-                                              Name of the referent.
-                                              This field is effectively required, but due to backwards compatibility is
-                                              allowed to be empty. Instances of this type with an empty value here are
-                                              almost certainly wrong.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            type: string
-                                          optional:
-                                            description: Specify whether the ConfigMap or its key must be defined
-                                            type: boolean
-                                        required:
-                                          - key
-                                        type: object
-                                        x-kubernetes-map-type: atomic
-                                      fieldRef:
-                                        description: |-
-                                          Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                          spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
-                                        properties:
-                                          apiVersion:
-                                            description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
-                                            type: string
-                                          fieldPath:
-                                            description: Path of the field to select in the specified API version.
-                                            type: string
-                                        required:
-                                          - fieldPath
-                                        type: object
-                                        x-kubernetes-map-type: atomic
-                                      resourceFieldRef:
-                                        description: |-
-                                          Selects a resource of the container: only resources limits and requests
-                                          (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
-                                        properties:
-                                          containerName:
-                                            description: 'Container name: required for volumes, optional for env vars'
-                                            type: string
-                                          divisor:
-                                            anyOf:
-                                              - type: integer
-                                              - type: string
-                                            description: Specifies the output format of the exposed resources, defaults to "1"
-                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                            x-kubernetes-int-or-string: true
-                                          resource:
-                                            description: 'Required: resource to select'
-                                            type: string
-                                        required:
-                                          - resource
-                                        type: object
-                                        x-kubernetes-map-type: atomic
-                                      secretKeyRef:
-                                        description: Selects a key of a secret in the pod's namespace
-                                        properties:
-                                          key:
-                                            description: The key of the secret to select from.  Must be a valid secret key.
-                                            type: string
-                                          name:
-                                            default: ""
-                                            description: |-
-                                              Name of the referent.
-                                              This field is effectively required, but due to backwards compatibility is
-                                              allowed to be empty. Instances of this type with an empty value here are
-                                              almost certainly wrong.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            type: string
-                                          optional:
-                                            description: Specify whether the Secret or its key must be defined
-                                            type: boolean
-                                        required:
-                                          - key
-                                        type: object
-                                        x-kubernetes-map-type: atomic
-                                    type: object
-                                required:
-                                  - name
-                                type: object
-                              type: array
-                            labels:
-                              additionalProperties:
-                                type: string
-                              description: labels to add to pods
-                              type: object
-                            nodeSelector:
-                              additionalProperties:
-                                type: string
-                              description: nodeSelector defines the nodeSelector to be supplied to podSpec
-                              type: object
-                            priorityClassName:
-                              description: priorityClassName defines the PriorityClass name to be applied to the pod
-                              type: string
-                            resourceAllocations:
-                              description: resourceAllocations defines the CPU, Memory and ephemeral-storage resource allocations for the Pod
-                              nullable: true
-                              properties:
-                                claims:
-                                  description: |-
-                                    Claims lists the names of resources, defined in spec.resourceClaims,
-                                    that are used by this container.
-
-                                    This is an alpha field and requires enabling the
-                                    DynamicResourceAllocation feature gate.
-
-                                    This field is immutable. It can only be set for containers.
-                                  items:
-                                    description: ResourceClaim references one entry in PodSpec.ResourceClaims.
-                                    properties:
-                                      name:
-                                        description: |-
-                                          Name must match the name of one entry in pod.spec.resourceClaims of
-                                          the Pod where this field is used. It makes that resource available
-                                          inside a container.
-                                        type: string
-                                      request:
-                                        description: |-
-                                          Request is the name chosen for a request in the referenced claim.
-                                          If empty, everything from the claim is made available, otherwise
-                                          only the result of this request.
-                                        type: string
-                                    required:
-                                      - name
-                                    type: object
-                                  type: array
-                                  x-kubernetes-list-map-keys:
-                                    - name
-                                  x-kubernetes-list-type: map
-                                limits:
-                                  additionalProperties:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                  description: |-
-                                    Limits describes the maximum amount of compute resources allowed.
-                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                                  type: object
-                                requests:
-                                  additionalProperties:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                  description: |-
-                                    Requests describes the minimum amount of compute resources required.
-                                    If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                    otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                                  type: object
-                              type: object
-                            tolerations:
-                              description: tolerations defines the list of tolerations to be applied to daemonset
-                              items:
-                                description: |-
-                                  The pod this Toleration is attached to tolerates any taint that matches
-                                  the triple <key,value,effect> using the matching operator <operator>.
-                                properties:
-                                  effect:
-                                    description: |-
-                                      Effect indicates the taint effect to match. Empty means match all taint effects.
-                                      When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
-                                    type: string
-                                  key:
-                                    description: |-
-                                      Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                                      If the key is empty, operator must be Exists; this combination means to match all values and all keys.
-                                    type: string
-                                  operator:
-                                    description: |-
-                                      Operator represents a key's relationship to the value.
-                                      Valid operators are Exists and Equal. Defaults to Equal.
-                                      Exists is equivalent to wildcard for value, so that a pod can
-                                      tolerate all taints of a particular category.
-                                    type: string
-                                  tolerationSeconds:
-                                    description: |-
-                                      TolerationSeconds represents the period of time the toleration (which must be
-                                      of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                                      it is not set, which means tolerate the taint forever (do not evict). Zero and
-                                      negative values will be treated as 0 (evict immediately) by the system.
-                                    format: int64
-                                    type: integer
-                                  value:
-                                    description: |-
-                                      Value is the taint value the toleration matches to.
-                                      If the operator is Exists, the value should be empty, otherwise just a regular string.
-                                    type: string
-                                type: object
-                              type: array
-                          type: object
-                        podLabels:
-                          additionalProperties:
-                            type: string
-                          description: PodLabels are labels to be added to pods created by node-agent, i.e., data mover pods.
-                          type: object
-                        podResources:
-                          description: PodResources is the resource config for various types of pods launched by node-agent, i.e., data mover pods.
-                          properties:
-                            cpuLimit:
-                              type: string
-                            cpuRequest:
-                              type: string
-                            memoryLimit:
-                              type: string
-                            memoryRequest:
-                              type: string
-                          type: object
-                        resourceTimeout:
-                          description: How long to wait for resource processes which are not covered by other specific timeout parameters. Default is 10 minutes.
-                          type: string
-                        restorePVC:
-                          description: RestoreVCConfig is the config for restorePVC (intermediate PVC) of generic restore
-                          properties:
-                            ignoreDelayBinding:
-                              description: IgnoreDelayBinding indicates to ignore delay binding the restorePVC when it is in WaitForFirstConsumer mode
+                            readOnly:
+                              description: ReadOnly sets the backupPVC's access mode
+                                as read only
                               type: boolean
+                            spcNoRelabeling:
+                              description: |-
+                                SPCNoRelabeling sets Spec.SecurityContext.SELinux.Type to "spc_t" for the pod mounting the backupPVC
+                                ignored if ReadOnly is false
+                              type: boolean
+                            storageClass:
+                              description: StorageClass is the name of storage class
+                                to be used by the backupPVC
+                              type: string
                           type: object
-                        supplementalGroups:
-                          description: supplementalGroups defines the linux groups to be applied to the NodeAgent Pod
-                          items:
+                        description: BackupPVCConfig is the config for backupPVC (intermediate
+                          PVC) of snapshot data movement
+                        type: object
+                      cacheLimitMB:
+                        description: CacheLimitMB specifies the size limit(in MB)
+                          for the local data cache
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      cachePVC:
+                        description: |-
+                          CachePVCConfig configures a dedicated PVC for Kopia repository cache during restore operations.
+                          When set, cache data is stored on a provisioned PVC instead of the pod's root filesystem,
+                          preventing ephemeral storage exhaustion on nodes during concurrent restores.
+                          If storageClass is omitted, the cluster's default StorageClass is used.
+                        properties:
+                          residentThresholdInMB:
+                            description: ResidentThresholdInMB specifies the minimum
+                              size of the backup data to create cache PVC
                             format: int64
                             type: integer
-                          type: array
-                        timeout:
-                          description: timeout defines the NodeAgent timeout, default value is 1h
-                          type: string
-                        uploaderType:
-                          description: The type of uploader to transfer the data of pod volumes, the supported values are 'restic' or 'kopia'
-                          enum:
-                            - restic
-                            - kopia
-                          type: string
-                      required:
-                        - uploaderType
-                      type: object
-                    repositoryMaintenance:
-                      additionalProperties:
-                        properties:
-                          loadAffinity:
-                            description: LoadAffinity is the config for data path load affinity.
-                            items:
+                          storageClass:
+                            description: StorageClass specifies the storage class
+                              for cache PVC
+                            type: string
+                        type: object
+                      dataMoverPrepareTimeout:
+                        description: How long to wait for preparing a DataUpload/DataDownload.
+                          Default is 30 minutes.
+                        type: string
+                      enable:
+                        description: |-
+                          enable defines a boolean pointer whether we want the daemonset to
+                          exist or not
+                        type: boolean
+                      fullMaintenanceInterval:
+                        description: |-
+                          fullMaintenanceInterval determines the time between kopia full maintenance operations.
+                          normalGC: 24 hours
+                          fastGC: 12 hours
+                          eagerGC: 6 hours
+                        enum:
+                        - normalGC
+                        - fastGC
+                        - eagerGC
+                        type: string
+                      loadAffinity:
+                        description: LoadAffinity is the config for data path load
+                          affinity.
+                        items:
+                          description: |-
+                            LoadAffinity is the config for data path load affinity.
+                            Used by the Node-Agent, that needs to match the DataMover and the RepositoryMaintenance pods.
+                          properties:
+                            nodeSelector:
+                              description: NodeSelector specifies the label selector
+                                to match nodes
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            storageClass:
                               description: |-
-                                LoadAffinity is the config for data path load affinity.
-                                Used by the Node-Agent, that needs to match the DataMover and the RepositoryMaintenance pods.
+                                StorageClass specifies the storage class to which this LoadAffinity rule applies.
+                                If empty, the affinity applies globally to all data mover operations.
+                                If set, the affinity applies only to data mover operations using this specific StorageClass.
+                              type: string
+                          type: object
+                        type: array
+                      loadConcurrency:
+                        description: LoadConcurrency is the config for data path load
+                          concurrency per node.
+                        properties:
+                          globalConfig:
+                            description: GlobalConfig specifies the concurrency number
+                              to all nodes for which per-node config is not specified
+                            type: integer
+                          perNodeConfig:
+                            description: PerNodeConfig specifies the concurrency number
+                              to nodes matched by rules
+                            items:
+                              description: RuledConfigs is the config for data path
+                                load concurrency per node.
                               properties:
                                 nodeSelector:
-                                  description: NodeSelector specifies the label selector to match nodes
+                                  description: NodeSelector specifies the label selector
+                                    to match nodes
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
                                       items:
                                         description: |-
                                           A label selector requirement is a selector that contains values, a key, and an operator that
                                           relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that the selector applies to.
+                                            description: key is the label key that
+                                              the selector applies to.
                                             type: string
                                           operator:
                                             description: |-
@@ -750,8 +457,8 @@ spec:
                                             type: array
                                             x-kubernetes-list-type: atomic
                                         required:
-                                          - key
-                                          - operator
+                                        - key
+                                        - operator
                                         type: object
                                       type: array
                                       x-kubernetes-list-type: atomic
@@ -765,548 +472,356 @@ spec:
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
-                                storageClass:
+                                number:
+                                  description: Number specifies the number value associated
+                                    to the matched nodes
+                                  type: integer
+                              required:
+                              - nodeSelector
+                              - number
+                              type: object
+                            type: array
+                          prepareQueueLength:
+                            description: PrepareQueueLength specifies the max number
+                              of loads that are under expose
+                            type: integer
+                        type: object
+                      podAnnotations:
+                        additionalProperties:
+                          type: string
+                        description: PodAnnotations are annotations to be added to
+                          pods created by node-agent, i.e., data mover pods.
+                        type: object
+                      podConfig:
+                        description: Pod specific configuration
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: annotations to add to pods
+                            type: object
+                          env:
+                            description: env defines the list of environment variables
+                              to be supplied to podSpec
+                            items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
+                              properties:
+                                name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
+                                  type: string
+                                value:
                                   description: |-
-                                    StorageClass specifies the storage class to which this LoadAffinity rule applies.
-                                    If empty, the affinity applies globally to all data mover operations.
-                                    If set, the affinity applies only to data mover operations using this specific StorageClass.
+                                    Variable references $(VAR_NAME) are expanded
+                                    using the previously defined environment variables in the container and
+                                    any service environment variables. If a variable cannot be resolved,
+                                    the reference in the input string will be unchanged. Double $$ are reduced
+                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                    "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                    Escaped references will never be expanded, regardless of whether the variable
+                                    exists or not.
+                                    Defaults to "".
+                                  type: string
+                                valueFrom:
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    fieldRef:
+                                      description: |-
+                                        Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                        spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    resourceFieldRef:
+                                      description: |-
+                                        Selects a resource of the container: only resources limits and requests
+                                        (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          labels:
+                            additionalProperties:
+                              type: string
+                            description: labels to add to pods
+                            type: object
+                          nodeSelector:
+                            additionalProperties:
+                              type: string
+                            description: nodeSelector defines the nodeSelector to
+                              be supplied to podSpec
+                            type: object
+                          priorityClassName:
+                            description: priorityClassName defines the PriorityClass
+                              name to be applied to the pod
+                            type: string
+                          resourceAllocations:
+                            description: resourceAllocations defines the CPU, Memory
+                              and ephemeral-storage resource allocations for the Pod
+                            nullable: true
+                            properties:
+                              claims:
+                                description: |-
+                                  Claims lists the names of resources, defined in spec.resourceClaims,
+                                  that are used by this container.
+
+                                  This is an alpha field and requires enabling the
+                                  DynamicResourceAllocation feature gate.
+
+                                  This field is immutable. It can only be set for containers.
+                                items:
+                                  description: ResourceClaim references one entry
+                                    in PodSpec.ResourceClaims.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name must match the name of one entry in pod.spec.resourceClaims of
+                                        the Pod where this field is used. It makes that resource available
+                                        inside a container.
+                                      type: string
+                                    request:
+                                      description: |-
+                                        Request is the name chosen for a request in the referenced claim.
+                                        If empty, everything from the claim is made available, otherwise
+                                        only the result of this request.
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: |-
+                                  Limits describes the maximum amount of compute resources allowed.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: |-
+                                  Requests describes the minimum amount of compute resources required.
+                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                            type: object
+                          tolerations:
+                            description: tolerations defines the list of tolerations
+                              to be applied to daemonset
+                            items:
+                              description: |-
+                                The pod this Toleration is attached to tolerates any taint that matches
+                                the triple <key,value,effect> using the matching operator <operator>.
+                              properties:
+                                effect:
+                                  description: |-
+                                    Effect indicates the taint effect to match. Empty means match all taint effects.
+                                    When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                  type: string
+                                key:
+                                  description: |-
+                                    Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                    If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    Operator represents a key's relationship to the value.
+                                    Valid operators are Exists and Equal. Defaults to Equal.
+                                    Exists is equivalent to wildcard for value, so that a pod can
+                                    tolerate all taints of a particular category.
+                                  type: string
+                                tolerationSeconds:
+                                  description: |-
+                                    TolerationSeconds represents the period of time the toleration (which must be
+                                    of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                    it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                    negative values will be treated as 0 (evict immediately) by the system.
+                                  format: int64
+                                  type: integer
+                                value:
+                                  description: |-
+                                    Value is the taint value the toleration matches to.
+                                    If the operator is Exists, the value should be empty, otherwise just a regular string.
                                   type: string
                               type: object
                             type: array
-                          podAnnotations:
-                            additionalProperties:
-                              type: string
-                            description: |-
-                              PodAnnotations are annotations to be added to maintenance job pods.
-                              This is only read from the global configuration, not per-repository.
-                            type: object
-                          podLabels:
-                            additionalProperties:
-                              type: string
-                            description: |-
-                              PodLabels are labels to be added to maintenance job pods.
-                              This is only read from the global configuration, not per-repository.
-                            type: object
-                          podResources:
-                            description: PodResources is the config for the CPU and memory resources setting.
-                            properties:
-                              cpuLimit:
-                                type: string
-                              cpuRequest:
-                                type: string
-                              memoryLimit:
-                                type: string
-                              memoryRequest:
-                                type: string
-                            type: object
                         type: object
-                      description: |-
-                        RepositoryMaintenance maps a BackupRepository identifier to its configuration.
-                        Keys can be:
-                         - "global" : Applies to all repositories without specific config.
-                         - "<namespace>" : The namespace of the BackupRepository.
-                         - "<repository name>" : The specific BackupRepository name referencing the BSL.
-                         - "<repository type>" : Either "kopia" or "restic".
-                      type: object
-                    restic:
-                      description: |-
-                        (do not use warning) restic field is for backwards compatibility and
-                        will be removed in the future. Use nodeAgent field instead
-                      properties:
-                        enable:
-                          description: |-
-                            enable defines a boolean pointer whether we want the daemonset to
-                            exist or not
-                          type: boolean
-                        podConfig:
-                          description: Pod specific configuration
-                          properties:
-                            annotations:
-                              additionalProperties:
-                                type: string
-                              description: annotations to add to pods
-                              type: object
-                            env:
-                              description: env defines the list of environment variables to be supplied to podSpec
-                              items:
-                                description: EnvVar represents an environment variable present in a Container.
-                                properties:
-                                  name:
-                                    description: Name of the environment variable. Must be a C_IDENTIFIER.
-                                    type: string
-                                  value:
-                                    description: |-
-                                      Variable references $(VAR_NAME) are expanded
-                                      using the previously defined environment variables in the container and
-                                      any service environment variables. If a variable cannot be resolved,
-                                      the reference in the input string will be unchanged. Double $$ are reduced
-                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                                      "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                                      Escaped references will never be expanded, regardless of whether the variable
-                                      exists or not.
-                                      Defaults to "".
-                                    type: string
-                                  valueFrom:
-                                    description: Source for the environment variable's value. Cannot be used if value is not empty.
-                                    properties:
-                                      configMapKeyRef:
-                                        description: Selects a key of a ConfigMap.
-                                        properties:
-                                          key:
-                                            description: The key to select.
-                                            type: string
-                                          name:
-                                            default: ""
-                                            description: |-
-                                              Name of the referent.
-                                              This field is effectively required, but due to backwards compatibility is
-                                              allowed to be empty. Instances of this type with an empty value here are
-                                              almost certainly wrong.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            type: string
-                                          optional:
-                                            description: Specify whether the ConfigMap or its key must be defined
-                                            type: boolean
-                                        required:
-                                          - key
-                                        type: object
-                                        x-kubernetes-map-type: atomic
-                                      fieldRef:
-                                        description: |-
-                                          Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                          spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
-                                        properties:
-                                          apiVersion:
-                                            description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
-                                            type: string
-                                          fieldPath:
-                                            description: Path of the field to select in the specified API version.
-                                            type: string
-                                        required:
-                                          - fieldPath
-                                        type: object
-                                        x-kubernetes-map-type: atomic
-                                      resourceFieldRef:
-                                        description: |-
-                                          Selects a resource of the container: only resources limits and requests
-                                          (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
-                                        properties:
-                                          containerName:
-                                            description: 'Container name: required for volumes, optional for env vars'
-                                            type: string
-                                          divisor:
-                                            anyOf:
-                                              - type: integer
-                                              - type: string
-                                            description: Specifies the output format of the exposed resources, defaults to "1"
-                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                            x-kubernetes-int-or-string: true
-                                          resource:
-                                            description: 'Required: resource to select'
-                                            type: string
-                                        required:
-                                          - resource
-                                        type: object
-                                        x-kubernetes-map-type: atomic
-                                      secretKeyRef:
-                                        description: Selects a key of a secret in the pod's namespace
-                                        properties:
-                                          key:
-                                            description: The key of the secret to select from.  Must be a valid secret key.
-                                            type: string
-                                          name:
-                                            default: ""
-                                            description: |-
-                                              Name of the referent.
-                                              This field is effectively required, but due to backwards compatibility is
-                                              allowed to be empty. Instances of this type with an empty value here are
-                                              almost certainly wrong.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            type: string
-                                          optional:
-                                            description: Specify whether the Secret or its key must be defined
-                                            type: boolean
-                                        required:
-                                          - key
-                                        type: object
-                                        x-kubernetes-map-type: atomic
-                                    type: object
-                                required:
-                                  - name
-                                type: object
-                              type: array
-                            labels:
-                              additionalProperties:
-                                type: string
-                              description: labels to add to pods
-                              type: object
-                            nodeSelector:
-                              additionalProperties:
-                                type: string
-                              description: nodeSelector defines the nodeSelector to be supplied to podSpec
-                              type: object
-                            priorityClassName:
-                              description: priorityClassName defines the PriorityClass name to be applied to the pod
-                              type: string
-                            resourceAllocations:
-                              description: resourceAllocations defines the CPU, Memory and ephemeral-storage resource allocations for the Pod
-                              nullable: true
-                              properties:
-                                claims:
-                                  description: |-
-                                    Claims lists the names of resources, defined in spec.resourceClaims,
-                                    that are used by this container.
-
-                                    This is an alpha field and requires enabling the
-                                    DynamicResourceAllocation feature gate.
-
-                                    This field is immutable. It can only be set for containers.
-                                  items:
-                                    description: ResourceClaim references one entry in PodSpec.ResourceClaims.
-                                    properties:
-                                      name:
-                                        description: |-
-                                          Name must match the name of one entry in pod.spec.resourceClaims of
-                                          the Pod where this field is used. It makes that resource available
-                                          inside a container.
-                                        type: string
-                                      request:
-                                        description: |-
-                                          Request is the name chosen for a request in the referenced claim.
-                                          If empty, everything from the claim is made available, otherwise
-                                          only the result of this request.
-                                        type: string
-                                    required:
-                                      - name
-                                    type: object
-                                  type: array
-                                  x-kubernetes-list-map-keys:
-                                    - name
-                                  x-kubernetes-list-type: map
-                                limits:
-                                  additionalProperties:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                    nullable: true
-                                  description: |-
-                                    Limits describes the maximum amount of compute resources allowed.
-                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                                  type: object
-                                  nullable: true
-                                requests:
-                                  additionalProperties:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                    nullable: true
-                                  description: |-
-                                    Requests describes the minimum amount of compute resources required.
-                                    If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                    otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                                  type: object
-                                  nullable: true
-                              type: object
-                            tolerations:
-                              description: tolerations defines the list of tolerations to be applied to daemonset
-                              items:
-                                description: |-
-                                  The pod this Toleration is attached to tolerates any taint that matches
-                                  the triple <key,value,effect> using the matching operator <operator>.
-                                properties:
-                                  effect:
-                                    description: |-
-                                      Effect indicates the taint effect to match. Empty means match all taint effects.
-                                      When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
-                                    type: string
-                                  key:
-                                    description: |-
-                                      Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                                      If the key is empty, operator must be Exists; this combination means to match all values and all keys.
-                                    type: string
-                                  operator:
-                                    description: |-
-                                      Operator represents a key's relationship to the value.
-                                      Valid operators are Exists and Equal. Defaults to Equal.
-                                      Exists is equivalent to wildcard for value, so that a pod can
-                                      tolerate all taints of a particular category.
-                                    type: string
-                                  tolerationSeconds:
-                                    description: |-
-                                      TolerationSeconds represents the period of time the toleration (which must be
-                                      of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                                      it is not set, which means tolerate the taint forever (do not evict). Zero and
-                                      negative values will be treated as 0 (evict immediately) by the system.
-                                    format: int64
-                                    type: integer
-                                  value:
-                                    description: |-
-                                      Value is the taint value the toleration matches to.
-                                      If the operator is Exists, the value should be empty, otherwise just a regular string.
-                                    type: string
-                                type: object
-                              type: array
-                          type: object
-                        supplementalGroups:
-                          description: supplementalGroups defines the linux groups to be applied to the NodeAgent Pod
-                          items:
-                            format: int64
-                            type: integer
-                          type: array
-                        timeout:
-                          description: timeout defines the NodeAgent timeout, default value is 1h
+                      podLabels:
+                        additionalProperties:
                           type: string
-                      type: object
-                    velero:
-                      properties:
-                        args:
-                          description: Velero args are settings to customize velero server arguments. Overrides values in other fields.
-                          properties:
-                            add_dir_header:
-                              description: If true, adds the file directory to the header of the log messages
-                              type: boolean
-                            alsologtostderr:
-                              description: log to standard error as well as files (no effect when -logtostderr=true)
-                              type: boolean
-                            backup-sync-period:
-                              description: How often (in nanoseconds) to ensure all Velero backups in object storage exist as Backup API objects in the cluster. This is the default sync period if none is explicitly specified for a backup storage location.
-                              format: int64
-                              type: integer
-                            client-burst:
-                              description: Maximum number of requests by the server to the Kubernetes API in a short period of time.
-                              type: integer
-                            client-page-size:
-                              description: Page size of requests by the server to the Kubernetes API when listing objects during a backup. Set to 0 to disable paging.
-                              type: integer
-                            client-qps:
-                              description: |-
-                                Maximum number of requests per second by the server to the Kubernetes API once the burst limit has been reached.
-                                this will be validated as a valid float32
-                              type: string
-                            colorized:
-                              description: Show colored output in TTY
-                              type: boolean
-                            default-backup-ttl:
-                              description: How long (in nanoseconds) to wait by default before backups can be garbage collected. (default is 720 hours)
-                              format: int64
-                              type: integer
-                            default-item-operation-timeout:
-                              description: How long (in nanoseconds) to wait on asynchronous BackupItemActions and RestoreItemActions to complete before timing out. (default is 1 hour)
-                              format: int64
-                              type: integer
-                            default-repo-maintain-frequency:
-                              description: How often (in nanoseconds) 'maintain' is run for backup repositories by default.
-                              format: int64
-                              type: integer
-                            default-volumes-to-fs-backup:
-                              description: Backup all volumes with pod volume file system backup by default.
-                              type: boolean
-                            disabled-controllers:
-                              description: List of controllers to disable on startup. Valid values are backup,backup-operations,backup-deletion,backup-finalizer,backup-sync,download-request,gc,backup-repo,restore,restore-operations,schedule,server-status-request
-                              enum:
-                                - backup
-                                - backup-operations
-                                - backup-deletion
-                                - backup-finalizer
-                                - backup-sync
-                                - download-request
-                                - gc
-                                - backup-repo
-                                - restore
-                                - restore-operations
-                                - schedule
-                                - server-status-request
-                              items:
-                                type: string
-                              type: array
-                            fs-backup-timeout:
-                              description: How long (in nanoseconds) pod volume file system backups/restores should be allowed to run before timing out. (default is 4 hours)
-                              format: int64
-                              type: integer
-                            garbage-collection-frequency:
-                              description: How often (in nanoseconds) garbage collection checks for expired backups. (default is 1 hour)
-                              format: int64
-                              type: integer
-                            item-operation-sync-frequency:
-                              description: How often (in nanoseconds) to check status on backup/restore operations after backup/restore processing.
-                              format: int64
-                              type: integer
-                            log-format:
-                              description: The format for log output. Valid values are text, json. (default text)
-                              enum:
-                                - text
-                                - json
-                              type: string
-                            log_backtrace_at:
-                              description: when logging hits line file:N, emit a stack trace
-                              type: string
-                            log_dir:
-                              description: If non-empty, write log files in this directory (no effect when -logtostderr=true)
-                              type: string
-                            log_file:
-                              description: If non-empty, use this log file (no effect when -logtostderr=true)
-                              type: string
-                            log_file_max_size:
-                              description: Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-                              format: int64
-                              minimum: 0
-                              type: integer
-                            logtostderr:
-                              description: |-
-                                Boolean flags. Not handled atomically because the flag.Value interface
-                                does not let us avoid the =true, and that shorthand is necessary for
-                                compatibility. TODO: does this matter enough to fix? Seems unlikely.
-                              type: boolean
-                            max-concurrent-k8s-connections:
-                              description: Max concurrent connections number that Velero can create with kube-apiserver. Default is 30. (default 30)
-                              type: integer
-                            metrics-address:
-                              description: The address to expose prometheus metrics
-                              type: string
-                            one_output:
-                              description: If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
-                              type: boolean
-                            profiler-address:
-                              description: The address to expose the pprof profiler.
-                              type: string
-                            resource-timeout:
-                              description: How long (in nanoseconds) to wait for resource processes which are not covered by other specific timeout parameters. (default is 10 minutes)
-                              format: int64
-                              type: integer
-                            restore-resource-priorities:
-                              description: Desired order of resource restores, the priority list contains two parts which are split by "-" element. The resources before "-" element are restored first as high priorities, the resources after "-" element are restored last as low priorities, and any resource not in the list will be restored alphabetically between the high and low priorities. (default securitycontextconstraints,customresourcedefinitions,klusterletconfigs.config.open-cluster-management.io,managedcluster.cluster.open-cluster-management.io,namespaces,roles,rolebindings,clusterrolebindings,klusterletaddonconfig.agent.open-cluster-management.io,managedclusteraddon.addon.open-cluster-management.io,storageclasses,volumesnapshotclass.snapshot.storage.k8s.io,volumesnapshotcontents.snapshot.storage.k8s.io,volumesnapshots.snapshot.storage.k8s.io,datauploads.velero.io,persistentvolumes,persistentvolumeclaims,serviceaccounts,secrets,configmaps,limitranges,pods,replicasets.apps,clusterclasses.cluster.x-k8s.io,endpoints,services,-,clusterbootstraps.run.tanzu.vmware.com,clusters.cluster.x-k8s.io,clusterresourcesets.addons.cluster.x-k8s.io)
-                              type: string
-                            skip_headers:
-                              description: If true, avoid header prefixes in the log messages
-                              type: boolean
-                            skip_log_headers:
-                              description: If true, avoid headers when opening log files (no effect when -logtostderr=true)
-                              type: boolean
-                            stderrthreshold:
-                              description: logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
-                              type: integer
-                            store-validation-frequency:
-                              description: How often (in nanoseconds) to verify if the storage is valid. Optional. Set this to `0` to disable sync. (default is 1 minute)
-                              format: int64
-                              type: integer
-                            terminating-resource-timeout:
-                              description: How long (in nanoseconds) to wait on persistent volumes and namespaces to terminate during a restore before timing out.
-                              format: int64
-                              type: integer
-                            v:
-                              description: number for the log level verbosity
-                              type: integer
-                            vmodule:
-                              description: comma-separated list of pattern=N settings for file-filtered logging
-                              type: string
-                          type: object
-                        client-burst:
-                          description: maximum number of requests by the server to the Kubernetes API in a short period of time. (default 100)
-                          type: integer
-                        client-qps:
-                          description: maximum number of requests per second by the server to the Kubernetes API once the burst limit has been reached. (default 100)
-                          type: integer
-                        concurrentBackups:
-                          description: |-
-                            Number of backups to process at the same time. Only backups which do not have any namespaces
-                            in common will run at the same time. Default is 1.
-                          type: integer
-                        customPlugins:
-                          description: customPlugins defines the custom plugin to be installed with Velero
-                          items:
-                            properties:
-                              image:
-                                type: string
-                              name:
-                                type: string
-                            required:
-                              - image
-                              - name
-                            type: object
-                          type: array
-                        defaultItemOperationTimeout:
-                          description: How long to wait on asynchronous BackupItemActions and RestoreItemActions to complete before timing out. Default value is 1h.
-                          type: string
-                        defaultPlugins:
-                          items:
-                            enum:
-                              - aws
-                              - legacy-aws
-                              - gcp
-                              - azure
-                              - csi
-                              - vsm
-                              - openshift
-                              - kubevirt
-                              - kubevirt-datamover
-                              - hypershift
+                        description: PodLabels are labels to be added to pods created
+                          by node-agent, i.e., data mover pods.
+                        type: object
+                      podResources:
+                        description: PodResources is the resource config for various
+                          types of pods launched by node-agent, i.e., data mover pods.
+                        properties:
+                          cpuLimit:
                             type: string
-                          type: array
-                        defaultSnapshotMoveData:
-                          description: Specify whether CSI snapshot data should be moved to backup storage by default
-                          type: boolean
-                        defaultVolumesToFSBackup:
-                          description: 'Deprecated: Use defaultVolumesToFsBackup instead (matches Velero backup spec).'
-                          type: boolean
-                        defaultVolumesToFsBackup:
-                          description: |-
-                            Use pod volume file system backup by default for volumes.
-                            Matches backup.spec.defaultVolumesToFsBackup in Velero API.
-                          type: boolean
-                        disableFsBackup:
-                          default: false
-                          description: |-
-                            DisableFsBackup determines whether the NodeAgent should disable file system backup.
-                            When set to true, the NodeAgent runs in non-privileged mode.
-                            Defaults to false.
-                          type: boolean
-                        disableInformerCache:
-                          description: Disable informer cache for Get calls on restore. With this enabled, it will speed up restore in cases where there are backup resources which already exist in the cluster, but for very large clusters this will increase velero memory usage. Default is false.
-                          type: boolean
-                        enableCSISnapshotEarlyFrequentPolling:
-                          description: |-
-                            set EnableCSISnapshotEarlyFrequentPolling to true to enable
-                            the 1-second polling interval for the first 10 seconds while waiting
-                            for the snaphandle
-                          type: boolean
-                        featureFlags:
-                          description: featureFlags defines the list of features to enable for Velero instance
-                          items:
+                          cpuRequest:
                             type: string
-                          type: array
-                        itemBlockWorkerCount:
-                          description: |-
-                            Number of workers in worker pool for processing item backup. This will allow multiple items within
-                            a Velero backup to be backed up at the same time which may improve performance for backups with
-                            a large number of items. Workers are per backup if concurrent backups are enabled. Default is 1.
+                          memoryLimit:
+                            type: string
+                          memoryRequest:
+                            type: string
+                        type: object
+                      resourceTimeout:
+                        description: How long to wait for resource processes which
+                          are not covered by other specific timeout parameters. Default
+                          is 10 minutes.
+                        type: string
+                      restorePVC:
+                        description: RestoreVCConfig is the config for restorePVC
+                          (intermediate PVC) of generic restore
+                        properties:
+                          ignoreDelayBinding:
+                            description: IgnoreDelayBinding indicates to ignore delay
+                              binding the restorePVC when it is in WaitForFirstConsumer
+                              mode
+                            type: boolean
+                        type: object
+                      supplementalGroups:
+                        description: supplementalGroups defines the linux groups to
+                          be applied to the NodeAgent Pod
+                        items:
+                          format: int64
                           type: integer
-                        itemOperationSyncFrequency:
-                          description: How often to check status on async backup/restore operations after backup processing. Default value is 2m.
-                          type: string
+                        type: array
+                      timeout:
+                        description: timeout defines the NodeAgent timeout, default
+                          value is 1h
+                        type: string
+                      uploaderType:
+                        description: The type of uploader to transfer the data of
+                          pod volumes, the supported values are 'restic' or 'kopia'
+                        enum:
+                        - restic
+                        - kopia
+                        type: string
+                    required:
+                    - uploaderType
+                    type: object
+                  repositoryMaintenance:
+                    additionalProperties:
+                      properties:
                         loadAffinity:
-                          description: LoadAffinityConfig is the config for data path load affinity.
+                          description: LoadAffinity is the config for data path load
+                            affinity.
                           items:
                             description: |-
                               LoadAffinity is the config for data path load affinity.
                               Used by the Node-Agent, that needs to match the DataMover and the RepositoryMaintenance pods.
                             properties:
                               nodeSelector:
-                                description: NodeSelector specifies the label selector to match nodes
+                                description: NodeSelector specifies the label selector
+                                  to match nodes
                                 properties:
                                   matchExpressions:
-                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
                                     items:
                                       description: |-
                                         A label selector requirement is a selector that contains values, a key, and an operator that
                                         relates the key and values.
                                       properties:
                                         key:
-                                          description: key is the label key that the selector applies to.
+                                          description: key is the label key that the
+                                            selector applies to.
                                           type: string
                                         operator:
                                           description: |-
@@ -1324,8 +839,8 @@ spec:
                                           type: array
                                           x-kubernetes-list-type: atomic
                                       required:
-                                        - key
-                                        - operator
+                                      - key
+                                      - operator
                                       type: object
                                     type: array
                                     x-kubernetes-list-type: atomic
@@ -1347,433 +862,2205 @@ spec:
                                 type: string
                             type: object
                           type: array
-                        logLevel:
-                          description: Velero server's log level (use debug for the most logging, leave unset for velero default)
-                          enum:
-                            - trace
-                            - debug
-                            - info
-                            - warning
-                            - error
-                            - fatal
-                            - panic
-                          type: string
-                        noDefaultBackupLocation:
-                          description: If you need to install Velero without a default backup storage location noDefaultBackupLocation flag is required for confirmation
-                          type: boolean
-                        podConfig:
-                          description: Pod specific configuration
+                        podAnnotations:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            PodAnnotations are annotations to be added to maintenance job pods.
+                            This is only read from the global configuration, not per-repository.
+                          type: object
+                        podLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            PodLabels are labels to be added to maintenance job pods.
+                            This is only read from the global configuration, not per-repository.
+                          type: object
+                        podResources:
+                          description: PodResources is the config for the CPU and
+                            memory resources setting.
                           properties:
-                            annotations:
-                              additionalProperties:
-                                type: string
-                              description: annotations to add to pods
-                              type: object
-                            env:
-                              description: env defines the list of environment variables to be supplied to podSpec
-                              items:
-                                description: EnvVar represents an environment variable present in a Container.
-                                properties:
-                                  name:
-                                    description: Name of the environment variable. Must be a C_IDENTIFIER.
-                                    type: string
-                                  value:
-                                    description: |-
-                                      Variable references $(VAR_NAME) are expanded
-                                      using the previously defined environment variables in the container and
-                                      any service environment variables. If a variable cannot be resolved,
-                                      the reference in the input string will be unchanged. Double $$ are reduced
-                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                                      "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                                      Escaped references will never be expanded, regardless of whether the variable
-                                      exists or not.
-                                      Defaults to "".
-                                    type: string
-                                  valueFrom:
-                                    description: Source for the environment variable's value. Cannot be used if value is not empty.
-                                    properties:
-                                      configMapKeyRef:
-                                        description: Selects a key of a ConfigMap.
-                                        properties:
-                                          key:
-                                            description: The key to select.
-                                            type: string
-                                          name:
-                                            default: ""
-                                            description: |-
-                                              Name of the referent.
-                                              This field is effectively required, but due to backwards compatibility is
-                                              allowed to be empty. Instances of this type with an empty value here are
-                                              almost certainly wrong.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            type: string
-                                          optional:
-                                            description: Specify whether the ConfigMap or its key must be defined
-                                            type: boolean
-                                        required:
-                                          - key
-                                        type: object
-                                        x-kubernetes-map-type: atomic
-                                      fieldRef:
-                                        description: |-
-                                          Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                          spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
-                                        properties:
-                                          apiVersion:
-                                            description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
-                                            type: string
-                                          fieldPath:
-                                            description: Path of the field to select in the specified API version.
-                                            type: string
-                                        required:
-                                          - fieldPath
-                                        type: object
-                                        x-kubernetes-map-type: atomic
-                                      resourceFieldRef:
-                                        description: |-
-                                          Selects a resource of the container: only resources limits and requests
-                                          (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
-                                        properties:
-                                          containerName:
-                                            description: 'Container name: required for volumes, optional for env vars'
-                                            type: string
-                                          divisor:
-                                            anyOf:
-                                              - type: integer
-                                              - type: string
-                                            description: Specifies the output format of the exposed resources, defaults to "1"
-                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                            x-kubernetes-int-or-string: true
-                                          resource:
-                                            description: 'Required: resource to select'
-                                            type: string
-                                        required:
-                                          - resource
-                                        type: object
-                                        x-kubernetes-map-type: atomic
-                                      secretKeyRef:
-                                        description: Selects a key of a secret in the pod's namespace
-                                        properties:
-                                          key:
-                                            description: The key of the secret to select from.  Must be a valid secret key.
-                                            type: string
-                                          name:
-                                            default: ""
-                                            description: |-
-                                              Name of the referent.
-                                              This field is effectively required, but due to backwards compatibility is
-                                              allowed to be empty. Instances of this type with an empty value here are
-                                              almost certainly wrong.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            type: string
-                                          optional:
-                                            description: Specify whether the Secret or its key must be defined
-                                            type: boolean
-                                        required:
-                                          - key
-                                        type: object
-                                        x-kubernetes-map-type: atomic
-                                    type: object
-                                required:
-                                  - name
-                                type: object
-                              type: array
-                            labels:
-                              additionalProperties:
-                                type: string
-                              description: labels to add to pods
-                              type: object
-                            nodeSelector:
-                              additionalProperties:
-                                type: string
-                              description: nodeSelector defines the nodeSelector to be supplied to podSpec
-                              type: object
-                            priorityClassName:
-                              description: priorityClassName defines the PriorityClass name to be applied to the pod
+                            cpuLimit:
                               type: string
-                            resourceAllocations:
-                              description: resourceAllocations defines the CPU, Memory and ephemeral-storage resource allocations for the Pod
-                              nullable: true
+                            cpuRequest:
+                              type: string
+                            memoryLimit:
+                              type: string
+                            memoryRequest:
+                              type: string
+                          type: object
+                      type: object
+                    description: |-
+                      RepositoryMaintenance maps a BackupRepository identifier to its configuration.
+                      Keys can be:
+                       - "global" : Applies to all repositories without specific config.
+                       - "<namespace>" : The namespace of the BackupRepository.
+                       - "<repository name>" : The specific BackupRepository name referencing the BSL.
+                       - "<repository type>" : Either "kopia" or "restic".
+                    type: object
+                  restic:
+                    description: |-
+                      (do not use warning) restic field is for backwards compatibility and
+                      will be removed in the future. Use nodeAgent field instead
+                    properties:
+                      enable:
+                        description: |-
+                          enable defines a boolean pointer whether we want the daemonset to
+                          exist or not
+                        type: boolean
+                      podConfig:
+                        description: Pod specific configuration
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: annotations to add to pods
+                            type: object
+                          env:
+                            description: env defines the list of environment variables
+                              to be supplied to podSpec
+                            items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
                               properties:
-                                claims:
+                                name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
+                                  type: string
+                                value:
                                   description: |-
-                                    Claims lists the names of resources, defined in spec.resourceClaims,
-                                    that are used by this container.
+                                    Variable references $(VAR_NAME) are expanded
+                                    using the previously defined environment variables in the container and
+                                    any service environment variables. If a variable cannot be resolved,
+                                    the reference in the input string will be unchanged. Double $$ are reduced
+                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                    "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                    Escaped references will never be expanded, regardless of whether the variable
+                                    exists or not.
+                                    Defaults to "".
+                                  type: string
+                                valueFrom:
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    fieldRef:
+                                      description: |-
+                                        Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                        spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    resourceFieldRef:
+                                      description: |-
+                                        Selects a resource of the container: only resources limits and requests
+                                        (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          labels:
+                            additionalProperties:
+                              type: string
+                            description: labels to add to pods
+                            type: object
+                          nodeSelector:
+                            additionalProperties:
+                              type: string
+                            description: nodeSelector defines the nodeSelector to
+                              be supplied to podSpec
+                            type: object
+                          priorityClassName:
+                            description: priorityClassName defines the PriorityClass
+                              name to be applied to the pod
+                            type: string
+                          resourceAllocations:
+                            description: resourceAllocations defines the CPU, Memory
+                              and ephemeral-storage resource allocations for the Pod
+                            nullable: true
+                            properties:
+                              claims:
+                                description: |-
+                                  Claims lists the names of resources, defined in spec.resourceClaims,
+                                  that are used by this container.
 
-                                    This is an alpha field and requires enabling the
-                                    DynamicResourceAllocation feature gate.
+                                  This is an alpha field and requires enabling the
+                                  DynamicResourceAllocation feature gate.
 
-                                    This field is immutable. It can only be set for containers.
+                                  This field is immutable. It can only be set for containers.
+                                items:
+                                  description: ResourceClaim references one entry
+                                    in PodSpec.ResourceClaims.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name must match the name of one entry in pod.spec.resourceClaims of
+                                        the Pod where this field is used. It makes that resource available
+                                        inside a container.
+                                      type: string
+                                    request:
+                                      description: |-
+                                        Request is the name chosen for a request in the referenced claim.
+                                        If empty, everything from the claim is made available, otherwise
+                                        only the result of this request.
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: |-
+                                  Limits describes the maximum amount of compute resources allowed.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: |-
+                                  Requests describes the minimum amount of compute resources required.
+                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                            type: object
+                          tolerations:
+                            description: tolerations defines the list of tolerations
+                              to be applied to daemonset
+                            items:
+                              description: |-
+                                The pod this Toleration is attached to tolerates any taint that matches
+                                the triple <key,value,effect> using the matching operator <operator>.
+                              properties:
+                                effect:
+                                  description: |-
+                                    Effect indicates the taint effect to match. Empty means match all taint effects.
+                                    When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                  type: string
+                                key:
+                                  description: |-
+                                    Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                    If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    Operator represents a key's relationship to the value.
+                                    Valid operators are Exists and Equal. Defaults to Equal.
+                                    Exists is equivalent to wildcard for value, so that a pod can
+                                    tolerate all taints of a particular category.
+                                  type: string
+                                tolerationSeconds:
+                                  description: |-
+                                    TolerationSeconds represents the period of time the toleration (which must be
+                                    of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                    it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                    negative values will be treated as 0 (evict immediately) by the system.
+                                  format: int64
+                                  type: integer
+                                value:
+                                  description: |-
+                                    Value is the taint value the toleration matches to.
+                                    If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                  type: string
+                              type: object
+                            type: array
+                        type: object
+                      supplementalGroups:
+                        description: supplementalGroups defines the linux groups to
+                          be applied to the NodeAgent Pod
+                        items:
+                          format: int64
+                          type: integer
+                        type: array
+                      timeout:
+                        description: timeout defines the NodeAgent timeout, default
+                          value is 1h
+                        type: string
+                    type: object
+                  velero:
+                    properties:
+                      args:
+                        description: Velero args are settings to customize velero
+                          server arguments. Overrides values in other fields.
+                        properties:
+                          add_dir_header:
+                            description: If true, adds the file directory to the header
+                              of the log messages
+                            type: boolean
+                          alsologtostderr:
+                            description: log to standard error as well as files (no
+                              effect when -logtostderr=true)
+                            type: boolean
+                          backup-sync-period:
+                            description: How often (in nanoseconds) to ensure all
+                              Velero backups in object storage exist as Backup API
+                              objects in the cluster. This is the default sync period
+                              if none is explicitly specified for a backup storage
+                              location.
+                            format: int64
+                            type: integer
+                          client-burst:
+                            description: Maximum number of requests by the server
+                              to the Kubernetes API in a short period of time.
+                            type: integer
+                          client-page-size:
+                            description: Page size of requests by the server to the
+                              Kubernetes API when listing objects during a backup.
+                              Set to 0 to disable paging.
+                            type: integer
+                          client-qps:
+                            description: |-
+                              Maximum number of requests per second by the server to the Kubernetes API once the burst limit has been reached.
+                              this will be validated as a valid float32
+                            type: string
+                          colorized:
+                            description: Show colored output in TTY
+                            type: boolean
+                          default-backup-ttl:
+                            description: How long (in nanoseconds) to wait by default
+                              before backups can be garbage collected. (default is
+                              720 hours)
+                            format: int64
+                            type: integer
+                          default-item-operation-timeout:
+                            description: How long (in nanoseconds) to wait on asynchronous
+                              BackupItemActions and RestoreItemActions to complete
+                              before timing out. (default is 1 hour)
+                            format: int64
+                            type: integer
+                          default-repo-maintain-frequency:
+                            description: How often (in nanoseconds) 'maintain' is
+                              run for backup repositories by default.
+                            format: int64
+                            type: integer
+                          default-volumes-to-fs-backup:
+                            description: Backup all volumes with pod volume file system
+                              backup by default.
+                            type: boolean
+                          disabled-controllers:
+                            description: List of controllers to disable on startup.
+                              Valid values are backup,backup-operations,backup-deletion,backup-finalizer,backup-sync,download-request,gc,backup-repo,restore,restore-operations,schedule,server-status-request
+                            enum:
+                            - backup
+                            - backup-operations
+                            - backup-deletion
+                            - backup-finalizer
+                            - backup-sync
+                            - download-request
+                            - gc
+                            - backup-repo
+                            - restore
+                            - restore-operations
+                            - schedule
+                            - server-status-request
+                            items:
+                              type: string
+                            type: array
+                          fs-backup-timeout:
+                            description: How long (in nanoseconds) pod volume file
+                              system backups/restores should be allowed to run before
+                              timing out. (default is 4 hours)
+                            format: int64
+                            type: integer
+                          garbage-collection-frequency:
+                            description: How often (in nanoseconds) garbage collection
+                              checks for expired backups. (default is 1 hour)
+                            format: int64
+                            type: integer
+                          item-operation-sync-frequency:
+                            description: How often (in nanoseconds) to check status
+                              on backup/restore operations after backup/restore processing.
+                            format: int64
+                            type: integer
+                          log-format:
+                            description: The format for log output. Valid values are
+                              text, json. (default text)
+                            enum:
+                            - text
+                            - json
+                            type: string
+                          log_backtrace_at:
+                            description: when logging hits line file:N, emit a stack
+                              trace
+                            type: string
+                          log_dir:
+                            description: If non-empty, write log files in this directory
+                              (no effect when -logtostderr=true)
+                            type: string
+                          log_file:
+                            description: If non-empty, use this log file (no effect
+                              when -logtostderr=true)
+                            type: string
+                          log_file_max_size:
+                            description: Defines the maximum size a log file can grow
+                              to (no effect when -logtostderr=true). Unit is megabytes.
+                              If the value is 0, the maximum file size is unlimited.
+                              (default 1800)
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          logtostderr:
+                            description: |-
+                              Boolean flags. Not handled atomically because the flag.Value interface
+                              does not let us avoid the =true, and that shorthand is necessary for
+                              compatibility. TODO: does this matter enough to fix? Seems unlikely.
+                            type: boolean
+                          max-concurrent-k8s-connections:
+                            description: Max concurrent connections number that Velero
+                              can create with kube-apiserver. Default is 30. (default
+                              30)
+                            type: integer
+                          metrics-address:
+                            description: The address to expose prometheus metrics
+                            type: string
+                          one_output:
+                            description: If true, only write logs to their native
+                              severity level (vs also writing to each lower severity
+                              level; no effect when -logtostderr=true)
+                            type: boolean
+                          profiler-address:
+                            description: The address to expose the pprof profiler.
+                            type: string
+                          resource-timeout:
+                            description: How long (in nanoseconds) to wait for resource
+                              processes which are not covered by other specific timeout
+                              parameters. (default is 10 minutes)
+                            format: int64
+                            type: integer
+                          restore-resource-priorities:
+                            description: Desired order of resource restores, the priority
+                              list contains two parts which are split by "-" element.
+                              The resources before "-" element are restored first
+                              as high priorities, the resources after "-" element
+                              are restored last as low priorities, and any resource
+                              not in the list will be restored alphabetically between
+                              the high and low priorities. (default securitycontextconstraints,customresourcedefinitions,klusterletconfigs.config.open-cluster-management.io,managedcluster.cluster.open-cluster-management.io,namespaces,roles,rolebindings,clusterrolebindings,klusterletaddonconfig.agent.open-cluster-management.io,managedclusteraddon.addon.open-cluster-management.io,storageclasses,volumesnapshotclass.snapshot.storage.k8s.io,volumesnapshotcontents.snapshot.storage.k8s.io,volumesnapshots.snapshot.storage.k8s.io,datauploads.velero.io,persistentvolumes,persistentvolumeclaims,serviceaccounts,secrets,configmaps,limitranges,pods,replicasets.apps,clusterclasses.cluster.x-k8s.io,endpoints,services,-,clusterbootstraps.run.tanzu.vmware.com,clusters.cluster.x-k8s.io,clusterresourcesets.addons.cluster.x-k8s.io)
+                            type: string
+                          skip_headers:
+                            description: If true, avoid header prefixes in the log
+                              messages
+                            type: boolean
+                          skip_log_headers:
+                            description: If true, avoid headers when opening log files
+                              (no effect when -logtostderr=true)
+                            type: boolean
+                          stderrthreshold:
+                            description: logs at or above this threshold go to stderr
+                              when writing to files and stderr (no effect when -logtostderr=true
+                              or -alsologtostderr=false) (default 2)
+                            type: integer
+                          store-validation-frequency:
+                            description: How often (in nanoseconds) to verify if the
+                              storage is valid. Optional. Set this to `0` to disable
+                              sync. (default is 1 minute)
+                            format: int64
+                            type: integer
+                          terminating-resource-timeout:
+                            description: How long (in nanoseconds) to wait on persistent
+                              volumes and namespaces to terminate during a restore
+                              before timing out.
+                            format: int64
+                            type: integer
+                          v:
+                            description: number for the log level verbosity
+                            type: integer
+                          vmodule:
+                            description: comma-separated list of pattern=N settings
+                              for file-filtered logging
+                            type: string
+                        type: object
+                      client-burst:
+                        description: maximum number of requests by the server to the
+                          Kubernetes API in a short period of time. (default 100)
+                        type: integer
+                      client-qps:
+                        description: maximum number of requests per second by the
+                          server to the Kubernetes API once the burst limit has been
+                          reached. (default 100)
+                        type: integer
+                      concurrentBackups:
+                        description: |-
+                          Number of backups to process at the same time. Only backups which do not have any namespaces
+                          in common will run at the same time. Default is 1.
+                        type: integer
+                      customPlugins:
+                        description: customPlugins defines the custom plugin to be
+                          installed with Velero
+                        items:
+                          properties:
+                            image:
+                              type: string
+                            name:
+                              type: string
+                          required:
+                          - image
+                          - name
+                          type: object
+                        type: array
+                      defaultItemOperationTimeout:
+                        description: How long to wait on asynchronous BackupItemActions
+                          and RestoreItemActions to complete before timing out. Default
+                          value is 1h.
+                        type: string
+                      defaultPlugins:
+                        items:
+                          enum:
+                          - aws
+                          - legacy-aws
+                          - gcp
+                          - azure
+                          - csi
+                          - vsm
+                          - openshift
+                          - kubevirt
+                          - kubevirt-datamover
+                          - hypershift
+                          type: string
+                        type: array
+                      defaultSnapshotMoveData:
+                        description: Specify whether CSI snapshot data should be moved
+                          to backup storage by default
+                        type: boolean
+                      defaultVolumesToFSBackup:
+                        description: 'Deprecated: Use defaultVolumesToFsBackup instead
+                          (matches Velero backup spec).'
+                        type: boolean
+                      defaultVolumesToFsBackup:
+                        description: |-
+                          Use pod volume file system backup by default for volumes.
+                          Matches backup.spec.defaultVolumesToFsBackup in Velero API.
+                        type: boolean
+                      disableFsBackup:
+                        default: false
+                        description: |-
+                          DisableFsBackup determines whether the NodeAgent should disable file system backup.
+                          When set to true, the NodeAgent runs in non-privileged mode.
+                          Defaults to false.
+                        type: boolean
+                      disableInformerCache:
+                        description: Disable informer cache for Get calls on restore.
+                          With this enabled, it will speed up restore in cases where
+                          there are backup resources which already exist in the cluster,
+                          but for very large clusters this will increase velero memory
+                          usage. Default is false.
+                        type: boolean
+                      enableCSISnapshotEarlyFrequentPolling:
+                        description: |-
+                          set EnableCSISnapshotEarlyFrequentPolling to true to enable
+                          the 1-second polling interval for the first 10 seconds while waiting
+                          for the snaphandle
+                        type: boolean
+                      featureFlags:
+                        description: featureFlags defines the list of features to
+                          enable for Velero instance
+                        items:
+                          type: string
+                        type: array
+                      itemBlockWorkerCount:
+                        description: |-
+                          Number of workers in worker pool for processing item backup. This will allow multiple items within
+                          a Velero backup to be backed up at the same time which may improve performance for backups with
+                          a large number of items. Workers are per backup if concurrent backups are enabled. Default is 1.
+                        type: integer
+                      itemOperationSyncFrequency:
+                        description: How often to check status on async backup/restore
+                          operations after backup processing. Default value is 2m.
+                        type: string
+                      loadAffinity:
+                        description: LoadAffinityConfig is the config for data path
+                          load affinity.
+                        items:
+                          description: |-
+                            LoadAffinity is the config for data path load affinity.
+                            Used by the Node-Agent, that needs to match the DataMover and the RepositoryMaintenance pods.
+                          properties:
+                            nodeSelector:
+                              description: NodeSelector specifies the label selector
+                                to match nodes
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
                                   items:
-                                    description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
                                     properties:
-                                      name:
-                                        description: |-
-                                          Name must match the name of one entry in pod.spec.resourceClaims of
-                                          the Pod where this field is used. It makes that resource available
-                                          inside a container.
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
                                         type: string
-                                      request:
+                                      operator:
                                         description: |-
-                                          Request is the name chosen for a request in the referenced claim.
-                                          If empty, everything from the claim is made available, otherwise
-                                          only the result of this request.
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
                                     required:
-                                      - name
+                                    - key
+                                    - operator
                                     type: object
                                   type: array
-                                  x-kubernetes-list-map-keys:
-                                    - name
-                                  x-kubernetes-list-type: map
-                                limits:
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
                                   additionalProperties:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                    nullable: true
+                                    type: string
                                   description: |-
-                                    Limits describes the maximum amount of compute resources allowed.
-                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
-                                  nullable: true
-                                requests:
-                                  additionalProperties:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                    nullable: true
-                                  description: |-
-                                    Requests describes the minimum amount of compute resources required.
-                                    If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                    otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                                  type: object
-                                  nullable: true
                               type: object
-                            tolerations:
-                              description: tolerations defines the list of tolerations to be applied to daemonset
+                              x-kubernetes-map-type: atomic
+                            storageClass:
+                              description: |-
+                                StorageClass specifies the storage class to which this LoadAffinity rule applies.
+                                If empty, the affinity applies globally to all data mover operations.
+                                If set, the affinity applies only to data mover operations using this specific StorageClass.
+                              type: string
+                          type: object
+                        type: array
+                      logLevel:
+                        description: Velero server's log level (use debug for the
+                          most logging, leave unset for velero default)
+                        enum:
+                        - trace
+                        - debug
+                        - info
+                        - warning
+                        - error
+                        - fatal
+                        - panic
+                        type: string
+                      noDefaultBackupLocation:
+                        description: If you need to install Velero without a default
+                          backup storage location noDefaultBackupLocation flag is
+                          required for confirmation
+                        type: boolean
+                      podConfig:
+                        description: Pod specific configuration
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: annotations to add to pods
+                            type: object
+                          env:
+                            description: env defines the list of environment variables
+                              to be supplied to podSpec
+                            items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
+                              properties:
+                                name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
+                                  type: string
+                                value:
+                                  description: |-
+                                    Variable references $(VAR_NAME) are expanded
+                                    using the previously defined environment variables in the container and
+                                    any service environment variables. If a variable cannot be resolved,
+                                    the reference in the input string will be unchanged. Double $$ are reduced
+                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                    "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                    Escaped references will never be expanded, regardless of whether the variable
+                                    exists or not.
+                                    Defaults to "".
+                                  type: string
+                                valueFrom:
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    fieldRef:
+                                      description: |-
+                                        Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                        spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    resourceFieldRef:
+                                      description: |-
+                                        Selects a resource of the container: only resources limits and requests
+                                        (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          labels:
+                            additionalProperties:
+                              type: string
+                            description: labels to add to pods
+                            type: object
+                          nodeSelector:
+                            additionalProperties:
+                              type: string
+                            description: nodeSelector defines the nodeSelector to
+                              be supplied to podSpec
+                            type: object
+                          priorityClassName:
+                            description: priorityClassName defines the PriorityClass
+                              name to be applied to the pod
+                            type: string
+                          resourceAllocations:
+                            description: resourceAllocations defines the CPU, Memory
+                              and ephemeral-storage resource allocations for the Pod
+                            nullable: true
+                            properties:
+                              claims:
+                                description: |-
+                                  Claims lists the names of resources, defined in spec.resourceClaims,
+                                  that are used by this container.
+
+                                  This is an alpha field and requires enabling the
+                                  DynamicResourceAllocation feature gate.
+
+                                  This field is immutable. It can only be set for containers.
+                                items:
+                                  description: ResourceClaim references one entry
+                                    in PodSpec.ResourceClaims.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name must match the name of one entry in pod.spec.resourceClaims of
+                                        the Pod where this field is used. It makes that resource available
+                                        inside a container.
+                                      type: string
+                                    request:
+                                      description: |-
+                                        Request is the name chosen for a request in the referenced claim.
+                                        If empty, everything from the claim is made available, otherwise
+                                        only the result of this request.
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: |-
+                                  Limits describes the maximum amount of compute resources allowed.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: |-
+                                  Requests describes the minimum amount of compute resources required.
+                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                            type: object
+                          tolerations:
+                            description: tolerations defines the list of tolerations
+                              to be applied to daemonset
+                            items:
+                              description: |-
+                                The pod this Toleration is attached to tolerates any taint that matches
+                                the triple <key,value,effect> using the matching operator <operator>.
+                              properties:
+                                effect:
+                                  description: |-
+                                    Effect indicates the taint effect to match. Empty means match all taint effects.
+                                    When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                  type: string
+                                key:
+                                  description: |-
+                                    Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                    If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    Operator represents a key's relationship to the value.
+                                    Valid operators are Exists and Equal. Defaults to Equal.
+                                    Exists is equivalent to wildcard for value, so that a pod can
+                                    tolerate all taints of a particular category.
+                                  type: string
+                                tolerationSeconds:
+                                  description: |-
+                                    TolerationSeconds represents the period of time the toleration (which must be
+                                    of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                    it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                    negative values will be treated as 0 (evict immediately) by the system.
+                                  format: int64
+                                  type: integer
+                                value:
+                                  description: |-
+                                    Value is the taint value the toleration matches to.
+                                    If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                  type: string
+                              type: object
+                            type: array
+                        type: object
+                      resourceTimeout:
+                        description: |-
+                          resourceTimeout defines how long to wait for several Velero resources before timeout occurs,
+                          such as Velero CRD availability, volumeSnapshot deletion, and repo availability.
+                          Default is 10m
+                        type: string
+                      restoreResourcesVersionPriority:
+                        description: |-
+                          restoreResourceVersionPriority represents a configmap that will be created if defined for use in conjunction with EnableAPIGroupVersions feature flag
+                          Defining this field automatically add EnableAPIGroupVersions to the velero server feature flag
+                        type: string
+                    type: object
+                type: object
+              features:
+                description: features defines the configuration for the DPA to enable
+                  the OADP tech preview features
+                properties:
+                  dataMover:
+                    description: |-
+                      (do not use warning) dataMover is for backwards compatibility and
+                      will be removed in the future. Use Velero Built-in Data Mover instead
+                    properties:
+                      credentialName:
+                        description: User supplied Restic Secret name
+                        type: string
+                      enable:
+                        description: enable flag is used to specify whether you want
+                          to deploy the volume snapshot mover controller
+                        type: boolean
+                      maxConcurrentBackupVolumes:
+                        description: the number of batched volumeSnapshotBackups that
+                          can be inProgress at once, default value is 10
+                        type: string
+                      maxConcurrentRestoreVolumes:
+                        description: the number of batched volumeSnapshotRestores
+                          that can be inProgress at once, default value is 10
+                        type: string
+                      pruneInterval:
+                        description: defines how often (in days) to prune the datamover
+                          snapshots from the repository
+                        type: string
+                      schedule:
+                        description: |-
+                          schedule is a cronspec (https://en.wikipedia.org/wiki/Cron#Overview) that
+                          can be used to schedule datamover(volsync) synchronization to occur at regular, time-based
+                          intervals. For example, in order to enforce datamover SnapshotRetainPolicy at a regular interval you need to
+                          specify this Schedule trigger as a cron expression, by default the trigger is a manual trigger. For more details
+                          on Volsync triggers, refer: https://volsync.readthedocs.io/en/stable/usage/triggers.html
+                        pattern: ^(\d+|\*)(/\d+)?(\s+(\d+|\*)(/\d+)?){4}$
+                        type: string
+                      snapshotRetainPolicy:
+                        description: defines the parameters that can be specified
+                          for retention of datamover snapshots
+                        properties:
+                          daily:
+                            description: Daily defines the number of snapshots to
+                              be kept daily
+                            type: string
+                          hourly:
+                            description: Hourly defines the number of snapshots to
+                              be kept hourly
+                            type: string
+                          monthly:
+                            description: Monthly defines the number of snapshots to
+                              be kept monthly
+                            type: string
+                          weekly:
+                            description: Weekly defines the number of snapshots to
+                              be kept weekly
+                            type: string
+                          within:
+                            description: Within defines the number of snapshots to
+                              be kept Within the given time period
+                            type: string
+                          yearly:
+                            description: Yearly defines the number of snapshots to
+                              be kept yearly
+                            type: string
+                        type: object
+                      timeout:
+                        description: User supplied timeout to be used for VolumeSnapshotBackup
+                          and VolumeSnapshotRestore to complete, default value is
+                          10m
+                        type: string
+                      volumeOptionsForStorageClasses:
+                        additionalProperties:
+                          properties:
+                            destinationVolumeOptions:
+                              description: VolumeOptions defines configurations for
+                                VolSync options
+                              properties:
+                                accessMode:
+                                  description: |-
+                                    accessMode can be used to override the accessMode of the source or
+                                    destination PVC
+                                  type: string
+                                cacheAccessMode:
+                                  description: cacheAccessMode is the access mode
+                                    to be used to provision the cache volume
+                                  type: string
+                                cacheCapacity:
+                                  description: cacheCapacity determines the size of
+                                    the restic metadata cache volume
+                                  type: string
+                                cacheStorageClassName:
+                                  description: |-
+                                    cacheStorageClassName is the storageClass that should be used when provisioning
+                                    the data mover cache volume
+                                  type: string
+                                storageClassName:
+                                  description: |-
+                                    storageClassName can be used to override the StorageClass of the source
+                                    or destination PVC
+                                  type: string
+                              type: object
+                            sourceVolumeOptions:
+                              description: VolumeOptions defines configurations for
+                                VolSync options
+                              properties:
+                                accessMode:
+                                  description: |-
+                                    accessMode can be used to override the accessMode of the source or
+                                    destination PVC
+                                  type: string
+                                cacheAccessMode:
+                                  description: cacheAccessMode is the access mode
+                                    to be used to provision the cache volume
+                                  type: string
+                                cacheCapacity:
+                                  description: cacheCapacity determines the size of
+                                    the restic metadata cache volume
+                                  type: string
+                                cacheStorageClassName:
+                                  description: |-
+                                    cacheStorageClassName is the storageClass that should be used when provisioning
+                                    the data mover cache volume
+                                  type: string
+                                storageClassName:
+                                  description: |-
+                                    storageClassName can be used to override the StorageClass of the source
+                                    or destination PVC
+                                  type: string
+                              type: object
+                          type: object
+                        description: defines configurations for data mover volume
+                          options for a storageClass
+                        type: object
+                    type: object
+                type: object
+              imagePullPolicy:
+                description: |-
+                  which imagePullPolicy to use in all container images used by OADP.
+                  By default, for images with sha256 or sha512 digest, OADP uses IfNotPresent and uses Always for all other images.
+                enum:
+                - Always
+                - IfNotPresent
+                - Never
+                type: string
+              logFormat:
+                default: text
+                description: The format for log output. Valid values are text, json.
+                  (default text)
+                enum:
+                - text
+                - json
+                type: string
+              nonAdmin:
+                description: nonAdmin defines the configuration for the DPA to enable
+                  backup and restore operations for non-admin users
+                properties:
+                  backupSyncPeriod:
+                    description: |-
+                      BackupSyncPeriod specifies the interval at which backups from the OADP namespace are synchronized with non-admin namespaces.
+                      A value of 0 disables sync.
+                      By default 2m
+                    type: string
+                  enable:
+                    description: Enables non admin feature, by default is disabled
+                    type: boolean
+                  enforceBSLSpec:
+                    description: which backupstoragelocation spec field values to
+                      enforce
+                    properties:
+                      accessMode:
+                        description: AccessMode defines the permissions for the backup
+                          storage location.
+                        enum:
+                        - ReadOnly
+                        - ReadWrite
+                        type: string
+                      backupSyncPeriod:
+                        description: BackupSyncPeriod defines how frequently to sync
+                          backup API objects from object storage. A value of 0 disables
+                          sync.
+                        nullable: true
+                        type: string
+                      config:
+                        additionalProperties:
+                          type: string
+                        description: Config is for provider-specific configuration
+                          fields.
+                        type: object
+                      credential:
+                        description: Credential contains the credential information
+                          intended to be used with this location
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            default: ""
+                            description: |-
+                              Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or its key must
+                              be defined
+                            type: boolean
+                        required:
+                        - key
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      objectStorage:
+                        description: ObjectStorageLocation defines the enforced values
+                          for the Velero ObjectStorageLocation
+                        nullable: true
+                        properties:
+                          bucket:
+                            description: Bucket is the bucket to use for object storage.
+                            type: string
+                          caCert:
+                            description: CACert defines a CA bundle to use when verifying
+                              TLS connections to the provider.
+                            format: byte
+                            type: string
+                          prefix:
+                            description: Prefix is the path inside a bucket to use
+                              for Velero storage. Optional.
+                            type: string
+                        type: object
+                      provider:
+                        description: Provider is the provider of the backup storage.
+                        type: string
+                      validationFrequency:
+                        description: ValidationFrequency defines how frequently to
+                          validate the corresponding object storage. A value of 0
+                          disables validation.
+                        nullable: true
+                        type: string
+                    type: object
+                  enforceBackupSpec:
+                    description: which bakup spec field values to enforce
+                    properties:
+                      csiSnapshotTimeout:
+                        description: |-
+                          CSISnapshotTimeout specifies the time used to wait for CSI VolumeSnapshot status turns to
+                          ReadyToUse during creation, before returning error as timeout.
+                          The default value is 10 minute.
+                        type: string
+                      datamover:
+                        description: |-
+                          DataMover specifies the data mover to be used by the backup.
+                          If DataMover is "" or "velero", the built-in data mover will be used.
+                        type: string
+                      defaultVolumesToFsBackup:
+                        description: |-
+                          DefaultVolumesToFsBackup specifies whether pod volume file system backup should be used
+                          for all volumes by default.
+                        nullable: true
+                        type: boolean
+                      defaultVolumesToRestic:
+                        description: |-
+                          DefaultVolumesToRestic specifies whether restic should be used to take a
+                          backup of all pod volumes by default.
+
+                          Deprecated: this field is no longer used and will be removed entirely in future. Use DefaultVolumesToFsBackup instead.
+                        nullable: true
+                        type: boolean
+                      excludedClusterScopedResources:
+                        description: |-
+                          ExcludedClusterScopedResources is a slice of cluster-scoped
+                          resource type names to exclude from the backup.
+                          If set to "*", all cluster-scoped resource types are excluded.
+                          The default value is empty.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      excludedNamespaceScopedResources:
+                        description: |-
+                          ExcludedNamespaceScopedResources is a slice of namespace-scoped
+                          resource type names to exclude from the backup.
+                          If set to "*", all namespace-scoped resource types are excluded.
+                          The default value is empty.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      excludedNamespaces:
+                        description: |-
+                          ExcludedNamespaces contains a list of namespaces that are not
+                          included in the backup.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      excludedResources:
+                        description: |-
+                          ExcludedResources is a slice of resource names that are not
+                          included in the backup.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      hooks:
+                        description: Hooks represent custom behaviors that should
+                          be executed at different phases of the backup.
+                        properties:
+                          resources:
+                            description: Resources are hooks that should be executed
+                              when backing up individual instances of a resource.
+                            items:
+                              description: |-
+                                BackupResourceHookSpec defines one or more BackupResourceHooks that should be executed based on
+                                the rules defined for namespaces, resources, and label selector.
+                              properties:
+                                excludedNamespaces:
+                                  description: ExcludedNamespaces specifies the namespaces
+                                    to which this hook spec does not apply.
+                                  items:
+                                    type: string
+                                  nullable: true
+                                  type: array
+                                excludedResources:
+                                  description: ExcludedResources specifies the resources
+                                    to which this hook spec does not apply.
+                                  items:
+                                    type: string
+                                  nullable: true
+                                  type: array
+                                includedNamespaces:
+                                  description: |-
+                                    IncludedNamespaces specifies the namespaces to which this hook spec applies. If empty, it applies
+                                    to all namespaces.
+                                  items:
+                                    type: string
+                                  nullable: true
+                                  type: array
+                                includedResources:
+                                  description: |-
+                                    IncludedResources specifies the resources to which this hook spec applies. If empty, it applies
+                                    to all resources.
+                                  items:
+                                    type: string
+                                  nullable: true
+                                  type: array
+                                labelSelector:
+                                  description: LabelSelector, if specified, filters
+                                    the resources to which this hook spec applies.
+                                  nullable: true
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                name:
+                                  description: Name is the name of this hook.
+                                  type: string
+                                post:
+                                  description: |-
+                                    PostHooks is a list of BackupResourceHooks to execute after storing the item in the backup.
+                                    These are executed after all "additional items" from item actions are processed.
+                                  items:
+                                    description: BackupResourceHook defines a hook
+                                      for a resource.
+                                    properties:
+                                      exec:
+                                        description: Exec defines an exec hook.
+                                        properties:
+                                          command:
+                                            description: Command is the command and
+                                              arguments to execute.
+                                            items:
+                                              type: string
+                                            minItems: 1
+                                            type: array
+                                          container:
+                                            description: |-
+                                              Container is the container in the pod where the command should be executed. If not specified,
+                                              the pod's first container is used.
+                                            type: string
+                                          onError:
+                                            description: OnError specifies how Velero
+                                              should behave if it encounters an error
+                                              executing this hook.
+                                            enum:
+                                            - Continue
+                                            - Fail
+                                            type: string
+                                          timeout:
+                                            description: |-
+                                              Timeout defines the maximum amount of time Velero should wait for the hook to complete before
+                                              considering the execution a failure.
+                                            type: string
+                                        required:
+                                        - command
+                                        type: object
+                                    required:
+                                    - exec
+                                    type: object
+                                  type: array
+                                pre:
+                                  description: |-
+                                    PreHooks is a list of BackupResourceHooks to execute prior to storing the item in the backup.
+                                    These are executed before any "additional items" from item actions are processed.
+                                  items:
+                                    description: BackupResourceHook defines a hook
+                                      for a resource.
+                                    properties:
+                                      exec:
+                                        description: Exec defines an exec hook.
+                                        properties:
+                                          command:
+                                            description: Command is the command and
+                                              arguments to execute.
+                                            items:
+                                              type: string
+                                            minItems: 1
+                                            type: array
+                                          container:
+                                            description: |-
+                                              Container is the container in the pod where the command should be executed. If not specified,
+                                              the pod's first container is used.
+                                            type: string
+                                          onError:
+                                            description: OnError specifies how Velero
+                                              should behave if it encounters an error
+                                              executing this hook.
+                                            enum:
+                                            - Continue
+                                            - Fail
+                                            type: string
+                                          timeout:
+                                            description: |-
+                                              Timeout defines the maximum amount of time Velero should wait for the hook to complete before
+                                              considering the execution a failure.
+                                            type: string
+                                        required:
+                                        - command
+                                        type: object
+                                    required:
+                                    - exec
+                                    type: object
+                                  type: array
+                              required:
+                              - name
+                              type: object
+                            nullable: true
+                            type: array
+                        type: object
+                      includeClusterResources:
+                        description: |-
+                          IncludeClusterResources specifies whether cluster-scoped resources
+                          should be included for consideration in the backup.
+                        nullable: true
+                        type: boolean
+                      includedClusterScopedResources:
+                        description: |-
+                          IncludedClusterScopedResources is a slice of cluster-scoped
+                          resource type names to include in the backup.
+                          If set to "*", all cluster-scoped resource types are included.
+                          The default value is empty, which means only related
+                          cluster-scoped resources are included.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      includedNamespaceScopedResources:
+                        description: |-
+                          IncludedNamespaceScopedResources is a slice of namespace-scoped
+                          resource type names to include in the backup.
+                          The default value is "*".
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      includedNamespaces:
+                        description: |-
+                          IncludedNamespaces is a slice of namespace names to include objects
+                          from. If empty, all namespaces are included.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      includedResources:
+                        description: |-
+                          IncludedResources is a slice of resource names to include
+                          in the backup. If empty, all resources are included.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      itemOperationTimeout:
+                        description: |-
+                          ItemOperationTimeout specifies the time used to wait for asynchronous BackupItemAction operations
+                          The default value is 4 hour.
+                        type: string
+                      labelSelector:
+                        description: |-
+                          LabelSelector is a metav1.LabelSelector to filter with
+                          when adding individual objects to the backup. If empty
+                          or nil, all objects are included. Optional.
+                        nullable: true
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      metadata:
+                        properties:
+                          labels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
+                      orLabelSelectors:
+                        description: |-
+                          OrLabelSelectors is list of metav1.LabelSelector to filter with
+                          when adding individual objects to the backup. If multiple provided
+                          they will be joined by the OR operator. LabelSelector as well as
+                          OrLabelSelectors cannot co-exist in backup request, only one of them
+                          can be used.
+                        items:
+                          description: |-
+                            A label selector is a label query over a set of resources. The result of matchLabels and
+                            matchExpressions are ANDed. An empty label selector matches all objects. A null
+                            label selector matches no objects.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
                               items:
                                 description: |-
-                                  The pod this Toleration is attached to tolerates any taint that matches
-                                  the triple <key,value,effect> using the matching operator <operator>.
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
                                 properties:
-                                  effect:
-                                    description: |-
-                                      Effect indicates the taint effect to match. Empty means match all taint effects.
-                                      When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
-                                    type: string
                                   key:
-                                    description: |-
-                                      Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                                      If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                    description: key is the label key that the selector
+                                      applies to.
                                     type: string
                                   operator:
                                     description: |-
-                                      Operator represents a key's relationship to the value.
-                                      Valid operators are Exists and Equal. Defaults to Equal.
-                                      Exists is equivalent to wildcard for value, so that a pod can
-                                      tolerate all taints of a particular category.
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                     type: string
-                                  tolerationSeconds:
+                                  values:
                                     description: |-
-                                      TolerationSeconds represents the period of time the toleration (which must be
-                                      of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                                      it is not set, which means tolerate the taint forever (do not evict). Zero and
-                                      negative values will be treated as 0 (evict immediately) by the system.
-                                    format: int64
-                                    type: integer
-                                  value:
-                                    description: |-
-                                      Value is the taint value the toleration matches to.
-                                      If the operator is Exists, the value should be empty, otherwise just a regular string.
-                                    type: string
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
                                 type: object
                               type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
                           type: object
-                        resourceTimeout:
-                          description: |-
-                            resourceTimeout defines how long to wait for several Velero resources before timeout occurs,
-                            such as Velero CRD availability, volumeSnapshot deletion, and repo availability.
-                            Default is 10m
+                          x-kubernetes-map-type: atomic
+                        nullable: true
+                        type: array
+                      orderedResources:
+                        additionalProperties:
                           type: string
-                        restoreResourcesVersionPriority:
-                          description: |-
-                            restoreResourceVersionPriority represents a configmap that will be created if defined for use in conjunction with EnableAPIGroupVersions feature flag
-                            Defining this field automatically add EnableAPIGroupVersions to the velero server feature flag
+                        description: |-
+                          OrderedResources specifies the backup order of resources of specific Kind.
+                          The map key is the resource name and value is a list of object names separated by commas.
+                          Each resource name has format "namespace/objectname".  For cluster resources, simply use "objectname".
+                        nullable: true
+                        type: object
+                      resourcePolicy:
+                        description: ResourcePolicy specifies the referenced resource
+                          policies that backup should follow
+                        properties:
+                          apiGroup:
+                            description: |-
+                              APIGroup is the group for the resource being referenced.
+                              If APIGroup is not specified, the specified Kind must be in the core API group.
+                              For any other third-party types, APIGroup is required.
+                            type: string
+                          kind:
+                            description: Kind is the type of resource being referenced
+                            type: string
+                          name:
+                            description: Name is the name of resource being referenced
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      snapshotMoveData:
+                        description: SnapshotMoveData specifies whether snapshot data
+                          should be moved
+                        nullable: true
+                        type: boolean
+                      snapshotVolumes:
+                        description: |-
+                          SnapshotVolumes specifies whether to take snapshots
+                          of any PV's referenced in the set of objects included
+                          in the Backup.
+                        nullable: true
+                        type: boolean
+                      storageLocation:
+                        description: StorageLocation is a string containing the name
+                          of a BackupStorageLocation where the backup should be stored.
+                        type: string
+                      ttl:
+                        description: |-
+                          TTL is a time.Duration-parseable string describing how long
+                          the Backup should be retained for.
+                        type: string
+                      uploaderConfig:
+                        description: UploaderConfig specifies the configuration for
+                          the uploader.
+                        nullable: true
+                        properties:
+                          parallelFilesUpload:
+                            description: ParallelFilesUpload is the number of files
+                              parallel uploads to perform when using the uploader.
+                            type: integer
+                        type: object
+                      volumeGroupSnapshotLabelKey:
+                        description: VolumeGroupSnapshotLabelKey specifies the label
+                          key to group PVCs under a VGS.
+                        type: string
+                      volumeSnapshotLocations:
+                        description: VolumeSnapshotLocations is a list containing
+                          names of VolumeSnapshotLocations associated with this backup.
+                        items:
                           type: string
-                      type: object
-                  type: object
-                features:
-                  description: features defines the configuration for the DPA to enable the OADP tech preview features
-                  properties:
-                    dataMover:
-                      description: |-
-                        (do not use warning) dataMover is for backwards compatibility and
-                        will be removed in the future. Use Velero Built-in Data Mover instead
-                      properties:
-                        credentialName:
-                          description: User supplied Restic Secret name
+                        type: array
+                    type: object
+                  enforceRestoreSpec:
+                    description: which restore spec field values to enforce
+                    properties:
+                      backupName:
+                        description: |-
+                          BackupName is the unique name of the Velero backup to restore
+                          from.
+                        type: string
+                      excludedNamespaces:
+                        description: |-
+                          ExcludedNamespaces contains a list of namespaces that are not
+                          included in the restore.
+                        items:
                           type: string
-                        enable:
-                          description: enable flag is used to specify whether you want to deploy the volume snapshot mover controller
-                          type: boolean
-                        maxConcurrentBackupVolumes:
-                          description: the number of batched volumeSnapshotBackups that can be inProgress at once, default value is 10
+                        nullable: true
+                        type: array
+                      excludedResources:
+                        description: |-
+                          ExcludedResources is a slice of resource names that are not
+                          included in the restore.
+                        items:
                           type: string
-                        maxConcurrentRestoreVolumes:
-                          description: the number of batched volumeSnapshotRestores that can be inProgress at once, default value is 10
+                        nullable: true
+                        type: array
+                      existingResourcePolicy:
+                        description: ExistingResourcePolicy specifies the restore
+                          behavior for the Kubernetes resource to be restored
+                        nullable: true
+                        type: string
+                      hooks:
+                        description: Hooks represent custom behaviors that should
+                          be executed during or post restore.
+                        properties:
+                          resources:
+                            items:
+                              description: |-
+                                RestoreResourceHookSpec defines one or more RestoreResrouceHooks that should be executed based on
+                                the rules defined for namespaces, resources, and label selector.
+                              properties:
+                                excludedNamespaces:
+                                  description: ExcludedNamespaces specifies the namespaces
+                                    to which this hook spec does not apply.
+                                  items:
+                                    type: string
+                                  nullable: true
+                                  type: array
+                                excludedResources:
+                                  description: ExcludedResources specifies the resources
+                                    to which this hook spec does not apply.
+                                  items:
+                                    type: string
+                                  nullable: true
+                                  type: array
+                                includedNamespaces:
+                                  description: |-
+                                    IncludedNamespaces specifies the namespaces to which this hook spec applies. If empty, it applies
+                                    to all namespaces.
+                                  items:
+                                    type: string
+                                  nullable: true
+                                  type: array
+                                includedResources:
+                                  description: |-
+                                    IncludedResources specifies the resources to which this hook spec applies. If empty, it applies
+                                    to all resources.
+                                  items:
+                                    type: string
+                                  nullable: true
+                                  type: array
+                                labelSelector:
+                                  description: LabelSelector, if specified, filters
+                                    the resources to which this hook spec applies.
+                                  nullable: true
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                name:
+                                  description: Name is the name of this hook.
+                                  type: string
+                                postHooks:
+                                  description: PostHooks is a list of RestoreResourceHooks
+                                    to execute during and after restoring a resource.
+                                  items:
+                                    description: RestoreResourceHook defines a restore
+                                      hook for a resource.
+                                    properties:
+                                      exec:
+                                        description: Exec defines an exec restore
+                                          hook.
+                                        properties:
+                                          command:
+                                            description: Command is the command and
+                                              arguments to execute from within a container
+                                              after a pod has been restored.
+                                            items:
+                                              type: string
+                                            minItems: 1
+                                            type: array
+                                          container:
+                                            description: |-
+                                              Container is the container in the pod where the command should be executed. If not specified,
+                                              the pod's first container is used.
+                                            type: string
+                                          execTimeout:
+                                            description: |-
+                                              ExecTimeout defines the maximum amount of time Velero should wait for the hook to complete before
+                                              considering the execution a failure.
+                                            type: string
+                                          onError:
+                                            description: OnError specifies how Velero
+                                              should behave if it encounters an error
+                                              executing this hook.
+                                            enum:
+                                            - Continue
+                                            - Fail
+                                            type: string
+                                          waitForReady:
+                                            description: WaitForReady ensures command
+                                              will be launched when container is Ready
+                                              instead of Running.
+                                            nullable: true
+                                            type: boolean
+                                          waitTimeout:
+                                            description: |-
+                                              WaitTimeout defines the maximum amount of time Velero should wait for the container to be Ready
+                                              before attempting to run the command.
+                                            type: string
+                                        required:
+                                        - command
+                                        type: object
+                                      init:
+                                        description: Init defines an init restore
+                                          hook.
+                                        properties:
+                                          initContainers:
+                                            description: InitContainers is list of
+                                              init containers to be added to a pod
+                                              during its restore.
+                                            items:
+                                              type: object
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            type: array
+                                            x-kubernetes-preserve-unknown-fields: true
+                                          timeout:
+                                            description: Timeout defines the maximum
+                                              amount of time Velero should wait for
+                                              the initContainers to complete.
+                                            type: string
+                                        type: object
+                                    type: object
+                                  type: array
+                              required:
+                              - name
+                              type: object
+                            type: array
+                        type: object
+                      includeClusterResources:
+                        description: |-
+                          IncludeClusterResources specifies whether cluster-scoped resources
+                          should be included for consideration in the restore. If null, defaults
+                          to true.
+                        nullable: true
+                        type: boolean
+                      includedNamespaces:
+                        description: |-
+                          IncludedNamespaces is a slice of namespace names to include objects
+                          from. If empty, all namespaces are included.
+                        items:
                           type: string
-                        pruneInterval:
-                          description: defines how often (in days) to prune the datamover snapshots from the repository
+                        nullable: true
+                        type: array
+                      includedResources:
+                        description: |-
+                          IncludedResources is a slice of resource names to include
+                          in the restore. If empty, all resources in the backup are included.
+                        items:
                           type: string
-                        schedule:
-                          description: |-
-                            schedule is a cronspec (https://en.wikipedia.org/wiki/Cron#Overview) that
-                            can be used to schedule datamover(volsync) synchronization to occur at regular, time-based
-                            intervals. For example, in order to enforce datamover SnapshotRetainPolicy at a regular interval you need to
-                            specify this Schedule trigger as a cron expression, by default the trigger is a manual trigger. For more details
-                            on Volsync triggers, refer: https://volsync.readthedocs.io/en/stable/usage/triggers.html
-                          pattern: ^(\d+|\*)(/\d+)?(\s+(\d+|\*)(/\d+)?){4}$
-                          type: string
-                        snapshotRetainPolicy:
-                          description: defines the parameters that can be specified for retention of datamover snapshots
-                          properties:
-                            daily:
-                              description: Daily defines the number of snapshots to be kept daily
+                        nullable: true
+                        type: array
+                      itemOperationTimeout:
+                        description: |-
+                          ItemOperationTimeout specifies the time used to wait for RestoreItemAction operations
+                          The default value is 4 hour.
+                        type: string
+                      labelSelector:
+                        description: |-
+                          LabelSelector is a metav1.LabelSelector to filter with
+                          when restoring individual objects from the backup. If empty
+                          or nil, all objects are included. Optional.
+                        nullable: true
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
                               type: string
-                            hourly:
-                              description: Hourly defines the number of snapshots to be kept hourly
-                              type: string
-                            monthly:
-                              description: Monthly defines the number of snapshots to be kept monthly
-                              type: string
-                            weekly:
-                              description: Weekly defines the number of snapshots to be kept weekly
-                              type: string
-                            within:
-                              description: Within defines the number of snapshots to be kept Within the given time period
-                              type: string
-                            yearly:
-                              description: Yearly defines the number of snapshots to be kept yearly
-                              type: string
-                          type: object
-                        timeout:
-                          description: User supplied timeout to be used for VolumeSnapshotBackup and VolumeSnapshotRestore to complete, default value is 10m
-                          type: string
-                        volumeOptionsForStorageClasses:
-                          additionalProperties:
-                            properties:
-                              destinationVolumeOptions:
-                                description: VolumeOptions defines configurations for VolSync options
-                                properties:
-                                  accessMode:
-                                    description: |-
-                                      accessMode can be used to override the accessMode of the source or
-                                      destination PVC
-                                    type: string
-                                  cacheAccessMode:
-                                    description: cacheAccessMode is the access mode to be used to provision the cache volume
-                                    type: string
-                                  cacheCapacity:
-                                    description: cacheCapacity determines the size of the restic metadata cache volume
-                                    type: string
-                                  cacheStorageClassName:
-                                    description: |-
-                                      cacheStorageClassName is the storageClass that should be used when provisioning
-                                      the data mover cache volume
-                                    type: string
-                                  storageClassName:
-                                    description: |-
-                                      storageClassName can be used to override the StorageClass of the source
-                                      or destination PVC
-                                    type: string
-                                type: object
-                              sourceVolumeOptions:
-                                description: VolumeOptions defines configurations for VolSync options
-                                properties:
-                                  accessMode:
-                                    description: |-
-                                      accessMode can be used to override the accessMode of the source or
-                                      destination PVC
-                                    type: string
-                                  cacheAccessMode:
-                                    description: cacheAccessMode is the access mode to be used to provision the cache volume
-                                    type: string
-                                  cacheCapacity:
-                                    description: cacheCapacity determines the size of the restic metadata cache volume
-                                    type: string
-                                  cacheStorageClassName:
-                                    description: |-
-                                      cacheStorageClassName is the storageClass that should be used when provisioning
-                                      the data mover cache volume
-                                    type: string
-                                  storageClassName:
-                                    description: |-
-                                      storageClassName can be used to override the StorageClass of the source
-                                      or destination PVC
-                                    type: string
-                                type: object
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
                             type: object
-                          description: defines configurations for data mover volume options for a storageClass
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      namespaceMapping:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          NamespaceMapping is a map of source namespace names
+                          to target namespace names to restore into. Any source
+                          namespaces not included in the map will be restored into
+                          namespaces of the same name.
+                        type: object
+                      orLabelSelectors:
+                        description: |-
+                          OrLabelSelectors is list of metav1.LabelSelector to filter with
+                          when restoring individual objects from the backup. If multiple provided
+                          they will be joined by the OR operator. LabelSelector as well as
+                          OrLabelSelectors cannot co-exist in restore request, only one of them
+                          can be used
+                        items:
+                          description: |-
+                            A label selector is a label query over a set of resources. The result of matchLabels and
+                            matchExpressions are ANDed. An empty label selector matches all objects. A null
+                            label selector matches no objects.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
                           type: object
-                      type: object
-                  type: object
-                imagePullPolicy:
-                  description: |-
-                    which imagePullPolicy to use in all container images used by OADP.
-                    By default, for images with sha256 or sha512 digest, OADP uses IfNotPresent and uses Always for all other images.
-                  enum:
-                    - Always
-                    - IfNotPresent
-                    - Never
+                          x-kubernetes-map-type: atomic
+                        nullable: true
+                        type: array
+                      preserveNodePorts:
+                        description: PreserveNodePorts specifies whether to restore
+                          old nodePorts from backup.
+                        nullable: true
+                        type: boolean
+                      resourceModifier:
+                        description: ResourceModifier specifies the reference to JSON
+                          resource patches that should be applied to resources before
+                          restoration.
+                        nullable: true
+                        properties:
+                          apiGroup:
+                            description: |-
+                              APIGroup is the group for the resource being referenced.
+                              If APIGroup is not specified, the specified Kind must be in the core API group.
+                              For any other third-party types, APIGroup is required.
+                            type: string
+                          kind:
+                            description: Kind is the type of resource being referenced
+                            type: string
+                          name:
+                            description: Name is the name of resource being referenced
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      restorePVs:
+                        description: |-
+                          RestorePVs specifies whether to restore all included
+                          PVs from snapshot
+                        nullable: true
+                        type: boolean
+                      restoreStatus:
+                        description: |-
+                          RestoreStatus specifies which resources we should restore the status
+                          field. If nil, no objects are included. Optional.
+                        nullable: true
+                        properties:
+                          excludedResources:
+                            description: ExcludedResources specifies the resources
+                              to which will not restore the status.
+                            items:
+                              type: string
+                            nullable: true
+                            type: array
+                          includedResources:
+                            description: |-
+                              IncludedResources specifies the resources to which will restore the status.
+                              If empty, it applies to all resources.
+                            items:
+                              type: string
+                            nullable: true
+                            type: array
+                        type: object
+                      scheduleName:
+                        description: |-
+                          ScheduleName is the unique name of the Velero schedule to restore
+                          from. If specified, and BackupName is empty, Velero will restore
+                          from the most recent successful backup created from this schedule.
+                        type: string
+                      uploaderConfig:
+                        description: UploaderConfig specifies the configuration for
+                          the restore.
+                        nullable: true
+                        properties:
+                          parallelFilesDownload:
+                            description: ParallelFilesDownload is the concurrency
+                              number setting for restore.
+                            type: integer
+                          writeSparseFiles:
+                            description: WriteSparseFiles is a flag to indicate whether
+                              write files sparsely or not.
+                            nullable: true
+                            type: boolean
+                        type: object
+                    type: object
+                  garbageCollectionPeriod:
+                    description: |-
+                      GarbageCollectionPeriod defines how frequently to look for possible leftover non admin related objects in OADP namespace.
+                      A value of 0 disables garbage collection.
+                      By default 24h
+                    type: string
+                  requireApprovalForBSL:
+                    description: |-
+                      RequireApprovalForBSL specifies whether cluster administrator approval is required
+                      for creating Velero BackupStorageLocation (BSL) resources.
+                      - If set to false, all NonAdminBackupStorageLocationApproval CRDs will be automatically approved,
+                        including those that were previously pending or rejected.
+                      - If set to true, any existing BackupStorageLocation CRDs that lack the necessary approvals may be deleted,
+                        leaving the associated NonAdminBackup objects non-restorable until approval is granted.
+                      Defaults to false
+                    type: boolean
+                type: object
+              podAnnotations:
+                additionalProperties:
                   type: string
-                logFormat:
-                  default: text
-                  description: The format for log output. Valid values are text, json. (default text)
-                  enum:
-                    - text
-                    - json
-                  type: string
-                nonAdmin:
-                  description: nonAdmin defines the configuration for the DPA to enable backup and restore operations for non-admin users
-                  properties:
-                    backupSyncPeriod:
-                      description: |-
-                        BackupSyncPeriod specifies the interval at which backups from the OADP namespace are synchronized with non-admin namespaces.
-                        A value of 0 disables sync.
-                        By default 2m
+                description: |-
+                  add annotations to pods deployed by operator
+                  Deprecated: Use PodConfig instead
+                type: object
+              podDnsConfig:
+                description: |-
+                  podDnsConfig defines the DNS parameters of a pod in addition to
+                  those generated from DNSPolicy.
+                  https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config
+                properties:
+                  nameservers:
+                    description: |-
+                      A list of DNS name server IP addresses.
+                      This will be appended to the base nameservers generated from DNSPolicy.
+                      Duplicated nameservers will be removed.
+                    items:
                       type: string
-                    enable:
-                      description: Enables non admin feature, by default is disabled
-                      type: boolean
-                    enforceBSLSpec:
-                      description: which backupstoragelocation spec field values to enforce
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  options:
+                    description: |-
+                      A list of DNS resolver options.
+                      This will be merged with the base options generated from DNSPolicy.
+                      Duplicated entries will be removed. Resolution options given in Options
+                      will override those that appear in the base DNSPolicy.
+                    items:
+                      description: PodDNSConfigOption defines DNS resolver options
+                        of a pod.
                       properties:
-                        accessMode:
-                          description: AccessMode defines the permissions for the backup storage location.
-                          enum:
-                            - ReadOnly
-                            - ReadWrite
+                        name:
+                          description: |-
+                            Name is this DNS resolver option's name.
+                            Required.
                           type: string
-                        backupSyncPeriod:
-                          description: BackupSyncPeriod defines how frequently to sync backup API objects from object storage. A value of 0 disables sync.
-                          nullable: true
+                        value:
+                          description: Value is this DNS resolver option's value.
                           type: string
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  searches:
+                    description: |-
+                      A list of DNS search domains for host-name lookup.
+                      This will be appended to the base search paths generated from DNSPolicy.
+                      Duplicated search paths will be removed.
+                    items:
+                      type: string
+                    type: array
+                    x-kubernetes-list-type: atomic
+                type: object
+              podDnsPolicy:
+                description: |-
+                  podDnsPolicy defines how a pod's DNS will be configured.
+                  https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
+                type: string
+              resourceAnnotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  resourceAnnotations defines annotations that will be applied to all resources managed by the DPA.
+                  Useful for GitOps tools like ArgoCD (e.g., argocd.argoproj.io/ignore-resource-updates: 'true').
+                type: object
+              resourceLabels:
+                additionalProperties:
+                  type: string
+                description: |-
+                  resourceLabels defines labels that will be applied to all resources managed by the DPA.
+                  These labels are merged with OADP-required labels. User-provided labels cannot override
+                  core operator labels (app.kubernetes.io/*, openshift.io/oadp).
+                type: object
+              snapshotLocations:
+                description: snapshotLocations defines the list of desired configuration
+                  to use for VolumeSnapshotLocations
+                items:
+                  description: SnapshotLocation defines the configuration for the
+                    DPA snapshot store
+                  properties:
+                    name:
+                      type: string
+                    velero:
+                      description: VolumeSnapshotLocationSpec defines the specification
+                        for a Velero VolumeSnapshotLocation.
+                      properties:
                         config:
                           additionalProperties:
                             type: string
-                          description: Config is for provider-specific configuration fields.
+                          description: Config is for provider-specific configuration
+                            fields.
                           type: object
                         credential:
-                          description: Credential contains the credential information intended to be used with this location
+                          description: Credential contains the credential information
+                            intended to be used with this location
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must be a valid secret key.
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
                               type: string
                             name:
                               default: ""
@@ -1785,1176 +3072,186 @@ spec:
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must be defined
+                              description: Specify whether the Secret or its key must
+                                be defined
                               type: boolean
                           required:
-                            - key
+                          - key
                           type: object
                           x-kubernetes-map-type: atomic
-                        objectStorage:
-                          description: ObjectStorageLocation defines the enforced values for the Velero ObjectStorageLocation
-                          nullable: true
-                          properties:
-                            bucket:
-                              description: Bucket is the bucket to use for object storage.
-                              type: string
-                            caCert:
-                              description: CACert defines a CA bundle to use when verifying TLS connections to the provider.
-                              format: byte
-                              type: string
-                            prefix:
-                              description: Prefix is the path inside a bucket to use for Velero storage. Optional.
-                              type: string
-                          type: object
                         provider:
-                          description: Provider is the provider of the backup storage.
+                          description: Provider is the provider of the volume storage.
                           type: string
-                        validationFrequency:
-                          description: ValidationFrequency defines how frequently to validate the corresponding object storage. A value of 0 disables validation.
-                          nullable: true
-                          type: string
+                      required:
+                      - provider
                       type: object
-                    enforceBackupSpec:
-                      description: which bakup spec field values to enforce
-                      properties:
-                        csiSnapshotTimeout:
-                          description: |-
-                            CSISnapshotTimeout specifies the time used to wait for CSI VolumeSnapshot status turns to
-                            ReadyToUse during creation, before returning error as timeout.
-                            The default value is 10 minute.
-                          type: string
-                        datamover:
-                          description: |-
-                            DataMover specifies the data mover to be used by the backup.
-                            If DataMover is "" or "velero", the built-in data mover will be used.
-                          type: string
-                        defaultVolumesToFsBackup:
-                          description: |-
-                            DefaultVolumesToFsBackup specifies whether pod volume file system backup should be used
-                            for all volumes by default.
-                          nullable: true
-                          type: boolean
-                        defaultVolumesToRestic:
-                          description: |-
-                            DefaultVolumesToRestic specifies whether restic should be used to take a
-                            backup of all pod volumes by default.
-
-                            Deprecated: this field is no longer used and will be removed entirely in future. Use DefaultVolumesToFsBackup instead.
-                          nullable: true
-                          type: boolean
-                        excludedClusterScopedResources:
-                          description: |-
-                            ExcludedClusterScopedResources is a slice of cluster-scoped
-                            resource type names to exclude from the backup.
-                            If set to "*", all cluster-scoped resource types are excluded.
-                            The default value is empty.
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        excludedNamespaceScopedResources:
-                          description: |-
-                            ExcludedNamespaceScopedResources is a slice of namespace-scoped
-                            resource type names to exclude from the backup.
-                            If set to "*", all namespace-scoped resource types are excluded.
-                            The default value is empty.
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        excludedNamespaces:
-                          description: |-
-                            ExcludedNamespaces contains a list of namespaces that are not
-                            included in the backup.
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        excludedResources:
-                          description: |-
-                            ExcludedResources is a slice of resource names that are not
-                            included in the backup.
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        hooks:
-                          description: Hooks represent custom behaviors that should be executed at different phases of the backup.
-                          properties:
-                            resources:
-                              description: Resources are hooks that should be executed when backing up individual instances of a resource.
-                              items:
-                                description: |-
-                                  BackupResourceHookSpec defines one or more BackupResourceHooks that should be executed based on
-                                  the rules defined for namespaces, resources, and label selector.
-                                properties:
-                                  excludedNamespaces:
-                                    description: ExcludedNamespaces specifies the namespaces to which this hook spec does not apply.
-                                    items:
-                                      type: string
-                                    nullable: true
-                                    type: array
-                                  excludedResources:
-                                    description: ExcludedResources specifies the resources to which this hook spec does not apply.
-                                    items:
-                                      type: string
-                                    nullable: true
-                                    type: array
-                                  includedNamespaces:
-                                    description: |-
-                                      IncludedNamespaces specifies the namespaces to which this hook spec applies. If empty, it applies
-                                      to all namespaces.
-                                    items:
-                                      type: string
-                                    nullable: true
-                                    type: array
-                                  includedResources:
-                                    description: |-
-                                      IncludedResources specifies the resources to which this hook spec applies. If empty, it applies
-                                      to all resources.
-                                    items:
-                                      type: string
-                                    nullable: true
-                                    type: array
-                                  labelSelector:
-                                    description: LabelSelector, if specified, filters the resources to which this hook spec applies.
-                                    nullable: true
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                        items:
-                                          description: |-
-                                            A label selector requirement is a selector that contains values, a key, and an operator that
-                                            relates the key and values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: |-
-                                                operator represents a key's relationship to a set of values.
-                                                Valid operators are In, NotIn, Exists and DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: |-
-                                                values is an array of string values. If the operator is In or NotIn,
-                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                              x-kubernetes-list-type: atomic
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                        x-kubernetes-list-type: atomic
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: |-
-                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                    x-kubernetes-map-type: atomic
-                                  name:
-                                    description: Name is the name of this hook.
-                                    type: string
-                                  post:
-                                    description: |-
-                                      PostHooks is a list of BackupResourceHooks to execute after storing the item in the backup.
-                                      These are executed after all "additional items" from item actions are processed.
-                                    items:
-                                      description: BackupResourceHook defines a hook for a resource.
-                                      properties:
-                                        exec:
-                                          description: Exec defines an exec hook.
-                                          properties:
-                                            command:
-                                              description: Command is the command and arguments to execute.
-                                              items:
-                                                type: string
-                                              minItems: 1
-                                              type: array
-                                            container:
-                                              description: |-
-                                                Container is the container in the pod where the command should be executed. If not specified,
-                                                the pod's first container is used.
-                                              type: string
-                                            onError:
-                                              description: OnError specifies how Velero should behave if it encounters an error executing this hook.
-                                              enum:
-                                                - Continue
-                                                - Fail
-                                              type: string
-                                            timeout:
-                                              description: |-
-                                                Timeout defines the maximum amount of time Velero should wait for the hook to complete before
-                                                considering the execution a failure.
-                                              type: string
-                                          required:
-                                            - command
-                                          type: object
-                                      required:
-                                        - exec
-                                      type: object
-                                    type: array
-                                  pre:
-                                    description: |-
-                                      PreHooks is a list of BackupResourceHooks to execute prior to storing the item in the backup.
-                                      These are executed before any "additional items" from item actions are processed.
-                                    items:
-                                      description: BackupResourceHook defines a hook for a resource.
-                                      properties:
-                                        exec:
-                                          description: Exec defines an exec hook.
-                                          properties:
-                                            command:
-                                              description: Command is the command and arguments to execute.
-                                              items:
-                                                type: string
-                                              minItems: 1
-                                              type: array
-                                            container:
-                                              description: |-
-                                                Container is the container in the pod where the command should be executed. If not specified,
-                                                the pod's first container is used.
-                                              type: string
-                                            onError:
-                                              description: OnError specifies how Velero should behave if it encounters an error executing this hook.
-                                              enum:
-                                                - Continue
-                                                - Fail
-                                              type: string
-                                            timeout:
-                                              description: |-
-                                                Timeout defines the maximum amount of time Velero should wait for the hook to complete before
-                                                considering the execution a failure.
-                                              type: string
-                                          required:
-                                            - command
-                                          type: object
-                                      required:
-                                        - exec
-                                      type: object
-                                    type: array
-                                required:
-                                  - name
-                                type: object
-                              nullable: true
-                              type: array
-                          type: object
-                        includeClusterResources:
-                          description: |-
-                            IncludeClusterResources specifies whether cluster-scoped resources
-                            should be included for consideration in the backup.
-                          nullable: true
-                          type: boolean
-                        includedClusterScopedResources:
-                          description: |-
-                            IncludedClusterScopedResources is a slice of cluster-scoped
-                            resource type names to include in the backup.
-                            If set to "*", all cluster-scoped resource types are included.
-                            The default value is empty, which means only related
-                            cluster-scoped resources are included.
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        includedNamespaceScopedResources:
-                          description: |-
-                            IncludedNamespaceScopedResources is a slice of namespace-scoped
-                            resource type names to include in the backup.
-                            The default value is "*".
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        includedNamespaces:
-                          description: |-
-                            IncludedNamespaces is a slice of namespace names to include objects
-                            from. If empty, all namespaces are included.
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        includedResources:
-                          description: |-
-                            IncludedResources is a slice of resource names to include
-                            in the backup. If empty, all resources are included.
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        itemOperationTimeout:
-                          description: |-
-                            ItemOperationTimeout specifies the time used to wait for asynchronous BackupItemAction operations
-                            The default value is 4 hour.
-                          type: string
-                        labelSelector:
-                          description: |-
-                            LabelSelector is a metav1.LabelSelector to filter with
-                            when adding individual objects to the backup. If empty
-                            or nil, all objects are included. Optional.
-                          nullable: true
-                          properties:
-                            matchExpressions:
-                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                              items:
-                                description: |-
-                                  A label selector requirement is a selector that contains values, a key, and an operator that
-                                  relates the key and values.
-                                properties:
-                                  key:
-                                    description: key is the label key that the selector applies to.
-                                    type: string
-                                  operator:
-                                    description: |-
-                                      operator represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists and DoesNotExist.
-                                    type: string
-                                  values:
-                                    description: |-
-                                      values is an array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. This array is replaced during a strategic
-                                      merge patch.
-                                    items:
-                                      type: string
-                                    type: array
-                                    x-kubernetes-list-type: atomic
-                                required:
-                                  - key
-                                  - operator
-                                type: object
-                              type: array
-                              x-kubernetes-list-type: atomic
-                            matchLabels:
-                              additionalProperties:
-                                type: string
-                              description: |-
-                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                operator is "In", and the values array contains only "value". The requirements are ANDed.
-                              type: object
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        metadata:
-                          properties:
-                            labels:
-                              additionalProperties:
-                                type: string
-                              type: object
-                          type: object
-                        orLabelSelectors:
-                          description: |-
-                            OrLabelSelectors is list of metav1.LabelSelector to filter with
-                            when adding individual objects to the backup. If multiple provided
-                            they will be joined by the OR operator. LabelSelector as well as
-                            OrLabelSelectors cannot co-exist in backup request, only one of them
-                            can be used.
-                          items:
-                            description: |-
-                              A label selector is a label query over a set of resources. The result of matchLabels and
-                              matchExpressions are ANDed. An empty label selector matches all objects. A null
-                              label selector matches no objects.
-                            properties:
-                              matchExpressions:
-                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                items:
-                                  description: |-
-                                    A label selector requirement is a selector that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  properties:
-                                    key:
-                                      description: key is the label key that the selector applies to.
-                                      type: string
-                                    operator:
-                                      description: |-
-                                        operator represents a key's relationship to a set of values.
-                                        Valid operators are In, NotIn, Exists and DoesNotExist.
-                                      type: string
-                                    values:
-                                      description: |-
-                                        values is an array of string values. If the operator is In or NotIn,
-                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                        the values array must be empty. This array is replaced during a strategic
-                                        merge patch.
-                                      items:
-                                        type: string
-                                      type: array
-                                      x-kubernetes-list-type: atomic
-                                  required:
-                                    - key
-                                    - operator
-                                  type: object
-                                type: array
-                                x-kubernetes-list-type: atomic
-                              matchLabels:
-                                additionalProperties:
-                                  type: string
-                                description: |-
-                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                type: object
-                            type: object
-                            x-kubernetes-map-type: atomic
-                          nullable: true
-                          type: array
-                        orderedResources:
-                          additionalProperties:
-                            type: string
-                          description: |-
-                            OrderedResources specifies the backup order of resources of specific Kind.
-                            The map key is the resource name and value is a list of object names separated by commas.
-                            Each resource name has format "namespace/objectname".  For cluster resources, simply use "objectname".
-                          nullable: true
-                          type: object
-                        resourcePolicy:
-                          description: ResourcePolicy specifies the referenced resource policies that backup should follow
-                          properties:
-                            apiGroup:
-                              description: |-
-                                APIGroup is the group for the resource being referenced.
-                                If APIGroup is not specified, the specified Kind must be in the core API group.
-                                For any other third-party types, APIGroup is required.
-                              type: string
-                            kind:
-                              description: Kind is the type of resource being referenced
-                              type: string
-                            name:
-                              description: Name is the name of resource being referenced
-                              type: string
-                          required:
-                            - kind
-                            - name
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        snapshotMoveData:
-                          description: SnapshotMoveData specifies whether snapshot data should be moved
-                          nullable: true
-                          type: boolean
-                        snapshotVolumes:
-                          description: |-
-                            SnapshotVolumes specifies whether to take snapshots
-                            of any PV's referenced in the set of objects included
-                            in the Backup.
-                          nullable: true
-                          type: boolean
-                        storageLocation:
-                          description: StorageLocation is a string containing the name of a BackupStorageLocation where the backup should be stored.
-                          type: string
-                        ttl:
-                          description: |-
-                            TTL is a time.Duration-parseable string describing how long
-                            the Backup should be retained for.
-                          type: string
-                        uploaderConfig:
-                          description: UploaderConfig specifies the configuration for the uploader.
-                          nullable: true
-                          properties:
-                            parallelFilesUpload:
-                              description: ParallelFilesUpload is the number of files parallel uploads to perform when using the uploader.
-                              type: integer
-                          type: object
-                        volumeGroupSnapshotLabelKey:
-                          description: VolumeGroupSnapshotLabelKey specifies the label key to group PVCs under a VGS.
-                          type: string
-                        volumeSnapshotLocations:
-                          description: VolumeSnapshotLocations is a list containing names of VolumeSnapshotLocations associated with this backup.
-                          items:
-                            type: string
-                          type: array
-                      type: object
-                    enforceRestoreSpec:
-                      description: which restore spec field values to enforce
-                      properties:
-                        backupName:
-                          description: |-
-                            BackupName is the unique name of the Velero backup to restore
-                            from.
-                          type: string
-                        excludedNamespaces:
-                          description: |-
-                            ExcludedNamespaces contains a list of namespaces that are not
-                            included in the restore.
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        excludedResources:
-                          description: |-
-                            ExcludedResources is a slice of resource names that are not
-                            included in the restore.
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        existingResourcePolicy:
-                          description: ExistingResourcePolicy specifies the restore behavior for the Kubernetes resource to be restored
-                          nullable: true
-                          type: string
-                        hooks:
-                          description: Hooks represent custom behaviors that should be executed during or post restore.
-                          properties:
-                            resources:
-                              items:
-                                description: |-
-                                  RestoreResourceHookSpec defines one or more RestoreResrouceHooks that should be executed based on
-                                  the rules defined for namespaces, resources, and label selector.
-                                properties:
-                                  excludedNamespaces:
-                                    description: ExcludedNamespaces specifies the namespaces to which this hook spec does not apply.
-                                    items:
-                                      type: string
-                                    nullable: true
-                                    type: array
-                                  excludedResources:
-                                    description: ExcludedResources specifies the resources to which this hook spec does not apply.
-                                    items:
-                                      type: string
-                                    nullable: true
-                                    type: array
-                                  includedNamespaces:
-                                    description: |-
-                                      IncludedNamespaces specifies the namespaces to which this hook spec applies. If empty, it applies
-                                      to all namespaces.
-                                    items:
-                                      type: string
-                                    nullable: true
-                                    type: array
-                                  includedResources:
-                                    description: |-
-                                      IncludedResources specifies the resources to which this hook spec applies. If empty, it applies
-                                      to all resources.
-                                    items:
-                                      type: string
-                                    nullable: true
-                                    type: array
-                                  labelSelector:
-                                    description: LabelSelector, if specified, filters the resources to which this hook spec applies.
-                                    nullable: true
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                        items:
-                                          description: |-
-                                            A label selector requirement is a selector that contains values, a key, and an operator that
-                                            relates the key and values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: |-
-                                                operator represents a key's relationship to a set of values.
-                                                Valid operators are In, NotIn, Exists and DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: |-
-                                                values is an array of string values. If the operator is In or NotIn,
-                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                              x-kubernetes-list-type: atomic
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                        x-kubernetes-list-type: atomic
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: |-
-                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                    x-kubernetes-map-type: atomic
-                                  name:
-                                    description: Name is the name of this hook.
-                                    type: string
-                                  postHooks:
-                                    description: PostHooks is a list of RestoreResourceHooks to execute during and after restoring a resource.
-                                    items:
-                                      description: RestoreResourceHook defines a restore hook for a resource.
-                                      properties:
-                                        exec:
-                                          description: Exec defines an exec restore hook.
-                                          properties:
-                                            command:
-                                              description: Command is the command and arguments to execute from within a container after a pod has been restored.
-                                              items:
-                                                type: string
-                                              minItems: 1
-                                              type: array
-                                            container:
-                                              description: |-
-                                                Container is the container in the pod where the command should be executed. If not specified,
-                                                the pod's first container is used.
-                                              type: string
-                                            execTimeout:
-                                              description: |-
-                                                ExecTimeout defines the maximum amount of time Velero should wait for the hook to complete before
-                                                considering the execution a failure.
-                                              type: string
-                                            onError:
-                                              description: OnError specifies how Velero should behave if it encounters an error executing this hook.
-                                              enum:
-                                                - Continue
-                                                - Fail
-                                              type: string
-                                            waitForReady:
-                                              description: WaitForReady ensures command will be launched when container is Ready instead of Running.
-                                              nullable: true
-                                              type: boolean
-                                            waitTimeout:
-                                              description: |-
-                                                WaitTimeout defines the maximum amount of time Velero should wait for the container to be Ready
-                                                before attempting to run the command.
-                                              type: string
-                                          required:
-                                            - command
-                                          type: object
-                                        init:
-                                          description: Init defines an init restore hook.
-                                          properties:
-                                            initContainers:
-                                              description: InitContainers is list of init containers to be added to a pod during its restore.
-                                              items:
-                                                type: object
-                                                x-kubernetes-preserve-unknown-fields: true
-                                              type: array
-                                              x-kubernetes-preserve-unknown-fields: true
-                                            timeout:
-                                              description: Timeout defines the maximum amount of time Velero should wait for the initContainers to complete.
-                                              type: string
-                                          type: object
-                                      type: object
-                                    type: array
-                                required:
-                                  - name
-                                type: object
-                              type: array
-                          type: object
-                        includeClusterResources:
-                          description: |-
-                            IncludeClusterResources specifies whether cluster-scoped resources
-                            should be included for consideration in the restore. If null, defaults
-                            to true.
-                          nullable: true
-                          type: boolean
-                        includedNamespaces:
-                          description: |-
-                            IncludedNamespaces is a slice of namespace names to include objects
-                            from. If empty, all namespaces are included.
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        includedResources:
-                          description: |-
-                            IncludedResources is a slice of resource names to include
-                            in the restore. If empty, all resources in the backup are included.
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        itemOperationTimeout:
-                          description: |-
-                            ItemOperationTimeout specifies the time used to wait for RestoreItemAction operations
-                            The default value is 4 hour.
-                          type: string
-                        labelSelector:
-                          description: |-
-                            LabelSelector is a metav1.LabelSelector to filter with
-                            when restoring individual objects from the backup. If empty
-                            or nil, all objects are included. Optional.
-                          nullable: true
-                          properties:
-                            matchExpressions:
-                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                              items:
-                                description: |-
-                                  A label selector requirement is a selector that contains values, a key, and an operator that
-                                  relates the key and values.
-                                properties:
-                                  key:
-                                    description: key is the label key that the selector applies to.
-                                    type: string
-                                  operator:
-                                    description: |-
-                                      operator represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists and DoesNotExist.
-                                    type: string
-                                  values:
-                                    description: |-
-                                      values is an array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. This array is replaced during a strategic
-                                      merge patch.
-                                    items:
-                                      type: string
-                                    type: array
-                                    x-kubernetes-list-type: atomic
-                                required:
-                                  - key
-                                  - operator
-                                type: object
-                              type: array
-                              x-kubernetes-list-type: atomic
-                            matchLabels:
-                              additionalProperties:
-                                type: string
-                              description: |-
-                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                operator is "In", and the values array contains only "value". The requirements are ANDed.
-                              type: object
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        namespaceMapping:
-                          additionalProperties:
-                            type: string
-                          description: |-
-                            NamespaceMapping is a map of source namespace names
-                            to target namespace names to restore into. Any source
-                            namespaces not included in the map will be restored into
-                            namespaces of the same name.
-                          type: object
-                        orLabelSelectors:
-                          description: |-
-                            OrLabelSelectors is list of metav1.LabelSelector to filter with
-                            when restoring individual objects from the backup. If multiple provided
-                            they will be joined by the OR operator. LabelSelector as well as
-                            OrLabelSelectors cannot co-exist in restore request, only one of them
-                            can be used
-                          items:
-                            description: |-
-                              A label selector is a label query over a set of resources. The result of matchLabels and
-                              matchExpressions are ANDed. An empty label selector matches all objects. A null
-                              label selector matches no objects.
-                            properties:
-                              matchExpressions:
-                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                items:
-                                  description: |-
-                                    A label selector requirement is a selector that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  properties:
-                                    key:
-                                      description: key is the label key that the selector applies to.
-                                      type: string
-                                    operator:
-                                      description: |-
-                                        operator represents a key's relationship to a set of values.
-                                        Valid operators are In, NotIn, Exists and DoesNotExist.
-                                      type: string
-                                    values:
-                                      description: |-
-                                        values is an array of string values. If the operator is In or NotIn,
-                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                        the values array must be empty. This array is replaced during a strategic
-                                        merge patch.
-                                      items:
-                                        type: string
-                                      type: array
-                                      x-kubernetes-list-type: atomic
-                                  required:
-                                    - key
-                                    - operator
-                                  type: object
-                                type: array
-                                x-kubernetes-list-type: atomic
-                              matchLabels:
-                                additionalProperties:
-                                  type: string
-                                description: |-
-                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                type: object
-                            type: object
-                            x-kubernetes-map-type: atomic
-                          nullable: true
-                          type: array
-                        preserveNodePorts:
-                          description: PreserveNodePorts specifies whether to restore old nodePorts from backup.
-                          nullable: true
-                          type: boolean
-                        resourceModifier:
-                          description: ResourceModifier specifies the reference to JSON resource patches that should be applied to resources before restoration.
-                          nullable: true
-                          properties:
-                            apiGroup:
-                              description: |-
-                                APIGroup is the group for the resource being referenced.
-                                If APIGroup is not specified, the specified Kind must be in the core API group.
-                                For any other third-party types, APIGroup is required.
-                              type: string
-                            kind:
-                              description: Kind is the type of resource being referenced
-                              type: string
-                            name:
-                              description: Name is the name of resource being referenced
-                              type: string
-                          required:
-                            - kind
-                            - name
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        restorePVs:
-                          description: |-
-                            RestorePVs specifies whether to restore all included
-                            PVs from snapshot
-                          nullable: true
-                          type: boolean
-                        restoreStatus:
-                          description: |-
-                            RestoreStatus specifies which resources we should restore the status
-                            field. If nil, no objects are included. Optional.
-                          nullable: true
-                          properties:
-                            excludedResources:
-                              description: ExcludedResources specifies the resources to which will not restore the status.
-                              items:
-                                type: string
-                              nullable: true
-                              type: array
-                            includedResources:
-                              description: |-
-                                IncludedResources specifies the resources to which will restore the status.
-                                If empty, it applies to all resources.
-                              items:
-                                type: string
-                              nullable: true
-                              type: array
-                          type: object
-                        scheduleName:
-                          description: |-
-                            ScheduleName is the unique name of the Velero schedule to restore
-                            from. If specified, and BackupName is empty, Velero will restore
-                            from the most recent successful backup created from this schedule.
-                          type: string
-                        uploaderConfig:
-                          description: UploaderConfig specifies the configuration for the restore.
-                          nullable: true
-                          properties:
-                            parallelFilesDownload:
-                              description: ParallelFilesDownload is the concurrency number setting for restore.
-                              type: integer
-                            writeSparseFiles:
-                              description: WriteSparseFiles is a flag to indicate whether write files sparsely or not.
-                              nullable: true
-                              type: boolean
-                          type: object
-                      type: object
-                    garbageCollectionPeriod:
-                      description: |-
-                        GarbageCollectionPeriod defines how frequently to look for possible leftover non admin related objects in OADP namespace.
-                        A value of 0 disables garbage collection.
-                        By default 24h
-                      type: string
-                    requireApprovalForBSL:
-                      description: |-
-                        RequireApprovalForBSL specifies whether cluster administrator approval is required
-                        for creating Velero BackupStorageLocation (BSL) resources.
-                        - If set to false, all NonAdminBackupStorageLocationApproval CRDs will be automatically approved,
-                          including those that were previously pending or rejected.
-                        - If set to true, any existing BackupStorageLocation CRDs that lack the necessary approvals may be deleted,
-                          leaving the associated NonAdminBackup objects non-restorable until approval is granted.
-                        Defaults to false
-                      type: boolean
+                  required:
+                  - velero
                   type: object
-                podAnnotations:
-                  additionalProperties:
-                    type: string
-                  description: |-
-                    add annotations to pods deployed by operator
-                    Deprecated: Use PodConfig instead
-                  type: object
-                podDnsConfig:
-                  description: |-
-                    podDnsConfig defines the DNS parameters of a pod in addition to
-                    those generated from DNSPolicy.
-                    https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config
-                  properties:
-                    nameservers:
-                      description: |-
-                        A list of DNS name server IP addresses.
-                        This will be appended to the base nameservers generated from DNSPolicy.
-                        Duplicated nameservers will be removed.
-                      items:
-                        type: string
-                      type: array
-                      x-kubernetes-list-type: atomic
-                    options:
-                      description: |-
-                        A list of DNS resolver options.
-                        This will be merged with the base options generated from DNSPolicy.
-                        Duplicated entries will be removed. Resolution options given in Options
-                        will override those that appear in the base DNSPolicy.
-                      items:
-                        description: PodDNSConfigOption defines DNS resolver options of a pod.
-                        properties:
-                          name:
-                            description: |-
-                              Name is this DNS resolver option's name.
-                              Required.
-                            type: string
-                          value:
-                            description: Value is this DNS resolver option's value.
-                            type: string
-                        type: object
-                      type: array
-                      x-kubernetes-list-type: atomic
-                    searches:
-                      description: |-
-                        A list of DNS search domains for host-name lookup.
-                        This will be appended to the base search paths generated from DNSPolicy.
-                        Duplicated search paths will be removed.
-                      items:
-                        type: string
-                      type: array
-                      x-kubernetes-list-type: atomic
-                  type: object
-                podDnsPolicy:
-                  description: |-
-                    podDnsPolicy defines how a pod's DNS will be configured.
-                    https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
+                type: array
+              unsupportedOverrides:
+                additionalProperties:
                   type: string
-                resourceAnnotations:
-                  additionalProperties:
-                    type: string
-                  description: |-
-                    resourceAnnotations defines annotations that will be applied to all resources managed by the DPA.
-                    Useful for GitOps tools like ArgoCD (e.g., argocd.argoproj.io/ignore-resource-updates: 'true').
-                  type: object
-                resourceLabels:
-                  additionalProperties:
-                    type: string
-                  description: |-
-                    resourceLabels defines labels that will be applied to all resources managed by the DPA.
-                    These labels are merged with OADP-required labels. User-provided labels cannot override
-                    core operator labels (app.kubernetes.io/*, openshift.io/oadp).
-                  type: object
-                snapshotLocations:
-                  description: snapshotLocations defines the list of desired configuration to use for VolumeSnapshotLocations
-                  items:
-                    description: SnapshotLocation defines the configuration for the DPA snapshot store
+                description: |-
+                  unsupportedOverrides can be used to override images used in deployments.
+                  Available keys are:
+                    - veleroImageFqin
+                    - awsPluginImageFqin
+                    - legacyAWSPluginImageFqin
+                    - openshiftPluginImageFqin
+                    - azurePluginImageFqin
+                    - gcpPluginImageFqin
+                    - kubevirtPluginImageFqin
+                    - kubevirtDatamoverPluginImageFqin
+                    - kubevirtDatamoverControllerImageFqin
+                    - hypershiftPluginImageFqin
+                    - nonAdminControllerImageFqin
+                    - vmFileRestoreControllerImageFqin
+                    - vmFileRestoreAccessImageFqin
+                    - vmFileRestoreSSHImageFqin
+                    - vmFileRestoreBrowserImageFqin
+                    - operator-type
+                    - tech-preview-ack
+                type: object
+              vmFileRestore:
+                description: vmFileRestore defines the configuration for the DPA to
+                  enable VM file restore feature
+                properties:
+                  enable:
+                    description: |-
+                      Enable flag to deploy VM file restore controller
+                      By default is disabled
+                    type: boolean
+                  resources:
+                    description: Resource requirements for the VM file restore controller
                     properties:
-                      name:
-                        type: string
-                      velero:
-                        description: VolumeSnapshotLocationSpec defines the specification for a Velero VolumeSnapshotLocation.
-                        properties:
-                          config:
-                            additionalProperties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This is an alpha field and requires enabling the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
                               type: string
-                            description: Config is for provider-specific configuration fields.
-                            type: object
-                          credential:
-                            description: Credential contains the credential information intended to be used with this location
-                            properties:
-                              key:
-                                description: The key of the secret to select from.  Must be a valid secret key.
-                                type: string
-                              name:
-                                default: ""
-                                description: |-
-                                  Name of the referent.
-                                  This field is effectively required, but due to backwards compatibility is
-                                  allowed to be empty. Instances of this type with an empty value here are
-                                  almost certainly wrong.
-                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                type: string
-                              optional:
-                                description: Specify whether the Secret or its key must be defined
-                                type: boolean
-                            required:
-                              - key
-                            type: object
-                            x-kubernetes-map-type: atomic
-                          provider:
-                            description: Provider is the provider of the volume storage.
-                            type: string
-                        required:
-                          - provider
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
-                    required:
-                      - velero
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
                     type: object
-                  type: array
-                unsupportedOverrides:
-                  additionalProperties:
-                    type: string
-                  description: |-
-                    unsupportedOverrides can be used to override images used in deployments.
-                    Available keys are:
-                      - veleroImageFqin
-                      - awsPluginImageFqin
-                      - legacyAWSPluginImageFqin
-                      - openshiftPluginImageFqin
-                      - azurePluginImageFqin
-                      - gcpPluginImageFqin
-                      - kubevirtPluginImageFqin
-                      - kubevirtDatamoverPluginImageFqin
-                      - kubevirtDatamoverControllerImageFqin
-                      - hypershiftPluginImageFqin
-                      - nonAdminControllerImageFqin
-                      - vmFileRestoreControllerImageFqin
-                      - vmFileRestoreAccessImageFqin
-                      - vmFileRestoreSSHImageFqin
-                      - vmFileRestoreBrowserImageFqin
-                      - operator-type
-                      - tech-preview-ack
-                  type: object
-                vmFileRestore:
-                  description: vmFileRestore defines the configuration for the DPA to enable VM file restore feature
+                type: object
+            required:
+            - configuration
+            type: object
+          status:
+            description: DataProtectionApplicationStatus defines the observed state
+              of DataProtectionApplication
+            properties:
+              conditions:
+                description: Conditions defines the observed state of DataProtectionApplication
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
-                    enable:
+                    lastTransitionTime:
                       description: |-
-                        Enable flag to deploy VM file restore controller
-                        By default is disabled
-                      type: boolean
-                    resources:
-                      description: Resource requirements for the VM file restore controller
-                      properties:
-                        claims:
-                          description: |-
-                            Claims lists the names of resources, defined in spec.resourceClaims,
-                            that are used by this container.
-
-                            This is an alpha field and requires enabling the
-                            DynamicResourceAllocation feature gate.
-
-                            This field is immutable. It can only be set for containers.
-                          items:
-                            description: ResourceClaim references one entry in PodSpec.ResourceClaims.
-                            properties:
-                              name:
-                                description: |-
-                                  Name must match the name of one entry in pod.spec.resourceClaims of
-                                  the Pod where this field is used. It makes that resource available
-                                  inside a container.
-                                type: string
-                              request:
-                                description: |-
-                                  Request is the name chosen for a request in the referenced claim.
-                                  If empty, everything from the claim is made available, otherwise
-                                  only the result of this request.
-                                type: string
-                            required:
-                              - name
-                            type: object
-                          type: array
-                          x-kubernetes-list-map-keys:
-                            - name
-                          x-kubernetes-list-type: map
-                        limits:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: |-
-                            Limits describes the maximum amount of compute resources allowed.
-                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                          type: object
-                        requests:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: |-
-                            Requests describes the minimum amount of compute resources required.
-                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                            otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                          type: object
-                      type: object
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
                   type: object
-              required:
-                - configuration
-              type: object
-            status:
-              description: DataProtectionApplicationStatus defines the observed state of DataProtectionApplication
-              properties:
-                conditions:
-                  description: Conditions defines the observed state of DataProtectionApplication
-                  items:
-                    description: Condition contains details for one aspect of the current state of this API Resource.
-                    properties:
-                      lastTransitionTime:
-                        description: |-
-                          lastTransitionTime is the last time the condition transitioned from one status to another.
-                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                        format: date-time
-                        type: string
-                      message:
-                        description: |-
-                          message is a human readable message indicating details about the transition.
-                          This may be an empty string.
-                        maxLength: 32768
-                        type: string
-                      observedGeneration:
-                        description: |-
-                          observedGeneration represents the .metadata.generation that the condition was set based upon.
-                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                          with respect to the current state of the instance.
-                        format: int64
-                        minimum: 0
-                        type: integer
-                      reason:
-                        description: |-
-                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                          Producers of specific condition types may define expected values and meanings for this field,
-                          and whether the values are considered a guaranteed API.
-                          The value should be a CamelCase string.
-                          This field may not be empty.
-                        maxLength: 1024
-                        minLength: 1
-                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                        type: string
-                      status:
-                        description: status of the condition, one of True, False, Unknown.
-                        enum:
-                          - "True"
-                          - "False"
-                          - Unknown
-                        type: string
-                      type:
-                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                        type: string
-                    required:
-                      - lastTransitionTime
-                      - message
-                      - reason
-                      - status
-                      - type
-                    type: object
-                  type: array
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
+++ b/config/crd/bases/oadp.openshift.io_dataprotectionapplications.yaml
@@ -12,727 +12,434 @@ spec:
     listKind: DataProtectionApplicationList
     plural: dataprotectionapplications
     shortNames:
-      - dpa
+    - dpa
     singular: dataprotectionapplication
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - description: DataProtectionApplication Reconciled Status
-          jsonPath: .status.conditions[?(@.type=='Reconciled')].status
-          name: Reconciled
-          type: string
-        - description: DataProtectionApplication creation timestamp
-          jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: |-
-            DataProtectionApplication represents configuration to install a data protection
-            application to safely backup and restore, perform disaster recovery and migrate
-            Kubernetes cluster resources and persistent volumes.
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-              type: string
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: DataProtectionApplicationSpec defines the desired state of Velero
-              properties:
-                backupImages:
-                  description: backupImages is used to specify whether you want to deploy a registry for enabling backup and restore of images
-                  type: boolean
-                backupLocations:
-                  description: backupLocations defines the list of desired configuration to use for BackupStorageLocations
-                  items:
-                    description: BackupLocation defines the configuration for the DPA backup storage
-                    properties:
-                      bucket:
-                        description: CloudStorageLocation defines BackupStorageLocation using bucket referenced by CloudStorage CR.
-                        properties:
-                          backupSyncPeriod:
-                            description: backupSyncPeriod defines how frequently to sync backup API objects from object storage. A value of 0 disables sync.
-                            nullable: true
-                            type: string
-                          caCert:
-                            description: CACert defines a CA bundle to use when verifying TLS connections to the provider.
-                            format: byte
-                            type: string
-                          cloudStorageRef:
-                            description: |-
-                              LocalObjectReference contains enough information to let you locate the
-                              referenced object inside the same namespace.
-                            properties:
-                              name:
-                                default: ""
-                                description: |-
-                                  Name of the referent.
-                                  This field is effectively required, but due to backwards compatibility is
-                                  allowed to be empty. Instances of this type with an empty value here are
-                                  almost certainly wrong.
-                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                type: string
-                            type: object
-                            x-kubernetes-map-type: atomic
-                          config:
-                            additionalProperties:
-                              type: string
-                            description: config is for provider-specific configuration fields.
-                            type: object
-                          credential:
-                            description: credential contains the credential information intended to be used with this location
-                            properties:
-                              key:
-                                description: The key of the secret to select from.  Must be a valid secret key.
-                                type: string
-                              name:
-                                default: ""
-                                description: |-
-                                  Name of the referent.
-                                  This field is effectively required, but due to backwards compatibility is
-                                  allowed to be empty. Instances of this type with an empty value here are
-                                  almost certainly wrong.
-                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                type: string
-                              optional:
-                                description: Specify whether the Secret or its key must be defined
-                                type: boolean
-                            required:
-                              - key
-                            type: object
-                            x-kubernetes-map-type: atomic
-                          default:
-                            description: default indicates this location is the default backup storage location.
-                            type: boolean
-                          prefix:
-                            description: Prefix is the path inside a bucket to use for Velero storage. Optional.
-                            type: string
-                        required:
-                          - cloudStorageRef
-                        type: object
-                      name:
-                        type: string
-                      velero:
-                        description: BackupStorageLocationSpec defines the desired state of a Velero BackupStorageLocation
-                        properties:
-                          accessMode:
-                            description: AccessMode defines the permissions for the backup storage location.
-                            enum:
-                              - ReadOnly
-                              - ReadWrite
-                            type: string
-                          backupSyncPeriod:
-                            description: BackupSyncPeriod defines how frequently to sync backup API objects from object storage. A value of 0 disables sync.
-                            nullable: true
-                            type: string
-                          config:
-                            additionalProperties:
-                              type: string
-                            description: Config is for provider-specific configuration fields.
-                            type: object
-                          credential:
-                            description: Credential contains the credential information intended to be used with this location
-                            properties:
-                              key:
-                                description: The key of the secret to select from.  Must be a valid secret key.
-                                type: string
-                              name:
-                                default: ""
-                                description: |-
-                                  Name of the referent.
-                                  This field is effectively required, but due to backwards compatibility is
-                                  allowed to be empty. Instances of this type with an empty value here are
-                                  almost certainly wrong.
-                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                type: string
-                              optional:
-                                description: Specify whether the Secret or its key must be defined
-                                type: boolean
-                            required:
-                              - key
-                            type: object
-                            x-kubernetes-map-type: atomic
-                          default:
-                            description: Default indicates this location is the default backup storage location.
-                            type: boolean
-                          objectStorage:
-                            description: ObjectStorageLocation specifies the settings necessary to connect to a provider's object storage.
-                            properties:
-                              bucket:
-                                description: Bucket is the bucket to use for object storage.
-                                type: string
-                              caCert:
-                                description: |-
-                                  CACert defines a CA bundle to use when verifying TLS connections to the provider.
-                                  Deprecated: Use CACertRef instead.
-                                format: byte
-                                type: string
-                              caCertRef:
-                                description: |-
-                                  CACertRef is a reference to a Secret containing the CA certificate bundle to use
-                                  when verifying TLS connections to the provider. The Secret must be in the same
-                                  namespace as the BackupStorageLocation.
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.  Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    default: ""
-                                    description: |-
-                                      Name of the referent.
-                                      This field is effectively required, but due to backwards compatibility is
-                                      allowed to be empty. Instances of this type with an empty value here are
-                                      almost certainly wrong.
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    type: string
-                                  optional:
-                                    description: Specify whether the Secret or its key must be defined
-                                    type: boolean
-                                required:
-                                  - key
-                                type: object
-                                x-kubernetes-map-type: atomic
-                              prefix:
-                                description: Prefix is the path inside a bucket to use for Velero storage. Optional.
-                                type: string
-                            required:
-                              - bucket
-                            type: object
-                          provider:
-                            description: Provider is the provider of the backup storage.
-                            type: string
-                          validationFrequency:
-                            description: ValidationFrequency defines how frequently to validate the corresponding object storage. A value of 0 disables validation.
-                            nullable: true
-                            type: string
-                        required:
-                          - objectStorage
-                          - provider
-                        type: object
-                    type: object
-                  type: array
-                configuration:
-                  description: configuration is used to configure the data protection application's server config
+  - additionalPrinterColumns:
+    - description: DataProtectionApplication Reconciled Status
+      jsonPath: .status.conditions[?(@.type=='Reconciled')].status
+      name: Reconciled
+      type: string
+    - description: DataProtectionApplication creation timestamp
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          DataProtectionApplication represents configuration to install a data protection
+          application to safely backup and restore, perform disaster recovery and migrate
+          Kubernetes cluster resources and persistent volumes.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DataProtectionApplicationSpec defines the desired state of
+              Velero
+            properties:
+              backupImages:
+                description: backupImages is used to specify whether you want to deploy
+                  a registry for enabling backup and restore of images
+                type: boolean
+              backupLocations:
+                description: backupLocations defines the list of desired configuration
+                  to use for BackupStorageLocations
+                items:
+                  description: BackupLocation defines the configuration for the DPA
+                    backup storage
                   properties:
-                    kubevirtDatamover:
-                      description: KubevirtDatamover configures the kubevirt-datamover-controller for VM backup/restore.
+                    bucket:
+                      description: CloudStorageLocation defines BackupStorageLocation
+                        using bucket referenced by CloudStorage CR.
                       properties:
-                        maxIncrementalBackups:
+                        backupSyncPeriod:
+                          description: backupSyncPeriod defines how frequently to
+                            sync backup API objects from object storage. A value of
+                            0 disables sync.
+                          nullable: true
+                          type: string
+                        caCert:
+                          description: CACert defines a CA bundle to use when verifying
+                            TLS connections to the provider.
+                          format: byte
+                          type: string
+                        cloudStorageRef:
                           description: |-
-                            MaxIncrementalBackups is the maximum number of incremental backups per VM
-                            before forcing a full backup. 0 means unlimited (default behavior).
-                            Can be overridden per-VM via the kubevirt-datamover.io/max-incremental-backups
-                            annotation on the VirtualMachine CR.
-                          format: int32
-                          minimum: 0
-                          type: integer
-                      type: object
-                    nodeAgent:
-                      description: NodeAgent is needed to allow selection between kopia or restic
-                      properties:
-                        backupPVC:
-                          additionalProperties:
-                            properties:
-                              annotations:
-                                additionalProperties:
-                                  type: string
-                                description: Annotations permits setting annotations for the backupPVC
-                                type: object
-                              readOnly:
-                                description: ReadOnly sets the backupPVC's access mode as read only
-                                type: boolean
-                              spcNoRelabeling:
-                                description: |-
-                                  SPCNoRelabeling sets Spec.SecurityContext.SELinux.Type to "spc_t" for the pod mounting the backupPVC
-                                  ignored if ReadOnly is false
-                                type: boolean
-                              storageClass:
-                                description: StorageClass is the name of storage class to be used by the backupPVC
-                                type: string
-                            type: object
-                          description: BackupPVCConfig is the config for backupPVC (intermediate PVC) of snapshot data movement
-                          type: object
-                        cacheLimitMB:
-                          description: CacheLimitMB specifies the size limit(in MB) for the local data cache
-                          format: int64
-                          minimum: 0
-                          type: integer
-                        cachePVC:
-                          description: |-
-                            CachePVCConfig configures a dedicated PVC for Kopia repository cache during restore operations.
-                            When set, cache data is stored on a provisioned PVC instead of the pod's root filesystem,
-                            preventing ephemeral storage exhaustion on nodes during concurrent restores.
-                            If storageClass is omitted, the cluster's default StorageClass is used.
+                            LocalObjectReference contains enough information to let you locate the
+                            referenced object inside the same namespace.
                           properties:
-                            residentThresholdInMB:
-                              description: ResidentThresholdInMB specifies the minimum size of the backup data to create cache PVC
-                              format: int64
-                              type: integer
-                            storageClass:
-                              description: StorageClass specifies the storage class for cache PVC
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                               type: string
                           type: object
-                        dataMoverPrepareTimeout:
-                          description: How long to wait for preparing a DataUpload/DataDownload. Default is 30 minutes.
-                          type: string
-                        enable:
-                          description: |-
-                            enable defines a boolean pointer whether we want the daemonset to
-                            exist or not
-                          type: boolean
-                        fullMaintenanceInterval:
-                          description: |-
-                            fullMaintenanceInterval determines the time between kopia full maintenance operations.
-                            normalGC: 24 hours
-                            fastGC: 12 hours
-                            eagerGC: 6 hours
-                          enum:
-                            - normalGC
-                            - fastGC
-                            - eagerGC
-                          type: string
-                        loadAffinity:
-                          description: LoadAffinity is the config for data path load affinity.
-                          items:
-                            description: |-
-                              LoadAffinity is the config for data path load affinity.
-                              Used by the Node-Agent, that needs to match the DataMover and the RepositoryMaintenance pods.
-                            properties:
-                              nodeSelector:
-                                description: NodeSelector specifies the label selector to match nodes
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                    items:
-                                      description: |-
-                                        A label selector requirement is a selector that contains values, a key, and an operator that
-                                        relates the key and values.
-                                      properties:
-                                        key:
-                                          description: key is the label key that the selector applies to.
-                                          type: string
-                                        operator:
-                                          description: |-
-                                            operator represents a key's relationship to a set of values.
-                                            Valid operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: |-
-                                            values is an array of string values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                            the values array must be empty. This array is replaced during a strategic
-                                            merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                          x-kubernetes-list-type: atomic
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                    x-kubernetes-list-type: atomic
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    description: |-
-                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                    type: object
-                                type: object
-                                x-kubernetes-map-type: atomic
-                              storageClass:
-                                description: |-
-                                  StorageClass specifies the storage class to which this LoadAffinity rule applies.
-                                  If empty, the affinity applies globally to all data mover operations.
-                                  If set, the affinity applies only to data mover operations using this specific StorageClass.
-                                type: string
-                            type: object
-                          type: array
-                        loadConcurrency:
-                          description: LoadConcurrency is the config for data path load concurrency per node.
-                          properties:
-                            globalConfig:
-                              description: GlobalConfig specifies the concurrency number to all nodes for which per-node config is not specified
-                              type: integer
-                            perNodeConfig:
-                              description: PerNodeConfig specifies the concurrency number to nodes matched by rules
-                              items:
-                                description: RuledConfigs is the config for data path load concurrency per node.
-                                properties:
-                                  nodeSelector:
-                                    description: NodeSelector specifies the label selector to match nodes
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                        items:
-                                          description: |-
-                                            A label selector requirement is a selector that contains values, a key, and an operator that
-                                            relates the key and values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: |-
-                                                operator represents a key's relationship to a set of values.
-                                                Valid operators are In, NotIn, Exists and DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: |-
-                                                values is an array of string values. If the operator is In or NotIn,
-                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                              x-kubernetes-list-type: atomic
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                        x-kubernetes-list-type: atomic
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: |-
-                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                    x-kubernetes-map-type: atomic
-                                  number:
-                                    description: Number specifies the number value associated to the matched nodes
-                                    type: integer
-                                required:
-                                  - nodeSelector
-                                  - number
-                                type: object
-                              type: array
-                            prepareQueueLength:
-                              description: PrepareQueueLength specifies the max number of loads that are under expose
-                              type: integer
-                          type: object
-                        podAnnotations:
+                          x-kubernetes-map-type: atomic
+                        config:
                           additionalProperties:
                             type: string
-                          description: PodAnnotations are annotations to be added to pods created by node-agent, i.e., data mover pods.
+                          description: config is for provider-specific configuration
+                            fields.
                           type: object
-                        podConfig:
-                          description: Pod specific configuration
+                        credential:
+                          description: credential contains the credential information
+                            intended to be used with this location
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        default:
+                          description: default indicates this location is the default
+                            backup storage location.
+                          type: boolean
+                        prefix:
+                          description: Prefix is the path inside a bucket to use for
+                            Velero storage. Optional.
+                          type: string
+                      required:
+                      - cloudStorageRef
+                      type: object
+                    name:
+                      type: string
+                    velero:
+                      description: BackupStorageLocationSpec defines the desired state
+                        of a Velero BackupStorageLocation
+                      properties:
+                        accessMode:
+                          description: AccessMode defines the permissions for the
+                            backup storage location.
+                          enum:
+                          - ReadOnly
+                          - ReadWrite
+                          type: string
+                        backupSyncPeriod:
+                          description: BackupSyncPeriod defines how frequently to
+                            sync backup API objects from object storage. A value of
+                            0 disables sync.
+                          nullable: true
+                          type: string
+                        config:
+                          additionalProperties:
+                            type: string
+                          description: Config is for provider-specific configuration
+                            fields.
+                          type: object
+                        credential:
+                          description: Credential contains the credential information
+                            intended to be used with this location
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        default:
+                          description: Default indicates this location is the default
+                            backup storage location.
+                          type: boolean
+                        objectStorage:
+                          description: ObjectStorageLocation specifies the settings
+                            necessary to connect to a provider's object storage.
+                          properties:
+                            bucket:
+                              description: Bucket is the bucket to use for object
+                                storage.
+                              type: string
+                            caCert:
+                              description: |-
+                                CACert defines a CA bundle to use when verifying TLS connections to the provider.
+                                Deprecated: Use CACertRef instead.
+                              format: byte
+                              type: string
+                            caCertRef:
+                              description: |-
+                                CACertRef is a reference to a Secret containing the CA certificate bundle to use
+                                when verifying TLS connections to the provider. The Secret must be in the same
+                                namespace as the BackupStorageLocation.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            prefix:
+                              description: Prefix is the path inside a bucket to use
+                                for Velero storage. Optional.
+                              type: string
+                          required:
+                          - bucket
+                          type: object
+                        provider:
+                          description: Provider is the provider of the backup storage.
+                          type: string
+                        validationFrequency:
+                          description: ValidationFrequency defines how frequently
+                            to validate the corresponding object storage. A value
+                            of 0 disables validation.
+                          nullable: true
+                          type: string
+                      required:
+                      - objectStorage
+                      - provider
+                      type: object
+                  type: object
+                type: array
+              configuration:
+                description: configuration is used to configure the data protection
+                  application's server config
+                properties:
+                  kubevirtDatamover:
+                    description: KubevirtDatamover configures the kubevirt-datamover-controller
+                      for VM backup/restore.
+                    properties:
+                      maxIncrementalBackups:
+                        description: |-
+                          MaxIncrementalBackups is the maximum number of incremental backups per VM
+                          before forcing a full backup. 0 means unlimited (default behavior).
+                          Can be overridden per-VM via the kubevirt-datamover.io/max-incremental-backups
+                          annotation on the VirtualMachine CR.
+                        format: int32
+                        minimum: 0
+                        type: integer
+                    type: object
+                  nodeAgent:
+                    description: NodeAgent is needed to allow selection between kopia
+                      or restic
+                    properties:
+                      backupPVC:
+                        additionalProperties:
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
-                              description: annotations to add to pods
+                              description: Annotations permits setting annotations
+                                for the backupPVC
                               type: object
-                            env:
-                              description: env defines the list of environment variables to be supplied to podSpec
-                              items:
-                                description: EnvVar represents an environment variable present in a Container.
-                                properties:
-                                  name:
-                                    description: Name of the environment variable. Must be a C_IDENTIFIER.
-                                    type: string
-                                  value:
-                                    description: |-
-                                      Variable references $(VAR_NAME) are expanded
-                                      using the previously defined environment variables in the container and
-                                      any service environment variables. If a variable cannot be resolved,
-                                      the reference in the input string will be unchanged. Double $$ are reduced
-                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                                      "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                                      Escaped references will never be expanded, regardless of whether the variable
-                                      exists or not.
-                                      Defaults to "".
-                                    type: string
-                                  valueFrom:
-                                    description: Source for the environment variable's value. Cannot be used if value is not empty.
-                                    properties:
-                                      configMapKeyRef:
-                                        description: Selects a key of a ConfigMap.
-                                        properties:
-                                          key:
-                                            description: The key to select.
-                                            type: string
-                                          name:
-                                            default: ""
-                                            description: |-
-                                              Name of the referent.
-                                              This field is effectively required, but due to backwards compatibility is
-                                              allowed to be empty. Instances of this type with an empty value here are
-                                              almost certainly wrong.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            type: string
-                                          optional:
-                                            description: Specify whether the ConfigMap or its key must be defined
-                                            type: boolean
-                                        required:
-                                          - key
-                                        type: object
-                                        x-kubernetes-map-type: atomic
-                                      fieldRef:
-                                        description: |-
-                                          Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                          spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
-                                        properties:
-                                          apiVersion:
-                                            description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
-                                            type: string
-                                          fieldPath:
-                                            description: Path of the field to select in the specified API version.
-                                            type: string
-                                        required:
-                                          - fieldPath
-                                        type: object
-                                        x-kubernetes-map-type: atomic
-                                      resourceFieldRef:
-                                        description: |-
-                                          Selects a resource of the container: only resources limits and requests
-                                          (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
-                                        properties:
-                                          containerName:
-                                            description: 'Container name: required for volumes, optional for env vars'
-                                            type: string
-                                          divisor:
-                                            anyOf:
-                                              - type: integer
-                                              - type: string
-                                            description: Specifies the output format of the exposed resources, defaults to "1"
-                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                            x-kubernetes-int-or-string: true
-                                          resource:
-                                            description: 'Required: resource to select'
-                                            type: string
-                                        required:
-                                          - resource
-                                        type: object
-                                        x-kubernetes-map-type: atomic
-                                      secretKeyRef:
-                                        description: Selects a key of a secret in the pod's namespace
-                                        properties:
-                                          key:
-                                            description: The key of the secret to select from.  Must be a valid secret key.
-                                            type: string
-                                          name:
-                                            default: ""
-                                            description: |-
-                                              Name of the referent.
-                                              This field is effectively required, but due to backwards compatibility is
-                                              allowed to be empty. Instances of this type with an empty value here are
-                                              almost certainly wrong.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            type: string
-                                          optional:
-                                            description: Specify whether the Secret or its key must be defined
-                                            type: boolean
-                                        required:
-                                          - key
-                                        type: object
-                                        x-kubernetes-map-type: atomic
-                                    type: object
-                                required:
-                                  - name
-                                type: object
-                              type: array
-                            labels:
-                              additionalProperties:
-                                type: string
-                              description: labels to add to pods
-                              type: object
-                            nodeSelector:
-                              additionalProperties:
-                                type: string
-                              description: nodeSelector defines the nodeSelector to be supplied to podSpec
-                              type: object
-                            priorityClassName:
-                              description: priorityClassName defines the PriorityClass name to be applied to the pod
-                              type: string
-                            resourceAllocations:
-                              description: resourceAllocations defines the CPU, Memory and ephemeral-storage resource allocations for the Pod
-                              nullable: true
-                              properties:
-                                claims:
-                                  description: |-
-                                    Claims lists the names of resources, defined in spec.resourceClaims,
-                                    that are used by this container.
-
-                                    This is an alpha field and requires enabling the
-                                    DynamicResourceAllocation feature gate.
-
-                                    This field is immutable. It can only be set for containers.
-                                  items:
-                                    description: ResourceClaim references one entry in PodSpec.ResourceClaims.
-                                    properties:
-                                      name:
-                                        description: |-
-                                          Name must match the name of one entry in pod.spec.resourceClaims of
-                                          the Pod where this field is used. It makes that resource available
-                                          inside a container.
-                                        type: string
-                                      request:
-                                        description: |-
-                                          Request is the name chosen for a request in the referenced claim.
-                                          If empty, everything from the claim is made available, otherwise
-                                          only the result of this request.
-                                        type: string
-                                    required:
-                                      - name
-                                    type: object
-                                  type: array
-                                  x-kubernetes-list-map-keys:
-                                    - name
-                                  x-kubernetes-list-type: map
-                                limits:
-                                  additionalProperties:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                  description: |-
-                                    Limits describes the maximum amount of compute resources allowed.
-                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                                  type: object
-                                requests:
-                                  additionalProperties:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                  description: |-
-                                    Requests describes the minimum amount of compute resources required.
-                                    If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                    otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                                  type: object
-                              type: object
-                            tolerations:
-                              description: tolerations defines the list of tolerations to be applied to daemonset
-                              items:
-                                description: |-
-                                  The pod this Toleration is attached to tolerates any taint that matches
-                                  the triple <key,value,effect> using the matching operator <operator>.
-                                properties:
-                                  effect:
-                                    description: |-
-                                      Effect indicates the taint effect to match. Empty means match all taint effects.
-                                      When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
-                                    type: string
-                                  key:
-                                    description: |-
-                                      Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                                      If the key is empty, operator must be Exists; this combination means to match all values and all keys.
-                                    type: string
-                                  operator:
-                                    description: |-
-                                      Operator represents a key's relationship to the value.
-                                      Valid operators are Exists and Equal. Defaults to Equal.
-                                      Exists is equivalent to wildcard for value, so that a pod can
-                                      tolerate all taints of a particular category.
-                                    type: string
-                                  tolerationSeconds:
-                                    description: |-
-                                      TolerationSeconds represents the period of time the toleration (which must be
-                                      of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                                      it is not set, which means tolerate the taint forever (do not evict). Zero and
-                                      negative values will be treated as 0 (evict immediately) by the system.
-                                    format: int64
-                                    type: integer
-                                  value:
-                                    description: |-
-                                      Value is the taint value the toleration matches to.
-                                      If the operator is Exists, the value should be empty, otherwise just a regular string.
-                                    type: string
-                                type: object
-                              type: array
-                          type: object
-                        podLabels:
-                          additionalProperties:
-                            type: string
-                          description: PodLabels are labels to be added to pods created by node-agent, i.e., data mover pods.
-                          type: object
-                        podResources:
-                          description: PodResources is the resource config for various types of pods launched by node-agent, i.e., data mover pods.
-                          properties:
-                            cpuLimit:
-                              type: string
-                            cpuRequest:
-                              type: string
-                            memoryLimit:
-                              type: string
-                            memoryRequest:
-                              type: string
-                          type: object
-                        resourceTimeout:
-                          description: How long to wait for resource processes which are not covered by other specific timeout parameters. Default is 10 minutes.
-                          type: string
-                        restorePVC:
-                          description: RestoreVCConfig is the config for restorePVC (intermediate PVC) of generic restore
-                          properties:
-                            ignoreDelayBinding:
-                              description: IgnoreDelayBinding indicates to ignore delay binding the restorePVC when it is in WaitForFirstConsumer mode
+                            readOnly:
+                              description: ReadOnly sets the backupPVC's access mode
+                                as read only
                               type: boolean
+                            spcNoRelabeling:
+                              description: |-
+                                SPCNoRelabeling sets Spec.SecurityContext.SELinux.Type to "spc_t" for the pod mounting the backupPVC
+                                ignored if ReadOnly is false
+                              type: boolean
+                            storageClass:
+                              description: StorageClass is the name of storage class
+                                to be used by the backupPVC
+                              type: string
                           type: object
-                        supplementalGroups:
-                          description: supplementalGroups defines the linux groups to be applied to the NodeAgent Pod
-                          items:
+                        description: BackupPVCConfig is the config for backupPVC (intermediate
+                          PVC) of snapshot data movement
+                        type: object
+                      cacheLimitMB:
+                        description: CacheLimitMB specifies the size limit(in MB)
+                          for the local data cache
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      cachePVC:
+                        description: |-
+                          CachePVCConfig configures a dedicated PVC for Kopia repository cache during restore operations.
+                          When set, cache data is stored on a provisioned PVC instead of the pod's root filesystem,
+                          preventing ephemeral storage exhaustion on nodes during concurrent restores.
+                          If storageClass is omitted, the cluster's default StorageClass is used.
+                        properties:
+                          residentThresholdInMB:
+                            description: ResidentThresholdInMB specifies the minimum
+                              size of the backup data to create cache PVC
                             format: int64
                             type: integer
-                          type: array
-                        timeout:
-                          description: timeout defines the NodeAgent timeout, default value is 1h
-                          type: string
-                        uploaderType:
-                          description: The type of uploader to transfer the data of pod volumes, the supported values are 'restic' or 'kopia'
-                          enum:
-                            - restic
-                            - kopia
-                          type: string
-                      required:
-                        - uploaderType
-                      type: object
-                    repositoryMaintenance:
-                      additionalProperties:
-                        properties:
-                          loadAffinity:
-                            description: LoadAffinity is the config for data path load affinity.
-                            items:
+                          storageClass:
+                            description: StorageClass specifies the storage class
+                              for cache PVC
+                            type: string
+                        type: object
+                      dataMoverPrepareTimeout:
+                        description: How long to wait for preparing a DataUpload/DataDownload.
+                          Default is 30 minutes.
+                        type: string
+                      enable:
+                        description: |-
+                          enable defines a boolean pointer whether we want the daemonset to
+                          exist or not
+                        type: boolean
+                      fullMaintenanceInterval:
+                        description: |-
+                          fullMaintenanceInterval determines the time between kopia full maintenance operations.
+                          normalGC: 24 hours
+                          fastGC: 12 hours
+                          eagerGC: 6 hours
+                        enum:
+                        - normalGC
+                        - fastGC
+                        - eagerGC
+                        type: string
+                      loadAffinity:
+                        description: LoadAffinity is the config for data path load
+                          affinity.
+                        items:
+                          description: |-
+                            LoadAffinity is the config for data path load affinity.
+                            Used by the Node-Agent, that needs to match the DataMover and the RepositoryMaintenance pods.
+                          properties:
+                            nodeSelector:
+                              description: NodeSelector specifies the label selector
+                                to match nodes
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            storageClass:
                               description: |-
-                                LoadAffinity is the config for data path load affinity.
-                                Used by the Node-Agent, that needs to match the DataMover and the RepositoryMaintenance pods.
+                                StorageClass specifies the storage class to which this LoadAffinity rule applies.
+                                If empty, the affinity applies globally to all data mover operations.
+                                If set, the affinity applies only to data mover operations using this specific StorageClass.
+                              type: string
+                          type: object
+                        type: array
+                      loadConcurrency:
+                        description: LoadConcurrency is the config for data path load
+                          concurrency per node.
+                        properties:
+                          globalConfig:
+                            description: GlobalConfig specifies the concurrency number
+                              to all nodes for which per-node config is not specified
+                            type: integer
+                          perNodeConfig:
+                            description: PerNodeConfig specifies the concurrency number
+                              to nodes matched by rules
+                            items:
+                              description: RuledConfigs is the config for data path
+                                load concurrency per node.
                               properties:
                                 nodeSelector:
-                                  description: NodeSelector specifies the label selector to match nodes
+                                  description: NodeSelector specifies the label selector
+                                    to match nodes
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
                                       items:
                                         description: |-
                                           A label selector requirement is a selector that contains values, a key, and an operator that
                                           relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that the selector applies to.
+                                            description: key is the label key that
+                                              the selector applies to.
                                             type: string
                                           operator:
                                             description: |-
@@ -750,8 +457,8 @@ spec:
                                             type: array
                                             x-kubernetes-list-type: atomic
                                         required:
-                                          - key
-                                          - operator
+                                        - key
+                                        - operator
                                         type: object
                                       type: array
                                       x-kubernetes-list-type: atomic
@@ -765,548 +472,356 @@ spec:
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
-                                storageClass:
+                                number:
+                                  description: Number specifies the number value associated
+                                    to the matched nodes
+                                  type: integer
+                              required:
+                              - nodeSelector
+                              - number
+                              type: object
+                            type: array
+                          prepareQueueLength:
+                            description: PrepareQueueLength specifies the max number
+                              of loads that are under expose
+                            type: integer
+                        type: object
+                      podAnnotations:
+                        additionalProperties:
+                          type: string
+                        description: PodAnnotations are annotations to be added to
+                          pods created by node-agent, i.e., data mover pods.
+                        type: object
+                      podConfig:
+                        description: Pod specific configuration
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: annotations to add to pods
+                            type: object
+                          env:
+                            description: env defines the list of environment variables
+                              to be supplied to podSpec
+                            items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
+                              properties:
+                                name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
+                                  type: string
+                                value:
                                   description: |-
-                                    StorageClass specifies the storage class to which this LoadAffinity rule applies.
-                                    If empty, the affinity applies globally to all data mover operations.
-                                    If set, the affinity applies only to data mover operations using this specific StorageClass.
+                                    Variable references $(VAR_NAME) are expanded
+                                    using the previously defined environment variables in the container and
+                                    any service environment variables. If a variable cannot be resolved,
+                                    the reference in the input string will be unchanged. Double $$ are reduced
+                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                    "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                    Escaped references will never be expanded, regardless of whether the variable
+                                    exists or not.
+                                    Defaults to "".
+                                  type: string
+                                valueFrom:
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    fieldRef:
+                                      description: |-
+                                        Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                        spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    resourceFieldRef:
+                                      description: |-
+                                        Selects a resource of the container: only resources limits and requests
+                                        (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          labels:
+                            additionalProperties:
+                              type: string
+                            description: labels to add to pods
+                            type: object
+                          nodeSelector:
+                            additionalProperties:
+                              type: string
+                            description: nodeSelector defines the nodeSelector to
+                              be supplied to podSpec
+                            type: object
+                          priorityClassName:
+                            description: priorityClassName defines the PriorityClass
+                              name to be applied to the pod
+                            type: string
+                          resourceAllocations:
+                            description: resourceAllocations defines the CPU, Memory
+                              and ephemeral-storage resource allocations for the Pod
+                            nullable: true
+                            properties:
+                              claims:
+                                description: |-
+                                  Claims lists the names of resources, defined in spec.resourceClaims,
+                                  that are used by this container.
+
+                                  This is an alpha field and requires enabling the
+                                  DynamicResourceAllocation feature gate.
+
+                                  This field is immutable. It can only be set for containers.
+                                items:
+                                  description: ResourceClaim references one entry
+                                    in PodSpec.ResourceClaims.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name must match the name of one entry in pod.spec.resourceClaims of
+                                        the Pod where this field is used. It makes that resource available
+                                        inside a container.
+                                      type: string
+                                    request:
+                                      description: |-
+                                        Request is the name chosen for a request in the referenced claim.
+                                        If empty, everything from the claim is made available, otherwise
+                                        only the result of this request.
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: |-
+                                  Limits describes the maximum amount of compute resources allowed.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: |-
+                                  Requests describes the minimum amount of compute resources required.
+                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                            type: object
+                          tolerations:
+                            description: tolerations defines the list of tolerations
+                              to be applied to daemonset
+                            items:
+                              description: |-
+                                The pod this Toleration is attached to tolerates any taint that matches
+                                the triple <key,value,effect> using the matching operator <operator>.
+                              properties:
+                                effect:
+                                  description: |-
+                                    Effect indicates the taint effect to match. Empty means match all taint effects.
+                                    When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                  type: string
+                                key:
+                                  description: |-
+                                    Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                    If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    Operator represents a key's relationship to the value.
+                                    Valid operators are Exists and Equal. Defaults to Equal.
+                                    Exists is equivalent to wildcard for value, so that a pod can
+                                    tolerate all taints of a particular category.
+                                  type: string
+                                tolerationSeconds:
+                                  description: |-
+                                    TolerationSeconds represents the period of time the toleration (which must be
+                                    of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                    it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                    negative values will be treated as 0 (evict immediately) by the system.
+                                  format: int64
+                                  type: integer
+                                value:
+                                  description: |-
+                                    Value is the taint value the toleration matches to.
+                                    If the operator is Exists, the value should be empty, otherwise just a regular string.
                                   type: string
                               type: object
                             type: array
-                          podAnnotations:
-                            additionalProperties:
-                              type: string
-                            description: |-
-                              PodAnnotations are annotations to be added to maintenance job pods.
-                              This is only read from the global configuration, not per-repository.
-                            type: object
-                          podLabels:
-                            additionalProperties:
-                              type: string
-                            description: |-
-                              PodLabels are labels to be added to maintenance job pods.
-                              This is only read from the global configuration, not per-repository.
-                            type: object
-                          podResources:
-                            description: PodResources is the config for the CPU and memory resources setting.
-                            properties:
-                              cpuLimit:
-                                type: string
-                              cpuRequest:
-                                type: string
-                              memoryLimit:
-                                type: string
-                              memoryRequest:
-                                type: string
-                            type: object
                         type: object
-                      description: |-
-                        RepositoryMaintenance maps a BackupRepository identifier to its configuration.
-                        Keys can be:
-                         - "global" : Applies to all repositories without specific config.
-                         - "<namespace>" : The namespace of the BackupRepository.
-                         - "<repository name>" : The specific BackupRepository name referencing the BSL.
-                         - "<repository type>" : Either "kopia" or "restic".
-                      type: object
-                    restic:
-                      description: |-
-                        (do not use warning) restic field is for backwards compatibility and
-                        will be removed in the future. Use nodeAgent field instead
-                      properties:
-                        enable:
-                          description: |-
-                            enable defines a boolean pointer whether we want the daemonset to
-                            exist or not
-                          type: boolean
-                        podConfig:
-                          description: Pod specific configuration
-                          properties:
-                            annotations:
-                              additionalProperties:
-                                type: string
-                              description: annotations to add to pods
-                              type: object
-                            env:
-                              description: env defines the list of environment variables to be supplied to podSpec
-                              items:
-                                description: EnvVar represents an environment variable present in a Container.
-                                properties:
-                                  name:
-                                    description: Name of the environment variable. Must be a C_IDENTIFIER.
-                                    type: string
-                                  value:
-                                    description: |-
-                                      Variable references $(VAR_NAME) are expanded
-                                      using the previously defined environment variables in the container and
-                                      any service environment variables. If a variable cannot be resolved,
-                                      the reference in the input string will be unchanged. Double $$ are reduced
-                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                                      "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                                      Escaped references will never be expanded, regardless of whether the variable
-                                      exists or not.
-                                      Defaults to "".
-                                    type: string
-                                  valueFrom:
-                                    description: Source for the environment variable's value. Cannot be used if value is not empty.
-                                    properties:
-                                      configMapKeyRef:
-                                        description: Selects a key of a ConfigMap.
-                                        properties:
-                                          key:
-                                            description: The key to select.
-                                            type: string
-                                          name:
-                                            default: ""
-                                            description: |-
-                                              Name of the referent.
-                                              This field is effectively required, but due to backwards compatibility is
-                                              allowed to be empty. Instances of this type with an empty value here are
-                                              almost certainly wrong.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            type: string
-                                          optional:
-                                            description: Specify whether the ConfigMap or its key must be defined
-                                            type: boolean
-                                        required:
-                                          - key
-                                        type: object
-                                        x-kubernetes-map-type: atomic
-                                      fieldRef:
-                                        description: |-
-                                          Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                          spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
-                                        properties:
-                                          apiVersion:
-                                            description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
-                                            type: string
-                                          fieldPath:
-                                            description: Path of the field to select in the specified API version.
-                                            type: string
-                                        required:
-                                          - fieldPath
-                                        type: object
-                                        x-kubernetes-map-type: atomic
-                                      resourceFieldRef:
-                                        description: |-
-                                          Selects a resource of the container: only resources limits and requests
-                                          (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
-                                        properties:
-                                          containerName:
-                                            description: 'Container name: required for volumes, optional for env vars'
-                                            type: string
-                                          divisor:
-                                            anyOf:
-                                              - type: integer
-                                              - type: string
-                                            description: Specifies the output format of the exposed resources, defaults to "1"
-                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                            x-kubernetes-int-or-string: true
-                                          resource:
-                                            description: 'Required: resource to select'
-                                            type: string
-                                        required:
-                                          - resource
-                                        type: object
-                                        x-kubernetes-map-type: atomic
-                                      secretKeyRef:
-                                        description: Selects a key of a secret in the pod's namespace
-                                        properties:
-                                          key:
-                                            description: The key of the secret to select from.  Must be a valid secret key.
-                                            type: string
-                                          name:
-                                            default: ""
-                                            description: |-
-                                              Name of the referent.
-                                              This field is effectively required, but due to backwards compatibility is
-                                              allowed to be empty. Instances of this type with an empty value here are
-                                              almost certainly wrong.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            type: string
-                                          optional:
-                                            description: Specify whether the Secret or its key must be defined
-                                            type: boolean
-                                        required:
-                                          - key
-                                        type: object
-                                        x-kubernetes-map-type: atomic
-                                    type: object
-                                required:
-                                  - name
-                                type: object
-                              type: array
-                            labels:
-                              additionalProperties:
-                                type: string
-                              description: labels to add to pods
-                              type: object
-                            nodeSelector:
-                              additionalProperties:
-                                type: string
-                              description: nodeSelector defines the nodeSelector to be supplied to podSpec
-                              type: object
-                            priorityClassName:
-                              description: priorityClassName defines the PriorityClass name to be applied to the pod
-                              type: string
-                            resourceAllocations:
-                              description: resourceAllocations defines the CPU, Memory and ephemeral-storage resource allocations for the Pod
-                              nullable: true
-                              properties:
-                                claims:
-                                  description: |-
-                                    Claims lists the names of resources, defined in spec.resourceClaims,
-                                    that are used by this container.
-
-                                    This is an alpha field and requires enabling the
-                                    DynamicResourceAllocation feature gate.
-
-                                    This field is immutable. It can only be set for containers.
-                                  items:
-                                    description: ResourceClaim references one entry in PodSpec.ResourceClaims.
-                                    properties:
-                                      name:
-                                        description: |-
-                                          Name must match the name of one entry in pod.spec.resourceClaims of
-                                          the Pod where this field is used. It makes that resource available
-                                          inside a container.
-                                        type: string
-                                      request:
-                                        description: |-
-                                          Request is the name chosen for a request in the referenced claim.
-                                          If empty, everything from the claim is made available, otherwise
-                                          only the result of this request.
-                                        type: string
-                                    required:
-                                      - name
-                                    type: object
-                                  type: array
-                                  x-kubernetes-list-map-keys:
-                                    - name
-                                  x-kubernetes-list-type: map
-                                limits:
-                                  additionalProperties:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                    nullable: true
-                                  description: |-
-                                    Limits describes the maximum amount of compute resources allowed.
-                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                                  type: object
-                                  nullable: true
-                                requests:
-                                  additionalProperties:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                    nullable: true
-                                  description: |-
-                                    Requests describes the minimum amount of compute resources required.
-                                    If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                    otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                                  type: object
-                                  nullable: true
-                              type: object
-                            tolerations:
-                              description: tolerations defines the list of tolerations to be applied to daemonset
-                              items:
-                                description: |-
-                                  The pod this Toleration is attached to tolerates any taint that matches
-                                  the triple <key,value,effect> using the matching operator <operator>.
-                                properties:
-                                  effect:
-                                    description: |-
-                                      Effect indicates the taint effect to match. Empty means match all taint effects.
-                                      When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
-                                    type: string
-                                  key:
-                                    description: |-
-                                      Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                                      If the key is empty, operator must be Exists; this combination means to match all values and all keys.
-                                    type: string
-                                  operator:
-                                    description: |-
-                                      Operator represents a key's relationship to the value.
-                                      Valid operators are Exists and Equal. Defaults to Equal.
-                                      Exists is equivalent to wildcard for value, so that a pod can
-                                      tolerate all taints of a particular category.
-                                    type: string
-                                  tolerationSeconds:
-                                    description: |-
-                                      TolerationSeconds represents the period of time the toleration (which must be
-                                      of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                                      it is not set, which means tolerate the taint forever (do not evict). Zero and
-                                      negative values will be treated as 0 (evict immediately) by the system.
-                                    format: int64
-                                    type: integer
-                                  value:
-                                    description: |-
-                                      Value is the taint value the toleration matches to.
-                                      If the operator is Exists, the value should be empty, otherwise just a regular string.
-                                    type: string
-                                type: object
-                              type: array
-                          type: object
-                        supplementalGroups:
-                          description: supplementalGroups defines the linux groups to be applied to the NodeAgent Pod
-                          items:
-                            format: int64
-                            type: integer
-                          type: array
-                        timeout:
-                          description: timeout defines the NodeAgent timeout, default value is 1h
+                      podLabels:
+                        additionalProperties:
                           type: string
-                      type: object
-                    velero:
-                      properties:
-                        args:
-                          description: Velero args are settings to customize velero server arguments. Overrides values in other fields.
-                          properties:
-                            add_dir_header:
-                              description: If true, adds the file directory to the header of the log messages
-                              type: boolean
-                            alsologtostderr:
-                              description: log to standard error as well as files (no effect when -logtostderr=true)
-                              type: boolean
-                            backup-sync-period:
-                              description: How often (in nanoseconds) to ensure all Velero backups in object storage exist as Backup API objects in the cluster. This is the default sync period if none is explicitly specified for a backup storage location.
-                              format: int64
-                              type: integer
-                            client-burst:
-                              description: Maximum number of requests by the server to the Kubernetes API in a short period of time.
-                              type: integer
-                            client-page-size:
-                              description: Page size of requests by the server to the Kubernetes API when listing objects during a backup. Set to 0 to disable paging.
-                              type: integer
-                            client-qps:
-                              description: |-
-                                Maximum number of requests per second by the server to the Kubernetes API once the burst limit has been reached.
-                                this will be validated as a valid float32
-                              type: string
-                            colorized:
-                              description: Show colored output in TTY
-                              type: boolean
-                            default-backup-ttl:
-                              description: How long (in nanoseconds) to wait by default before backups can be garbage collected. (default is 720 hours)
-                              format: int64
-                              type: integer
-                            default-item-operation-timeout:
-                              description: How long (in nanoseconds) to wait on asynchronous BackupItemActions and RestoreItemActions to complete before timing out. (default is 1 hour)
-                              format: int64
-                              type: integer
-                            default-repo-maintain-frequency:
-                              description: How often (in nanoseconds) 'maintain' is run for backup repositories by default.
-                              format: int64
-                              type: integer
-                            default-volumes-to-fs-backup:
-                              description: Backup all volumes with pod volume file system backup by default.
-                              type: boolean
-                            disabled-controllers:
-                              description: List of controllers to disable on startup. Valid values are backup,backup-operations,backup-deletion,backup-finalizer,backup-sync,download-request,gc,backup-repo,restore,restore-operations,schedule,server-status-request
-                              enum:
-                                - backup
-                                - backup-operations
-                                - backup-deletion
-                                - backup-finalizer
-                                - backup-sync
-                                - download-request
-                                - gc
-                                - backup-repo
-                                - restore
-                                - restore-operations
-                                - schedule
-                                - server-status-request
-                              items:
-                                type: string
-                              type: array
-                            fs-backup-timeout:
-                              description: How long (in nanoseconds) pod volume file system backups/restores should be allowed to run before timing out. (default is 4 hours)
-                              format: int64
-                              type: integer
-                            garbage-collection-frequency:
-                              description: How often (in nanoseconds) garbage collection checks for expired backups. (default is 1 hour)
-                              format: int64
-                              type: integer
-                            item-operation-sync-frequency:
-                              description: How often (in nanoseconds) to check status on backup/restore operations after backup/restore processing.
-                              format: int64
-                              type: integer
-                            log-format:
-                              description: The format for log output. Valid values are text, json. (default text)
-                              enum:
-                                - text
-                                - json
-                              type: string
-                            log_backtrace_at:
-                              description: when logging hits line file:N, emit a stack trace
-                              type: string
-                            log_dir:
-                              description: If non-empty, write log files in this directory (no effect when -logtostderr=true)
-                              type: string
-                            log_file:
-                              description: If non-empty, use this log file (no effect when -logtostderr=true)
-                              type: string
-                            log_file_max_size:
-                              description: Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-                              format: int64
-                              minimum: 0
-                              type: integer
-                            logtostderr:
-                              description: |-
-                                Boolean flags. Not handled atomically because the flag.Value interface
-                                does not let us avoid the =true, and that shorthand is necessary for
-                                compatibility. TODO: does this matter enough to fix? Seems unlikely.
-                              type: boolean
-                            max-concurrent-k8s-connections:
-                              description: Max concurrent connections number that Velero can create with kube-apiserver. Default is 30. (default 30)
-                              type: integer
-                            metrics-address:
-                              description: The address to expose prometheus metrics
-                              type: string
-                            one_output:
-                              description: If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
-                              type: boolean
-                            profiler-address:
-                              description: The address to expose the pprof profiler.
-                              type: string
-                            resource-timeout:
-                              description: How long (in nanoseconds) to wait for resource processes which are not covered by other specific timeout parameters. (default is 10 minutes)
-                              format: int64
-                              type: integer
-                            restore-resource-priorities:
-                              description: Desired order of resource restores, the priority list contains two parts which are split by "-" element. The resources before "-" element are restored first as high priorities, the resources after "-" element are restored last as low priorities, and any resource not in the list will be restored alphabetically between the high and low priorities. (default securitycontextconstraints,customresourcedefinitions,klusterletconfigs.config.open-cluster-management.io,managedcluster.cluster.open-cluster-management.io,namespaces,roles,rolebindings,clusterrolebindings,klusterletaddonconfig.agent.open-cluster-management.io,managedclusteraddon.addon.open-cluster-management.io,storageclasses,volumesnapshotclass.snapshot.storage.k8s.io,volumesnapshotcontents.snapshot.storage.k8s.io,volumesnapshots.snapshot.storage.k8s.io,datauploads.velero.io,persistentvolumes,persistentvolumeclaims,serviceaccounts,secrets,configmaps,limitranges,pods,replicasets.apps,clusterclasses.cluster.x-k8s.io,endpoints,services,-,clusterbootstraps.run.tanzu.vmware.com,clusters.cluster.x-k8s.io,clusterresourcesets.addons.cluster.x-k8s.io)
-                              type: string
-                            skip_headers:
-                              description: If true, avoid header prefixes in the log messages
-                              type: boolean
-                            skip_log_headers:
-                              description: If true, avoid headers when opening log files (no effect when -logtostderr=true)
-                              type: boolean
-                            stderrthreshold:
-                              description: logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
-                              type: integer
-                            store-validation-frequency:
-                              description: How often (in nanoseconds) to verify if the storage is valid. Optional. Set this to `0` to disable sync. (default is 1 minute)
-                              format: int64
-                              type: integer
-                            terminating-resource-timeout:
-                              description: How long (in nanoseconds) to wait on persistent volumes and namespaces to terminate during a restore before timing out.
-                              format: int64
-                              type: integer
-                            v:
-                              description: number for the log level verbosity
-                              type: integer
-                            vmodule:
-                              description: comma-separated list of pattern=N settings for file-filtered logging
-                              type: string
-                          type: object
-                        client-burst:
-                          description: maximum number of requests by the server to the Kubernetes API in a short period of time. (default 100)
-                          type: integer
-                        client-qps:
-                          description: maximum number of requests per second by the server to the Kubernetes API once the burst limit has been reached. (default 100)
-                          type: integer
-                        concurrentBackups:
-                          description: |-
-                            Number of backups to process at the same time. Only backups which do not have any namespaces
-                            in common will run at the same time. Default is 1.
-                          type: integer
-                        customPlugins:
-                          description: customPlugins defines the custom plugin to be installed with Velero
-                          items:
-                            properties:
-                              image:
-                                type: string
-                              name:
-                                type: string
-                            required:
-                              - image
-                              - name
-                            type: object
-                          type: array
-                        defaultItemOperationTimeout:
-                          description: How long to wait on asynchronous BackupItemActions and RestoreItemActions to complete before timing out. Default value is 1h.
-                          type: string
-                        defaultPlugins:
-                          items:
-                            enum:
-                              - aws
-                              - legacy-aws
-                              - gcp
-                              - azure
-                              - csi
-                              - vsm
-                              - openshift
-                              - kubevirt
-                              - kubevirt-datamover
-                              - hypershift
+                        description: PodLabels are labels to be added to pods created
+                          by node-agent, i.e., data mover pods.
+                        type: object
+                      podResources:
+                        description: PodResources is the resource config for various
+                          types of pods launched by node-agent, i.e., data mover pods.
+                        properties:
+                          cpuLimit:
                             type: string
-                          type: array
-                        defaultSnapshotMoveData:
-                          description: Specify whether CSI snapshot data should be moved to backup storage by default
-                          type: boolean
-                        defaultVolumesToFSBackup:
-                          description: 'Deprecated: Use defaultVolumesToFsBackup instead (matches Velero backup spec).'
-                          type: boolean
-                        defaultVolumesToFsBackup:
-                          description: |-
-                            Use pod volume file system backup by default for volumes.
-                            Matches backup.spec.defaultVolumesToFsBackup in Velero API.
-                          type: boolean
-                        disableFsBackup:
-                          default: false
-                          description: |-
-                            DisableFsBackup determines whether the NodeAgent should disable file system backup.
-                            When set to true, the NodeAgent runs in non-privileged mode.
-                            Defaults to false.
-                          type: boolean
-                        disableInformerCache:
-                          description: Disable informer cache for Get calls on restore. With this enabled, it will speed up restore in cases where there are backup resources which already exist in the cluster, but for very large clusters this will increase velero memory usage. Default is false.
-                          type: boolean
-                        enableCSISnapshotEarlyFrequentPolling:
-                          description: |-
-                            set EnableCSISnapshotEarlyFrequentPolling to true to enable
-                            the 1-second polling interval for the first 10 seconds while waiting
-                            for the snaphandle
-                          type: boolean
-                        featureFlags:
-                          description: featureFlags defines the list of features to enable for Velero instance
-                          items:
+                          cpuRequest:
                             type: string
-                          type: array
-                        itemBlockWorkerCount:
-                          description: |-
-                            Number of workers in worker pool for processing item backup. This will allow multiple items within
-                            a Velero backup to be backed up at the same time which may improve performance for backups with
-                            a large number of items. Workers are per backup if concurrent backups are enabled. Default is 1.
+                          memoryLimit:
+                            type: string
+                          memoryRequest:
+                            type: string
+                        type: object
+                      resourceTimeout:
+                        description: How long to wait for resource processes which
+                          are not covered by other specific timeout parameters. Default
+                          is 10 minutes.
+                        type: string
+                      restorePVC:
+                        description: RestoreVCConfig is the config for restorePVC
+                          (intermediate PVC) of generic restore
+                        properties:
+                          ignoreDelayBinding:
+                            description: IgnoreDelayBinding indicates to ignore delay
+                              binding the restorePVC when it is in WaitForFirstConsumer
+                              mode
+                            type: boolean
+                        type: object
+                      supplementalGroups:
+                        description: supplementalGroups defines the linux groups to
+                          be applied to the NodeAgent Pod
+                        items:
+                          format: int64
                           type: integer
-                        itemOperationSyncFrequency:
-                          description: How often to check status on async backup/restore operations after backup processing. Default value is 2m.
-                          type: string
+                        type: array
+                      timeout:
+                        description: timeout defines the NodeAgent timeout, default
+                          value is 1h
+                        type: string
+                      uploaderType:
+                        description: The type of uploader to transfer the data of
+                          pod volumes, the supported values are 'restic' or 'kopia'
+                        enum:
+                        - restic
+                        - kopia
+                        type: string
+                    required:
+                    - uploaderType
+                    type: object
+                  repositoryMaintenance:
+                    additionalProperties:
+                      properties:
                         loadAffinity:
-                          description: LoadAffinityConfig is the config for data path load affinity.
+                          description: LoadAffinity is the config for data path load
+                            affinity.
                           items:
                             description: |-
                               LoadAffinity is the config for data path load affinity.
                               Used by the Node-Agent, that needs to match the DataMover and the RepositoryMaintenance pods.
                             properties:
                               nodeSelector:
-                                description: NodeSelector specifies the label selector to match nodes
+                                description: NodeSelector specifies the label selector
+                                  to match nodes
                                 properties:
                                   matchExpressions:
-                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
                                     items:
                                       description: |-
                                         A label selector requirement is a selector that contains values, a key, and an operator that
                                         relates the key and values.
                                       properties:
                                         key:
-                                          description: key is the label key that the selector applies to.
+                                          description: key is the label key that the
+                                            selector applies to.
                                           type: string
                                         operator:
                                           description: |-
@@ -1324,8 +839,8 @@ spec:
                                           type: array
                                           x-kubernetes-list-type: atomic
                                       required:
-                                        - key
-                                        - operator
+                                      - key
+                                      - operator
                                       type: object
                                     type: array
                                     x-kubernetes-list-type: atomic
@@ -1347,433 +862,2205 @@ spec:
                                 type: string
                             type: object
                           type: array
-                        logLevel:
-                          description: Velero server's log level (use debug for the most logging, leave unset for velero default)
-                          enum:
-                            - trace
-                            - debug
-                            - info
-                            - warning
-                            - error
-                            - fatal
-                            - panic
-                          type: string
-                        noDefaultBackupLocation:
-                          description: If you need to install Velero without a default backup storage location noDefaultBackupLocation flag is required for confirmation
-                          type: boolean
-                        podConfig:
-                          description: Pod specific configuration
+                        podAnnotations:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            PodAnnotations are annotations to be added to maintenance job pods.
+                            This is only read from the global configuration, not per-repository.
+                          type: object
+                        podLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            PodLabels are labels to be added to maintenance job pods.
+                            This is only read from the global configuration, not per-repository.
+                          type: object
+                        podResources:
+                          description: PodResources is the config for the CPU and
+                            memory resources setting.
                           properties:
-                            annotations:
-                              additionalProperties:
-                                type: string
-                              description: annotations to add to pods
-                              type: object
-                            env:
-                              description: env defines the list of environment variables to be supplied to podSpec
-                              items:
-                                description: EnvVar represents an environment variable present in a Container.
-                                properties:
-                                  name:
-                                    description: Name of the environment variable. Must be a C_IDENTIFIER.
-                                    type: string
-                                  value:
-                                    description: |-
-                                      Variable references $(VAR_NAME) are expanded
-                                      using the previously defined environment variables in the container and
-                                      any service environment variables. If a variable cannot be resolved,
-                                      the reference in the input string will be unchanged. Double $$ are reduced
-                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                                      "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                                      Escaped references will never be expanded, regardless of whether the variable
-                                      exists or not.
-                                      Defaults to "".
-                                    type: string
-                                  valueFrom:
-                                    description: Source for the environment variable's value. Cannot be used if value is not empty.
-                                    properties:
-                                      configMapKeyRef:
-                                        description: Selects a key of a ConfigMap.
-                                        properties:
-                                          key:
-                                            description: The key to select.
-                                            type: string
-                                          name:
-                                            default: ""
-                                            description: |-
-                                              Name of the referent.
-                                              This field is effectively required, but due to backwards compatibility is
-                                              allowed to be empty. Instances of this type with an empty value here are
-                                              almost certainly wrong.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            type: string
-                                          optional:
-                                            description: Specify whether the ConfigMap or its key must be defined
-                                            type: boolean
-                                        required:
-                                          - key
-                                        type: object
-                                        x-kubernetes-map-type: atomic
-                                      fieldRef:
-                                        description: |-
-                                          Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                          spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
-                                        properties:
-                                          apiVersion:
-                                            description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
-                                            type: string
-                                          fieldPath:
-                                            description: Path of the field to select in the specified API version.
-                                            type: string
-                                        required:
-                                          - fieldPath
-                                        type: object
-                                        x-kubernetes-map-type: atomic
-                                      resourceFieldRef:
-                                        description: |-
-                                          Selects a resource of the container: only resources limits and requests
-                                          (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
-                                        properties:
-                                          containerName:
-                                            description: 'Container name: required for volumes, optional for env vars'
-                                            type: string
-                                          divisor:
-                                            anyOf:
-                                              - type: integer
-                                              - type: string
-                                            description: Specifies the output format of the exposed resources, defaults to "1"
-                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                            x-kubernetes-int-or-string: true
-                                          resource:
-                                            description: 'Required: resource to select'
-                                            type: string
-                                        required:
-                                          - resource
-                                        type: object
-                                        x-kubernetes-map-type: atomic
-                                      secretKeyRef:
-                                        description: Selects a key of a secret in the pod's namespace
-                                        properties:
-                                          key:
-                                            description: The key of the secret to select from.  Must be a valid secret key.
-                                            type: string
-                                          name:
-                                            default: ""
-                                            description: |-
-                                              Name of the referent.
-                                              This field is effectively required, but due to backwards compatibility is
-                                              allowed to be empty. Instances of this type with an empty value here are
-                                              almost certainly wrong.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            type: string
-                                          optional:
-                                            description: Specify whether the Secret or its key must be defined
-                                            type: boolean
-                                        required:
-                                          - key
-                                        type: object
-                                        x-kubernetes-map-type: atomic
-                                    type: object
-                                required:
-                                  - name
-                                type: object
-                              type: array
-                            labels:
-                              additionalProperties:
-                                type: string
-                              description: labels to add to pods
-                              type: object
-                            nodeSelector:
-                              additionalProperties:
-                                type: string
-                              description: nodeSelector defines the nodeSelector to be supplied to podSpec
-                              type: object
-                            priorityClassName:
-                              description: priorityClassName defines the PriorityClass name to be applied to the pod
+                            cpuLimit:
                               type: string
-                            resourceAllocations:
-                              description: resourceAllocations defines the CPU, Memory and ephemeral-storage resource allocations for the Pod
-                              nullable: true
+                            cpuRequest:
+                              type: string
+                            memoryLimit:
+                              type: string
+                            memoryRequest:
+                              type: string
+                          type: object
+                      type: object
+                    description: |-
+                      RepositoryMaintenance maps a BackupRepository identifier to its configuration.
+                      Keys can be:
+                       - "global" : Applies to all repositories without specific config.
+                       - "<namespace>" : The namespace of the BackupRepository.
+                       - "<repository name>" : The specific BackupRepository name referencing the BSL.
+                       - "<repository type>" : Either "kopia" or "restic".
+                    type: object
+                  restic:
+                    description: |-
+                      (do not use warning) restic field is for backwards compatibility and
+                      will be removed in the future. Use nodeAgent field instead
+                    properties:
+                      enable:
+                        description: |-
+                          enable defines a boolean pointer whether we want the daemonset to
+                          exist or not
+                        type: boolean
+                      podConfig:
+                        description: Pod specific configuration
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: annotations to add to pods
+                            type: object
+                          env:
+                            description: env defines the list of environment variables
+                              to be supplied to podSpec
+                            items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
                               properties:
-                                claims:
+                                name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
+                                  type: string
+                                value:
                                   description: |-
-                                    Claims lists the names of resources, defined in spec.resourceClaims,
-                                    that are used by this container.
+                                    Variable references $(VAR_NAME) are expanded
+                                    using the previously defined environment variables in the container and
+                                    any service environment variables. If a variable cannot be resolved,
+                                    the reference in the input string will be unchanged. Double $$ are reduced
+                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                    "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                    Escaped references will never be expanded, regardless of whether the variable
+                                    exists or not.
+                                    Defaults to "".
+                                  type: string
+                                valueFrom:
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    fieldRef:
+                                      description: |-
+                                        Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                        spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    resourceFieldRef:
+                                      description: |-
+                                        Selects a resource of the container: only resources limits and requests
+                                        (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          labels:
+                            additionalProperties:
+                              type: string
+                            description: labels to add to pods
+                            type: object
+                          nodeSelector:
+                            additionalProperties:
+                              type: string
+                            description: nodeSelector defines the nodeSelector to
+                              be supplied to podSpec
+                            type: object
+                          priorityClassName:
+                            description: priorityClassName defines the PriorityClass
+                              name to be applied to the pod
+                            type: string
+                          resourceAllocations:
+                            description: resourceAllocations defines the CPU, Memory
+                              and ephemeral-storage resource allocations for the Pod
+                            nullable: true
+                            properties:
+                              claims:
+                                description: |-
+                                  Claims lists the names of resources, defined in spec.resourceClaims,
+                                  that are used by this container.
 
-                                    This is an alpha field and requires enabling the
-                                    DynamicResourceAllocation feature gate.
+                                  This is an alpha field and requires enabling the
+                                  DynamicResourceAllocation feature gate.
 
-                                    This field is immutable. It can only be set for containers.
+                                  This field is immutable. It can only be set for containers.
+                                items:
+                                  description: ResourceClaim references one entry
+                                    in PodSpec.ResourceClaims.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name must match the name of one entry in pod.spec.resourceClaims of
+                                        the Pod where this field is used. It makes that resource available
+                                        inside a container.
+                                      type: string
+                                    request:
+                                      description: |-
+                                        Request is the name chosen for a request in the referenced claim.
+                                        If empty, everything from the claim is made available, otherwise
+                                        only the result of this request.
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: |-
+                                  Limits describes the maximum amount of compute resources allowed.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: |-
+                                  Requests describes the minimum amount of compute resources required.
+                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                            type: object
+                          tolerations:
+                            description: tolerations defines the list of tolerations
+                              to be applied to daemonset
+                            items:
+                              description: |-
+                                The pod this Toleration is attached to tolerates any taint that matches
+                                the triple <key,value,effect> using the matching operator <operator>.
+                              properties:
+                                effect:
+                                  description: |-
+                                    Effect indicates the taint effect to match. Empty means match all taint effects.
+                                    When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                  type: string
+                                key:
+                                  description: |-
+                                    Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                    If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    Operator represents a key's relationship to the value.
+                                    Valid operators are Exists and Equal. Defaults to Equal.
+                                    Exists is equivalent to wildcard for value, so that a pod can
+                                    tolerate all taints of a particular category.
+                                  type: string
+                                tolerationSeconds:
+                                  description: |-
+                                    TolerationSeconds represents the period of time the toleration (which must be
+                                    of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                    it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                    negative values will be treated as 0 (evict immediately) by the system.
+                                  format: int64
+                                  type: integer
+                                value:
+                                  description: |-
+                                    Value is the taint value the toleration matches to.
+                                    If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                  type: string
+                              type: object
+                            type: array
+                        type: object
+                      supplementalGroups:
+                        description: supplementalGroups defines the linux groups to
+                          be applied to the NodeAgent Pod
+                        items:
+                          format: int64
+                          type: integer
+                        type: array
+                      timeout:
+                        description: timeout defines the NodeAgent timeout, default
+                          value is 1h
+                        type: string
+                    type: object
+                  velero:
+                    properties:
+                      args:
+                        description: Velero args are settings to customize velero
+                          server arguments. Overrides values in other fields.
+                        properties:
+                          add_dir_header:
+                            description: If true, adds the file directory to the header
+                              of the log messages
+                            type: boolean
+                          alsologtostderr:
+                            description: log to standard error as well as files (no
+                              effect when -logtostderr=true)
+                            type: boolean
+                          backup-sync-period:
+                            description: How often (in nanoseconds) to ensure all
+                              Velero backups in object storage exist as Backup API
+                              objects in the cluster. This is the default sync period
+                              if none is explicitly specified for a backup storage
+                              location.
+                            format: int64
+                            type: integer
+                          client-burst:
+                            description: Maximum number of requests by the server
+                              to the Kubernetes API in a short period of time.
+                            type: integer
+                          client-page-size:
+                            description: Page size of requests by the server to the
+                              Kubernetes API when listing objects during a backup.
+                              Set to 0 to disable paging.
+                            type: integer
+                          client-qps:
+                            description: |-
+                              Maximum number of requests per second by the server to the Kubernetes API once the burst limit has been reached.
+                              this will be validated as a valid float32
+                            type: string
+                          colorized:
+                            description: Show colored output in TTY
+                            type: boolean
+                          default-backup-ttl:
+                            description: How long (in nanoseconds) to wait by default
+                              before backups can be garbage collected. (default is
+                              720 hours)
+                            format: int64
+                            type: integer
+                          default-item-operation-timeout:
+                            description: How long (in nanoseconds) to wait on asynchronous
+                              BackupItemActions and RestoreItemActions to complete
+                              before timing out. (default is 1 hour)
+                            format: int64
+                            type: integer
+                          default-repo-maintain-frequency:
+                            description: How often (in nanoseconds) 'maintain' is
+                              run for backup repositories by default.
+                            format: int64
+                            type: integer
+                          default-volumes-to-fs-backup:
+                            description: Backup all volumes with pod volume file system
+                              backup by default.
+                            type: boolean
+                          disabled-controllers:
+                            description: List of controllers to disable on startup.
+                              Valid values are backup,backup-operations,backup-deletion,backup-finalizer,backup-sync,download-request,gc,backup-repo,restore,restore-operations,schedule,server-status-request
+                            enum:
+                            - backup
+                            - backup-operations
+                            - backup-deletion
+                            - backup-finalizer
+                            - backup-sync
+                            - download-request
+                            - gc
+                            - backup-repo
+                            - restore
+                            - restore-operations
+                            - schedule
+                            - server-status-request
+                            items:
+                              type: string
+                            type: array
+                          fs-backup-timeout:
+                            description: How long (in nanoseconds) pod volume file
+                              system backups/restores should be allowed to run before
+                              timing out. (default is 4 hours)
+                            format: int64
+                            type: integer
+                          garbage-collection-frequency:
+                            description: How often (in nanoseconds) garbage collection
+                              checks for expired backups. (default is 1 hour)
+                            format: int64
+                            type: integer
+                          item-operation-sync-frequency:
+                            description: How often (in nanoseconds) to check status
+                              on backup/restore operations after backup/restore processing.
+                            format: int64
+                            type: integer
+                          log-format:
+                            description: The format for log output. Valid values are
+                              text, json. (default text)
+                            enum:
+                            - text
+                            - json
+                            type: string
+                          log_backtrace_at:
+                            description: when logging hits line file:N, emit a stack
+                              trace
+                            type: string
+                          log_dir:
+                            description: If non-empty, write log files in this directory
+                              (no effect when -logtostderr=true)
+                            type: string
+                          log_file:
+                            description: If non-empty, use this log file (no effect
+                              when -logtostderr=true)
+                            type: string
+                          log_file_max_size:
+                            description: Defines the maximum size a log file can grow
+                              to (no effect when -logtostderr=true). Unit is megabytes.
+                              If the value is 0, the maximum file size is unlimited.
+                              (default 1800)
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          logtostderr:
+                            description: |-
+                              Boolean flags. Not handled atomically because the flag.Value interface
+                              does not let us avoid the =true, and that shorthand is necessary for
+                              compatibility. TODO: does this matter enough to fix? Seems unlikely.
+                            type: boolean
+                          max-concurrent-k8s-connections:
+                            description: Max concurrent connections number that Velero
+                              can create with kube-apiserver. Default is 30. (default
+                              30)
+                            type: integer
+                          metrics-address:
+                            description: The address to expose prometheus metrics
+                            type: string
+                          one_output:
+                            description: If true, only write logs to their native
+                              severity level (vs also writing to each lower severity
+                              level; no effect when -logtostderr=true)
+                            type: boolean
+                          profiler-address:
+                            description: The address to expose the pprof profiler.
+                            type: string
+                          resource-timeout:
+                            description: How long (in nanoseconds) to wait for resource
+                              processes which are not covered by other specific timeout
+                              parameters. (default is 10 minutes)
+                            format: int64
+                            type: integer
+                          restore-resource-priorities:
+                            description: Desired order of resource restores, the priority
+                              list contains two parts which are split by "-" element.
+                              The resources before "-" element are restored first
+                              as high priorities, the resources after "-" element
+                              are restored last as low priorities, and any resource
+                              not in the list will be restored alphabetically between
+                              the high and low priorities. (default securitycontextconstraints,customresourcedefinitions,klusterletconfigs.config.open-cluster-management.io,managedcluster.cluster.open-cluster-management.io,namespaces,roles,rolebindings,clusterrolebindings,klusterletaddonconfig.agent.open-cluster-management.io,managedclusteraddon.addon.open-cluster-management.io,storageclasses,volumesnapshotclass.snapshot.storage.k8s.io,volumesnapshotcontents.snapshot.storage.k8s.io,volumesnapshots.snapshot.storage.k8s.io,datauploads.velero.io,persistentvolumes,persistentvolumeclaims,serviceaccounts,secrets,configmaps,limitranges,pods,replicasets.apps,clusterclasses.cluster.x-k8s.io,endpoints,services,-,clusterbootstraps.run.tanzu.vmware.com,clusters.cluster.x-k8s.io,clusterresourcesets.addons.cluster.x-k8s.io)
+                            type: string
+                          skip_headers:
+                            description: If true, avoid header prefixes in the log
+                              messages
+                            type: boolean
+                          skip_log_headers:
+                            description: If true, avoid headers when opening log files
+                              (no effect when -logtostderr=true)
+                            type: boolean
+                          stderrthreshold:
+                            description: logs at or above this threshold go to stderr
+                              when writing to files and stderr (no effect when -logtostderr=true
+                              or -alsologtostderr=false) (default 2)
+                            type: integer
+                          store-validation-frequency:
+                            description: How often (in nanoseconds) to verify if the
+                              storage is valid. Optional. Set this to `0` to disable
+                              sync. (default is 1 minute)
+                            format: int64
+                            type: integer
+                          terminating-resource-timeout:
+                            description: How long (in nanoseconds) to wait on persistent
+                              volumes and namespaces to terminate during a restore
+                              before timing out.
+                            format: int64
+                            type: integer
+                          v:
+                            description: number for the log level verbosity
+                            type: integer
+                          vmodule:
+                            description: comma-separated list of pattern=N settings
+                              for file-filtered logging
+                            type: string
+                        type: object
+                      client-burst:
+                        description: maximum number of requests by the server to the
+                          Kubernetes API in a short period of time. (default 100)
+                        type: integer
+                      client-qps:
+                        description: maximum number of requests per second by the
+                          server to the Kubernetes API once the burst limit has been
+                          reached. (default 100)
+                        type: integer
+                      concurrentBackups:
+                        description: |-
+                          Number of backups to process at the same time. Only backups which do not have any namespaces
+                          in common will run at the same time. Default is 1.
+                        type: integer
+                      customPlugins:
+                        description: customPlugins defines the custom plugin to be
+                          installed with Velero
+                        items:
+                          properties:
+                            image:
+                              type: string
+                            name:
+                              type: string
+                          required:
+                          - image
+                          - name
+                          type: object
+                        type: array
+                      defaultItemOperationTimeout:
+                        description: How long to wait on asynchronous BackupItemActions
+                          and RestoreItemActions to complete before timing out. Default
+                          value is 1h.
+                        type: string
+                      defaultPlugins:
+                        items:
+                          enum:
+                          - aws
+                          - legacy-aws
+                          - gcp
+                          - azure
+                          - csi
+                          - vsm
+                          - openshift
+                          - kubevirt
+                          - kubevirt-datamover
+                          - hypershift
+                          type: string
+                        type: array
+                      defaultSnapshotMoveData:
+                        description: Specify whether CSI snapshot data should be moved
+                          to backup storage by default
+                        type: boolean
+                      defaultVolumesToFSBackup:
+                        description: 'Deprecated: Use defaultVolumesToFsBackup instead
+                          (matches Velero backup spec).'
+                        type: boolean
+                      defaultVolumesToFsBackup:
+                        description: |-
+                          Use pod volume file system backup by default for volumes.
+                          Matches backup.spec.defaultVolumesToFsBackup in Velero API.
+                        type: boolean
+                      disableFsBackup:
+                        default: false
+                        description: |-
+                          DisableFsBackup determines whether the NodeAgent should disable file system backup.
+                          When set to true, the NodeAgent runs in non-privileged mode.
+                          Defaults to false.
+                        type: boolean
+                      disableInformerCache:
+                        description: Disable informer cache for Get calls on restore.
+                          With this enabled, it will speed up restore in cases where
+                          there are backup resources which already exist in the cluster,
+                          but for very large clusters this will increase velero memory
+                          usage. Default is false.
+                        type: boolean
+                      enableCSISnapshotEarlyFrequentPolling:
+                        description: |-
+                          set EnableCSISnapshotEarlyFrequentPolling to true to enable
+                          the 1-second polling interval for the first 10 seconds while waiting
+                          for the snaphandle
+                        type: boolean
+                      featureFlags:
+                        description: featureFlags defines the list of features to
+                          enable for Velero instance
+                        items:
+                          type: string
+                        type: array
+                      itemBlockWorkerCount:
+                        description: |-
+                          Number of workers in worker pool for processing item backup. This will allow multiple items within
+                          a Velero backup to be backed up at the same time which may improve performance for backups with
+                          a large number of items. Workers are per backup if concurrent backups are enabled. Default is 1.
+                        type: integer
+                      itemOperationSyncFrequency:
+                        description: How often to check status on async backup/restore
+                          operations after backup processing. Default value is 2m.
+                        type: string
+                      loadAffinity:
+                        description: LoadAffinityConfig is the config for data path
+                          load affinity.
+                        items:
+                          description: |-
+                            LoadAffinity is the config for data path load affinity.
+                            Used by the Node-Agent, that needs to match the DataMover and the RepositoryMaintenance pods.
+                          properties:
+                            nodeSelector:
+                              description: NodeSelector specifies the label selector
+                                to match nodes
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
                                   items:
-                                    description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
                                     properties:
-                                      name:
-                                        description: |-
-                                          Name must match the name of one entry in pod.spec.resourceClaims of
-                                          the Pod where this field is used. It makes that resource available
-                                          inside a container.
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
                                         type: string
-                                      request:
+                                      operator:
                                         description: |-
-                                          Request is the name chosen for a request in the referenced claim.
-                                          If empty, everything from the claim is made available, otherwise
-                                          only the result of this request.
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
                                     required:
-                                      - name
+                                    - key
+                                    - operator
                                     type: object
                                   type: array
-                                  x-kubernetes-list-map-keys:
-                                    - name
-                                  x-kubernetes-list-type: map
-                                limits:
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
                                   additionalProperties:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                    nullable: true
+                                    type: string
                                   description: |-
-                                    Limits describes the maximum amount of compute resources allowed.
-                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
-                                  nullable: true
-                                requests:
-                                  additionalProperties:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                    nullable: true
-                                  description: |-
-                                    Requests describes the minimum amount of compute resources required.
-                                    If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                    otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                                  type: object
-                                  nullable: true
                               type: object
-                            tolerations:
-                              description: tolerations defines the list of tolerations to be applied to daemonset
+                              x-kubernetes-map-type: atomic
+                            storageClass:
+                              description: |-
+                                StorageClass specifies the storage class to which this LoadAffinity rule applies.
+                                If empty, the affinity applies globally to all data mover operations.
+                                If set, the affinity applies only to data mover operations using this specific StorageClass.
+                              type: string
+                          type: object
+                        type: array
+                      logLevel:
+                        description: Velero server's log level (use debug for the
+                          most logging, leave unset for velero default)
+                        enum:
+                        - trace
+                        - debug
+                        - info
+                        - warning
+                        - error
+                        - fatal
+                        - panic
+                        type: string
+                      noDefaultBackupLocation:
+                        description: If you need to install Velero without a default
+                          backup storage location noDefaultBackupLocation flag is
+                          required for confirmation
+                        type: boolean
+                      podConfig:
+                        description: Pod specific configuration
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: annotations to add to pods
+                            type: object
+                          env:
+                            description: env defines the list of environment variables
+                              to be supplied to podSpec
+                            items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
+                              properties:
+                                name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
+                                  type: string
+                                value:
+                                  description: |-
+                                    Variable references $(VAR_NAME) are expanded
+                                    using the previously defined environment variables in the container and
+                                    any service environment variables. If a variable cannot be resolved,
+                                    the reference in the input string will be unchanged. Double $$ are reduced
+                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                    "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                    Escaped references will never be expanded, regardless of whether the variable
+                                    exists or not.
+                                    Defaults to "".
+                                  type: string
+                                valueFrom:
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    fieldRef:
+                                      description: |-
+                                        Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                        spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    resourceFieldRef:
+                                      description: |-
+                                        Selects a resource of the container: only resources limits and requests
+                                        (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          labels:
+                            additionalProperties:
+                              type: string
+                            description: labels to add to pods
+                            type: object
+                          nodeSelector:
+                            additionalProperties:
+                              type: string
+                            description: nodeSelector defines the nodeSelector to
+                              be supplied to podSpec
+                            type: object
+                          priorityClassName:
+                            description: priorityClassName defines the PriorityClass
+                              name to be applied to the pod
+                            type: string
+                          resourceAllocations:
+                            description: resourceAllocations defines the CPU, Memory
+                              and ephemeral-storage resource allocations for the Pod
+                            nullable: true
+                            properties:
+                              claims:
+                                description: |-
+                                  Claims lists the names of resources, defined in spec.resourceClaims,
+                                  that are used by this container.
+
+                                  This is an alpha field and requires enabling the
+                                  DynamicResourceAllocation feature gate.
+
+                                  This field is immutable. It can only be set for containers.
+                                items:
+                                  description: ResourceClaim references one entry
+                                    in PodSpec.ResourceClaims.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name must match the name of one entry in pod.spec.resourceClaims of
+                                        the Pod where this field is used. It makes that resource available
+                                        inside a container.
+                                      type: string
+                                    request:
+                                      description: |-
+                                        Request is the name chosen for a request in the referenced claim.
+                                        If empty, everything from the claim is made available, otherwise
+                                        only the result of this request.
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: |-
+                                  Limits describes the maximum amount of compute resources allowed.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: |-
+                                  Requests describes the minimum amount of compute resources required.
+                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                            type: object
+                          tolerations:
+                            description: tolerations defines the list of tolerations
+                              to be applied to daemonset
+                            items:
+                              description: |-
+                                The pod this Toleration is attached to tolerates any taint that matches
+                                the triple <key,value,effect> using the matching operator <operator>.
+                              properties:
+                                effect:
+                                  description: |-
+                                    Effect indicates the taint effect to match. Empty means match all taint effects.
+                                    When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                  type: string
+                                key:
+                                  description: |-
+                                    Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                    If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    Operator represents a key's relationship to the value.
+                                    Valid operators are Exists and Equal. Defaults to Equal.
+                                    Exists is equivalent to wildcard for value, so that a pod can
+                                    tolerate all taints of a particular category.
+                                  type: string
+                                tolerationSeconds:
+                                  description: |-
+                                    TolerationSeconds represents the period of time the toleration (which must be
+                                    of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                    it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                    negative values will be treated as 0 (evict immediately) by the system.
+                                  format: int64
+                                  type: integer
+                                value:
+                                  description: |-
+                                    Value is the taint value the toleration matches to.
+                                    If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                  type: string
+                              type: object
+                            type: array
+                        type: object
+                      resourceTimeout:
+                        description: |-
+                          resourceTimeout defines how long to wait for several Velero resources before timeout occurs,
+                          such as Velero CRD availability, volumeSnapshot deletion, and repo availability.
+                          Default is 10m
+                        type: string
+                      restoreResourcesVersionPriority:
+                        description: |-
+                          restoreResourceVersionPriority represents a configmap that will be created if defined for use in conjunction with EnableAPIGroupVersions feature flag
+                          Defining this field automatically add EnableAPIGroupVersions to the velero server feature flag
+                        type: string
+                    type: object
+                type: object
+              features:
+                description: features defines the configuration for the DPA to enable
+                  the OADP tech preview features
+                properties:
+                  dataMover:
+                    description: |-
+                      (do not use warning) dataMover is for backwards compatibility and
+                      will be removed in the future. Use Velero Built-in Data Mover instead
+                    properties:
+                      credentialName:
+                        description: User supplied Restic Secret name
+                        type: string
+                      enable:
+                        description: enable flag is used to specify whether you want
+                          to deploy the volume snapshot mover controller
+                        type: boolean
+                      maxConcurrentBackupVolumes:
+                        description: the number of batched volumeSnapshotBackups that
+                          can be inProgress at once, default value is 10
+                        type: string
+                      maxConcurrentRestoreVolumes:
+                        description: the number of batched volumeSnapshotRestores
+                          that can be inProgress at once, default value is 10
+                        type: string
+                      pruneInterval:
+                        description: defines how often (in days) to prune the datamover
+                          snapshots from the repository
+                        type: string
+                      schedule:
+                        description: |-
+                          schedule is a cronspec (https://en.wikipedia.org/wiki/Cron#Overview) that
+                          can be used to schedule datamover(volsync) synchronization to occur at regular, time-based
+                          intervals. For example, in order to enforce datamover SnapshotRetainPolicy at a regular interval you need to
+                          specify this Schedule trigger as a cron expression, by default the trigger is a manual trigger. For more details
+                          on Volsync triggers, refer: https://volsync.readthedocs.io/en/stable/usage/triggers.html
+                        pattern: ^(\d+|\*)(/\d+)?(\s+(\d+|\*)(/\d+)?){4}$
+                        type: string
+                      snapshotRetainPolicy:
+                        description: defines the parameters that can be specified
+                          for retention of datamover snapshots
+                        properties:
+                          daily:
+                            description: Daily defines the number of snapshots to
+                              be kept daily
+                            type: string
+                          hourly:
+                            description: Hourly defines the number of snapshots to
+                              be kept hourly
+                            type: string
+                          monthly:
+                            description: Monthly defines the number of snapshots to
+                              be kept monthly
+                            type: string
+                          weekly:
+                            description: Weekly defines the number of snapshots to
+                              be kept weekly
+                            type: string
+                          within:
+                            description: Within defines the number of snapshots to
+                              be kept Within the given time period
+                            type: string
+                          yearly:
+                            description: Yearly defines the number of snapshots to
+                              be kept yearly
+                            type: string
+                        type: object
+                      timeout:
+                        description: User supplied timeout to be used for VolumeSnapshotBackup
+                          and VolumeSnapshotRestore to complete, default value is
+                          10m
+                        type: string
+                      volumeOptionsForStorageClasses:
+                        additionalProperties:
+                          properties:
+                            destinationVolumeOptions:
+                              description: VolumeOptions defines configurations for
+                                VolSync options
+                              properties:
+                                accessMode:
+                                  description: |-
+                                    accessMode can be used to override the accessMode of the source or
+                                    destination PVC
+                                  type: string
+                                cacheAccessMode:
+                                  description: cacheAccessMode is the access mode
+                                    to be used to provision the cache volume
+                                  type: string
+                                cacheCapacity:
+                                  description: cacheCapacity determines the size of
+                                    the restic metadata cache volume
+                                  type: string
+                                cacheStorageClassName:
+                                  description: |-
+                                    cacheStorageClassName is the storageClass that should be used when provisioning
+                                    the data mover cache volume
+                                  type: string
+                                storageClassName:
+                                  description: |-
+                                    storageClassName can be used to override the StorageClass of the source
+                                    or destination PVC
+                                  type: string
+                              type: object
+                            sourceVolumeOptions:
+                              description: VolumeOptions defines configurations for
+                                VolSync options
+                              properties:
+                                accessMode:
+                                  description: |-
+                                    accessMode can be used to override the accessMode of the source or
+                                    destination PVC
+                                  type: string
+                                cacheAccessMode:
+                                  description: cacheAccessMode is the access mode
+                                    to be used to provision the cache volume
+                                  type: string
+                                cacheCapacity:
+                                  description: cacheCapacity determines the size of
+                                    the restic metadata cache volume
+                                  type: string
+                                cacheStorageClassName:
+                                  description: |-
+                                    cacheStorageClassName is the storageClass that should be used when provisioning
+                                    the data mover cache volume
+                                  type: string
+                                storageClassName:
+                                  description: |-
+                                    storageClassName can be used to override the StorageClass of the source
+                                    or destination PVC
+                                  type: string
+                              type: object
+                          type: object
+                        description: defines configurations for data mover volume
+                          options for a storageClass
+                        type: object
+                    type: object
+                type: object
+              imagePullPolicy:
+                description: |-
+                  which imagePullPolicy to use in all container images used by OADP.
+                  By default, for images with sha256 or sha512 digest, OADP uses IfNotPresent and uses Always for all other images.
+                enum:
+                - Always
+                - IfNotPresent
+                - Never
+                type: string
+              logFormat:
+                default: text
+                description: The format for log output. Valid values are text, json.
+                  (default text)
+                enum:
+                - text
+                - json
+                type: string
+              nonAdmin:
+                description: nonAdmin defines the configuration for the DPA to enable
+                  backup and restore operations for non-admin users
+                properties:
+                  backupSyncPeriod:
+                    description: |-
+                      BackupSyncPeriod specifies the interval at which backups from the OADP namespace are synchronized with non-admin namespaces.
+                      A value of 0 disables sync.
+                      By default 2m
+                    type: string
+                  enable:
+                    description: Enables non admin feature, by default is disabled
+                    type: boolean
+                  enforceBSLSpec:
+                    description: which backupstoragelocation spec field values to
+                      enforce
+                    properties:
+                      accessMode:
+                        description: AccessMode defines the permissions for the backup
+                          storage location.
+                        enum:
+                        - ReadOnly
+                        - ReadWrite
+                        type: string
+                      backupSyncPeriod:
+                        description: BackupSyncPeriod defines how frequently to sync
+                          backup API objects from object storage. A value of 0 disables
+                          sync.
+                        nullable: true
+                        type: string
+                      config:
+                        additionalProperties:
+                          type: string
+                        description: Config is for provider-specific configuration
+                          fields.
+                        type: object
+                      credential:
+                        description: Credential contains the credential information
+                          intended to be used with this location
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            default: ""
+                            description: |-
+                              Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or its key must
+                              be defined
+                            type: boolean
+                        required:
+                        - key
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      objectStorage:
+                        description: ObjectStorageLocation defines the enforced values
+                          for the Velero ObjectStorageLocation
+                        nullable: true
+                        properties:
+                          bucket:
+                            description: Bucket is the bucket to use for object storage.
+                            type: string
+                          caCert:
+                            description: CACert defines a CA bundle to use when verifying
+                              TLS connections to the provider.
+                            format: byte
+                            type: string
+                          prefix:
+                            description: Prefix is the path inside a bucket to use
+                              for Velero storage. Optional.
+                            type: string
+                        type: object
+                      provider:
+                        description: Provider is the provider of the backup storage.
+                        type: string
+                      validationFrequency:
+                        description: ValidationFrequency defines how frequently to
+                          validate the corresponding object storage. A value of 0
+                          disables validation.
+                        nullable: true
+                        type: string
+                    type: object
+                  enforceBackupSpec:
+                    description: which bakup spec field values to enforce
+                    properties:
+                      csiSnapshotTimeout:
+                        description: |-
+                          CSISnapshotTimeout specifies the time used to wait for CSI VolumeSnapshot status turns to
+                          ReadyToUse during creation, before returning error as timeout.
+                          The default value is 10 minute.
+                        type: string
+                      datamover:
+                        description: |-
+                          DataMover specifies the data mover to be used by the backup.
+                          If DataMover is "" or "velero", the built-in data mover will be used.
+                        type: string
+                      defaultVolumesToFsBackup:
+                        description: |-
+                          DefaultVolumesToFsBackup specifies whether pod volume file system backup should be used
+                          for all volumes by default.
+                        nullable: true
+                        type: boolean
+                      defaultVolumesToRestic:
+                        description: |-
+                          DefaultVolumesToRestic specifies whether restic should be used to take a
+                          backup of all pod volumes by default.
+
+                          Deprecated: this field is no longer used and will be removed entirely in future. Use DefaultVolumesToFsBackup instead.
+                        nullable: true
+                        type: boolean
+                      excludedClusterScopedResources:
+                        description: |-
+                          ExcludedClusterScopedResources is a slice of cluster-scoped
+                          resource type names to exclude from the backup.
+                          If set to "*", all cluster-scoped resource types are excluded.
+                          The default value is empty.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      excludedNamespaceScopedResources:
+                        description: |-
+                          ExcludedNamespaceScopedResources is a slice of namespace-scoped
+                          resource type names to exclude from the backup.
+                          If set to "*", all namespace-scoped resource types are excluded.
+                          The default value is empty.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      excludedNamespaces:
+                        description: |-
+                          ExcludedNamespaces contains a list of namespaces that are not
+                          included in the backup.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      excludedResources:
+                        description: |-
+                          ExcludedResources is a slice of resource names that are not
+                          included in the backup.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      hooks:
+                        description: Hooks represent custom behaviors that should
+                          be executed at different phases of the backup.
+                        properties:
+                          resources:
+                            description: Resources are hooks that should be executed
+                              when backing up individual instances of a resource.
+                            items:
+                              description: |-
+                                BackupResourceHookSpec defines one or more BackupResourceHooks that should be executed based on
+                                the rules defined for namespaces, resources, and label selector.
+                              properties:
+                                excludedNamespaces:
+                                  description: ExcludedNamespaces specifies the namespaces
+                                    to which this hook spec does not apply.
+                                  items:
+                                    type: string
+                                  nullable: true
+                                  type: array
+                                excludedResources:
+                                  description: ExcludedResources specifies the resources
+                                    to which this hook spec does not apply.
+                                  items:
+                                    type: string
+                                  nullable: true
+                                  type: array
+                                includedNamespaces:
+                                  description: |-
+                                    IncludedNamespaces specifies the namespaces to which this hook spec applies. If empty, it applies
+                                    to all namespaces.
+                                  items:
+                                    type: string
+                                  nullable: true
+                                  type: array
+                                includedResources:
+                                  description: |-
+                                    IncludedResources specifies the resources to which this hook spec applies. If empty, it applies
+                                    to all resources.
+                                  items:
+                                    type: string
+                                  nullable: true
+                                  type: array
+                                labelSelector:
+                                  description: LabelSelector, if specified, filters
+                                    the resources to which this hook spec applies.
+                                  nullable: true
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                name:
+                                  description: Name is the name of this hook.
+                                  type: string
+                                post:
+                                  description: |-
+                                    PostHooks is a list of BackupResourceHooks to execute after storing the item in the backup.
+                                    These are executed after all "additional items" from item actions are processed.
+                                  items:
+                                    description: BackupResourceHook defines a hook
+                                      for a resource.
+                                    properties:
+                                      exec:
+                                        description: Exec defines an exec hook.
+                                        properties:
+                                          command:
+                                            description: Command is the command and
+                                              arguments to execute.
+                                            items:
+                                              type: string
+                                            minItems: 1
+                                            type: array
+                                          container:
+                                            description: |-
+                                              Container is the container in the pod where the command should be executed. If not specified,
+                                              the pod's first container is used.
+                                            type: string
+                                          onError:
+                                            description: OnError specifies how Velero
+                                              should behave if it encounters an error
+                                              executing this hook.
+                                            enum:
+                                            - Continue
+                                            - Fail
+                                            type: string
+                                          timeout:
+                                            description: |-
+                                              Timeout defines the maximum amount of time Velero should wait for the hook to complete before
+                                              considering the execution a failure.
+                                            type: string
+                                        required:
+                                        - command
+                                        type: object
+                                    required:
+                                    - exec
+                                    type: object
+                                  type: array
+                                pre:
+                                  description: |-
+                                    PreHooks is a list of BackupResourceHooks to execute prior to storing the item in the backup.
+                                    These are executed before any "additional items" from item actions are processed.
+                                  items:
+                                    description: BackupResourceHook defines a hook
+                                      for a resource.
+                                    properties:
+                                      exec:
+                                        description: Exec defines an exec hook.
+                                        properties:
+                                          command:
+                                            description: Command is the command and
+                                              arguments to execute.
+                                            items:
+                                              type: string
+                                            minItems: 1
+                                            type: array
+                                          container:
+                                            description: |-
+                                              Container is the container in the pod where the command should be executed. If not specified,
+                                              the pod's first container is used.
+                                            type: string
+                                          onError:
+                                            description: OnError specifies how Velero
+                                              should behave if it encounters an error
+                                              executing this hook.
+                                            enum:
+                                            - Continue
+                                            - Fail
+                                            type: string
+                                          timeout:
+                                            description: |-
+                                              Timeout defines the maximum amount of time Velero should wait for the hook to complete before
+                                              considering the execution a failure.
+                                            type: string
+                                        required:
+                                        - command
+                                        type: object
+                                    required:
+                                    - exec
+                                    type: object
+                                  type: array
+                              required:
+                              - name
+                              type: object
+                            nullable: true
+                            type: array
+                        type: object
+                      includeClusterResources:
+                        description: |-
+                          IncludeClusterResources specifies whether cluster-scoped resources
+                          should be included for consideration in the backup.
+                        nullable: true
+                        type: boolean
+                      includedClusterScopedResources:
+                        description: |-
+                          IncludedClusterScopedResources is a slice of cluster-scoped
+                          resource type names to include in the backup.
+                          If set to "*", all cluster-scoped resource types are included.
+                          The default value is empty, which means only related
+                          cluster-scoped resources are included.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      includedNamespaceScopedResources:
+                        description: |-
+                          IncludedNamespaceScopedResources is a slice of namespace-scoped
+                          resource type names to include in the backup.
+                          The default value is "*".
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      includedNamespaces:
+                        description: |-
+                          IncludedNamespaces is a slice of namespace names to include objects
+                          from. If empty, all namespaces are included.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      includedResources:
+                        description: |-
+                          IncludedResources is a slice of resource names to include
+                          in the backup. If empty, all resources are included.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      itemOperationTimeout:
+                        description: |-
+                          ItemOperationTimeout specifies the time used to wait for asynchronous BackupItemAction operations
+                          The default value is 4 hour.
+                        type: string
+                      labelSelector:
+                        description: |-
+                          LabelSelector is a metav1.LabelSelector to filter with
+                          when adding individual objects to the backup. If empty
+                          or nil, all objects are included. Optional.
+                        nullable: true
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      metadata:
+                        properties:
+                          labels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
+                      orLabelSelectors:
+                        description: |-
+                          OrLabelSelectors is list of metav1.LabelSelector to filter with
+                          when adding individual objects to the backup. If multiple provided
+                          they will be joined by the OR operator. LabelSelector as well as
+                          OrLabelSelectors cannot co-exist in backup request, only one of them
+                          can be used.
+                        items:
+                          description: |-
+                            A label selector is a label query over a set of resources. The result of matchLabels and
+                            matchExpressions are ANDed. An empty label selector matches all objects. A null
+                            label selector matches no objects.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
                               items:
                                 description: |-
-                                  The pod this Toleration is attached to tolerates any taint that matches
-                                  the triple <key,value,effect> using the matching operator <operator>.
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
                                 properties:
-                                  effect:
-                                    description: |-
-                                      Effect indicates the taint effect to match. Empty means match all taint effects.
-                                      When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
-                                    type: string
                                   key:
-                                    description: |-
-                                      Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                                      If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                    description: key is the label key that the selector
+                                      applies to.
                                     type: string
                                   operator:
                                     description: |-
-                                      Operator represents a key's relationship to the value.
-                                      Valid operators are Exists and Equal. Defaults to Equal.
-                                      Exists is equivalent to wildcard for value, so that a pod can
-                                      tolerate all taints of a particular category.
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                     type: string
-                                  tolerationSeconds:
+                                  values:
                                     description: |-
-                                      TolerationSeconds represents the period of time the toleration (which must be
-                                      of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                                      it is not set, which means tolerate the taint forever (do not evict). Zero and
-                                      negative values will be treated as 0 (evict immediately) by the system.
-                                    format: int64
-                                    type: integer
-                                  value:
-                                    description: |-
-                                      Value is the taint value the toleration matches to.
-                                      If the operator is Exists, the value should be empty, otherwise just a regular string.
-                                    type: string
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
                                 type: object
                               type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
                           type: object
-                        resourceTimeout:
-                          description: |-
-                            resourceTimeout defines how long to wait for several Velero resources before timeout occurs,
-                            such as Velero CRD availability, volumeSnapshot deletion, and repo availability.
-                            Default is 10m
+                          x-kubernetes-map-type: atomic
+                        nullable: true
+                        type: array
+                      orderedResources:
+                        additionalProperties:
                           type: string
-                        restoreResourcesVersionPriority:
-                          description: |-
-                            restoreResourceVersionPriority represents a configmap that will be created if defined for use in conjunction with EnableAPIGroupVersions feature flag
-                            Defining this field automatically add EnableAPIGroupVersions to the velero server feature flag
+                        description: |-
+                          OrderedResources specifies the backup order of resources of specific Kind.
+                          The map key is the resource name and value is a list of object names separated by commas.
+                          Each resource name has format "namespace/objectname".  For cluster resources, simply use "objectname".
+                        nullable: true
+                        type: object
+                      resourcePolicy:
+                        description: ResourcePolicy specifies the referenced resource
+                          policies that backup should follow
+                        properties:
+                          apiGroup:
+                            description: |-
+                              APIGroup is the group for the resource being referenced.
+                              If APIGroup is not specified, the specified Kind must be in the core API group.
+                              For any other third-party types, APIGroup is required.
+                            type: string
+                          kind:
+                            description: Kind is the type of resource being referenced
+                            type: string
+                          name:
+                            description: Name is the name of resource being referenced
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      snapshotMoveData:
+                        description: SnapshotMoveData specifies whether snapshot data
+                          should be moved
+                        nullable: true
+                        type: boolean
+                      snapshotVolumes:
+                        description: |-
+                          SnapshotVolumes specifies whether to take snapshots
+                          of any PV's referenced in the set of objects included
+                          in the Backup.
+                        nullable: true
+                        type: boolean
+                      storageLocation:
+                        description: StorageLocation is a string containing the name
+                          of a BackupStorageLocation where the backup should be stored.
+                        type: string
+                      ttl:
+                        description: |-
+                          TTL is a time.Duration-parseable string describing how long
+                          the Backup should be retained for.
+                        type: string
+                      uploaderConfig:
+                        description: UploaderConfig specifies the configuration for
+                          the uploader.
+                        nullable: true
+                        properties:
+                          parallelFilesUpload:
+                            description: ParallelFilesUpload is the number of files
+                              parallel uploads to perform when using the uploader.
+                            type: integer
+                        type: object
+                      volumeGroupSnapshotLabelKey:
+                        description: VolumeGroupSnapshotLabelKey specifies the label
+                          key to group PVCs under a VGS.
+                        type: string
+                      volumeSnapshotLocations:
+                        description: VolumeSnapshotLocations is a list containing
+                          names of VolumeSnapshotLocations associated with this backup.
+                        items:
                           type: string
-                      type: object
-                  type: object
-                features:
-                  description: features defines the configuration for the DPA to enable the OADP tech preview features
-                  properties:
-                    dataMover:
-                      description: |-
-                        (do not use warning) dataMover is for backwards compatibility and
-                        will be removed in the future. Use Velero Built-in Data Mover instead
-                      properties:
-                        credentialName:
-                          description: User supplied Restic Secret name
+                        type: array
+                    type: object
+                  enforceRestoreSpec:
+                    description: which restore spec field values to enforce
+                    properties:
+                      backupName:
+                        description: |-
+                          BackupName is the unique name of the Velero backup to restore
+                          from.
+                        type: string
+                      excludedNamespaces:
+                        description: |-
+                          ExcludedNamespaces contains a list of namespaces that are not
+                          included in the restore.
+                        items:
                           type: string
-                        enable:
-                          description: enable flag is used to specify whether you want to deploy the volume snapshot mover controller
-                          type: boolean
-                        maxConcurrentBackupVolumes:
-                          description: the number of batched volumeSnapshotBackups that can be inProgress at once, default value is 10
+                        nullable: true
+                        type: array
+                      excludedResources:
+                        description: |-
+                          ExcludedResources is a slice of resource names that are not
+                          included in the restore.
+                        items:
                           type: string
-                        maxConcurrentRestoreVolumes:
-                          description: the number of batched volumeSnapshotRestores that can be inProgress at once, default value is 10
+                        nullable: true
+                        type: array
+                      existingResourcePolicy:
+                        description: ExistingResourcePolicy specifies the restore
+                          behavior for the Kubernetes resource to be restored
+                        nullable: true
+                        type: string
+                      hooks:
+                        description: Hooks represent custom behaviors that should
+                          be executed during or post restore.
+                        properties:
+                          resources:
+                            items:
+                              description: |-
+                                RestoreResourceHookSpec defines one or more RestoreResrouceHooks that should be executed based on
+                                the rules defined for namespaces, resources, and label selector.
+                              properties:
+                                excludedNamespaces:
+                                  description: ExcludedNamespaces specifies the namespaces
+                                    to which this hook spec does not apply.
+                                  items:
+                                    type: string
+                                  nullable: true
+                                  type: array
+                                excludedResources:
+                                  description: ExcludedResources specifies the resources
+                                    to which this hook spec does not apply.
+                                  items:
+                                    type: string
+                                  nullable: true
+                                  type: array
+                                includedNamespaces:
+                                  description: |-
+                                    IncludedNamespaces specifies the namespaces to which this hook spec applies. If empty, it applies
+                                    to all namespaces.
+                                  items:
+                                    type: string
+                                  nullable: true
+                                  type: array
+                                includedResources:
+                                  description: |-
+                                    IncludedResources specifies the resources to which this hook spec applies. If empty, it applies
+                                    to all resources.
+                                  items:
+                                    type: string
+                                  nullable: true
+                                  type: array
+                                labelSelector:
+                                  description: LabelSelector, if specified, filters
+                                    the resources to which this hook spec applies.
+                                  nullable: true
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                name:
+                                  description: Name is the name of this hook.
+                                  type: string
+                                postHooks:
+                                  description: PostHooks is a list of RestoreResourceHooks
+                                    to execute during and after restoring a resource.
+                                  items:
+                                    description: RestoreResourceHook defines a restore
+                                      hook for a resource.
+                                    properties:
+                                      exec:
+                                        description: Exec defines an exec restore
+                                          hook.
+                                        properties:
+                                          command:
+                                            description: Command is the command and
+                                              arguments to execute from within a container
+                                              after a pod has been restored.
+                                            items:
+                                              type: string
+                                            minItems: 1
+                                            type: array
+                                          container:
+                                            description: |-
+                                              Container is the container in the pod where the command should be executed. If not specified,
+                                              the pod's first container is used.
+                                            type: string
+                                          execTimeout:
+                                            description: |-
+                                              ExecTimeout defines the maximum amount of time Velero should wait for the hook to complete before
+                                              considering the execution a failure.
+                                            type: string
+                                          onError:
+                                            description: OnError specifies how Velero
+                                              should behave if it encounters an error
+                                              executing this hook.
+                                            enum:
+                                            - Continue
+                                            - Fail
+                                            type: string
+                                          waitForReady:
+                                            description: WaitForReady ensures command
+                                              will be launched when container is Ready
+                                              instead of Running.
+                                            nullable: true
+                                            type: boolean
+                                          waitTimeout:
+                                            description: |-
+                                              WaitTimeout defines the maximum amount of time Velero should wait for the container to be Ready
+                                              before attempting to run the command.
+                                            type: string
+                                        required:
+                                        - command
+                                        type: object
+                                      init:
+                                        description: Init defines an init restore
+                                          hook.
+                                        properties:
+                                          initContainers:
+                                            description: InitContainers is list of
+                                              init containers to be added to a pod
+                                              during its restore.
+                                            items:
+                                              type: object
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            type: array
+                                            x-kubernetes-preserve-unknown-fields: true
+                                          timeout:
+                                            description: Timeout defines the maximum
+                                              amount of time Velero should wait for
+                                              the initContainers to complete.
+                                            type: string
+                                        type: object
+                                    type: object
+                                  type: array
+                              required:
+                              - name
+                              type: object
+                            type: array
+                        type: object
+                      includeClusterResources:
+                        description: |-
+                          IncludeClusterResources specifies whether cluster-scoped resources
+                          should be included for consideration in the restore. If null, defaults
+                          to true.
+                        nullable: true
+                        type: boolean
+                      includedNamespaces:
+                        description: |-
+                          IncludedNamespaces is a slice of namespace names to include objects
+                          from. If empty, all namespaces are included.
+                        items:
                           type: string
-                        pruneInterval:
-                          description: defines how often (in days) to prune the datamover snapshots from the repository
+                        nullable: true
+                        type: array
+                      includedResources:
+                        description: |-
+                          IncludedResources is a slice of resource names to include
+                          in the restore. If empty, all resources in the backup are included.
+                        items:
                           type: string
-                        schedule:
-                          description: |-
-                            schedule is a cronspec (https://en.wikipedia.org/wiki/Cron#Overview) that
-                            can be used to schedule datamover(volsync) synchronization to occur at regular, time-based
-                            intervals. For example, in order to enforce datamover SnapshotRetainPolicy at a regular interval you need to
-                            specify this Schedule trigger as a cron expression, by default the trigger is a manual trigger. For more details
-                            on Volsync triggers, refer: https://volsync.readthedocs.io/en/stable/usage/triggers.html
-                          pattern: ^(\d+|\*)(/\d+)?(\s+(\d+|\*)(/\d+)?){4}$
-                          type: string
-                        snapshotRetainPolicy:
-                          description: defines the parameters that can be specified for retention of datamover snapshots
-                          properties:
-                            daily:
-                              description: Daily defines the number of snapshots to be kept daily
+                        nullable: true
+                        type: array
+                      itemOperationTimeout:
+                        description: |-
+                          ItemOperationTimeout specifies the time used to wait for RestoreItemAction operations
+                          The default value is 4 hour.
+                        type: string
+                      labelSelector:
+                        description: |-
+                          LabelSelector is a metav1.LabelSelector to filter with
+                          when restoring individual objects from the backup. If empty
+                          or nil, all objects are included. Optional.
+                        nullable: true
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
                               type: string
-                            hourly:
-                              description: Hourly defines the number of snapshots to be kept hourly
-                              type: string
-                            monthly:
-                              description: Monthly defines the number of snapshots to be kept monthly
-                              type: string
-                            weekly:
-                              description: Weekly defines the number of snapshots to be kept weekly
-                              type: string
-                            within:
-                              description: Within defines the number of snapshots to be kept Within the given time period
-                              type: string
-                            yearly:
-                              description: Yearly defines the number of snapshots to be kept yearly
-                              type: string
-                          type: object
-                        timeout:
-                          description: User supplied timeout to be used for VolumeSnapshotBackup and VolumeSnapshotRestore to complete, default value is 10m
-                          type: string
-                        volumeOptionsForStorageClasses:
-                          additionalProperties:
-                            properties:
-                              destinationVolumeOptions:
-                                description: VolumeOptions defines configurations for VolSync options
-                                properties:
-                                  accessMode:
-                                    description: |-
-                                      accessMode can be used to override the accessMode of the source or
-                                      destination PVC
-                                    type: string
-                                  cacheAccessMode:
-                                    description: cacheAccessMode is the access mode to be used to provision the cache volume
-                                    type: string
-                                  cacheCapacity:
-                                    description: cacheCapacity determines the size of the restic metadata cache volume
-                                    type: string
-                                  cacheStorageClassName:
-                                    description: |-
-                                      cacheStorageClassName is the storageClass that should be used when provisioning
-                                      the data mover cache volume
-                                    type: string
-                                  storageClassName:
-                                    description: |-
-                                      storageClassName can be used to override the StorageClass of the source
-                                      or destination PVC
-                                    type: string
-                                type: object
-                              sourceVolumeOptions:
-                                description: VolumeOptions defines configurations for VolSync options
-                                properties:
-                                  accessMode:
-                                    description: |-
-                                      accessMode can be used to override the accessMode of the source or
-                                      destination PVC
-                                    type: string
-                                  cacheAccessMode:
-                                    description: cacheAccessMode is the access mode to be used to provision the cache volume
-                                    type: string
-                                  cacheCapacity:
-                                    description: cacheCapacity determines the size of the restic metadata cache volume
-                                    type: string
-                                  cacheStorageClassName:
-                                    description: |-
-                                      cacheStorageClassName is the storageClass that should be used when provisioning
-                                      the data mover cache volume
-                                    type: string
-                                  storageClassName:
-                                    description: |-
-                                      storageClassName can be used to override the StorageClass of the source
-                                      or destination PVC
-                                    type: string
-                                type: object
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
                             type: object
-                          description: defines configurations for data mover volume options for a storageClass
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      namespaceMapping:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          NamespaceMapping is a map of source namespace names
+                          to target namespace names to restore into. Any source
+                          namespaces not included in the map will be restored into
+                          namespaces of the same name.
+                        type: object
+                      orLabelSelectors:
+                        description: |-
+                          OrLabelSelectors is list of metav1.LabelSelector to filter with
+                          when restoring individual objects from the backup. If multiple provided
+                          they will be joined by the OR operator. LabelSelector as well as
+                          OrLabelSelectors cannot co-exist in restore request, only one of them
+                          can be used
+                        items:
+                          description: |-
+                            A label selector is a label query over a set of resources. The result of matchLabels and
+                            matchExpressions are ANDed. An empty label selector matches all objects. A null
+                            label selector matches no objects.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
                           type: object
-                      type: object
-                  type: object
-                imagePullPolicy:
-                  description: |-
-                    which imagePullPolicy to use in all container images used by OADP.
-                    By default, for images with sha256 or sha512 digest, OADP uses IfNotPresent and uses Always for all other images.
-                  enum:
-                    - Always
-                    - IfNotPresent
-                    - Never
+                          x-kubernetes-map-type: atomic
+                        nullable: true
+                        type: array
+                      preserveNodePorts:
+                        description: PreserveNodePorts specifies whether to restore
+                          old nodePorts from backup.
+                        nullable: true
+                        type: boolean
+                      resourceModifier:
+                        description: ResourceModifier specifies the reference to JSON
+                          resource patches that should be applied to resources before
+                          restoration.
+                        nullable: true
+                        properties:
+                          apiGroup:
+                            description: |-
+                              APIGroup is the group for the resource being referenced.
+                              If APIGroup is not specified, the specified Kind must be in the core API group.
+                              For any other third-party types, APIGroup is required.
+                            type: string
+                          kind:
+                            description: Kind is the type of resource being referenced
+                            type: string
+                          name:
+                            description: Name is the name of resource being referenced
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      restorePVs:
+                        description: |-
+                          RestorePVs specifies whether to restore all included
+                          PVs from snapshot
+                        nullable: true
+                        type: boolean
+                      restoreStatus:
+                        description: |-
+                          RestoreStatus specifies which resources we should restore the status
+                          field. If nil, no objects are included. Optional.
+                        nullable: true
+                        properties:
+                          excludedResources:
+                            description: ExcludedResources specifies the resources
+                              to which will not restore the status.
+                            items:
+                              type: string
+                            nullable: true
+                            type: array
+                          includedResources:
+                            description: |-
+                              IncludedResources specifies the resources to which will restore the status.
+                              If empty, it applies to all resources.
+                            items:
+                              type: string
+                            nullable: true
+                            type: array
+                        type: object
+                      scheduleName:
+                        description: |-
+                          ScheduleName is the unique name of the Velero schedule to restore
+                          from. If specified, and BackupName is empty, Velero will restore
+                          from the most recent successful backup created from this schedule.
+                        type: string
+                      uploaderConfig:
+                        description: UploaderConfig specifies the configuration for
+                          the restore.
+                        nullable: true
+                        properties:
+                          parallelFilesDownload:
+                            description: ParallelFilesDownload is the concurrency
+                              number setting for restore.
+                            type: integer
+                          writeSparseFiles:
+                            description: WriteSparseFiles is a flag to indicate whether
+                              write files sparsely or not.
+                            nullable: true
+                            type: boolean
+                        type: object
+                    type: object
+                  garbageCollectionPeriod:
+                    description: |-
+                      GarbageCollectionPeriod defines how frequently to look for possible leftover non admin related objects in OADP namespace.
+                      A value of 0 disables garbage collection.
+                      By default 24h
+                    type: string
+                  requireApprovalForBSL:
+                    description: |-
+                      RequireApprovalForBSL specifies whether cluster administrator approval is required
+                      for creating Velero BackupStorageLocation (BSL) resources.
+                      - If set to false, all NonAdminBackupStorageLocationApproval CRDs will be automatically approved,
+                        including those that were previously pending or rejected.
+                      - If set to true, any existing BackupStorageLocation CRDs that lack the necessary approvals may be deleted,
+                        leaving the associated NonAdminBackup objects non-restorable until approval is granted.
+                      Defaults to false
+                    type: boolean
+                type: object
+              podAnnotations:
+                additionalProperties:
                   type: string
-                logFormat:
-                  default: text
-                  description: The format for log output. Valid values are text, json. (default text)
-                  enum:
-                    - text
-                    - json
-                  type: string
-                nonAdmin:
-                  description: nonAdmin defines the configuration for the DPA to enable backup and restore operations for non-admin users
-                  properties:
-                    backupSyncPeriod:
-                      description: |-
-                        BackupSyncPeriod specifies the interval at which backups from the OADP namespace are synchronized with non-admin namespaces.
-                        A value of 0 disables sync.
-                        By default 2m
+                description: |-
+                  add annotations to pods deployed by operator
+                  Deprecated: Use PodConfig instead
+                type: object
+              podDnsConfig:
+                description: |-
+                  podDnsConfig defines the DNS parameters of a pod in addition to
+                  those generated from DNSPolicy.
+                  https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config
+                properties:
+                  nameservers:
+                    description: |-
+                      A list of DNS name server IP addresses.
+                      This will be appended to the base nameservers generated from DNSPolicy.
+                      Duplicated nameservers will be removed.
+                    items:
                       type: string
-                    enable:
-                      description: Enables non admin feature, by default is disabled
-                      type: boolean
-                    enforceBSLSpec:
-                      description: which backupstoragelocation spec field values to enforce
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  options:
+                    description: |-
+                      A list of DNS resolver options.
+                      This will be merged with the base options generated from DNSPolicy.
+                      Duplicated entries will be removed. Resolution options given in Options
+                      will override those that appear in the base DNSPolicy.
+                    items:
+                      description: PodDNSConfigOption defines DNS resolver options
+                        of a pod.
                       properties:
-                        accessMode:
-                          description: AccessMode defines the permissions for the backup storage location.
-                          enum:
-                            - ReadOnly
-                            - ReadWrite
+                        name:
+                          description: |-
+                            Name is this DNS resolver option's name.
+                            Required.
                           type: string
-                        backupSyncPeriod:
-                          description: BackupSyncPeriod defines how frequently to sync backup API objects from object storage. A value of 0 disables sync.
-                          nullable: true
+                        value:
+                          description: Value is this DNS resolver option's value.
                           type: string
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  searches:
+                    description: |-
+                      A list of DNS search domains for host-name lookup.
+                      This will be appended to the base search paths generated from DNSPolicy.
+                      Duplicated search paths will be removed.
+                    items:
+                      type: string
+                    type: array
+                    x-kubernetes-list-type: atomic
+                type: object
+              podDnsPolicy:
+                description: |-
+                  podDnsPolicy defines how a pod's DNS will be configured.
+                  https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
+                type: string
+              resourceAnnotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  resourceAnnotations defines annotations that will be applied to all resources managed by the DPA.
+                  Useful for GitOps tools like ArgoCD (e.g., argocd.argoproj.io/ignore-resource-updates: 'true').
+                type: object
+              resourceLabels:
+                additionalProperties:
+                  type: string
+                description: |-
+                  resourceLabels defines labels that will be applied to all resources managed by the DPA.
+                  These labels are merged with OADP-required labels. User-provided labels cannot override
+                  core operator labels (app.kubernetes.io/*, openshift.io/oadp).
+                type: object
+              snapshotLocations:
+                description: snapshotLocations defines the list of desired configuration
+                  to use for VolumeSnapshotLocations
+                items:
+                  description: SnapshotLocation defines the configuration for the
+                    DPA snapshot store
+                  properties:
+                    name:
+                      type: string
+                    velero:
+                      description: VolumeSnapshotLocationSpec defines the specification
+                        for a Velero VolumeSnapshotLocation.
+                      properties:
                         config:
                           additionalProperties:
                             type: string
-                          description: Config is for provider-specific configuration fields.
+                          description: Config is for provider-specific configuration
+                            fields.
                           type: object
                         credential:
-                          description: Credential contains the credential information intended to be used with this location
+                          description: Credential contains the credential information
+                            intended to be used with this location
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must be a valid secret key.
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
                               type: string
                             name:
                               default: ""
@@ -1785,1173 +3072,183 @@ spec:
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must be defined
+                              description: Specify whether the Secret or its key must
+                                be defined
                               type: boolean
                           required:
-                            - key
+                          - key
                           type: object
                           x-kubernetes-map-type: atomic
-                        objectStorage:
-                          description: ObjectStorageLocation defines the enforced values for the Velero ObjectStorageLocation
-                          nullable: true
-                          properties:
-                            bucket:
-                              description: Bucket is the bucket to use for object storage.
-                              type: string
-                            caCert:
-                              description: CACert defines a CA bundle to use when verifying TLS connections to the provider.
-                              format: byte
-                              type: string
-                            prefix:
-                              description: Prefix is the path inside a bucket to use for Velero storage. Optional.
-                              type: string
-                          type: object
                         provider:
-                          description: Provider is the provider of the backup storage.
+                          description: Provider is the provider of the volume storage.
                           type: string
-                        validationFrequency:
-                          description: ValidationFrequency defines how frequently to validate the corresponding object storage. A value of 0 disables validation.
-                          nullable: true
-                          type: string
+                      required:
+                      - provider
                       type: object
-                    enforceBackupSpec:
-                      description: which bakup spec field values to enforce
-                      properties:
-                        csiSnapshotTimeout:
-                          description: |-
-                            CSISnapshotTimeout specifies the time used to wait for CSI VolumeSnapshot status turns to
-                            ReadyToUse during creation, before returning error as timeout.
-                            The default value is 10 minute.
-                          type: string
-                        datamover:
-                          description: |-
-                            DataMover specifies the data mover to be used by the backup.
-                            If DataMover is "" or "velero", the built-in data mover will be used.
-                          type: string
-                        defaultVolumesToFsBackup:
-                          description: |-
-                            DefaultVolumesToFsBackup specifies whether pod volume file system backup should be used
-                            for all volumes by default.
-                          nullable: true
-                          type: boolean
-                        defaultVolumesToRestic:
-                          description: |-
-                            DefaultVolumesToRestic specifies whether restic should be used to take a
-                            backup of all pod volumes by default.
-
-                            Deprecated: this field is no longer used and will be removed entirely in future. Use DefaultVolumesToFsBackup instead.
-                          nullable: true
-                          type: boolean
-                        excludedClusterScopedResources:
-                          description: |-
-                            ExcludedClusterScopedResources is a slice of cluster-scoped
-                            resource type names to exclude from the backup.
-                            If set to "*", all cluster-scoped resource types are excluded.
-                            The default value is empty.
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        excludedNamespaceScopedResources:
-                          description: |-
-                            ExcludedNamespaceScopedResources is a slice of namespace-scoped
-                            resource type names to exclude from the backup.
-                            If set to "*", all namespace-scoped resource types are excluded.
-                            The default value is empty.
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        excludedNamespaces:
-                          description: |-
-                            ExcludedNamespaces contains a list of namespaces that are not
-                            included in the backup.
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        excludedResources:
-                          description: |-
-                            ExcludedResources is a slice of resource names that are not
-                            included in the backup.
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        hooks:
-                          description: Hooks represent custom behaviors that should be executed at different phases of the backup.
-                          properties:
-                            resources:
-                              description: Resources are hooks that should be executed when backing up individual instances of a resource.
-                              items:
-                                description: |-
-                                  BackupResourceHookSpec defines one or more BackupResourceHooks that should be executed based on
-                                  the rules defined for namespaces, resources, and label selector.
-                                properties:
-                                  excludedNamespaces:
-                                    description: ExcludedNamespaces specifies the namespaces to which this hook spec does not apply.
-                                    items:
-                                      type: string
-                                    nullable: true
-                                    type: array
-                                  excludedResources:
-                                    description: ExcludedResources specifies the resources to which this hook spec does not apply.
-                                    items:
-                                      type: string
-                                    nullable: true
-                                    type: array
-                                  includedNamespaces:
-                                    description: |-
-                                      IncludedNamespaces specifies the namespaces to which this hook spec applies. If empty, it applies
-                                      to all namespaces.
-                                    items:
-                                      type: string
-                                    nullable: true
-                                    type: array
-                                  includedResources:
-                                    description: |-
-                                      IncludedResources specifies the resources to which this hook spec applies. If empty, it applies
-                                      to all resources.
-                                    items:
-                                      type: string
-                                    nullable: true
-                                    type: array
-                                  labelSelector:
-                                    description: LabelSelector, if specified, filters the resources to which this hook spec applies.
-                                    nullable: true
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                        items:
-                                          description: |-
-                                            A label selector requirement is a selector that contains values, a key, and an operator that
-                                            relates the key and values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: |-
-                                                operator represents a key's relationship to a set of values.
-                                                Valid operators are In, NotIn, Exists and DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: |-
-                                                values is an array of string values. If the operator is In or NotIn,
-                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                              x-kubernetes-list-type: atomic
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                        x-kubernetes-list-type: atomic
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: |-
-                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                    x-kubernetes-map-type: atomic
-                                  name:
-                                    description: Name is the name of this hook.
-                                    type: string
-                                  post:
-                                    description: |-
-                                      PostHooks is a list of BackupResourceHooks to execute after storing the item in the backup.
-                                      These are executed after all "additional items" from item actions are processed.
-                                    items:
-                                      description: BackupResourceHook defines a hook for a resource.
-                                      properties:
-                                        exec:
-                                          description: Exec defines an exec hook.
-                                          properties:
-                                            command:
-                                              description: Command is the command and arguments to execute.
-                                              items:
-                                                type: string
-                                              minItems: 1
-                                              type: array
-                                            container:
-                                              description: |-
-                                                Container is the container in the pod where the command should be executed. If not specified,
-                                                the pod's first container is used.
-                                              type: string
-                                            onError:
-                                              description: OnError specifies how Velero should behave if it encounters an error executing this hook.
-                                              enum:
-                                                - Continue
-                                                - Fail
-                                              type: string
-                                            timeout:
-                                              description: |-
-                                                Timeout defines the maximum amount of time Velero should wait for the hook to complete before
-                                                considering the execution a failure.
-                                              type: string
-                                          required:
-                                            - command
-                                          type: object
-                                      required:
-                                        - exec
-                                      type: object
-                                    type: array
-                                  pre:
-                                    description: |-
-                                      PreHooks is a list of BackupResourceHooks to execute prior to storing the item in the backup.
-                                      These are executed before any "additional items" from item actions are processed.
-                                    items:
-                                      description: BackupResourceHook defines a hook for a resource.
-                                      properties:
-                                        exec:
-                                          description: Exec defines an exec hook.
-                                          properties:
-                                            command:
-                                              description: Command is the command and arguments to execute.
-                                              items:
-                                                type: string
-                                              minItems: 1
-                                              type: array
-                                            container:
-                                              description: |-
-                                                Container is the container in the pod where the command should be executed. If not specified,
-                                                the pod's first container is used.
-                                              type: string
-                                            onError:
-                                              description: OnError specifies how Velero should behave if it encounters an error executing this hook.
-                                              enum:
-                                                - Continue
-                                                - Fail
-                                              type: string
-                                            timeout:
-                                              description: |-
-                                                Timeout defines the maximum amount of time Velero should wait for the hook to complete before
-                                                considering the execution a failure.
-                                              type: string
-                                          required:
-                                            - command
-                                          type: object
-                                      required:
-                                        - exec
-                                      type: object
-                                    type: array
-                                required:
-                                  - name
-                                type: object
-                              nullable: true
-                              type: array
-                          type: object
-                        includeClusterResources:
-                          description: |-
-                            IncludeClusterResources specifies whether cluster-scoped resources
-                            should be included for consideration in the backup.
-                          nullable: true
-                          type: boolean
-                        includedClusterScopedResources:
-                          description: |-
-                            IncludedClusterScopedResources is a slice of cluster-scoped
-                            resource type names to include in the backup.
-                            If set to "*", all cluster-scoped resource types are included.
-                            The default value is empty, which means only related
-                            cluster-scoped resources are included.
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        includedNamespaceScopedResources:
-                          description: |-
-                            IncludedNamespaceScopedResources is a slice of namespace-scoped
-                            resource type names to include in the backup.
-                            The default value is "*".
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        includedNamespaces:
-                          description: |-
-                            IncludedNamespaces is a slice of namespace names to include objects
-                            from. If empty, all namespaces are included.
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        includedResources:
-                          description: |-
-                            IncludedResources is a slice of resource names to include
-                            in the backup. If empty, all resources are included.
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        itemOperationTimeout:
-                          description: |-
-                            ItemOperationTimeout specifies the time used to wait for asynchronous BackupItemAction operations
-                            The default value is 4 hour.
-                          type: string
-                        labelSelector:
-                          description: |-
-                            LabelSelector is a metav1.LabelSelector to filter with
-                            when adding individual objects to the backup. If empty
-                            or nil, all objects are included. Optional.
-                          nullable: true
-                          properties:
-                            matchExpressions:
-                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                              items:
-                                description: |-
-                                  A label selector requirement is a selector that contains values, a key, and an operator that
-                                  relates the key and values.
-                                properties:
-                                  key:
-                                    description: key is the label key that the selector applies to.
-                                    type: string
-                                  operator:
-                                    description: |-
-                                      operator represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists and DoesNotExist.
-                                    type: string
-                                  values:
-                                    description: |-
-                                      values is an array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. This array is replaced during a strategic
-                                      merge patch.
-                                    items:
-                                      type: string
-                                    type: array
-                                    x-kubernetes-list-type: atomic
-                                required:
-                                  - key
-                                  - operator
-                                type: object
-                              type: array
-                              x-kubernetes-list-type: atomic
-                            matchLabels:
-                              additionalProperties:
-                                type: string
-                              description: |-
-                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                operator is "In", and the values array contains only "value". The requirements are ANDed.
-                              type: object
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        metadata:
-                          properties:
-                            labels:
-                              additionalProperties:
-                                type: string
-                              type: object
-                          type: object
-                        orLabelSelectors:
-                          description: |-
-                            OrLabelSelectors is list of metav1.LabelSelector to filter with
-                            when adding individual objects to the backup. If multiple provided
-                            they will be joined by the OR operator. LabelSelector as well as
-                            OrLabelSelectors cannot co-exist in backup request, only one of them
-                            can be used.
-                          items:
-                            description: |-
-                              A label selector is a label query over a set of resources. The result of matchLabels and
-                              matchExpressions are ANDed. An empty label selector matches all objects. A null
-                              label selector matches no objects.
-                            properties:
-                              matchExpressions:
-                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                items:
-                                  description: |-
-                                    A label selector requirement is a selector that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  properties:
-                                    key:
-                                      description: key is the label key that the selector applies to.
-                                      type: string
-                                    operator:
-                                      description: |-
-                                        operator represents a key's relationship to a set of values.
-                                        Valid operators are In, NotIn, Exists and DoesNotExist.
-                                      type: string
-                                    values:
-                                      description: |-
-                                        values is an array of string values. If the operator is In or NotIn,
-                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                        the values array must be empty. This array is replaced during a strategic
-                                        merge patch.
-                                      items:
-                                        type: string
-                                      type: array
-                                      x-kubernetes-list-type: atomic
-                                  required:
-                                    - key
-                                    - operator
-                                  type: object
-                                type: array
-                                x-kubernetes-list-type: atomic
-                              matchLabels:
-                                additionalProperties:
-                                  type: string
-                                description: |-
-                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                type: object
-                            type: object
-                            x-kubernetes-map-type: atomic
-                          nullable: true
-                          type: array
-                        orderedResources:
-                          additionalProperties:
-                            type: string
-                          description: |-
-                            OrderedResources specifies the backup order of resources of specific Kind.
-                            The map key is the resource name and value is a list of object names separated by commas.
-                            Each resource name has format "namespace/objectname".  For cluster resources, simply use "objectname".
-                          nullable: true
-                          type: object
-                        resourcePolicy:
-                          description: ResourcePolicy specifies the referenced resource policies that backup should follow
-                          properties:
-                            apiGroup:
-                              description: |-
-                                APIGroup is the group for the resource being referenced.
-                                If APIGroup is not specified, the specified Kind must be in the core API group.
-                                For any other third-party types, APIGroup is required.
-                              type: string
-                            kind:
-                              description: Kind is the type of resource being referenced
-                              type: string
-                            name:
-                              description: Name is the name of resource being referenced
-                              type: string
-                          required:
-                            - kind
-                            - name
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        snapshotMoveData:
-                          description: SnapshotMoveData specifies whether snapshot data should be moved
-                          nullable: true
-                          type: boolean
-                        snapshotVolumes:
-                          description: |-
-                            SnapshotVolumes specifies whether to take snapshots
-                            of any PV's referenced in the set of objects included
-                            in the Backup.
-                          nullable: true
-                          type: boolean
-                        storageLocation:
-                          description: StorageLocation is a string containing the name of a BackupStorageLocation where the backup should be stored.
-                          type: string
-                        ttl:
-                          description: |-
-                            TTL is a time.Duration-parseable string describing how long
-                            the Backup should be retained for.
-                          type: string
-                        uploaderConfig:
-                          description: UploaderConfig specifies the configuration for the uploader.
-                          nullable: true
-                          properties:
-                            parallelFilesUpload:
-                              description: ParallelFilesUpload is the number of files parallel uploads to perform when using the uploader.
-                              type: integer
-                          type: object
-                        volumeGroupSnapshotLabelKey:
-                          description: VolumeGroupSnapshotLabelKey specifies the label key to group PVCs under a VGS.
-                          type: string
-                        volumeSnapshotLocations:
-                          description: VolumeSnapshotLocations is a list containing names of VolumeSnapshotLocations associated with this backup.
-                          items:
-                            type: string
-                          type: array
-                      type: object
-                    enforceRestoreSpec:
-                      description: which restore spec field values to enforce
-                      properties:
-                        backupName:
-                          description: |-
-                            BackupName is the unique name of the Velero backup to restore
-                            from.
-                          type: string
-                        excludedNamespaces:
-                          description: |-
-                            ExcludedNamespaces contains a list of namespaces that are not
-                            included in the restore.
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        excludedResources:
-                          description: |-
-                            ExcludedResources is a slice of resource names that are not
-                            included in the restore.
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        existingResourcePolicy:
-                          description: ExistingResourcePolicy specifies the restore behavior for the Kubernetes resource to be restored
-                          nullable: true
-                          type: string
-                        hooks:
-                          description: Hooks represent custom behaviors that should be executed during or post restore.
-                          properties:
-                            resources:
-                              items:
-                                description: |-
-                                  RestoreResourceHookSpec defines one or more RestoreResrouceHooks that should be executed based on
-                                  the rules defined for namespaces, resources, and label selector.
-                                properties:
-                                  excludedNamespaces:
-                                    description: ExcludedNamespaces specifies the namespaces to which this hook spec does not apply.
-                                    items:
-                                      type: string
-                                    nullable: true
-                                    type: array
-                                  excludedResources:
-                                    description: ExcludedResources specifies the resources to which this hook spec does not apply.
-                                    items:
-                                      type: string
-                                    nullable: true
-                                    type: array
-                                  includedNamespaces:
-                                    description: |-
-                                      IncludedNamespaces specifies the namespaces to which this hook spec applies. If empty, it applies
-                                      to all namespaces.
-                                    items:
-                                      type: string
-                                    nullable: true
-                                    type: array
-                                  includedResources:
-                                    description: |-
-                                      IncludedResources specifies the resources to which this hook spec applies. If empty, it applies
-                                      to all resources.
-                                    items:
-                                      type: string
-                                    nullable: true
-                                    type: array
-                                  labelSelector:
-                                    description: LabelSelector, if specified, filters the resources to which this hook spec applies.
-                                    nullable: true
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                        items:
-                                          description: |-
-                                            A label selector requirement is a selector that contains values, a key, and an operator that
-                                            relates the key and values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: |-
-                                                operator represents a key's relationship to a set of values.
-                                                Valid operators are In, NotIn, Exists and DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: |-
-                                                values is an array of string values. If the operator is In or NotIn,
-                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                              x-kubernetes-list-type: atomic
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                        x-kubernetes-list-type: atomic
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: |-
-                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                    x-kubernetes-map-type: atomic
-                                  name:
-                                    description: Name is the name of this hook.
-                                    type: string
-                                  postHooks:
-                                    description: PostHooks is a list of RestoreResourceHooks to execute during and after restoring a resource.
-                                    items:
-                                      description: RestoreResourceHook defines a restore hook for a resource.
-                                      properties:
-                                        exec:
-                                          description: Exec defines an exec restore hook.
-                                          properties:
-                                            command:
-                                              description: Command is the command and arguments to execute from within a container after a pod has been restored.
-                                              items:
-                                                type: string
-                                              minItems: 1
-                                              type: array
-                                            container:
-                                              description: |-
-                                                Container is the container in the pod where the command should be executed. If not specified,
-                                                the pod's first container is used.
-                                              type: string
-                                            execTimeout:
-                                              description: |-
-                                                ExecTimeout defines the maximum amount of time Velero should wait for the hook to complete before
-                                                considering the execution a failure.
-                                              type: string
-                                            onError:
-                                              description: OnError specifies how Velero should behave if it encounters an error executing this hook.
-                                              enum:
-                                                - Continue
-                                                - Fail
-                                              type: string
-                                            waitForReady:
-                                              description: WaitForReady ensures command will be launched when container is Ready instead of Running.
-                                              nullable: true
-                                              type: boolean
-                                            waitTimeout:
-                                              description: |-
-                                                WaitTimeout defines the maximum amount of time Velero should wait for the container to be Ready
-                                                before attempting to run the command.
-                                              type: string
-                                          required:
-                                            - command
-                                          type: object
-                                        init:
-                                          description: Init defines an init restore hook.
-                                          properties:
-                                            initContainers:
-                                              description: InitContainers is list of init containers to be added to a pod during its restore.
-                                              items:
-                                                type: object
-                                                x-kubernetes-preserve-unknown-fields: true
-                                              type: array
-                                              x-kubernetes-preserve-unknown-fields: true
-                                            timeout:
-                                              description: Timeout defines the maximum amount of time Velero should wait for the initContainers to complete.
-                                              type: string
-                                          type: object
-                                      type: object
-                                    type: array
-                                required:
-                                  - name
-                                type: object
-                              type: array
-                          type: object
-                        includeClusterResources:
-                          description: |-
-                            IncludeClusterResources specifies whether cluster-scoped resources
-                            should be included for consideration in the restore. If null, defaults
-                            to true.
-                          nullable: true
-                          type: boolean
-                        includedNamespaces:
-                          description: |-
-                            IncludedNamespaces is a slice of namespace names to include objects
-                            from. If empty, all namespaces are included.
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        includedResources:
-                          description: |-
-                            IncludedResources is a slice of resource names to include
-                            in the restore. If empty, all resources in the backup are included.
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        itemOperationTimeout:
-                          description: |-
-                            ItemOperationTimeout specifies the time used to wait for RestoreItemAction operations
-                            The default value is 4 hour.
-                          type: string
-                        labelSelector:
-                          description: |-
-                            LabelSelector is a metav1.LabelSelector to filter with
-                            when restoring individual objects from the backup. If empty
-                            or nil, all objects are included. Optional.
-                          nullable: true
-                          properties:
-                            matchExpressions:
-                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                              items:
-                                description: |-
-                                  A label selector requirement is a selector that contains values, a key, and an operator that
-                                  relates the key and values.
-                                properties:
-                                  key:
-                                    description: key is the label key that the selector applies to.
-                                    type: string
-                                  operator:
-                                    description: |-
-                                      operator represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists and DoesNotExist.
-                                    type: string
-                                  values:
-                                    description: |-
-                                      values is an array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. This array is replaced during a strategic
-                                      merge patch.
-                                    items:
-                                      type: string
-                                    type: array
-                                    x-kubernetes-list-type: atomic
-                                required:
-                                  - key
-                                  - operator
-                                type: object
-                              type: array
-                              x-kubernetes-list-type: atomic
-                            matchLabels:
-                              additionalProperties:
-                                type: string
-                              description: |-
-                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                operator is "In", and the values array contains only "value". The requirements are ANDed.
-                              type: object
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        namespaceMapping:
-                          additionalProperties:
-                            type: string
-                          description: |-
-                            NamespaceMapping is a map of source namespace names
-                            to target namespace names to restore into. Any source
-                            namespaces not included in the map will be restored into
-                            namespaces of the same name.
-                          type: object
-                        orLabelSelectors:
-                          description: |-
-                            OrLabelSelectors is list of metav1.LabelSelector to filter with
-                            when restoring individual objects from the backup. If multiple provided
-                            they will be joined by the OR operator. LabelSelector as well as
-                            OrLabelSelectors cannot co-exist in restore request, only one of them
-                            can be used
-                          items:
-                            description: |-
-                              A label selector is a label query over a set of resources. The result of matchLabels and
-                              matchExpressions are ANDed. An empty label selector matches all objects. A null
-                              label selector matches no objects.
-                            properties:
-                              matchExpressions:
-                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                items:
-                                  description: |-
-                                    A label selector requirement is a selector that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  properties:
-                                    key:
-                                      description: key is the label key that the selector applies to.
-                                      type: string
-                                    operator:
-                                      description: |-
-                                        operator represents a key's relationship to a set of values.
-                                        Valid operators are In, NotIn, Exists and DoesNotExist.
-                                      type: string
-                                    values:
-                                      description: |-
-                                        values is an array of string values. If the operator is In or NotIn,
-                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                        the values array must be empty. This array is replaced during a strategic
-                                        merge patch.
-                                      items:
-                                        type: string
-                                      type: array
-                                      x-kubernetes-list-type: atomic
-                                  required:
-                                    - key
-                                    - operator
-                                  type: object
-                                type: array
-                                x-kubernetes-list-type: atomic
-                              matchLabels:
-                                additionalProperties:
-                                  type: string
-                                description: |-
-                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                type: object
-                            type: object
-                            x-kubernetes-map-type: atomic
-                          nullable: true
-                          type: array
-                        preserveNodePorts:
-                          description: PreserveNodePorts specifies whether to restore old nodePorts from backup.
-                          nullable: true
-                          type: boolean
-                        resourceModifier:
-                          description: ResourceModifier specifies the reference to JSON resource patches that should be applied to resources before restoration.
-                          nullable: true
-                          properties:
-                            apiGroup:
-                              description: |-
-                                APIGroup is the group for the resource being referenced.
-                                If APIGroup is not specified, the specified Kind must be in the core API group.
-                                For any other third-party types, APIGroup is required.
-                              type: string
-                            kind:
-                              description: Kind is the type of resource being referenced
-                              type: string
-                            name:
-                              description: Name is the name of resource being referenced
-                              type: string
-                          required:
-                            - kind
-                            - name
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        restorePVs:
-                          description: |-
-                            RestorePVs specifies whether to restore all included
-                            PVs from snapshot
-                          nullable: true
-                          type: boolean
-                        restoreStatus:
-                          description: |-
-                            RestoreStatus specifies which resources we should restore the status
-                            field. If nil, no objects are included. Optional.
-                          nullable: true
-                          properties:
-                            excludedResources:
-                              description: ExcludedResources specifies the resources to which will not restore the status.
-                              items:
-                                type: string
-                              nullable: true
-                              type: array
-                            includedResources:
-                              description: |-
-                                IncludedResources specifies the resources to which will restore the status.
-                                If empty, it applies to all resources.
-                              items:
-                                type: string
-                              nullable: true
-                              type: array
-                          type: object
-                        scheduleName:
-                          description: |-
-                            ScheduleName is the unique name of the Velero schedule to restore
-                            from. If specified, and BackupName is empty, Velero will restore
-                            from the most recent successful backup created from this schedule.
-                          type: string
-                        uploaderConfig:
-                          description: UploaderConfig specifies the configuration for the restore.
-                          nullable: true
-                          properties:
-                            parallelFilesDownload:
-                              description: ParallelFilesDownload is the concurrency number setting for restore.
-                              type: integer
-                            writeSparseFiles:
-                              description: WriteSparseFiles is a flag to indicate whether write files sparsely or not.
-                              nullable: true
-                              type: boolean
-                          type: object
-                      type: object
-                    garbageCollectionPeriod:
-                      description: |-
-                        GarbageCollectionPeriod defines how frequently to look for possible leftover non admin related objects in OADP namespace.
-                        A value of 0 disables garbage collection.
-                        By default 24h
-                      type: string
-                    requireApprovalForBSL:
-                      description: |-
-                        RequireApprovalForBSL specifies whether cluster administrator approval is required
-                        for creating Velero BackupStorageLocation (BSL) resources.
-                        - If set to false, all NonAdminBackupStorageLocationApproval CRDs will be automatically approved,
-                          including those that were previously pending or rejected.
-                        - If set to true, any existing BackupStorageLocation CRDs that lack the necessary approvals may be deleted,
-                          leaving the associated NonAdminBackup objects non-restorable until approval is granted.
-                        Defaults to false
-                      type: boolean
+                  required:
+                  - velero
                   type: object
-                podAnnotations:
-                  additionalProperties:
-                    type: string
-                  description: |-
-                    add annotations to pods deployed by operator
-                    Deprecated: Use PodConfig instead
-                  type: object
-                podDnsConfig:
-                  description: |-
-                    podDnsConfig defines the DNS parameters of a pod in addition to
-                    those generated from DNSPolicy.
-                    https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config
-                  properties:
-                    nameservers:
-                      description: |-
-                        A list of DNS name server IP addresses.
-                        This will be appended to the base nameservers generated from DNSPolicy.
-                        Duplicated nameservers will be removed.
-                      items:
-                        type: string
-                      type: array
-                      x-kubernetes-list-type: atomic
-                    options:
-                      description: |-
-                        A list of DNS resolver options.
-                        This will be merged with the base options generated from DNSPolicy.
-                        Duplicated entries will be removed. Resolution options given in Options
-                        will override those that appear in the base DNSPolicy.
-                      items:
-                        description: PodDNSConfigOption defines DNS resolver options of a pod.
-                        properties:
-                          name:
-                            description: |-
-                              Name is this DNS resolver option's name.
-                              Required.
-                            type: string
-                          value:
-                            description: Value is this DNS resolver option's value.
-                            type: string
-                        type: object
-                      type: array
-                      x-kubernetes-list-type: atomic
-                    searches:
-                      description: |-
-                        A list of DNS search domains for host-name lookup.
-                        This will be appended to the base search paths generated from DNSPolicy.
-                        Duplicated search paths will be removed.
-                      items:
-                        type: string
-                      type: array
-                      x-kubernetes-list-type: atomic
-                  type: object
-                podDnsPolicy:
-                  description: |-
-                    podDnsPolicy defines how a pod's DNS will be configured.
-                    https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
+                type: array
+              unsupportedOverrides:
+                additionalProperties:
                   type: string
-                resourceAnnotations:
-                  additionalProperties:
-                    type: string
-                  description: |-
-                    resourceAnnotations defines annotations that will be applied to all resources managed by the DPA.
-                    Useful for GitOps tools like ArgoCD (e.g., argocd.argoproj.io/ignore-resource-updates: 'true').
-                  type: object
-                resourceLabels:
-                  additionalProperties:
-                    type: string
-                  description: |-
-                    resourceLabels defines labels that will be applied to all resources managed by the DPA.
-                    These labels are merged with OADP-required labels. User-provided labels cannot override
-                    core operator labels (app.kubernetes.io/*, openshift.io/oadp).
-                  type: object
-                snapshotLocations:
-                  description: snapshotLocations defines the list of desired configuration to use for VolumeSnapshotLocations
-                  items:
-                    description: SnapshotLocation defines the configuration for the DPA snapshot store
+                description: |-
+                  unsupportedOverrides can be used to override images used in deployments.
+                  Available keys are:
+                    - veleroImageFqin
+                    - awsPluginImageFqin
+                    - legacyAWSPluginImageFqin
+                    - openshiftPluginImageFqin
+                    - azurePluginImageFqin
+                    - gcpPluginImageFqin
+                    - kubevirtPluginImageFqin
+                    - kubevirtDatamoverPluginImageFqin
+                    - kubevirtDatamoverControllerImageFqin
+                    - hypershiftPluginImageFqin
+                    - nonAdminControllerImageFqin
+                    - vmFileRestoreControllerImageFqin
+                    - vmFileRestoreAccessImageFqin
+                    - vmFileRestoreSSHImageFqin
+                    - vmFileRestoreBrowserImageFqin
+                    - operator-type
+                    - tech-preview-ack
+                type: object
+              vmFileRestore:
+                description: vmFileRestore defines the configuration for the DPA to
+                  enable VM file restore feature
+                properties:
+                  enable:
+                    description: |-
+                      Enable flag to deploy VM file restore controller
+                      By default is disabled
+                    type: boolean
+                  resources:
+                    description: Resource requirements for the VM file restore controller
                     properties:
-                      name:
-                        type: string
-                      velero:
-                        description: VolumeSnapshotLocationSpec defines the specification for a Velero VolumeSnapshotLocation.
-                        properties:
-                          config:
-                            additionalProperties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This is an alpha field and requires enabling the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
                               type: string
-                            description: Config is for provider-specific configuration fields.
-                            type: object
-                          credential:
-                            description: Credential contains the credential information intended to be used with this location
-                            properties:
-                              key:
-                                description: The key of the secret to select from.  Must be a valid secret key.
-                                type: string
-                              name:
-                                default: ""
-                                description: |-
-                                  Name of the referent.
-                                  This field is effectively required, but due to backwards compatibility is
-                                  allowed to be empty. Instances of this type with an empty value here are
-                                  almost certainly wrong.
-                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                type: string
-                              optional:
-                                description: Specify whether the Secret or its key must be defined
-                                type: boolean
-                            required:
-                              - key
-                            type: object
-                            x-kubernetes-map-type: atomic
-                          provider:
-                            description: Provider is the provider of the volume storage.
-                            type: string
-                        required:
-                          - provider
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
-                    required:
-                      - velero
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
                     type: object
-                  type: array
-                unsupportedOverrides:
-                  additionalProperties:
-                    type: string
-                  description: |-
-                    unsupportedOverrides can be used to override images used in deployments.
-                    Available keys are:
-                      - veleroImageFqin
-                      - awsPluginImageFqin
-                      - legacyAWSPluginImageFqin
-                      - openshiftPluginImageFqin
-                      - azurePluginImageFqin
-                      - gcpPluginImageFqin
-                      - kubevirtPluginImageFqin
-                      - kubevirtDatamoverPluginImageFqin
-                      - kubevirtDatamoverControllerImageFqin
-                      - hypershiftPluginImageFqin
-                      - nonAdminControllerImageFqin
-                      - vmFileRestoreControllerImageFqin
-                      - vmFileRestoreAccessImageFqin
-                      - vmFileRestoreSSHImageFqin
-                      - vmFileRestoreBrowserImageFqin
-                      - operator-type
-                      - tech-preview-ack
-                  type: object
-                vmFileRestore:
-                  description: vmFileRestore defines the configuration for the DPA to enable VM file restore feature
+                type: object
+            required:
+            - configuration
+            type: object
+          status:
+            description: DataProtectionApplicationStatus defines the observed state
+              of DataProtectionApplication
+            properties:
+              conditions:
+                description: Conditions defines the observed state of DataProtectionApplication
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
-                    enable:
+                    lastTransitionTime:
                       description: |-
-                        Enable flag to deploy VM file restore controller
-                        By default is disabled
-                      type: boolean
-                    resources:
-                      description: Resource requirements for the VM file restore controller
-                      properties:
-                        claims:
-                          description: |-
-                            Claims lists the names of resources, defined in spec.resourceClaims,
-                            that are used by this container.
-
-                            This is an alpha field and requires enabling the
-                            DynamicResourceAllocation feature gate.
-
-                            This field is immutable. It can only be set for containers.
-                          items:
-                            description: ResourceClaim references one entry in PodSpec.ResourceClaims.
-                            properties:
-                              name:
-                                description: |-
-                                  Name must match the name of one entry in pod.spec.resourceClaims of
-                                  the Pod where this field is used. It makes that resource available
-                                  inside a container.
-                                type: string
-                              request:
-                                description: |-
-                                  Request is the name chosen for a request in the referenced claim.
-                                  If empty, everything from the claim is made available, otherwise
-                                  only the result of this request.
-                                type: string
-                            required:
-                              - name
-                            type: object
-                          type: array
-                          x-kubernetes-list-map-keys:
-                            - name
-                          x-kubernetes-list-type: map
-                        limits:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: |-
-                            Limits describes the maximum amount of compute resources allowed.
-                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                          type: object
-                        requests:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: |-
-                            Requests describes the minimum amount of compute resources required.
-                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                            otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                          type: object
-                      type: object
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
                   type: object
-              required:
-                - configuration
-              type: object
-            status:
-              description: DataProtectionApplicationStatus defines the observed state of DataProtectionApplication
-              properties:
-                conditions:
-                  description: Conditions defines the observed state of DataProtectionApplication
-                  items:
-                    description: Condition contains details for one aspect of the current state of this API Resource.
-                    properties:
-                      lastTransitionTime:
-                        description: |-
-                          lastTransitionTime is the last time the condition transitioned from one status to another.
-                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                        format: date-time
-                        type: string
-                      message:
-                        description: |-
-                          message is a human readable message indicating details about the transition.
-                          This may be an empty string.
-                        maxLength: 32768
-                        type: string
-                      observedGeneration:
-                        description: |-
-                          observedGeneration represents the .metadata.generation that the condition was set based upon.
-                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                          with respect to the current state of the instance.
-                        format: int64
-                        minimum: 0
-                        type: integer
-                      reason:
-                        description: |-
-                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                          Producers of specific condition types may define expected values and meanings for this field,
-                          and whether the values are considered a guaranteed API.
-                          The value should be a CamelCase string.
-                          This field may not be empty.
-                        maxLength: 1024
-                        minLength: 1
-                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                        type: string
-                      status:
-                        description: status of the condition, one of True, False, Unknown.
-                        enum:
-                          - "True"
-                          - "False"
-                          - Unknown
-                        type: string
-                      type:
-                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                        type: string
-                    required:
-                      - lastTransitionTime
-                      - message
-                      - reason
-                      - status
-                      - type
-                    type: object
-                  type: array
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/quota/resource_quota.yaml
+++ b/config/quota/resource_quota.yaml
@@ -1,0 +1,19 @@
+# Example ResourceQuota matching operator defaults (create-if-absent).
+# The operator creates this object in the DPA namespace when missing; it is not
+# shipped as a CSV-owned bundle manifest so OLM upgrades cannot reset admin edits.
+# Do not add this file to config/default kustomization (keeps it out of the OLM bundle).
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: oadp-resource-quota
+  namespace: openshift-adp
+  labels:
+    app.kubernetes.io/name: oadp-operator
+    app.kubernetes.io/managed-by: oadp-operator
+  annotations:
+    oadp.openshift.io/quota-policy: create-if-absent
+spec:
+  hard:
+    pods: "200"
+    requests.cpu: "50"
+    requests.memory: 64Gi

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -36,6 +36,15 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - resourcequotas
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
   - apps
   resources:
   - daemonsets

--- a/docs/config/resource_quota.md
+++ b/docs/config/resource_quota.md
@@ -1,0 +1,47 @@
+# ResourceQuota for the OADP namespace
+
+When a DataProtectionApplication (DPA) is reconciled, the OADP operator ensures a
+namespace-scoped `ResourceQuota` named `oadp-resource-quota` exists in the DPA
+namespace (typically `openshift-adp`).
+
+## Defaults
+
+| Hard resource | Default |
+|---------------|---------|
+| `pods` | `200` |
+| `requests.cpu` | `50` |
+| `requests.memory` | `64Gi` |
+
+These values are a mid-size cluster ceiling (operator, Velero, node-agent DaemonSet,
+optional helpers, and some concurrent backup/restore pods). The default quota does
+**not** set `limits.cpu` or `limits.memory` because default Velero and node-agent
+pods specify requests only; tracking limits in the quota can cause admission to
+reject those pods.
+
+## Create-if-absent
+
+- If the quota is **missing**, the operator creates it with the defaults above.
+- If the quota **exists**, the operator leaves it unchanged (admin edits survive
+  reconcile and upgrades).
+- If an admin **deletes** the quota, the next DPA reconcile recreates the defaults.
+
+## Inspect and adjust
+
+```bash
+oc describe resourcequota oadp-resource-quota -n openshift-adp
+
+oc edit resourcequota oadp-resource-quota -n openshift-adp
+
+oc patch resourcequota oadp-resource-quota -n openshift-adp --type merge \
+  -p '{"spec":{"hard":{"pods":"400","requests.cpu":"100","requests.memory":"128Gi"}}}'
+```
+
+Node-agent is a DaemonSet: large clusters may need higher `pods` / `requests.cpu` /
+`requests.memory`. If pods are Pending because of quota, raise the hard limits.
+
+Admins who set container limits on all workloads may optionally add `limits.cpu` /
+`limits.memory` to the quota via `oc edit`.
+
+## Design
+
+See [docs/design/2026-07-16-resourcequota-design.md](../design/2026-07-16-resourcequota-design.md).

--- a/docs/design/2026-07-16-resourcequota-design.md
+++ b/docs/design/2026-07-16-resourcequota-design.md
@@ -1,0 +1,149 @@
+# Design proposal: ResourceQuota for the OADP namespace
+
+## Abstract
+
+Ship a default namespace-scoped `ResourceQuota` for the OADP install namespace (typically `openshift-adp`) so compliance checks that require a ResourceQuota pass on install, while allowing cluster admins to adjust hard limits without the operator overwriting their changes on reconcile or upgrade.
+
+## Background
+
+Compliance scans commonly flag pods running in namespaces without a `ResourceQuota` applied. OADP installs into a suggested namespace (`openshift-adp` via `operatorframework.io/suggested-namespace`) and also supports other namespaces (for example ACM’s `open-cluster-management-backup`).
+
+Today OADP sets per-container resource requests/limits (operator Deployment, Velero/node-agent defaults, DPA `resourceAllocations`) but does **not** create a namespace-level `ResourceQuota`. There is no existing ResourceQuota manifest in `config/` or the OLM bundle.
+
+A fixed quota is sensitive to cluster size because node-agent is a DaemonSet: pod count and aggregate CPU/memory scale with node count. Defaults must therefore be a generous ceiling, not a tight right-size.
+
+## Goals
+
+- Clear the compliance finding: the OADP namespace has a `ResourceQuota` applied after install / when a DPA is reconciled.
+- Ship product defaults (not docs-only).
+- Allow admins to adjust the quota (`oc edit` / `oc patch`) with changes preserved across operator reconciles and upgrades (create-if-absent).
+- Apply in whatever namespace the DPA lives in (not hardcoded only to `openshift-adp`).
+
+## Non Goals
+
+- `LimitRange` (separate finding / follow-up if required).
+- `ClusterResourceQuota`.
+- DPA API fields to configure quota (admins edit the ResourceQuota object directly).
+- Automatic quota scaling based on node count.
+- Per-cloud or per-profile default matrices.
+- Deleting or resetting admin-modified quotas.
+
+## Decision summary
+
+| Choice | Decision |
+|--------|----------|
+| Delivery | Ship defaults with the product; operator ensures object exists |
+| Admin adjustability | Create-if-absent; never update `.spec` if the named quota exists |
+| Default sizing | Generous mid-size ceiling (node-agent + Velero + operator + helpers + some backup/restore pods) |
+| Configuration surface | Direct edit of `ResourceQuota`; no new DPA fields |
+| Object name | `oadp-resource-quota` |
+
+## High-level design
+
+### Shipped object
+
+A single namespaced ResourceQuota:
+
+```yaml
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: oadp-resource-quota
+  namespace: openshift-adp   # or DPA namespace
+  labels:
+    app.kubernetes.io/name: oadp-operator
+    app.kubernetes.io/managed-by: oadp-operator
+  annotations:
+    oadp.openshift.io/quota-policy: create-if-absent
+spec:
+  hard:
+    pods: "200"
+    requests.cpu: "50"
+    requests.memory: 64Gi
+    limits.cpu: "100"
+    limits.memory: 128Gi
+```
+
+Defaults are a **ceiling** for a typical mid-size cluster. Large clusters or heavy concurrent data-mover workloads may need higher hard limits; small clusters may lower them.
+
+Canonical default values live in operator code (or a single shared constant/source used by the operator). A matching YAML under `config/` documents the same content for review and examples.
+
+### Lifecycle (create-if-absent)
+
+1. On DPA reconcile, look up `ResourceQuota/oadp-resource-quota` in the DPA namespace.
+2. If **missing** → create with shipped defaults.
+3. If **present** → do nothing (no patch of `.spec`).
+4. Quota is **not** a DPA-owned child for deletion purposes; namespace deletion removes it. DPA teardown does not delete the quota.
+5. If an admin **deletes** the quota, the next DPA reconcile recreates defaults.
+
+### OLM / bundle interaction
+
+Pure CSV-owned bundle objects are reconciled by OLM and can reset admin edits on upgrade. To honor create-if-absent:
+
+- The **operator** is authoritative: it creates `oadp-resource-quota` if absent and never updates `.spec` when present.
+- Keep a matching example under `config/` (and optional docs sample) for review; do **not** add the ResourceQuota as a CSV-owned bundle manifest, so OLM cannot clobber admin edits on upgrade.
+- Practical day-1 timing: the quota appears when a DPA is reconciled (normal install path creates a DPA shortly after operator install). That is sufficient to clear the compliance finding for pods that run because of the DPA.
+
+### RBAC
+
+Extend manager permissions (kubebuilder markers → `make manifests` / bundle):
+
+```text
+//+kubebuilder:rbac:groups="",resources=resourcequotas,verbs=get;list;watch;create
+```
+
+No `update`, `patch`, or `delete` on `resourcequotas`, so the operator cannot overwrite or remove admin edits even if a bug attempts Update.
+
+### Admin workflow
+
+```bash
+# Inspect
+oc describe resourcequota oadp-resource-quota -n openshift-adp
+
+# Adjust (survives reconcile/upgrade)
+oc edit resourcequota oadp-resource-quota -n openshift-adp
+# or
+oc patch resourcequota oadp-resource-quota -n openshift-adp --type merge -p '{"spec":{"hard":{"pods":"400"}}}'
+```
+
+Document that node-agent is a DaemonSet and large clusters may need higher `pods` / CPU / memory limits. If pods are Pending due to quota, raise hard limits.
+
+## Edge cases
+
+| Case | Behavior |
+|------|----------|
+| Admin deletes the quota | Next DPA reconcile recreates defaults |
+| Admin creates an additional ResourceQuota | Both apply; effective limit is the intersection (most restrictive). Operator only manages `oadp-resource-quota` |
+| ACM / custom install namespace | Same ensure logic in the DPA’s namespace |
+| Multiple DPAs in one namespace | Idempotent ensure; still one `oadp-resource-quota` |
+| Quota too tight → pods Pending | Docs/support: raise hard limits; no auto-scale |
+| No DPA yet | Quota is not ensured until a DPA is reconciled (expected shortly after install) |
+
+## Testing
+
+- **Unit:** missing → created with defaults; existing custom `.spec` → unchanged (operator does not patch).
+- **E2E (light/optional):** after deploy + DPA, `ResourceQuota/oadp-resource-quota` exists in the test namespace.
+
+## Documentation
+
+Add a short admin note under `docs/config/` covering defaults, inspect/adjust commands, recreate-on-delete behavior, and node-agent / large-cluster sizing guidance.
+
+## Alternatives considered
+
+1. **Bundle-only OLM-owned ResourceQuota** — Simple, but upgrades reset admin edits; rejected for adjustability requirement.
+2. **Docs/sample only** — No upgrade conflict, but does not ship an applied quota; rejected.
+3. **Second “override” ResourceQuota** — Cannot loosen a tight default (intersection); rejected as the primary adjust mechanism.
+4. **DPA API for quota** — Extra API surface; admins can already edit ResourceQuota; deferred/out of scope.
+
+## Implementation sketch (for planning)
+
+1. Add default constants + `ensureResourceQuota` helper (get → create if not found).
+2. Call ensure from DPA reconcile in the DPA namespace.
+3. Add kubebuilder RBAC; regenerate manifests/bundle.
+4. Add `config/` example YAML matching defaults (not CSV-owned in the bundle).
+5. Unit tests for create-if-absent.
+6. Admin docs under `docs/config/`.
+
+## Open questions
+
+None for v1 of this design. Default hard-limit numbers may be tuned during implementation review if QE/support have preferred ceilings.

--- a/docs/design/2026-07-16-resourcequota-design.md
+++ b/docs/design/2026-07-16-resourcequota-design.md
@@ -35,6 +35,7 @@ A fixed quota is sensitive to cluster size because node-agent is a DaemonSet: po
 | Delivery | Ship defaults with the product; operator ensures object exists |
 | Admin adjustability | Create-if-absent; never update `.spec` if the named quota exists |
 | Default sizing | Generous mid-size ceiling (node-agent + Velero + operator + helpers + some backup/restore pods) |
+| Hard resources | `pods`, `requests.cpu`, `requests.memory` only — **no** `limits.*` (see below) |
 | Configuration surface | Direct edit of `ResourceQuota`; no new DPA fields |
 | Object name | `oadp-resource-quota` |
 
@@ -60,13 +61,30 @@ spec:
     pods: "200"
     requests.cpu: "50"
     requests.memory: 64Gi
-    limits.cpu: "100"
-    limits.memory: 128Gi
 ```
 
 Defaults are a **ceiling** for a typical mid-size cluster. Large clusters or heavy concurrent data-mover workloads may need higher hard limits; small clusters may lower them.
 
 Canonical default values live in operator code (or a single shared constant/source used by the operator). A matching YAML under `config/` documents the same content for review and examples.
+
+### Comparison to established OADP pod resources
+
+Default per-container resources today:
+
+| Component | Requests | Limits |
+|-----------|----------|--------|
+| Velero | 500m / 128Mi | *none* |
+| Node-agent (per pod) | 500m / 128Mi | *none* |
+| Operator manager | 500m / 128Mi | 1 / 512Mi |
+| VM file restore / kubevirt datamover | 10m / 64Mi | 500m / 128Mi |
+| CLI download | 50m / 32Mi | 100m / 64Mi |
+
+**Quota vs defaults:** The namespace hard limits are aggregate ceilings, not “barely above one Velero pod.”
+
+- Steady-state (operator + Velero, no node-agent): ~1 CPU / ~256Mi requests → well under `requests.cpu: 50` / `requests.memory: 64Gi`.
+- With node-agent (DaemonSet): each node adds 500m / 128Mi requests. Rough headroom before hitting the ceiling is on the order of ~90+ node-agent pods for `requests.cpu: 50`, or ~190+ nodes for `pods: 200` (plus operator/Velero/helpers).
+
+**Why `limits.*` are omitted from the default quota:** Default Velero and node-agent pods set **requests only** (no limits). If a ResourceQuota tracks `limits.cpu` / `limits.memory`, admission can reject pods that omit limits (unless a LimitRange supplies defaults). Shipping `limits.*` would risk breaking the default Velero/node-agent stack. Admins who set container limits everywhere may add `limits.*` to the quota themselves via `oc edit`.
 
 ### Lifecycle (create-if-absent)
 
@@ -106,7 +124,7 @@ oc edit resourcequota oadp-resource-quota -n openshift-adp
 oc patch resourcequota oadp-resource-quota -n openshift-adp --type merge -p '{"spec":{"hard":{"pods":"400"}}}'
 ```
 
-Document that node-agent is a DaemonSet and large clusters may need higher `pods` / CPU / memory limits. If pods are Pending due to quota, raise hard limits.
+Document that node-agent is a DaemonSet and large clusters may need higher `pods` / `requests.cpu` / `requests.memory`. If pods are Pending due to quota, raise hard limits. Note that default Velero/node-agent have no container limits, so the shipped quota intentionally omits `limits.*`.
 
 ## Edge cases
 
@@ -134,6 +152,7 @@ Add a short admin note under `docs/config/` covering defaults, inspect/adjust co
 2. **Docs/sample only** — No upgrade conflict, but does not ship an applied quota; rejected.
 3. **Second “override” ResourceQuota** — Cannot loosen a tight default (intersection); rejected as the primary adjust mechanism.
 4. **DPA API for quota** — Extra API surface; admins can already edit ResourceQuota; deferred/out of scope.
+5. **Include `limits.cpu` / `limits.memory` in default hard list** — Rejected for v1 because default Velero/node-agent pods lack container limits and would risk admission failure; admins can add these fields manually if their workloads all set limits.
 
 ## Implementation sketch (for planning)
 

--- a/internal/controller/dataprotectionapplication_controller.go
+++ b/internal/controller/dataprotectionapplication_controller.go
@@ -70,7 +70,9 @@ var debugMode = os.Getenv("DEBUG") == "true"
 //+kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,verbs=use,resourceNames=privileged
 //+kubebuilder:rbac:groups="",resources=secrets;configmaps;pods;services;serviceaccounts;endpoints;persistentvolumeclaims;events,verbs=get;list;watch;create;update;patch;delete;deletecollection
+//+kubebuilder:rbac:groups="",resources=resourcequotas,verbs=get;list;watch;create
 //+kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch;create;update;patch
+
 //+kubebuilder:rbac:groups=apps,resources=deployments;daemonsets,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=console.openshift.io,resources=consoleclidownloads,verbs=get;list;watch;create;update;patch;delete
@@ -98,6 +100,7 @@ func (r *DataProtectionApplicationReconciler) Reconcile(ctx context.Context, req
 
 	_, err := ReconcileBatch(r.Log,
 		r.ValidateDataProtectionCR,
+		r.ReconcileResourceQuota,
 		r.ReconcileFsRestoreHelperConfig,
 		r.ReconcileBackupStorageLocations,
 		r.ReconcileRegistrySecrets,

--- a/internal/controller/resourcequota.go
+++ b/internal/controller/resourcequota.go
@@ -1,0 +1,72 @@
+package controller
+
+import (
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const (
+	oadpResourceQuotaName             = "oadp-resource-quota"
+	oadpResourceQuotaPolicyAnnotation = "oadp.openshift.io/quota-policy"
+	oadpResourceQuotaPolicyValue      = "create-if-absent"
+)
+
+// defaultOADPResourceQuotaHard is a generous mid-size ceiling for the OADP
+// namespace. It intentionally omits limits.* because default Velero and
+// node-agent pods set requests only; tracking limits in the quota can reject
+// those pods at admission.
+func defaultOADPResourceQuotaHard() corev1.ResourceList {
+	return corev1.ResourceList{
+		corev1.ResourcePods:           resource.MustParse("200"),
+		corev1.ResourceRequestsCPU:    resource.MustParse("50"),
+		corev1.ResourceRequestsMemory: resource.MustParse("64Gi"),
+	}
+}
+
+// ReconcileResourceQuota ensures ResourceQuota/oadp-resource-quota exists in
+// the DPA namespace. Create-if-absent: never updates an existing quota's spec.
+func (r *DataProtectionApplicationReconciler) ReconcileResourceQuota(log logr.Logger) (bool, error) {
+	log = log.WithValues("resourcequota", oadpResourceQuotaName)
+
+	ns := r.dpa.Namespace
+	existing := &corev1.ResourceQuota{}
+	err := r.Get(r.Context, types.NamespacedName{Name: oadpResourceQuotaName, Namespace: ns}, existing)
+	if err == nil {
+		log.V(1).Info("ResourceQuota already exists; leaving unchanged")
+		return true, nil
+	}
+	if !apierrors.IsNotFound(err) {
+		return false, err
+	}
+
+	quota := &corev1.ResourceQuota{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      oadpResourceQuotaName,
+			Namespace: ns,
+			Labels: map[string]string{
+				"app.kubernetes.io/name":       "oadp-operator",
+				"app.kubernetes.io/managed-by": "oadp-operator",
+			},
+			Annotations: map[string]string{
+				oadpResourceQuotaPolicyAnnotation: oadpResourceQuotaPolicyValue,
+			},
+		},
+		Spec: corev1.ResourceQuotaSpec{
+			Hard: defaultOADPResourceQuotaHard(),
+		},
+	}
+
+	log.Info("Creating default ResourceQuota")
+	if err := r.Create(r.Context, quota); err != nil {
+		// Another reconcile may have created it concurrently.
+		if apierrors.IsAlreadyExists(err) {
+			return true, nil
+		}
+		return false, err
+	}
+	return true, nil
+}

--- a/internal/controller/resourcequota_test.go
+++ b/internal/controller/resourcequota_test.go
@@ -1,0 +1,135 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
+)
+
+func TestDPAReconciler_ReconcileResourceQuota(t *testing.T) {
+	ns := "test-ns"
+	dpa := &oadpv1alpha1.DataProtectionApplication{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-dpa",
+			Namespace: ns,
+		},
+	}
+
+	t.Run("creates default ResourceQuota when missing", func(t *testing.T) {
+		fakeClient, err := getFakeClientFromObjects(dpa)
+		require.NoError(t, err)
+
+		r := &DataProtectionApplicationReconciler{
+			Client:  fakeClient,
+			Scheme:  fakeClient.Scheme(),
+			Context: context.Background(),
+			dpa:     dpa,
+		}
+
+		cont, err := r.ReconcileResourceQuota(logr.Discard())
+		require.NoError(t, err)
+		assert.True(t, cont)
+
+		got := &corev1.ResourceQuota{}
+		err = fakeClient.Get(context.Background(), types.NamespacedName{
+			Name:      oadpResourceQuotaName,
+			Namespace: ns,
+		}, got)
+		require.NoError(t, err)
+
+		assert.Equal(t, "create-if-absent", got.Annotations[oadpResourceQuotaPolicyAnnotation])
+		assert.Equal(t, "oadp-operator", got.Labels["app.kubernetes.io/name"])
+		assert.Equal(t, "oadp-operator", got.Labels["app.kubernetes.io/managed-by"])
+
+		assert.True(t, resource.MustParse("200").Equal(got.Spec.Hard[corev1.ResourcePods]))
+		assert.True(t, resource.MustParse("50").Equal(got.Spec.Hard[corev1.ResourceRequestsCPU]))
+		assert.True(t, resource.MustParse("64Gi").Equal(got.Spec.Hard[corev1.ResourceRequestsMemory]))
+		_, hasLimitsCPU := got.Spec.Hard[corev1.ResourceLimitsCPU]
+		_, hasLimitsMemory := got.Spec.Hard[corev1.ResourceLimitsMemory]
+		assert.False(t, hasLimitsCPU, "default quota must not set limits.cpu")
+		assert.False(t, hasLimitsMemory, "default quota must not set limits.memory")
+	})
+
+	t.Run("does not overwrite existing custom ResourceQuota", func(t *testing.T) {
+		custom := &corev1.ResourceQuota{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      oadpResourceQuotaName,
+				Namespace: ns,
+			},
+			Spec: corev1.ResourceQuotaSpec{
+				Hard: corev1.ResourceList{
+					corev1.ResourcePods:           resource.MustParse("10"),
+					corev1.ResourceRequestsCPU:    resource.MustParse("2"),
+					corev1.ResourceRequestsMemory: resource.MustParse("4Gi"),
+				},
+			},
+		}
+
+		fakeClient, err := getFakeClientFromObjects(dpa, custom)
+		require.NoError(t, err)
+
+		r := &DataProtectionApplicationReconciler{
+			Client:  fakeClient,
+			Scheme:  fakeClient.Scheme(),
+			Context: context.Background(),
+			dpa:     dpa,
+		}
+
+		cont, err := r.ReconcileResourceQuota(logr.Discard())
+		require.NoError(t, err)
+		assert.True(t, cont)
+
+		got := &corev1.ResourceQuota{}
+		err = fakeClient.Get(context.Background(), client.ObjectKeyFromObject(custom), got)
+		require.NoError(t, err)
+
+		assert.True(t, resource.MustParse("10").Equal(got.Spec.Hard[corev1.ResourcePods]))
+		assert.True(t, resource.MustParse("2").Equal(got.Spec.Hard[corev1.ResourceRequestsCPU]))
+		assert.True(t, resource.MustParse("4Gi").Equal(got.Spec.Hard[corev1.ResourceRequestsMemory]))
+	})
+
+	t.Run("recreates defaults after admin deletes ResourceQuota", func(t *testing.T) {
+		fakeClient, err := getFakeClientFromObjects(dpa)
+		require.NoError(t, err)
+
+		r := &DataProtectionApplicationReconciler{
+			Client:  fakeClient,
+			Scheme:  fakeClient.Scheme(),
+			Context: context.Background(),
+			dpa:     dpa,
+		}
+
+		_, err = r.ReconcileResourceQuota(logr.Discard())
+		require.NoError(t, err)
+
+		existing := &corev1.ResourceQuota{}
+		err = fakeClient.Get(context.Background(), types.NamespacedName{
+			Name:      oadpResourceQuotaName,
+			Namespace: ns,
+		}, existing)
+		require.NoError(t, err)
+		require.NoError(t, fakeClient.Delete(context.Background(), existing))
+
+		cont, err := r.ReconcileResourceQuota(logr.Discard())
+		require.NoError(t, err)
+		assert.True(t, cont)
+
+		got := &corev1.ResourceQuota{}
+		err = fakeClient.Get(context.Background(), types.NamespacedName{
+			Name:      oadpResourceQuotaName,
+			Namespace: ns,
+		}, got)
+		require.NoError(t, err)
+		assert.True(t, resource.MustParse("200").Equal(got.Spec.Hard[corev1.ResourcePods]))
+	})
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic creation of a namespace resource quota with default limits for pods, CPU requests, and memory requests.
  * Preserves administrator-customized quota values and recreates the quota if it is deleted.
  * Expanded restore and configuration options in the Data Protection Application schema.

* **Documentation**
  * Added resource quota configuration and design documentation.

* **Bug Fixes**
  * Updated operator permissions to manage resource quota visibility and creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->