### PR TITLE
feat: use velero SA and add bound-sa-token volume for KDM controller

### DIFF
--- a/bundle/manifests/oadp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/oadp-operator.clusterserviceversion.yaml
@@ -875,130 +875,6 @@ spec:
         - apiGroups:
           - ""
           resources:
-          - persistentvolumeclaims
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - ""
-          resources:
-          - persistentvolumes
-          verbs:
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - ""
-          resources:
-          - pods
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - watch
-        - apiGroups:
-          - ""
-          resources:
-          - pods/log
-          verbs:
-          - get
-        - apiGroups:
-          - ""
-          resources:
-          - secrets
-          verbs:
-          - get
-          - list
-          - watch
-        - apiGroups:
-          - backup.kubevirt.io
-          resources:
-          - virtualmachinebackups
-          - virtualmachinebackuptrackers
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - backup.kubevirt.io
-          resources:
-          - virtualmachinebackups/status
-          verbs:
-          - get
-        - apiGroups:
-          - backup.kubevirt.io
-          resources:
-          - virtualmachinebackuptrackers/status
-          verbs:
-          - get
-          - patch
-          - update
-        - apiGroups:
-          - kubevirt.io
-          resources:
-          - virtualmachines
-          verbs:
-          - get
-          - list
-          - watch
-        - apiGroups:
-          - velero.io
-          resources:
-          - backupstoragelocations
-          verbs:
-          - get
-          - list
-          - watch
-        - apiGroups:
-          - velero.io
-          resources:
-          - datadownloads
-          - datauploads
-          verbs:
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - velero.io
-          resources:
-          - datadownloads/status
-          - datauploads/status
-          verbs:
-          - get
-          - patch
-          - update
-        - apiGroups:
-          - authentication.k8s.io
-          resources:
-          - tokenreviews
-          verbs:
-          - create
-        - apiGroups:
-          - authorization.k8s.io
-          resources:
-          - subjectaccessreviews
-          verbs:
-          - create
-        serviceAccountName: oadp-kubevirt-datamover-controller-manager
-      - rules:
-        - apiGroups:
-          - ""
-          resources:
           - namespaces
           - pods
           - secrets
@@ -1374,6 +1250,128 @@ spec:
           - list
           - delete
         - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumes
+          verbs:
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods/log
+          verbs:
+          - get
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - backup.kubevirt.io
+          resources:
+          - virtualmachinebackups
+          - virtualmachinebackuptrackers
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - backup.kubevirt.io
+          resources:
+          - virtualmachinebackups/status
+          verbs:
+          - get
+        - apiGroups:
+          - backup.kubevirt.io
+          resources:
+          - virtualmachinebackuptrackers/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - virtualmachines
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - velero.io
+          resources:
+          - backupstoragelocations
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - velero.io
+          resources:
+          - datadownloads
+          - datauploads
+          verbs:
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - velero.io
+          resources:
+          - datadownloads/status
+          - datauploads/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        - apiGroups:
           - build.openshift.io
           - migration.openshift.io
           - rbac.authorization.k8s.io
@@ -1578,39 +1576,6 @@ spec:
           verbs:
           - create
           - patch
-        serviceAccountName: oadp-kubevirt-datamover-controller-manager
-      - rules:
-        - apiGroups:
-          - ""
-          resources:
-          - configmaps
-          verbs:
-          - get
-          - list
-          - watch
-          - create
-          - update
-          - patch
-          - delete
-        - apiGroups:
-          - coordination.k8s.io
-          resources:
-          - leases
-          verbs:
-          - get
-          - list
-          - watch
-          - create
-          - update
-          - patch
-          - delete
-        - apiGroups:
-          - ""
-          resources:
-          - events
-          verbs:
-          - create
-          - patch
         serviceAccountName: oadp-vm-file-restore-controller-manager
       - rules:
         - apiGroups:
@@ -1645,6 +1610,39 @@ spec:
           - create
           - patch
         serviceAccountName: openshift-adp-controller-manager
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        serviceAccountName: velero
     strategy: deployment
   installModes:
   - supported: true

--- a/config/kubevirt-datamover-controller_rbac/kustomization.yaml
+++ b/config/kubevirt-datamover-controller_rbac/kustomization.yaml
@@ -5,7 +5,6 @@ resources:
 # if your manager will use a service account that exists at
 # runtime. Be sure to update RoleBinding and ClusterRoleBinding
 # subjects if changing service account names.
-- service_account.yaml
 - role.yaml
 - role_binding.yaml
 - leader_election_role.yaml

--- a/config/kubevirt-datamover-controller_rbac/leader_election_role_binding.yaml
+++ b/config/kubevirt-datamover-controller_rbac/leader_election_role_binding.yaml
@@ -11,5 +11,5 @@ roleRef:
   name: leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: controller-manager
+  name: velero
   namespace: system

--- a/config/kubevirt-datamover-controller_rbac/metrics_auth_role_binding.yaml
+++ b/config/kubevirt-datamover-controller_rbac/metrics_auth_role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: metrics-auth-role
 subjects:
 - kind: ServiceAccount
-  name: controller-manager
+  name: velero
   namespace: system

--- a/config/kubevirt-datamover-controller_rbac/role_binding.yaml
+++ b/config/kubevirt-datamover-controller_rbac/role_binding.yaml
@@ -11,5 +11,5 @@ roleRef:
   name: manager-role
 subjects:
 - kind: ServiceAccount
-  name: controller-manager
+  name: velero
   namespace: system

--- a/internal/controller/kubevirt_datamover_controller.go
+++ b/internal/controller/kubevirt_datamover_controller.go
@@ -264,6 +264,11 @@ func ensureKubevirtDatamoverRequiredSpecs(
 				Name:      "tmp",
 				MountPath: "/tmp",
 			},
+			{
+				Name:      "bound-sa-token",
+				MountPath: "/var/run/secrets/openshift/serviceaccount",
+				ReadOnly:  true,
+			},
 		},
 		SecurityContext: &corev1.SecurityContext{
 			AllowPrivilegeEscalation: ptr.To(false),
@@ -329,9 +334,25 @@ func ensureKubevirtDatamoverRequiredSpecs(
 				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},
 		},
+		{
+			Name: "bound-sa-token",
+			VolumeSource: corev1.VolumeSource{
+				Projected: &corev1.ProjectedVolumeSource{
+					Sources: []corev1.VolumeProjection{
+						{
+							ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+								Audience:          "openshift",
+								ExpirationSeconds: ptr.To(int64(3600)),
+								Path:              "token",
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 	deploymentObject.Spec.Template.Spec.RestartPolicy = corev1.RestartPolicyAlways
-	deploymentObject.Spec.Template.Spec.ServiceAccountName = kubevirtDatamoverObjectName
+	deploymentObject.Spec.Template.Spec.ServiceAccountName = "velero"
 	return nil
 }
 

--- a/internal/controller/kubevirt_datamover_controller_test.go
+++ b/internal/controller/kubevirt_datamover_controller_test.go
@@ -810,8 +810,8 @@ func TestEnsureKubevirtDatamoverRequiredSpecs(t *testing.T) {
 			}
 
 			// Verify service account name
-			if deployment.Spec.Template.Spec.ServiceAccountName != kubevirtDatamoverObjectName {
-				t.Errorf("serviceAccountName: expected %s, got %s", kubevirtDatamoverObjectName, deployment.Spec.Template.Spec.ServiceAccountName)
+			if deployment.Spec.Template.Spec.ServiceAccountName != "velero" {
+				t.Errorf("serviceAccountName: expected velero, got %s", deployment.Spec.Template.Spec.ServiceAccountName)
 			}
 
 			// Verify container
@@ -949,6 +949,17 @@ func TestEnsureKubevirtDatamoverRequiredSpecs(t *testing.T) {
 				t.Error("expected /tmp emptyDir volume on pod spec")
 			}
 
+			hasBoundSATokenVolume := false
+			for _, v := range volumes {
+				if v.Name == "bound-sa-token" && v.VolumeSource.Projected != nil {
+					hasBoundSATokenVolume = true
+					break
+				}
+			}
+			if !hasBoundSATokenVolume {
+				t.Error("expected bound-sa-token projected volume on pod spec")
+			}
+
 			// Verify /tmp volume mount on container (only for new containers)
 			if len(tt.existingContainers) == 0 {
 				hasTmpMount := false
@@ -960,6 +971,17 @@ func TestEnsureKubevirtDatamoverRequiredSpecs(t *testing.T) {
 				}
 				if !hasTmpMount {
 					t.Error("expected /tmp volumeMount on container")
+				}
+
+				hasBoundSATokenMount := false
+				for _, vm := range container.VolumeMounts {
+					if vm.Name == "bound-sa-token" && vm.MountPath == "/var/run/secrets/openshift/serviceaccount" && vm.ReadOnly {
+						hasBoundSATokenMount = true
+						break
+					}
+				}
+				if !hasBoundSATokenMount {
+					t.Error("expected bound-sa-token volumeMount on container")
 				}
 			}
 
@@ -1009,7 +1031,7 @@ func TestBuildKubevirtDatamoverDeployment(t *testing.T) {
 			expectedImage:    defaultKubevirtDatamoverImage,
 			expectedEnvCount: 3, // WATCH_NAMESPACE, DATAMOVER_IMAGE, LOG_LEVEL (empty)
 			expectedReplicas: 1,
-			expectedSAName:   kubevirtDatamoverObjectName,
+			expectedSAName:   "velero",
 			expectError:      false,
 		},
 		{
@@ -1032,7 +1054,7 @@ func TestBuildKubevirtDatamoverDeployment(t *testing.T) {
 			expectedImage:    "custom-registry.io/kdm:v1.0",
 			expectedEnvCount: 3, // WATCH_NAMESPACE, DATAMOVER_IMAGE, LOG_LEVEL (empty)
 			expectedReplicas: 1,
-			expectedSAName:   kubevirtDatamoverObjectName,
+			expectedSAName:   "velero",
 			expectError:      false,
 		},
 		{
@@ -1055,7 +1077,7 @@ func TestBuildKubevirtDatamoverDeployment(t *testing.T) {
 			expectedImage:    "env-registry.io/kdm:v2.0",
 			expectedEnvCount: 3, // WATCH_NAMESPACE, DATAMOVER_IMAGE, LOG_LEVEL (empty)
 			expectedReplicas: 1,
-			expectedSAName:   kubevirtDatamoverObjectName,
+			expectedSAName:   "velero",
 			expectError:      false,
 		},
 		{
@@ -1078,7 +1100,7 @@ func TestBuildKubevirtDatamoverDeployment(t *testing.T) {
 			expectedImage:    defaultKubevirtDatamoverImage,
 			expectedEnvCount: 4, // WATCH_NAMESPACE, DATAMOVER_IMAGE, LOG_LEVEL, LOG_FORMAT
 			expectedReplicas: 1,
-			expectedSAName:   kubevirtDatamoverObjectName,
+			expectedSAName:   "velero",
 			expectError:      false,
 		},
 		{
@@ -1098,7 +1120,7 @@ func TestBuildKubevirtDatamoverDeployment(t *testing.T) {
 			expectedImage:    defaultKubevirtDatamoverImage,
 			expectedEnvCount: 3, // WATCH_NAMESPACE, DATAMOVER_IMAGE, LOG_LEVEL (empty)
 			expectedReplicas: 1,
-			expectedSAName:   kubevirtDatamoverObjectName,
+			expectedSAName:   "velero",
 			expectError:      false,
 		},
 	}
@@ -1224,6 +1246,28 @@ func TestBuildKubevirtDatamoverDeployment(t *testing.T) {
 			}
 			if !hasTmpMount {
 				t.Error("expected /tmp volumeMount on container")
+			}
+
+			hasBoundSATokenVolume := false
+			for _, v := range deployment.Spec.Template.Spec.Volumes {
+				if v.Name == "bound-sa-token" && v.VolumeSource.Projected != nil {
+					hasBoundSATokenVolume = true
+					break
+				}
+			}
+			if !hasBoundSATokenVolume {
+				t.Error("expected bound-sa-token projected volume on pod spec")
+			}
+
+			hasBoundSATokenMount := false
+			for _, vm := range container.VolumeMounts {
+				if vm.Name == "bound-sa-token" && vm.MountPath == "/var/run/secrets/openshift/serviceaccount" && vm.ReadOnly {
+					hasBoundSATokenMount = true
+					break
+				}
+			}
+			if !hasBoundSATokenMount {
+				t.Error("expected bound-sa-token volumeMount on container")
 			}
 
 			// Verify labels


### PR DESCRIPTION
## Summary

- Switch KDM controller deployment from `oadp-kubevirt-datamover-controller-manager` SA to `velero` SA, since KDM is always deployed by OADP and the velero SA already has IAM trust configured on STS clusters
- Add `bound-sa-token` projected volume and mount to the KDM controller deployment for STS authentication
- Update CSV `serviceAccountName` entries to bind KDM RBAC permissions to the `velero` SA

## Test plan

- [x] Verify unit tests pass (`go test ./internal/controller/ -run "TestEnsureKubevirtDatamoverRequiredSpecs|TestBuildKubevirtDatamoverDeployment"`)
- [x] Deploy on a ROSA STS or OCP STS cluster with OADP STS configuration
- [x] Verify KDM controller pod starts successfully with `velero` SA
- [x] Verify KDM controller can authenticate to S3 for BSL checkpoint lookup
- [x] Verify non-STS clusters are unaffected
- [x] Verify KDM controller retains required RBAC permissions (can manage DataUploads, Pods, VMBs)

Companion PR: migtools/kubevirt-datamover-controller#158 - adds bound-sa-token volume to datamover pod
Parent issue: migtools/kubevirt-datamover-controller#25

Fixes: migtools/kubevirt-datamover-controller#24

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated KubeVirt DataMover deployments to use the Velero service account.
  * Added a projected OpenShift service-account token with the required audience and one-hour expiration.
  * Mounted the token read-only at the expected path for deployment authentication.
  * Consolidated required Kubernetes, KubeVirt, Velero, authentication, and authorization permissions into the Velero permission set.
  * Updated leader-election, metrics, and related access bindings to use the Velero service account consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->