### PR TITLE
docs: add CI plugin image sync guidance to common.go

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -65,6 +65,28 @@ var DefaultRestoreResourcePriorities = types.Priorities{
 	},
 }
 
+// CI Plugin Image Synchronization
+//
+// Each image constant below corresponds to a RELATED_IMAGE_* environment variable
+// in config/manager/manager.yaml. In production, OLM injects these from the CSV;
+// during CI e2e tests, ci-operator substitutes them with freshly-built CI images
+// so that tests always run against the latest plugin code.
+//
+// To keep CI substitutions in sync, every image here must have a matching pair of
+// entries in the openshift/release ci-operator config for each OADP release branch:
+//
+//   1. A base_images entry that imports the image from the CI registry
+//      (namespace: konveyor, name: <plugin>, tag: <branch or latest>).
+//
+//   2. An operator.substitutions entry that replaces the quay.io pullspec
+//      in the CSV with the CI image reference.
+//
+// When adding, removing, or renaming a plugin image constant:
+//   - Update the corresponding RELATED_IMAGE_* env var in config/manager/manager.yaml
+//   - Update the base_images + operator.substitutions in openshift/release
+//     ci-operator/config/openshift/oadp-operator/ for every affected branch config
+//   - See https://github.com/openshift/oadp-operator/issues/2343 for background
+
 // Images
 const (
 	VeleroImage                  = "quay.io/konveyor/velero:latest"


### PR DESCRIPTION
Adds a Go comment block above `// Images` in `pkg/common/common.go` explaining:
- Each image constant → `RELATED_IMAGE_*` env var → needs `base_images` + `operator.substitutions` in openshift/release
- Step-by-step checklist for adding/removing/renaming plugin images
- Link to issue #2343 for background

Supersedes #2345 (which targeted `oadp-1.6` and included a separate `docs/` guide + `config/manager/manager.yaml` changes) — this PR is comment-only, targets `oadp-dev`, no `docs/` file.

pairs to https://github.com/openshift/release/pull/82762

> [!NOTE]
> Proposed by chai-bot (redhat-chai-bot), opened as draft via Claude Code. AI-generated — review for accuracy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for keeping plugin image constants synchronized with related image variables and CI configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->