### PR TITLE
Make controller-gen/kustomize/golangci-lint/envtest tool-binary caching reliable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -316,9 +316,23 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 	fi
 	@ln -sf "$(LOCALBIN)/$(BRANCH_VERSION)/controller-gen" "$(LOCALBIN)/controller-gen"
 
-.PHONY: envtest
+# Remove setup-envtest if it exists but cannot execute on this platform.
+# This can happen when a containerized Make target (e.g. podman/docker build
+# with a different GOARCH) writes a linux binary into the shared bin/ directory,
+# replacing the native host binary needed by `make test`.
+# Checked via exit code 126 specifically (POSIX "found but cannot execute" /
+# exec format error) rather than any nonzero exit, since setup-envtest's own
+# --help exits 2 by its own convention on a perfectly working binary.
+.PHONY: envtest $(ENVTEST)
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
+	@if [ -f $(ENVTEST) ]; then \
+		$(ENVTEST) --help >/dev/null 2>&1; \
+		if [ $$? -eq 126 ]; then \
+			echo "Removing incompatible setup-envtest binary (wrong architecture)"; \
+			rm -f $(ENVTEST); \
+		fi; \
+	fi
 	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20250308055145-5fe7bb3edc86)
 
 .PHONY: operator-sdk

--- a/Makefile
+++ b/Makefile
@@ -541,15 +541,25 @@ rm -rf $$TMP_DIR ;\
 }
 endef
 
-# go-install-tool-versioned installs $2 to branch-specific path $1, but only if $1 is missing
-# or $1.version doesn't match the pinned version $3. Uses a sidecar marker file instead of
-# introspecting the binary's own --version output, because that output is unreliable for some
-# tools when installed via `go install` (e.g. kustomize reports "(devel)" or an unexpanded
-# `$$Format:%H$$` placeholder instead of its real version, depending on build-time factors).
+# go-install-tool-versioned installs $2 to branch-specific path $1, but only if $1 is missing,
+# $1.version doesn't match the pinned version $3, or $1 exists but cannot execute on this
+# platform (checked via exit code 126, POSIX "found but cannot execute" / exec format error —
+# this can happen when a containerized build with a different GOARCH bind-mounts the host's
+# bin/ directory, e.g. `docker run --platform linux/amd64 -v $$PWD:$$PWD ... make manifests`).
+# Uses a sidecar marker file for the version check instead of introspecting the binary's own
+# --version output, because that output is unreliable for some tools when installed via
+# `go install` (e.g. kustomize reports "(devel)" or an unexpanded `$$Format:%H$$` placeholder
+# instead of its real version, depending on build-time factors).
 define go-install-tool-versioned
-@if [ -f $(1) ] && [ -f $(1).version ] && [ "$$(cat $(1).version)" = "$(3)" ]; then \
+@ARCH_OK=1 ;\
+if [ -f $(1) ]; then \
+	$(1) --version >/dev/null 2>&1 ;\
+	if [ $$? -eq 126 ]; then ARCH_OK=0 ; fi ;\
+fi ;\
+if [ "$$ARCH_OK" = "1" ] && [ -f $(1) ] && [ -f $(1).version ] && [ "$$(cat $(1).version)" = "$(3)" ]; then \
 	echo "$(notdir $(1)) $(3) is already installed" ;\
 else \
+	if [ "$$ARCH_OK" = "0" ]; then echo "$(notdir $(1)) exists but cannot execute on this platform, removing and re-downloading" ; fi ;\
 	set -e ;\
 	mkdir -p $(dir $(1)) ;\
 	rm -f $(1) $(1).version ;\

--- a/Makefile
+++ b/Makefile
@@ -316,12 +316,8 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 	fi
 	@ln -sf "$(LOCALBIN)/$(BRANCH_VERSION)/controller-gen" "$(LOCALBIN)/controller-gen"
 
-# Uses go-install-tool-versioned (see its doc comment above) instead of a bespoke arch check
-# here: an earlier version of this check ran `$(ENVTEST) --help` and treated any nonzero exit
-# as "wrong architecture" — but setup-envtest's own --help exits 2 by its own convention even
-# on a perfectly healthy binary, which under this Makefile's `.SHELLFLAGS = -ec` aborts the
-# whole recipe (confirmed with real GNU Make 4.4.1) rather than being caught, so it was
-# unconditionally reinstalling setup-envtest on every single invocation.
+# Uses go-install-tool-versioned (see its doc comment below) for both the version and
+# architecture check, rather than a bespoke arch-only check here.
 .PHONY: envtest $(ENVTEST)
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
@@ -535,28 +531,23 @@ endef
 
 # go-install-tool-versioned installs $2 to branch-specific path $1, but only if $1 is missing,
 # doesn't have the pinned module version $3 embedded in it, or was built for a different
-# GOOS/GOARCH than this host. Uses `go version -m` to read the binary's embedded build info
-# directly (module version, GOOS, GOARCH) instead of executing it or trusting a sidecar marker
-# file — this avoids two real failure modes found in earlier attempts at this check:
-#   - Introspecting the binary's own --version/--help output is unreliable: some tools report
-#     a version string that depends on ldflags their own release process sets, which `go
-#     install` doesn't set (e.g. kustomize reporting "(devel)" or an unexpanded `$$Format:%H$$`
-#     placeholder), and some tools exit nonzero on --version even when perfectly healthy (e.g.
-#     kustomize exits 1, setup-envtest's --help exits 2) — so a naive "nonzero exit means
-#     broken" check is wrong, and worse, a bare failing probe command under `set -e`/`-o
-#     pipefail` (this Makefile's .SHELLFLAGS, honored by GNU Make 3.82+ — silently ignored by
-#     the ancient Make 3.81 macOS ships, which is why this went unnoticed locally) aborts the
-#     entire recipe rather than being caught. Verified directly against real GNU Make 4.4.1:
-#     the previous exit-code-126 version of this macro reliably crashed `make kustomize`
-#     with "Error 1" every time the binary already existed.
-#   - Actually executing the binary to test compatibility (this macro's own earlier approach,
-#     and the same technique in #2152) can't detect a wrong-arch binary at all in a container
-#     with qemu-user-static/binfmt_misc registered (common in multi-arch CI/build images):
-#     the foreign-arch binary runs under emulation and returns its own exit code, not an
-#     exec-format-error, defeating the whole check silently in exactly the environments where
-#     it matters most.
-# `go version -m` reads the embedded build info without ever executing the binary, sidestepping
-# both problems at once.
+# GOOS/GOARCH than this host. Uses `go version -m` to read a binary's embedded build info
+# (module version, GOOS, GOARCH) instead of executing it or trusting a sidecar marker file:
+#   - A binary's own --version/--help output is not a reliable version or health signal. It
+#     can depend on ldflags a tool's own release process sets, which `go install` doesn't set
+#     (e.g. kustomize can report "(devel)" or an unexpanded `$$Format:%H$$` placeholder instead
+#     of its real version), and some tools exit nonzero on --version even when perfectly
+#     healthy (kustomize exits 1, setup-envtest's --help exits 2) — so "nonzero exit means
+#     broken" is the wrong signal. It's also dangerous under this Makefile's
+#     `.SHELLFLAGS = -ec` (enables `set -e`, honored by GNU Make 3.82+ but silently ignored by
+#     the Make 3.81 macOS ships): a bare probe command that exits nonzero aborts the whole
+#     recipe unless it's wrapped in an `if`/`||` guard.
+#   - Executing the binary to test compatibility can't detect a wrong-arch binary at all
+#     inside a container with qemu-user-static/binfmt_misc registered (common in multi-arch
+#     CI/build images): the foreign-arch binary runs under emulation and returns its own exit
+#     code rather than an exec-format-error.
+# Reading embedded build info sidesteps both: no execution means no exit-code heuristic to
+# get wrong and no qemu blind spot.
 define go-install-tool-versioned
 @BUILDINFO="$$(go version -m $(1) 2>/dev/null)" || BUILDINFO="" ;\
 MOD_VERSION="$$(printf '%s\n' "$$BUILDINFO" | awk '$$1=="mod"{print $$3; exit}')" ;\

--- a/Makefile
+++ b/Makefile
@@ -316,24 +316,16 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 	fi
 	@ln -sf "$(LOCALBIN)/$(BRANCH_VERSION)/controller-gen" "$(LOCALBIN)/controller-gen"
 
-# Remove setup-envtest if it exists but cannot execute on this platform.
-# This can happen when a containerized Make target (e.g. podman/docker build
-# with a different GOARCH) writes a linux binary into the shared bin/ directory,
-# replacing the native host binary needed by `make test`.
-# Checked via exit code 126 specifically (POSIX "found but cannot execute" /
-# exec format error) rather than any nonzero exit, since setup-envtest's own
-# --help exits 2 by its own convention on a perfectly working binary.
+# Uses go-install-tool-versioned (see its doc comment above) instead of a bespoke arch check
+# here: an earlier version of this check ran `$(ENVTEST) --help` and treated any nonzero exit
+# as "wrong architecture" — but setup-envtest's own --help exits 2 by its own convention even
+# on a perfectly healthy binary, which under this Makefile's `.SHELLFLAGS = -ec` aborts the
+# whole recipe (confirmed with real GNU Make 4.4.1) rather than being caught, so it was
+# unconditionally reinstalling setup-envtest on every single invocation.
 .PHONY: envtest $(ENVTEST)
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	@if [ -f $(ENVTEST) ]; then \
-		$(ENVTEST) --help >/dev/null 2>&1; \
-		if [ $$? -eq 126 ]; then \
-			echo "Removing incompatible setup-envtest binary (wrong architecture)"; \
-			rm -f $(ENVTEST); \
-		fi; \
-	fi
-	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20250308055145-5fe7bb3edc86)
+	$(call go-install-tool-versioned,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20250308055145-5fe7bb3edc86,v0.0.0-20250308055145-5fe7bb3edc86)
 
 .PHONY: operator-sdk
 OPERATOR_SDK ?= $(LOCALBIN)/$(BRANCH_VERSION)/operator-sdk
@@ -542,27 +534,38 @@ rm -rf $$TMP_DIR ;\
 endef
 
 # go-install-tool-versioned installs $2 to branch-specific path $1, but only if $1 is missing,
-# $1.version doesn't match the pinned version $3, or $1 exists but cannot execute on this
-# platform (checked via exit code 126, POSIX "found but cannot execute" / exec format error —
-# this can happen when a containerized build with a different GOARCH bind-mounts the host's
-# bin/ directory, e.g. `docker run --platform linux/amd64 -v $$PWD:$$PWD ... make manifests`).
-# Uses a sidecar marker file for the version check instead of introspecting the binary's own
-# --version output, because that output is unreliable for some tools when installed via
-# `go install` (e.g. kustomize reports "(devel)" or an unexpanded `$$Format:%H$$` placeholder
-# instead of its real version, depending on build-time factors).
+# doesn't have the pinned module version $3 embedded in it, or was built for a different
+# GOOS/GOARCH than this host. Uses `go version -m` to read the binary's embedded build info
+# directly (module version, GOOS, GOARCH) instead of executing it or trusting a sidecar marker
+# file — this avoids two real failure modes found in earlier attempts at this check:
+#   - Introspecting the binary's own --version/--help output is unreliable: some tools report
+#     a version string that depends on ldflags their own release process sets, which `go
+#     install` doesn't set (e.g. kustomize reporting "(devel)" or an unexpanded `$$Format:%H$$`
+#     placeholder), and some tools exit nonzero on --version even when perfectly healthy (e.g.
+#     kustomize exits 1, setup-envtest's --help exits 2) — so a naive "nonzero exit means
+#     broken" check is wrong, and worse, a bare failing probe command under `set -e`/`-o
+#     pipefail` (this Makefile's .SHELLFLAGS, honored by GNU Make 3.82+ — silently ignored by
+#     the ancient Make 3.81 macOS ships, which is why this went unnoticed locally) aborts the
+#     entire recipe rather than being caught. Verified directly against real GNU Make 4.4.1:
+#     the previous exit-code-126 version of this macro reliably crashed `make kustomize`
+#     with "Error 1" every time the binary already existed.
+#   - Actually executing the binary to test compatibility (this macro's own earlier approach,
+#     and the same technique in #2152) can't detect a wrong-arch binary at all in a container
+#     with qemu-user-static/binfmt_misc registered (common in multi-arch CI/build images):
+#     the foreign-arch binary runs under emulation and returns its own exit code, not an
+#     exec-format-error, defeating the whole check silently in exactly the environments where
+#     it matters most.
+# `go version -m` reads the embedded build info without ever executing the binary, sidestepping
+# both problems at once.
 define go-install-tool-versioned
-@ARCH_OK=1 ;\
-if [ -f $(1) ]; then \
-	$(1) --version >/dev/null 2>&1 ;\
-	if [ $$? -eq 126 ]; then ARCH_OK=0 ; fi ;\
-fi ;\
-if [ "$$ARCH_OK" = "1" ] && [ -f $(1) ] && [ -f $(1).version ] && [ "$$(cat $(1).version)" = "$(3)" ]; then \
+@BUILDINFO="$$(go version -m $(1) 2>/dev/null)" || BUILDINFO="" ;\
+MOD_VERSION="$$(printf '%s\n' "$$BUILDINFO" | awk '$$1=="mod"{print $$3; exit}')" ;\
+if [ -n "$$BUILDINFO" ] && [ "$$MOD_VERSION" = "$(3)" ] && printf '%s\n' "$$BUILDINFO" | grep -qF "GOOS=$$(go env GOOS)" && printf '%s\n' "$$BUILDINFO" | grep -qF "GOARCH=$$(go env GOARCH)"; then \
 	echo "$(notdir $(1)) $(3) is already installed" ;\
 else \
-	if [ "$$ARCH_OK" = "0" ]; then echo "$(notdir $(1)) exists but cannot execute on this platform, removing and re-downloading" ; fi ;\
 	set -e ;\
 	mkdir -p $(dir $(1)) ;\
-	rm -f $(1) $(1).version ;\
+	rm -f $(1) ;\
 	TMP_DIR=$$(mktemp -d) ;\
 	cd $$TMP_DIR ;\
 	go mod init tmp ;\
@@ -570,7 +573,6 @@ else \
 	GOBIN=$(dir $(1)) go install -a -mod=mod $(2) ;\
 	cd - >/dev/null ;\
 	rm -rf $$TMP_DIR ;\
-	echo "$(3)" > $(1).version ;\
 fi
 endef
 

--- a/Makefile
+++ b/Makefile
@@ -214,12 +214,7 @@ GOLANGCI_LINT = $(LOCALBIN)/$(BRANCH_VERSION)/golangci-lint
 .PHONY: golangci-lint $(GOLANGCI_LINT)
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
-	@if [ -f $(GOLANGCI_LINT) ] && $(GOLANGCI_LINT) --version | grep -q $(GOLANGCI_LINT_VERSION); then \
-		echo "golangci-lint $(GOLANGCI_LINT_VERSION) is already installed"; \
-	else \
-		echo "Installing golangci-lint $(GOLANGCI_LINT_VERSION)"; \
-		$(call go-install-tool-branch,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)); \
-	fi
+	$(call go-install-tool-versioned,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION),$(GOLANGCI_LINT_VERSION))
 	@if [ -L "$(LOCALBIN)/golangci-lint" ]; then \
 		unlink "$(LOCALBIN)/golangci-lint"; \
 	fi
@@ -303,19 +298,19 @@ KUSTOMIZE ?= $(LOCALBIN)/$(BRANCH_VERSION)/kustomize
 CONTROLLER_GEN ?= $(LOCALBIN)/$(BRANCH_VERSION)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 
-.PHONY: kustomize
+.PHONY: kustomize $(KUSTOMIZE)
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary. If wrong version is installed, it will be removed before downloading.
 $(KUSTOMIZE): $(LOCALBIN)
-	$(call go-install-tool-branch,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v5@$(KUSTOMIZE_VERSION))
+	$(call go-install-tool-versioned,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v5@$(KUSTOMIZE_VERSION),$(KUSTOMIZE_VERSION))
 	@if [ -L "$(LOCALBIN)/kustomize" ]; then \
 		unlink "$(LOCALBIN)/kustomize"; \
 	fi
 	@ln -sf "$(LOCALBIN)/$(BRANCH_VERSION)/kustomize" "$(LOCALBIN)/kustomize"
 
-.PHONY: controller-gen
+.PHONY: controller-gen $(CONTROLLER_GEN)
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary. If wrong version is installed, it will be overwritten.
 $(CONTROLLER_GEN): $(LOCALBIN)
-	$(call go-install-tool-branch,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION))
+	$(call go-install-tool-versioned,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION),$(CONTROLLER_TOOLS_VERSION))
 	@if [ -L "$(LOCALBIN)/controller-gen" ]; then \
 		unlink "$(LOCALBIN)/controller-gen"; \
 	fi
@@ -530,6 +525,29 @@ echo "Downloading $(2) to branch directory" ;\
 GOBIN=$(dir $(1)) go install -a -mod=mod $(2) ;\
 rm -rf $$TMP_DIR ;\
 }
+endef
+
+# go-install-tool-versioned installs $2 to branch-specific path $1, but only if $1 is missing
+# or $1.version doesn't match the pinned version $3. Uses a sidecar marker file instead of
+# introspecting the binary's own --version output, because that output is unreliable for some
+# tools when installed via `go install` (e.g. kustomize reports "(devel)" or an unexpanded
+# `$$Format:%H$$` placeholder instead of its real version, depending on build-time factors).
+define go-install-tool-versioned
+@if [ -f $(1) ] && [ -f $(1).version ] && [ "$$(cat $(1).version)" = "$(3)" ]; then \
+	echo "$(notdir $(1)) $(3) is already installed" ;\
+else \
+	set -e ;\
+	mkdir -p $(dir $(1)) ;\
+	rm -f $(1) $(1).version ;\
+	TMP_DIR=$$(mktemp -d) ;\
+	cd $$TMP_DIR ;\
+	go mod init tmp ;\
+	echo "Installing $(notdir $(1)) $(3)" ;\
+	GOBIN=$(dir $(1)) go install -a -mod=mod $(2) ;\
+	cd - >/dev/null ;\
+	rm -rf $$TMP_DIR ;\
+	echo "$(3)" > $(1).version ;\
+fi
 endef
 
 YQ = $(LOCALBIN)/yq


### PR DESCRIPTION
Folds in #2152 (same author, same theme, reviewer bandwidth is thin — consolidating into one PR rather than two small ones).

## Summary

`go-install-tool-branch` only installs a build tool (controller-gen, kustomize, golangci-lint) when the binary is **missing**, never verifying the pinned version against what's already on disk. Once a binary lands at `bin/<branch>/<tool>`, it's reused forever — even across branch switches, even after `CONTROLLER_TOOLS_VERSION`/`KUSTOMIZE_VERSION`/`GOLANGCI_LINT_VERSION` change — because `bin/` is gitignored and nothing else resets it. `kustomize`/`controller-gen` targets also weren't fully `.PHONY`, so Make's own mtime-based staleness check could skip the recipe entirely before any check even ran.

None of the four tools (`controller-gen`/`kustomize`/`golangci-lint`/`setup-envtest`, the last folded in from #2152) were checked for architecture compatibility either. This repo's own Makefile documents running `make test` inside `docker run --platform linux/amd64 -v $PWD:$PWD ...` to reproduce Prow's CI environment — that bind-mounts the real host directory into a forced-arch container, so any `go install` in there writes a foreign-arch binary straight onto the host's `bin/` tree (same path, not a copy). Not envtest-specific — any of these four cached tool binaries can be clobbered this way.

## Design

`go-install-tool-versioned` reads a binary's **embedded build info** via `go version -m` — the module version and `GOOS`/`GOARCH` a binary was built with — instead of executing it or trusting a sidecar marker file:

```
$ go version -m bin/oadp-dev/kustomize
	mod	sigs.k8s.io/kustomize/kustomize/v5	v5.2.1	h1:...
	build	GOARCH=arm64
	build	GOOS=darwin
```

- **Version**: the `mod` line's version, not the tool's own `--version` output. That output isn't a reliable version or health signal on its own: it can depend on ldflags a tool's own release process sets (which `go install` doesn't set — verified in practice: three `bin/*/kustomize` binaries on this machine, installed identically, reported `(devel)`, an unexpanded `$Format:%H$` placeholder, and a correct `v5.2.1`), and some tools exit nonzero on `--version` even when perfectly healthy (`kustomize` exits `1`, `setup-envtest`'s `--help` exits `2`). A bare probe command that exits nonzero is also dangerous under this Makefile's `.SHELLFLAGS = -ec` (enables `set -e`, honored by GNU Make 3.82+): it aborts the whole recipe unless wrapped in an `if`/`||` guard.
- **Architecture**: the `build GOOS=.../GOARCH=...` lines against this host's own, instead of executing the binary and interpreting its exit code — which can't detect a wrong-arch binary at all inside a container with `qemu-user-static`/`binfmt_misc` registered (standard for multi-arch CI/build images), since the foreign-arch binary just runs under emulation and returns its own exit code rather than an exec-format-error.

Reading embedded build info sidesteps both problems at once: no execution means no exit-code heuristic to get wrong and no qemu blind spot. `setup-envtest`'s arch check is folded into this same shared macro rather than kept as a separate mechanism.

## Known limitations

- **`ENVTESTPATH`'s arch selection has a separate, pre-existing bug — tracked as #2377, not fixed here.** Its `ifeq`-based amd64 fallback is decided at Makefile-parse time and picks the amd64-forced variant on any cold `bin/`, regardless of actual host arch — confirmed via direct repro (see #2377). It's invisible on amd64 CI (no CI/release-branch risk) and only affects arm64 local dev with a cold checkout, so it's out of scope here rather than a reason to expand this PR's diff a third time.
- Unversioned tool symlinks (`bin/<tool>` → last-branch-wins, pre-existing behavior) are a separate, lower-priority observation, also worth a follow-up.

## Testing

Verified against **GNU Make 4.4.1** specifically (installed via Homebrew), not just the macOS-default Make 3.81 — the latter silently ignores `.SHELLFLAGS`, so it can't exercise `set -e` recipe behavior at all.

- `rm -rf bin/oadp-dev` then `gmake controller-gen` / `gmake kustomize` / `gmake golangci-lint` / `gmake envtest` individually — each installs fresh.
- Re-running each immediately after → "already installed", no reinstall, no network call.
- Simulated a wrong-arch binary for all four tools (cross-compiled a real `linux/amd64` binary, copied it over the working native binary) → each correctly detected via `go version -m`'s `GOARCH`/`GOOS` fields, removed, reinstalled with a valid native binary.
- `gmake generate manifests bundle` → zero diff against a clean checkout.
- `gmake test` → exit 0, all packages pass, `api is up to date`, `bundle is up to date`.
- `coderabbit review --agent` → 0 findings.

Cherry-picked to `oadp-1.4` as #2368.

> [!Note]
> Responses generated with Claude


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool installation validation using embedded version and architecture metadata.
  * Automatically removes mismatched binaries and installs the requested versions.
  * Preserves unversioned command aliases where applicable.
  * Removed reliance on separate version marker files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->