### PR TITLE
add Azure Workload Identity support to kubevirt-datamover controller

### DIFF
--- a/internal/controller/kubevirt_datamover_controller.go
+++ b/internal/controller/kubevirt_datamover_controller.go
@@ -21,6 +21,7 @@ import (
 
 	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
 	"github.com/openshift/oadp-operator/pkg/common"
+	"github.com/openshift/oadp-operator/pkg/credentials/stsflow"
 )
 
 const (
@@ -179,6 +180,20 @@ func ensureKubevirtDatamoverRequiredSpecs(
 		})
 	}
 
+	// Add Azure workload identity environment variables if configured
+	var envFrom []corev1.EnvFromSource
+	azureClientID := os.Getenv(stsflow.ClientIDEnvKey)
+	if azureClientID != "" && os.Getenv(stsflow.TenantIDEnvKey) != "" && os.Getenv(stsflow.SubscriptionIDEnvKey) != "" {
+		envFrom = append(envFrom, corev1.EnvFromSource{
+			SecretRef: &corev1.SecretEnvSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: stsflow.AzureWorkloadIdentitySecretName,
+				},
+			},
+		})
+		r.Log.Info("Added Azure workload identity secret reference to KubeVirt DataMover container")
+	}
+
 	// Track DPA resource version for change detection
 	currentKubevirtDatamoverEnabled := r.checkKubevirtDatamoverEnabled()
 	if len(kdmDpaResourceVersion) == 0 ||
@@ -251,6 +266,7 @@ func ensureKubevirtDatamoverRequiredSpecs(
 		Command:         []string{"/manager"},
 		Args:            args,
 		Env:             envVars,
+		EnvFrom:         envFrom,
 		Ports: []corev1.ContainerPort{
 			{
 				Name:          "https",
@@ -315,6 +331,7 @@ func ensureKubevirtDatamoverRequiredSpecs(
 				kubevirtDatamoverContainer.ImagePullPolicy = imagePullPolicy
 				kubevirtDatamoverContainer.Args = args
 				kubevirtDatamoverContainer.Env = envVars
+				kubevirtDatamoverContainer.EnvFrom = envFrom
 				kubevirtDatamoverContainer.Resources = resources
 				kubevirtDatamoverContainer.TerminationMessagePolicy = corev1.TerminationMessageFallbackToLogsOnError
 				kubevirtDatamoverContainerFound = true


### PR DESCRIPTION


## Why the changes were made
For Azure Workload Identity, the same AZURE env vars we're adding to the Velero deployment also need to be added to the KDM controller.

https://github.com/migtools/kubevirt-datamover-controller/issues/98
<!-- Explain why this PR is important, what problems it fixes, link related issues -->

## How to test the changes made

In an Azure STS cluster, the following env vars should be added to the KDM controller
```
$ oc exec deployment/oadp-kubevirt-datamover-controller-manager -n openshift-adp -- env | grep AZURE
AZURE_CLIENT_ID=...
AZURE_FEDERATED_TOKEN_FILE=/var/run/secrets/openshift/serviceaccount/token
AZURE_TENANT_ID=...
```
<!-- Explain how the changes introduced by this PR can be tested and verified, with commands and pictures -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Azure Workload Identity in the KubeVirt DataMover.
  * Deployments can now use configured workload identity credentials when the required Azure settings are available.
  * Existing DataMover deployments are updated consistently to apply the identity configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->