### PR TITLE
[oadp-1.5] Fix DPA reconcile race: use MergeFrom patch for status update

### DIFF
--- a/internal/controller/dataprotectionapplication_controller.go
+++ b/internal/controller/dataprotectionapplication_controller.go
@@ -92,7 +92,9 @@ func (r *DataProtectionApplicationReconciler) Reconcile(ctx context.Context, req
 	}
 	// origDpa snapshots status before reconciliation mutates it, so the final
 	// status update is a merge patch (no resourceVersion check) instead of a
-	// full update, avoiding optimistic-lock conflicts from concurrent reconciles.
+	// full update, avoiding optimistic-lock conflicts when the informer cache
+	// still lags behind a status write this controller (or another actor)
+	// already made to the object.
 	origDpa := r.dpa.DeepCopy()
 
 	// set client to pkg/client for use in non-reconcile functions

--- a/internal/controller/dataprotectionapplication_controller.go
+++ b/internal/controller/dataprotectionapplication_controller.go
@@ -90,6 +90,10 @@ func (r *DataProtectionApplicationReconciler) Reconcile(ctx context.Context, req
 		logger.Error(err, "unable to fetch DataProtectionApplication CR")
 		return result, nil
 	}
+	// origDpa snapshots status before reconciliation mutates it, so the final
+	// status update is a merge patch (no resourceVersion check) instead of a
+	// full update, avoiding optimistic-lock conflicts from concurrent reconciles.
+	origDpa := r.dpa.DeepCopy()
 
 	// set client to pkg/client for use in non-reconcile functions
 	oadpclient.SetClient(r.Client)
@@ -135,7 +139,7 @@ func (r *DataProtectionApplicationReconciler) Reconcile(ctx context.Context, req
 			},
 		)
 	}
-	statusErr := r.Client.Status().Update(ctx, r.dpa)
+	statusErr := r.Client.Status().Patch(ctx, r.dpa, client.MergeFrom(origDpa))
 	if err == nil { // Don't mask previous error
 		err = statusErr
 	}


### PR DESCRIPTION
Cherry-pick of #2353 onto oadp-1.5.

Conflict resolution: oadp-dev had `updateReadinessConditions` code not present in oadp-1.5; resolved by keeping the oadp-1.5 structure and only applying the `Update` → `Patch(MergeFrom)` change.

> [!NOTE]
> Proposed by chai-bot (redhat-chai-bot), opened as draft via Claude Code.