### PR TITLE
Fix DPA reconcile race: use MergeFrom patch for status update

### DIFF
--- a/internal/controller/dataprotectionapplication_controller.go
+++ b/internal/controller/dataprotectionapplication_controller.go
@@ -94,7 +94,9 @@ func (r *DataProtectionApplicationReconciler) Reconcile(ctx context.Context, req
 	}
 	// origDpa snapshots status before reconciliation mutates it, so the final
 	// status update is a merge patch (no resourceVersion check) instead of a
-	// full update, avoiding optimistic-lock conflicts from concurrent reconciles.
+	// full update, avoiding optimistic-lock conflicts when the informer cache
+	// still lags behind a status write this controller (or another actor)
+	// already made to the object.
 	origDpa := r.dpa.DeepCopy()
 
 	// set client to pkg/client for use in non-reconcile functions

--- a/internal/controller/dataprotectionapplication_controller.go
+++ b/internal/controller/dataprotectionapplication_controller.go
@@ -92,6 +92,10 @@ func (r *DataProtectionApplicationReconciler) Reconcile(ctx context.Context, req
 		logger.Error(err, "unable to fetch DataProtectionApplication CR")
 		return result, nil
 	}
+	// origDpa snapshots status before reconciliation mutates it, so the final
+	// status update is a merge patch (no resourceVersion check) instead of a
+	// full update, avoiding optimistic-lock conflicts from concurrent reconciles.
+	origDpa := r.dpa.DeepCopy()
 
 	// set client to pkg/client for use in non-reconcile functions
 	oadpclient.SetClient(r.Client)
@@ -149,7 +153,7 @@ func (r *DataProtectionApplicationReconciler) Reconcile(ctx context.Context, req
 		}
 	}
 
-	statusErr := r.Client.Status().Update(ctx, r.dpa)
+	statusErr := r.Client.Status().Patch(ctx, r.dpa, client.MergeFrom(origDpa))
 	if err == nil { // Don't mask previous error
 		err = statusErr
 	}


### PR DESCRIPTION
## Why the changes were made

Fixes #2236.

`DataProtectionApplicationReconciler.Reconcile` wrote status with a full `r.Client.Status().Update(ctx, r.dpa)`, which requires the in-memory object's `resourceVersion` to match the server's exactly. When the informer cache still lagged behind a prior status write (by this controller or another actor), the update was rejected with:

```
Operation cannot be fulfilled on dataprotectionapplications.oadp.openshift.io: the object has been modified; please apply your changes to the latest version and try again
```

controller-runtime then requeued with backoff, leaving the `Reconciled` condition transiently `False`/stale — which the E2E test's `Consistently(IsReconciledTrue(), 1min, 15s)` check catches, causing the flaky `NoDefaultBackupLocation` test failure described in the issue.

This switches the final status write to `r.Client.Status().Patch(ctx, r.dpa, client.MergeFrom(origDpa))`, where `origDpa` is a `DeepCopy` taken right after the initial `Get`, before any reconcile sub-function mutates `r.dpa`'s status. A JSON merge patch has no `resourceVersion` precondition, so it no longer fails on a stale cache read — it just applies the current status.

## How to test the changes made

- `go build ./...`
- `go test ./internal/controller/...` (54 specs, envtest) — all pass
- Reviewed by two independent Fable-agent review rounds (round 1 found one nit — a comment inaccuracy, fixed in the second commit; round 2 converged with zero findings)

> [!Note]
> Responses generated with Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of application status updates during concurrent changes.
  * Reduced resource-version conflicts that could prevent status updates from being saved successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->