### PR TITLE
OADP-8445: Add readiness probes to CLI and VMDP

### DIFF
--- a/internal/controller/cli_download_controller.go
+++ b/internal/controller/cli_download_controller.go
@@ -95,6 +95,16 @@ func (c *CLIDownloadSetup) reconcileCLIResources(ctx context.Context, operatorDe
 		c.Log.Info("Created CLI server deployment", "image", cliServerImage)
 	} else if err != nil {
 		return fmt.Errorf("failed to get CLI server deployment: %w", err)
+	} else if len(deployment.Spec.Template.Spec.Containers) > 0 &&
+		deployment.Spec.Template.Spec.Containers[0].ReadinessProbe == nil {
+		// Deployment exists from a version before probes were added; backfill them.
+		desired := buildCLIServerDeployment(c.Namespace, cliServerImage)
+		deployment.Spec.Template.Spec.Containers[0].ReadinessProbe = desired.Spec.Template.Spec.Containers[0].ReadinessProbe
+		deployment.Spec.Template.Spec.Containers[0].LivenessProbe = desired.Spec.Template.Spec.Containers[0].LivenessProbe
+		if err := c.Client.Update(ctx, deployment); err != nil {
+			return fmt.Errorf("failed to update CLI server deployment with probes: %w", err)
+		}
+		c.Log.Info("Updated CLI server deployment with readiness/liveness probes")
 	}
 
 	// 2. Create or update the service
@@ -322,6 +332,26 @@ func buildCLIServerDeployment(namespace, image string) *appsv1.Deployment {
 									Drop: []corev1.Capability{"ALL"},
 								},
 								ReadOnlyRootFilesystem: &readOnlyRootFilesystem,
+							},
+							ReadinessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path: "/",
+										Port: intstr.FromString("http"),
+									},
+								},
+								InitialDelaySeconds: 5,
+								PeriodSeconds:       10,
+							},
+							LivenessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path: "/",
+										Port: intstr.FromString("http"),
+									},
+								},
+								InitialDelaySeconds: 15,
+								PeriodSeconds:       20,
 							},
 						},
 					},

--- a/internal/controller/vmdp_download_controller.go
+++ b/internal/controller/vmdp_download_controller.go
@@ -90,6 +90,16 @@ func (v *VMDPDownloadSetup) reconcileVMDPResources(ctx context.Context, operator
 		v.Log.Info("Created VMDP server deployment", "image", vmdpServerImage)
 	} else if err != nil {
 		return fmt.Errorf("failed to get VMDP server deployment: %w", err)
+	} else if len(deployment.Spec.Template.Spec.Containers) > 0 &&
+		deployment.Spec.Template.Spec.Containers[0].ReadinessProbe == nil {
+		// Deployment exists from a version before probes were added; backfill them.
+		desired := buildVMDPServerDeployment(v.Namespace, vmdpServerImage)
+		deployment.Spec.Template.Spec.Containers[0].ReadinessProbe = desired.Spec.Template.Spec.Containers[0].ReadinessProbe
+		deployment.Spec.Template.Spec.Containers[0].LivenessProbe = desired.Spec.Template.Spec.Containers[0].LivenessProbe
+		if err := v.Client.Update(ctx, deployment); err != nil {
+			return fmt.Errorf("failed to update VMDP server deployment with probes: %w", err)
+		}
+		v.Log.Info("Updated VMDP server deployment with readiness/liveness probes")
 	}
 
 	// 2. Create or update the service
@@ -304,6 +314,26 @@ func buildVMDPServerDeployment(namespace, image string) *appsv1.Deployment {
 									Drop: []corev1.Capability{"ALL"},
 								},
 								ReadOnlyRootFilesystem: &readOnlyRootFilesystem,
+							},
+							ReadinessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path: "/",
+										Port: intstr.FromString("http"),
+									},
+								},
+								InitialDelaySeconds: 5,
+								PeriodSeconds:       10,
+							},
+							LivenessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path: "/",
+										Port: intstr.FromString("http"),
+									},
+								},
+								InitialDelaySeconds: 15,
+								PeriodSeconds:       20,
 							},
 						},
 					},


### PR DESCRIPTION
## Why the changes were made

The Telco certification lifecycle-readiness-probe check fails because the oadp-cli-server and oadp-vmdp-server containers (deployed to serve CLI binary downloads via ConsoleCLIDownload) have no ReadinessProbe defined.

This PR adds a ReadinessProbe and LivenessProbe to both containers, and also backfills the probes onto any already-running Deployments on operator upgrade.

Jira link: https://redhat.atlassian.net/browse/OADP-8445

## How to test the changes made

1. Deploy the operator from this branch:
```bash
make deploy
```
2. Confirm both download-server Deployments now have probes defined
```bash
oc -n openshift-adp get deploy openshift-adp-oadp-cli-server \
  -o jsonpath='{.spec.template.spec.containers[0].readinessProbe}{"\n"}'
oc -n openshift-adp get deploy openshift-adp-oadp-vmdp-server \
  -o jsonpath='{.spec.template.spec.containers[0].readinessProbe}{"\n"}'
```
Both should return a populated httpGet probe object (path /, port 8080), not empty.
3. Confirm the pods report Ready:
```bash
oc get pods -n openshift-adp -l app=oadp-cli
oc get pods -n openshift-adp -l app=oadp-vmdp
```
READY column should show 1/1.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HTTP readiness and liveness health checks to newly created CLI and VMDP server deployments.
  * Existing deployments without readiness checks are automatically updated with both health checks.
  * Health checks use the server’s HTTP endpoint and include configured timing settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->