### PR TITLE
docs change, use oc oadp CLI instead of velero across remaining docs, added restore logs

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -74,9 +74,9 @@ This section includes how to debug a failed restore. For more specific issues re
     ```
     oc oadp restore describe <restoreName> --details
     ```
-    - Get the backup logs: 
+    - Get the restore logs: 
     ```
-    oc oadp backup logs <restoreName>
+    oc oadp restore logs <restoreName>
     ```
  
 ## Deleting Backups

--- a/docs/config/aws/oadp-aws-sts-cloud-authentication.adoc
+++ b/docs/config/aws/oadp-aws-sts-cloud-authentication.adoc
@@ -475,14 +475,14 @@ EOF
 oc wait --for=condition=available deployment/nginx-test -n test-backup-aws --timeout=60s
 
 # Create backup
-velero backup create aws-sts-test --include-namespaces=test-backup-aws
+oc oadp backup create aws-sts-test --include-namespaces=test-backup-aws
 ----
 
 . Monitor the backup status:
 +
 [source,bash]
 ----
-velero backup describe aws-sts-test --details
+oc oadp backup describe aws-sts-test --details
 
 # Verify backup files in S3 bucket
 aws s3 ls s3://${VELERO_BUCKET_NAME}/velero/backups/ --recursive

--- a/docs/config/aws/oadp-rosa-sts-cloud-authentication.adoc
+++ b/docs/config/aws/oadp-rosa-sts-cloud-authentication.adoc
@@ -520,14 +520,14 @@ EOF
 oc wait --for=condition=available deployment/rosa-test-app -n test-backup-rosa --timeout=300s
 
 # Create backup
-velero backup create rosa-sts-test --include-namespaces=test-backup-rosa
+oc oadp backup create rosa-sts-test --include-namespaces=test-backup-rosa
 ----
 
 . Monitor backup status:
 +
 [source,bash]
 ----
-velero backup describe rosa-sts-test --details
+oc oadp backup describe rosa-sts-test --details
 
 # Verify backup files in S3
 aws s3 ls s3://${VELERO_BUCKET_NAME}/velero/backups/ --recursive

--- a/docs/config/azure/oadp-azure-sts-cloud-authentication.adoc
+++ b/docs/config/azure/oadp-azure-sts-cloud-authentication.adoc
@@ -425,14 +425,14 @@ EOF
 oc wait --for=condition=available deployment/nginx-test -n test-backup-azure --timeout=60s
 
 # Create backup
-velero backup create azure-workload-id-test --include-namespaces=test-backup-azure
+oc oadp backup create azure-workload-id-test --include-namespaces=test-backup-azure
 ----
 
 . Monitor the backup status:
 +
 [source,bash]
 ----
-velero backup describe azure-workload-id-test --details
+oc oadp backup describe azure-workload-id-test --details
 
 # Verify backup files in Azure Storage
 az storage blob list --container-name ${CONTAINER_NAME} --account-name ${STORAGE_ACCOUNT_NAME} --auth-mode login --prefix velero/backups/

--- a/docs/config/ca-certificate-bundle-for-imagestream-backups.md
+++ b/docs/config/ca-certificate-bundle-for-imagestream-backups.md
@@ -1040,7 +1040,7 @@ oc get deployment velero -n openshift-adp -o yaml | grep AWS_CA_BUNDLE
 oc exec -n openshift-adp deployment/velero -- cat /etc/velero/ca-certs/ca-bundle.pem
 
 # Test imagestream backup
-velero backup create test-imagestream-backup --include-resources imagestreams
+oc oadp backup create test-imagestream-backup --include-resources imagestreams
 ```
 
 ### Common Issues
@@ -1119,7 +1119,7 @@ oc get backupstoragelocation -n openshift-adp default -o jsonpath='{.spec.provid
 **Prevention**:
 
 1. Plan `backupImages` changes during maintenance windows
-2. Verify no backups running: `velero backup get --output json | jq '.items[] | select(.status.phase=="InProgress")'`
+2. Verify no backups running: `oc oadp backup get --output json | jq '.items[] | select(.status.phase=="InProgress")'`
 3. Set `backupImages` correctly in initial DPA configuration
 
 **Note**: If you need to trigger discovery of Non-DPA BSL changes, use safe trigger mechanisms instead of toggling `backupImages`. See [Triggering Discovery of Non-DPA BSL Changes](#triggering-discovery-of-non-dpa-bsl-changes) for DPA annotation method that updates ConfigMap without restarting pod.

--- a/docs/config/gcp/oadp-gcp-wif-cloud-authentication.adoc
+++ b/docs/config/gcp/oadp-gcp-wif-cloud-authentication.adoc
@@ -314,14 +314,14 @@ EOF
 oc wait --for=condition=available deployment/hello-openshift -n test-backup-gcp --timeout=60s
 
 # Create backup
-velero backup create wif-test --include-namespaces=test-backup-gcp
+oc oadp backup create wif-test --include-namespaces=test-backup-gcp
 ----
 
 . Monitor the backup status:
 +
 [source,bash]
 ----
-velero backup describe wif-test --details
+oc oadp backup describe wif-test --details
 
 # Verify backup files in GCS bucket
 gsutil ls -r gs://${BUCKET_NAME}/velero/backups/

--- a/docs/examples/datamover_resources.sh
+++ b/docs/examples/datamover_resources.sh
@@ -50,7 +50,7 @@ fi
 
 function backup_summary () {
     echo -e "Get Backups:\n"
-    oc -n openshift-adp exec deployment/velero -c velero -it -- ./velero get backup ;
+    oc oadp backup get ;
     echo -e "\nTotal Snapshots: " `oc get volumesnapshot -A | sed 1d | wc -l` ; 
     echo "Total OADP Snapshots: " `oc get volumesnapshot -n openshift-adp | sed 1d | wc -l` ;
     echo "Total SnapshotContents: " `oc get volumesnapshotcontents -A | sed 1d | wc -l` ; 
@@ -67,7 +67,7 @@ function backup_summary () {
 
 function restore_summary () {
     echo -e "Get Restores:\n"
-    oc -n openshift-adp exec deployment/velero -c velero -it -- ./velero get restore ;
+    oc oadp restore get ;
     echo -e "\nTotal VSR: " `oc get vsr -A 2>/dev/null | sed 1d | wc -l` ;
     echo "Completed: " `oc get vsr -A 2>/dev/null | grep -c Completed` ;
     echo "InProgress: " `oc get vsr -A 2>/dev/null | grep -c InProgress` ;

--- a/docs/oadp_cheat_sheet.md
+++ b/docs/oadp_cheat_sheet.md
@@ -61,66 +61,67 @@ oc explain dataprotectionapplications.oadp.openshift.io
 oc explain dataprotectionapplications.oadp.openshift.io.spec.features.dataMover
 ```
 
-## Velero commands:
+## OADP CLI commands:
 
-## Enable Velero and Restic Cli
+The `oc oadp` (or `kubectl oadp`) plugin wraps Velero and Restic directly, so no
+alias or pod exec is required to run the commands below. For raw `restic`
+access (not just Velero's restic subcommands), you can still alias it:
 ```
-alias velero='oc -n openshift-adp exec deployment/velero -c velero -it -- ./velero'
 alias restic='oc -n openshift-adp exec deployment/velero -c velero -it -- /usr/bin/restic'
 ```
 
-#### Enable Velero Shell completion
+#### Enable OADP CLI Shell completion
 
 ##### Bash
 Linux:
 ```
-velero completion bash > /etc/bash_completion.d/velero
+oc oadp completion bash > /etc/bash_completion.d/oc-oadp
 ```
 MacOS:
 ```
-velero completion bash > /usr/local/etc/bash_completion.d/velero
+oc oadp completion bash > /usr/local/etc/bash_completion.d/oc-oadp
 ```
 
 ### List Backups
 ```
-velero backup get
+oc oadp backup get
 ```
 
 ## Create a Backup 
 
 #### Backup with Defaults
 ```
-velero backup create backup $backup_name --include-namespaces $namespace
+oc oadp backup create backup $backup_name --include-namespaces $namespace
 ```
 
 #### Backup using restic for PV data
 ```
-velero backup create backup $backup_name --include-namespaces $namespace --default-volumes-to-fs-backup
+oc oadp backup create backup $backup_name --include-namespaces $namespace --default-volumes-to-fs-backup
 ```
 
 #### Create a backup excluding the velero and default namespaces.
 ```  
-velero backup create $backup_name --exclude-namespaces velero,default
+oc oadp backup create $backup_name --exclude-namespaces velero,default
 ```
 
 #### Create a backup based on a schedule named daily-backup.
 ```
-velero backup create --from-schedule daily-backup
+oc oadp backup create --from-schedule daily-backup
 ```
 
 #### View the YAML for a backup that doesn't snapshot volumes, without sending it to the server.
 ```
-velero backup create $backup_name --snapshot-volumes=false -o yaml
+oc oadp backup create $backup_name --snapshot-volumes=false -o yaml
 ```
 
 #### Wait for a backup to complete before returning from the command.
 ```
-velero backup create $backup_name --wait
+oc oadp backup create $backup_name --wait
 ```
 
 #### Delete a Backup
 ```
-velero backup delete $backup_name
+oc oadp backup delete $backup_name
 ```
 
 ## Debug a Failed or Partially Failed Backup
@@ -129,12 +130,12 @@ Two simple steps should provide the information required
 
 #### Logs
 ```
-velero backup logs $backup_name
+oc oadp backup logs $backup_name
 ```
 
 #### Describe
 ```
-velero backup describe $backup_name --details
+oc oadp backup describe $backup_name --details
 ```
 
 ```
@@ -145,7 +146,7 @@ Annotations:  velero.io/source-cluster-k8s-gitversion=v1.23.5+b0357ed
               velero.io/source-cluster-k8s-major-version=1
               velero.io/source-cluster-k8s-minor-version=23
 
-Phase:  (run `velero backup logs mssql-persistent` for more information)
+Phase:  (run `oc oadp backup logs mssql-persistent` for more information)
 
 Errors:    2
 Warnings:  0

--- a/docs/standardized-flow-implementation.md
+++ b/docs/standardized-flow-implementation.md
@@ -411,12 +411,12 @@ The installation process is similar for all cloud providers, with cloud-specific
 
 1. Create a test backup:
    ```bash
-   velero backup create test-backup --include-namespaces=<namespace>
+   oc oadp backup create test-backup --include-namespaces=<namespace>
    ```
 
 2. Verify the backup completed:
    ```bash
-   velero backup describe test-backup
+   oc oadp backup describe test-backup
    ```
 
 ## Troubleshooting

--- a/docs/upgrade_1-2_to_1-3.md
+++ b/docs/upgrade_1-2_to_1-3.md
@@ -106,7 +106,7 @@ Follow theses [basic install verification](../docs/install_olm.md#verify-install
 For example:
 
 ```
-velero backup create example-backup --include-namespaces mysql-persistent --snapshot-move-data=true
+oc oadp backup create example-backup --include-namespaces mysql-persistent --snapshot-move-data=true
 ```
 or
 ```yaml


### PR DESCRIPTION
## Why the changes were made

The rest of the docs under `docs/` still told users to use raw `velero` commands, even though the `oc oadp` CLI plugin now supports the same commands directly. This updates the remaining docs to use `oc oadp` for consistency with the TROUBLESHOOTING.md fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated troubleshooting, testing, upgrade, and authentication examples to use the `oc oadp` or `kubectl oadp` commands.
  * Corrected restore log instructions.
  * Updated backup creation, inspection, listing, deletion, and diagnostic examples.
  * Added plugin-based shell completion guidance to the cheat sheet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->