### PR TITLE
Remove inactive users from OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,19 +1,15 @@
 approvers:
   - jwmatthews
   - sseago
-  - jmontleon
   - shawn-hurley
-  - rayfordj
   - dymurray
   - shubham-pampattiwar
   - kaovilai
-  - mrnold
   - mpryc
   - joeavaikath
 reviewers:
   - sseago
   - shubham-pampattiwar
   - kaovilai
-  - mrnold
   - mpryc
   - joeavaikath


### PR DESCRIPTION
Remove inactive users from OWNERS approvers/reviewers.

---
@kaovilai requested in [Slack thread](https://redhat-internal.slack.com/archives/C0BHTAWB542/p1785509108887839)