### PR TITLE
[oadp-1.4] Fix DPA reconcile race: use MergeFrom patch for status update

### DIFF
--- a/controllers/dpa_controller.go
+++ b/controllers/dpa_controller.go
@@ -87,6 +87,10 @@ func (r *DPAReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		log.Error(err, "unable to fetch DataProtectionApplication CR")
 		return result, nil
 	}
+	// origDpa snapshots status before reconciliation mutates it, so the final
+	// status update is a merge patch (no resourceVersion check) instead of a
+	// full update, avoiding optimistic-lock conflicts from concurrent reconciles.
+	origDpa := dpa.DeepCopy()
 
 	// set client to pkg/client for use in non-reconcile functions
 	oadpClient.SetClient(r.Client)
@@ -128,7 +132,7 @@ func (r *DPAReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 			},
 		)
 	}
-	statusErr := r.Client.Status().Update(ctx, &dpa)
+	statusErr := r.Client.Status().Patch(ctx, &dpa, client.MergeFrom(origDpa))
 	if err == nil { // Don't mask previous error
 		err = statusErr
 	}

--- a/controllers/dpa_controller.go
+++ b/controllers/dpa_controller.go
@@ -89,7 +89,9 @@ func (r *DPAReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	}
 	// origDpa snapshots status before reconciliation mutates it, so the final
 	// status update is a merge patch (no resourceVersion check) instead of a
-	// full update, avoiding optimistic-lock conflicts from concurrent reconciles.
+	// full update, avoiding optimistic-lock conflicts when the informer cache
+	// still lags behind a status write this controller (or another actor)
+	// already made to the object.
 	origDpa := dpa.DeepCopy()
 
 	// set client to pkg/client for use in non-reconcile functions


### PR DESCRIPTION
Cherry-pick of #2353 onto oadp-1.4.

Conflict resolution: oadp-1.4 uses a local `dpa` variable instead of the `r.dpa` struct field, so adapted `origDpa := r.dpa.DeepCopy()` → `origDpa := dpa.DeepCopy()` and `r.Client.Status().Patch(ctx, r.dpa, ...)` → `r.Client.Status().Patch(ctx, &dpa, ...)`.

> [!NOTE]
> Proposed by chai-bot (redhat-chai-bot), opened as draft via Claude Code.