### PR TITLE
fix extended support versions

### DIFF
--- a/PARTNERS.md
+++ b/PARTNERS.md
@@ -28,12 +28,12 @@ better stability and maintainability.
 | 5.1               | 1.7          | v1.20          | Q2 2027                       |                             |
 | 5.2               | 1.7          | v1.20          | Q3 2027                       | yes                         |
 | 5.3               | 1.8          | TBD            | TBD                           |                             |
-| 5.4               | 1.8          | TBD            | TBD                           | yes                         |
-| 5.5               | 1.9          | TBD            | TBD                           |                             |
-| 5.6               | 1.9          | TBD            | TBD                           | yes                         |
-| 5.7               | 1.10         | TBD            | TBD                           |                             |
-| 5.8               | 1.10         | TBD            | TBD                           | yes                         |
-| 5.9               | 1.11         | TBD            | TBD                           |                             |
+| 5.4               | 1.8          | TBD            | TBD                           |                             |
+| 5.5               | 1.8          | TBD            | TBD                           | yes                         |
+| 5.6               | 1.9          | TBD            | TBD                           |                             |
+| 5.7               | 1.9          | TBD            | TBD                           |                             |
+| 5.8               | 1.9          | TBD            | TBD                           | yes                         |
+| 5.9               | 1.10         | TBD            | TBD                           |                             |
 
 ### OADP Plugins of interest
 | OpenShift Version | OADP Version | Velero Version | kubevirt-velero-plugin | hypershift-oadp-plugin   | channel               |


### PR DESCRIPTION
ocp 5.2, 5.5 and 5.8
oddly enough :)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the OpenShift supported versions table to reflect current extended lifecycle support for versions 5.4–5.9.
  * Removed extended support designations for 5.4 and 5.6 and added it for 5.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->