### PR TITLE
Add datadownloads RBAC to kubevirt-datamover ClusterRole

### DIFF
--- a/bundle/manifests/oadp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/oadp-operator.clusterserviceversion.yaml
@@ -965,6 +965,7 @@ spec:
         - apiGroups:
           - velero.io
           resources:
+          - datadownloads
           - datauploads
           verbs:
           - get
@@ -975,6 +976,7 @@ spec:
         - apiGroups:
           - velero.io
           resources:
+          - datadownloads/status
           - datauploads/status
           verbs:
           - get

--- a/config/kubevirt-datamover-controller_rbac/role.yaml
+++ b/config/kubevirt-datamover-controller_rbac/role.yaml
@@ -97,6 +97,7 @@ rules:
 - apiGroups:
   - velero.io
   resources:
+  - datadownloads
   - datauploads
   verbs:
   - get
@@ -107,6 +108,7 @@ rules:
 - apiGroups:
   - velero.io
   resources:
+  - datadownloads/status
   - datauploads/status
   verbs:
   - get


### PR DESCRIPTION
## Why the changes were made

The ClusterRole bound to `oadp-kubevirt-datamover-controller-manager` was missing RBAC for `datadownloads`/`datadownloads/status`, which Phase 3 (DataDownload) support in kubevirt-datamover-controller ([migtools/kubevirt-datamover-controller#124](https://github.com/migtools/kubevirt-datamover-controller/pull/124)) needs. Without it, the controller-runtime cache's watch on `DataDownload` fails continuously with:

```
datadownloads.velero.io is forbidden: ... cannot list resource "datadownloads" ... at the cluster scope
```

This stalls the entire manager's reconcile loop — not just DataDownload, but DataUpload too, since they share one cache/manager process.

`config/kubevirt-datamover-controller_rbac/role.yaml` is updated to match upstream's `config/rbac/role.yaml` (adding `datadownloads`/`datadownloads/status` to the existing `datauploads`/`datauploads/status` rule blocks), and `make bundle` was re-run to propagate the change into the CSV.

Fixes #2351

## How to test the changes made

Deploy, then:
```
oc logs deployment/oadp-kubevirt-datamover-controller-manager -n openshift-adp
```
should show no `Failed to watch ... datadownloads` errors, and a `DataUpload` created via a real velero backup should progress past an empty `status.phase`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved KubeVirt data mover support by enabling required access to Velero data download resources.
  * Helps ensure data transfer operations can be monitored and managed reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->