### PR TITLE
[oadp-1.4] Make controller-gen/kustomize/golangci-lint/envtest tool-binary caching reliable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -712,15 +712,25 @@ rm -rf $$TMP_DIR ;\
 }
 endef
 
-# go-install-tool-versioned installs $2 to branch-specific path $1, but only if $1 is missing
-# or $1.version doesn't match the pinned version $3. Uses a sidecar marker file instead of
-# introspecting the binary's own --version output, because that output is unreliable for some
-# tools when installed via `go install` (e.g. kustomize reports "(devel)" or an unexpanded
-# `$$Format:%H$$` placeholder instead of its real version, depending on build-time factors).
+# go-install-tool-versioned installs $2 to branch-specific path $1, but only if $1 is missing,
+# $1.version doesn't match the pinned version $3, or $1 exists but cannot execute on this
+# platform (checked via exit code 126, POSIX "found but cannot execute" / exec format error —
+# this can happen when a containerized build with a different GOARCH bind-mounts the host's
+# bin/ directory, e.g. `docker run --platform linux/amd64 -v $$PWD:$$PWD ... make manifests`).
+# Uses a sidecar marker file for the version check instead of introspecting the binary's own
+# --version output, because that output is unreliable for some tools when installed via
+# `go install` (e.g. kustomize reports "(devel)" or an unexpanded `$$Format:%H$$` placeholder
+# instead of its real version, depending on build-time factors).
 define go-install-tool-versioned
-@if [ -f $(1) ] && [ -f $(1).version ] && [ "$$(cat $(1).version)" = "$(3)" ]; then \
+@ARCH_OK=1 ;\
+if [ -f $(1) ]; then \
+	$(1) --version >/dev/null 2>&1 ;\
+	if [ $$? -eq 126 ]; then ARCH_OK=0 ; fi ;\
+fi ;\
+if [ "$$ARCH_OK" = "1" ] && [ -f $(1) ] && [ -f $(1).version ] && [ "$$(cat $(1).version)" = "$(3)" ]; then \
 	echo "$(notdir $(1)) $(3) is already installed" ;\
 else \
+	if [ "$$ARCH_OK" = "0" ]; then echo "$(notdir $(1)) exists but cannot execute on this platform, removing and re-downloading" ; fi ;\
 	set -e ;\
 	mkdir -p $(dir $(1)) ;\
 	rm -f $(1) $(1).version ;\

--- a/Makefile
+++ b/Makefile
@@ -304,13 +304,8 @@ ENVTESTPATH = $(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)
 ifeq ($(shell $(ENVTEST) list | grep $(ENVTEST_K8S_VERSION)),)
 	ENVTESTPATH = $(shell $(ENVTEST) --arch=amd64 use $(ENVTEST_K8S_VERSION) -p path)
 endif
-# Uses go-install-tool-versioned (see its doc comment above) instead of a bespoke
-# check-envtest-arch target: an earlier version of this check ran `$(ENVTEST) --help` and
-# treated any nonzero exit as "wrong architecture" — but setup-envtest's own --help exits 2
-# by its own convention even on a perfectly healthy binary, which under this Makefile's
-# `.SHELLFLAGS = -ec` aborts the whole recipe (confirmed with real GNU Make 4.4.1) rather
-# than being caught, so it was unconditionally reinstalling setup-envtest on every single
-# invocation.
+# Uses go-install-tool-versioned (see its doc comment above) for both the version and
+# architecture check, rather than a bespoke arch-only check here.
 .PHONY: envtest $(ENVTEST)
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
@@ -707,28 +702,23 @@ endef
 
 # go-install-tool-versioned installs $2 to branch-specific path $1, but only if $1 is missing,
 # doesn't have the pinned module version $3 embedded in it, or was built for a different
-# GOOS/GOARCH than this host. Uses `go version -m` to read the binary's embedded build info
-# directly (module version, GOOS, GOARCH) instead of executing it or trusting a sidecar marker
-# file — this avoids two real failure modes found in earlier attempts at this check:
-#   - Introspecting the binary's own --version/--help output is unreliable: some tools report
-#     a version string that depends on ldflags their own release process sets, which `go
-#     install` doesn't set (e.g. kustomize reporting "(devel)" or an unexpanded `$$Format:%H$$`
-#     placeholder), and some tools exit nonzero on --version even when perfectly healthy (e.g.
-#     kustomize exits 1, setup-envtest's --help exits 2) — so a naive "nonzero exit means
-#     broken" check is wrong, and worse, a bare failing probe command under `set -e`/`-o
-#     pipefail` (this Makefile's .SHELLFLAGS, honored by GNU Make 3.82+ — silently ignored by
-#     the ancient Make 3.81 macOS ships, which is why this went unnoticed locally) aborts the
-#     entire recipe rather than being caught. Verified directly against real GNU Make 4.4.1:
-#     the previous exit-code-126 version of this macro reliably crashed `make kustomize`
-#     with "Error 1" every time the binary already existed.
-#   - Actually executing the binary to test compatibility (this macro's own earlier approach,
-#     and the same technique in #2152) can't detect a wrong-arch binary at all in a container
-#     with qemu-user-static/binfmt_misc registered (common in multi-arch CI/build images):
-#     the foreign-arch binary runs under emulation and returns its own exit code, not an
-#     exec-format-error, defeating the whole check silently in exactly the environments where
-#     it matters most.
-# `go version -m` reads the embedded build info without ever executing the binary, sidestepping
-# both problems at once.
+# GOOS/GOARCH than this host. Uses `go version -m` to read a binary's embedded build info
+# (module version, GOOS, GOARCH) instead of executing it or trusting a sidecar marker file:
+#   - A binary's own --version/--help output is not a reliable version or health signal. It
+#     can depend on ldflags a tool's own release process sets, which `go install` doesn't set
+#     (e.g. kustomize can report "(devel)" or an unexpanded `$$Format:%H$$` placeholder instead
+#     of its real version), and some tools exit nonzero on --version even when perfectly
+#     healthy (kustomize exits 1, setup-envtest's --help exits 2) — so "nonzero exit means
+#     broken" is the wrong signal. It's also dangerous under this Makefile's
+#     `.SHELLFLAGS = -ec` (enables `set -e`, honored by GNU Make 3.82+ but silently ignored by
+#     the Make 3.81 macOS ships): a bare probe command that exits nonzero aborts the whole
+#     recipe unless it's wrapped in an `if`/`||` guard.
+#   - Executing the binary to test compatibility can't detect a wrong-arch binary at all
+#     inside a container with qemu-user-static/binfmt_misc registered (common in multi-arch
+#     CI/build images): the foreign-arch binary runs under emulation and returns its own exit
+#     code rather than an exec-format-error.
+# Reading embedded build info sidesteps both: no execution means no exit-code heuristic to
+# get wrong and no qemu blind spot.
 define go-install-tool-versioned
 @BUILDINFO="$$(go version -m $(1) 2>/dev/null)" || BUILDINFO="" ;\
 MOD_VERSION="$$(printf '%s\n' "$$BUILDINFO" | awk '$$1=="mod"{print $$3; exit}')" ;\

--- a/Makefile
+++ b/Makefile
@@ -706,28 +706,51 @@ rm -rf $$TMP_DIR ;\
 }
 endef
 
-.PHONY: golangci-lint
+# go-install-tool-versioned installs $2 to branch-specific path $1, but only if $1 is missing
+# or $1.version doesn't match the pinned version $3. Uses a sidecar marker file instead of
+# introspecting the binary's own --version output, because that output is unreliable for some
+# tools when installed via `go install` (e.g. kustomize reports "(devel)" or an unexpanded
+# `$$Format:%H$$` placeholder instead of its real version, depending on build-time factors).
+define go-install-tool-versioned
+@if [ -f $(1) ] && [ -f $(1).version ] && [ "$$(cat $(1).version)" = "$(3)" ]; then \
+	echo "$(notdir $(1)) $(3) is already installed" ;\
+else \
+	set -e ;\
+	mkdir -p $(dir $(1)) ;\
+	rm -f $(1) $(1).version ;\
+	TMP_DIR=$$(mktemp -d) ;\
+	cd $$TMP_DIR ;\
+	go mod init tmp ;\
+	echo "Installing $(notdir $(1)) $(3)" ;\
+	GOBIN=$(dir $(1)) go install -mod=mod $(2) ;\
+	cd - >/dev/null ;\
+	rm -rf $$TMP_DIR ;\
+	echo "$(3)" > $(1).version ;\
+fi
+endef
+
+.PHONY: golangci-lint $(GOLANGCI_LINT)
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
-	$(call go-install-tool-branch,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION))
+	$(call go-install-tool-versioned,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION),$(GOLANGCI_LINT_VERSION))
 	@if [ -L "$(LOCALBIN)/golangci-lint" ]; then \
 		unlink "$(LOCALBIN)/golangci-lint"; \
 	fi
 	@ln -sf "$(LOCALBIN)/$(BRANCH_VERSION)/golangci-lint" "$(LOCALBIN)/golangci-lint"
 
-.PHONY: kustomize
+.PHONY: kustomize $(KUSTOMIZE)
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary. If wrong version is installed, it will be removed before downloading.
 $(KUSTOMIZE): $(LOCALBIN)
-	$(call go-install-tool-branch,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v4@$(KUSTOMIZE_VERSION))
+	$(call go-install-tool-versioned,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v4@$(KUSTOMIZE_VERSION),$(KUSTOMIZE_VERSION))
 	@if [ -L "$(LOCALBIN)/kustomize" ]; then \
 		unlink "$(LOCALBIN)/kustomize"; \
 	fi
 	@ln -sf "$(LOCALBIN)/$(BRANCH_VERSION)/kustomize" "$(LOCALBIN)/kustomize"
 
-.PHONY: controller-gen
+.PHONY: controller-gen $(CONTROLLER_GEN)
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary. If wrong version is installed, it will be overwritten.
 $(CONTROLLER_GEN): $(LOCALBIN)
-	$(call go-install-tool-branch,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION))
+	$(call go-install-tool-versioned,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION),$(CONTROLLER_TOOLS_VERSION))
 	@if [ -L "$(LOCALBIN)/controller-gen" ]; then \
 		unlink "$(LOCALBIN)/controller-gen"; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -304,11 +304,17 @@ ENVTESTPATH = $(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)
 ifeq ($(shell $(ENVTEST) list | grep $(ENVTEST_K8S_VERSION)),)
 	ENVTESTPATH = $(shell $(ENVTEST) --arch=amd64 use $(ENVTEST_K8S_VERSION) -p path)
 endif
+# Checked via exit code 126 specifically (POSIX "found but cannot execute" /
+# exec format error) rather than any nonzero exit, since setup-envtest's own
+# --help exits 2 by its own convention on a perfectly working binary.
 .PHONY: check-envtest-arch
 check-envtest-arch:
-	@if [ -f $(ENVTEST) ] && ! $(ENVTEST) --help >/dev/null 2>&1; then \
-		echo "$(ENVTEST) is not executable on this platform, removing and re-downloading"; \
-		rm -f $(ENVTEST); \
+	@if [ -f $(ENVTEST) ]; then \
+		$(ENVTEST) --help >/dev/null 2>&1; \
+		if [ $$? -eq 126 ]; then \
+			echo "$(ENVTEST) is not executable on this platform, removing and re-downloading"; \
+			rm -f $(ENVTEST); \
+		fi; \
 	fi
 
 $(ENVTEST): check-envtest-arch ## Download envtest-setup locally if necessary.

--- a/Makefile
+++ b/Makefile
@@ -304,24 +304,17 @@ ENVTESTPATH = $(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)
 ifeq ($(shell $(ENVTEST) list | grep $(ENVTEST_K8S_VERSION)),)
 	ENVTESTPATH = $(shell $(ENVTEST) --arch=amd64 use $(ENVTEST_K8S_VERSION) -p path)
 endif
-# Checked via exit code 126 specifically (POSIX "found but cannot execute" /
-# exec format error) rather than any nonzero exit, since setup-envtest's own
-# --help exits 2 by its own convention on a perfectly working binary.
-.PHONY: check-envtest-arch
-check-envtest-arch:
-	@if [ -f $(ENVTEST) ]; then \
-		$(ENVTEST) --help >/dev/null 2>&1; \
-		if [ $$? -eq 126 ]; then \
-			echo "$(ENVTEST) is not executable on this platform, removing and re-downloading"; \
-			rm -f $(ENVTEST); \
-		fi; \
-	fi
-
-$(ENVTEST): check-envtest-arch ## Download envtest-setup locally if necessary.
-	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20250308055145-5fe7bb3edc86)
-
-.PHONY: envtest
-envtest: $(ENVTEST)
+# Uses go-install-tool-versioned (see its doc comment above) instead of a bespoke
+# check-envtest-arch target: an earlier version of this check ran `$(ENVTEST) --help` and
+# treated any nonzero exit as "wrong architecture" — but setup-envtest's own --help exits 2
+# by its own convention even on a perfectly healthy binary, which under this Makefile's
+# `.SHELLFLAGS = -ec` aborts the whole recipe (confirmed with real GNU Make 4.4.1) rather
+# than being caught, so it was unconditionally reinstalling setup-envtest on every single
+# invocation.
+.PHONY: envtest $(ENVTEST)
+envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
+$(ENVTEST): $(LOCALBIN)
+	$(call go-install-tool-versioned,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20250308055145-5fe7bb3edc86,v0.0.0-20250308055145-5fe7bb3edc86)
 
 # If test results in prow are different, it is because the environment used.
 # You can simulate their env by running
@@ -713,27 +706,38 @@ rm -rf $$TMP_DIR ;\
 endef
 
 # go-install-tool-versioned installs $2 to branch-specific path $1, but only if $1 is missing,
-# $1.version doesn't match the pinned version $3, or $1 exists but cannot execute on this
-# platform (checked via exit code 126, POSIX "found but cannot execute" / exec format error —
-# this can happen when a containerized build with a different GOARCH bind-mounts the host's
-# bin/ directory, e.g. `docker run --platform linux/amd64 -v $$PWD:$$PWD ... make manifests`).
-# Uses a sidecar marker file for the version check instead of introspecting the binary's own
-# --version output, because that output is unreliable for some tools when installed via
-# `go install` (e.g. kustomize reports "(devel)" or an unexpanded `$$Format:%H$$` placeholder
-# instead of its real version, depending on build-time factors).
+# doesn't have the pinned module version $3 embedded in it, or was built for a different
+# GOOS/GOARCH than this host. Uses `go version -m` to read the binary's embedded build info
+# directly (module version, GOOS, GOARCH) instead of executing it or trusting a sidecar marker
+# file — this avoids two real failure modes found in earlier attempts at this check:
+#   - Introspecting the binary's own --version/--help output is unreliable: some tools report
+#     a version string that depends on ldflags their own release process sets, which `go
+#     install` doesn't set (e.g. kustomize reporting "(devel)" or an unexpanded `$$Format:%H$$`
+#     placeholder), and some tools exit nonzero on --version even when perfectly healthy (e.g.
+#     kustomize exits 1, setup-envtest's --help exits 2) — so a naive "nonzero exit means
+#     broken" check is wrong, and worse, a bare failing probe command under `set -e`/`-o
+#     pipefail` (this Makefile's .SHELLFLAGS, honored by GNU Make 3.82+ — silently ignored by
+#     the ancient Make 3.81 macOS ships, which is why this went unnoticed locally) aborts the
+#     entire recipe rather than being caught. Verified directly against real GNU Make 4.4.1:
+#     the previous exit-code-126 version of this macro reliably crashed `make kustomize`
+#     with "Error 1" every time the binary already existed.
+#   - Actually executing the binary to test compatibility (this macro's own earlier approach,
+#     and the same technique in #2152) can't detect a wrong-arch binary at all in a container
+#     with qemu-user-static/binfmt_misc registered (common in multi-arch CI/build images):
+#     the foreign-arch binary runs under emulation and returns its own exit code, not an
+#     exec-format-error, defeating the whole check silently in exactly the environments where
+#     it matters most.
+# `go version -m` reads the embedded build info without ever executing the binary, sidestepping
+# both problems at once.
 define go-install-tool-versioned
-@ARCH_OK=1 ;\
-if [ -f $(1) ]; then \
-	$(1) --version >/dev/null 2>&1 ;\
-	if [ $$? -eq 126 ]; then ARCH_OK=0 ; fi ;\
-fi ;\
-if [ "$$ARCH_OK" = "1" ] && [ -f $(1) ] && [ -f $(1).version ] && [ "$$(cat $(1).version)" = "$(3)" ]; then \
+@BUILDINFO="$$(go version -m $(1) 2>/dev/null)" || BUILDINFO="" ;\
+MOD_VERSION="$$(printf '%s\n' "$$BUILDINFO" | awk '$$1=="mod"{print $$3; exit}')" ;\
+if [ -n "$$BUILDINFO" ] && [ "$$MOD_VERSION" = "$(3)" ] && printf '%s\n' "$$BUILDINFO" | grep -qF "GOOS=$$(go env GOOS)" && printf '%s\n' "$$BUILDINFO" | grep -qF "GOARCH=$$(go env GOARCH)"; then \
 	echo "$(notdir $(1)) $(3) is already installed" ;\
 else \
-	if [ "$$ARCH_OK" = "0" ]; then echo "$(notdir $(1)) exists but cannot execute on this platform, removing and re-downloading" ; fi ;\
 	set -e ;\
 	mkdir -p $(dir $(1)) ;\
-	rm -f $(1) $(1).version ;\
+	rm -f $(1) ;\
 	TMP_DIR=$$(mktemp -d) ;\
 	cd $$TMP_DIR ;\
 	go mod init tmp ;\
@@ -741,7 +745,6 @@ else \
 	GOBIN=$(dir $(1)) go install -mod=mod $(2) ;\
 	cd - >/dev/null ;\
 	rm -rf $$TMP_DIR ;\
-	echo "$(3)" > $(1).version ;\
 fi
 endef
 

--- a/Makefile
+++ b/Makefile
@@ -300,17 +300,14 @@ vet: check-go ## Run go vet against code.
 	go vet -mod=mod ./...
 
 ENVTEST := $(shell pwd)/bin/setup-envtest
-ENVTESTPATH = $(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)
-ifeq ($(shell $(ENVTEST) list | grep $(ENVTEST_K8S_VERSION)),)
-	ENVTESTPATH = $(shell $(ENVTEST) --arch=amd64 use $(ENVTEST_K8S_VERSION) -p path)
-endif
-# Uses go-install-tool-versioned (see its doc comment above) instead of a bespoke
-# check-envtest-arch target: an earlier version of this check ran `$(ENVTEST) --help` and
-# treated any nonzero exit as "wrong architecture" — but setup-envtest's own --help exits 2
-# by its own convention even on a perfectly healthy binary, which under this Makefile's
-# `.SHELLFLAGS = -ec` aborts the whole recipe (confirmed with real GNU Make 4.4.1) rather
-# than being caught, so it was unconditionally reinstalling setup-envtest on every single
-# invocation.
+# Native-arch resolution first, falling back to amd64 only if that fails (e.g. no
+# native-arch envtest assets published for this k8s version). Done as a single shell
+# expression (not a make ifeq) so it's decided when ENVTESTPATH is actually referenced
+# in a recipe, after $(ENVTEST) is guaranteed installed for the host's real arch --
+# not at Makefile-parse time against a possibly-cold bin/ (see issue #2377).
+ENVTESTPATH = $(shell out=$$($(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path 2>/dev/null); if [ -z "$$out" ]; then out=$$($(ENVTEST) --arch=amd64 use $(ENVTEST_K8S_VERSION) -p path 2>/dev/null); fi; echo "$$out")
+# Uses go-install-tool-versioned (see its doc comment below) for both the version and
+# architecture check, rather than a bespoke arch-only check here.
 .PHONY: envtest $(ENVTEST)
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)

--- a/Makefile
+++ b/Makefile
@@ -300,14 +300,17 @@ vet: check-go ## Run go vet against code.
 	go vet -mod=mod ./...
 
 ENVTEST := $(shell pwd)/bin/setup-envtest
-# Native-arch resolution first, falling back to amd64 only if that fails (e.g. no
-# native-arch envtest assets published for this k8s version). Done as a single shell
-# expression (not a make ifeq) so it's decided when ENVTESTPATH is actually referenced
-# in a recipe, after $(ENVTEST) is guaranteed installed for the host's real arch --
-# not at Makefile-parse time against a possibly-cold bin/ (see issue #2377).
-ENVTESTPATH = $(shell out=$$($(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path 2>/dev/null); if [ -z "$$out" ]; then out=$$($(ENVTEST) --arch=amd64 use $(ENVTEST_K8S_VERSION) -p path 2>/dev/null); fi; echo "$$out")
-# Uses go-install-tool-versioned (see its doc comment below) for both the version and
-# architecture check, rather than a bespoke arch-only check here.
+ENVTESTPATH = $(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)
+ifeq ($(shell $(ENVTEST) list | grep $(ENVTEST_K8S_VERSION)),)
+	ENVTESTPATH = $(shell $(ENVTEST) --arch=amd64 use $(ENVTEST_K8S_VERSION) -p path)
+endif
+# Uses go-install-tool-versioned (see its doc comment above) instead of a bespoke
+# check-envtest-arch target: an earlier version of this check ran `$(ENVTEST) --help` and
+# treated any nonzero exit as "wrong architecture" — but setup-envtest's own --help exits 2
+# by its own convention even on a perfectly healthy binary, which under this Makefile's
+# `.SHELLFLAGS = -ec` aborts the whole recipe (confirmed with real GNU Make 4.4.1) rather
+# than being caught, so it was unconditionally reinstalling setup-envtest on every single
+# invocation.
 .PHONY: envtest $(ENVTEST)
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)


### PR DESCRIPTION
Cherry-pick of #2367 to `oadp-1.4` — same fix, plus this branch's own pre-existing envtest arch-check bug (see below).

## Summary

`go-install-tool-branch` only installs a build tool when its binary is **missing**, never verifying the pinned version against what's already on disk. Once a binary lands at `bin/<branch>/<tool>`, it's reused forever — even after `CONTROLLER_TOOLS_VERSION`/`KUSTOMIZE_VERSION`/`GOLANGCI_LINT_VERSION` change — because `bin/` is gitignored. `kustomize`/`controller-gen` targets also weren't fully `.PHONY`, so Make's own mtime-based staleness check could skip the recipe before any check ran.

None of the four tools (`controller-gen`/`kustomize`/`golangci-lint`/`setup-envtest`, the last folded in from #2152) were checked for architecture compatibility either. This repo's own Makefile documents a `docker run --platform linux/amd64 -v $PWD:$PWD ...` workflow to reproduce Prow's CI environment — that bind-mounts the host directory into a forced-arch container, so any `go install` in there writes a foreign-arch binary straight onto the host's `bin/` tree (same path, not a copy).

This branch already had a bespoke `check-envtest-arch` target (from #2100) attempting to guard against exactly this for `setup-envtest`, but it checked `$(ENVTEST) --help`'s exit code and treated any nonzero result as "wrong architecture" — `setup-envtest`'s own `--help` exits `2` by its own convention even on a perfectly healthy binary, so it was unconditionally reinstalling `setup-envtest` on every single invocation.

## Design

`go-install-tool-versioned` reads a binary's **embedded build info** via `go version -m` — the module version and `GOOS`/`GOARCH` it was built with — instead of executing the binary or trusting a sidecar marker file:

- A binary's own `--version`/`--help` output isn't a reliable version or health signal: it can depend on ldflags a tool's own release process sets (which `go install` doesn't set — e.g. `kustomize` can report `(devel)` or an unexpanded `$Format:%H$` placeholder instead of its real version), and some tools exit nonzero on `--version` even when perfectly healthy (`kustomize` exits `1`, `setup-envtest`'s `--help` exits `2`). A bare probe command that exits nonzero is also dangerous under this Makefile's `.SHELLFLAGS = -ec` (enables `set -e`, honored by GNU Make 3.82+): it aborts the whole recipe unless wrapped in an `if`/`||` guard.
- Executing the binary to test compatibility can't detect a wrong-arch binary at all inside a container with `qemu-user-static`/`binfmt_misc` registered (standard for multi-arch CI/build images) — the foreign-arch binary just runs under emulation and returns its own exit code, not an exec-format-error.

Reading embedded build info sidesteps both: no execution means no exit-code heuristic to get wrong and no qemu blind spot. `setup-envtest`'s arch check is folded into this same shared macro rather than kept as a separate mechanism.

## Known limitations

- **`ENVTESTPATH`'s arch selection has a separate, pre-existing bug — tracked as #2377, not fixed here.** Its `ifeq`-based amd64 fallback is decided at Makefile-parse time and picks the amd64-forced variant on any cold `bin/`, regardless of actual host arch — confirmed via direct repro (see #2377). It's invisible on amd64 CI (no CI/release-branch risk) and only affects arm64 local dev with a cold checkout, so it's out of scope here rather than a reason to expand this PR's diff a third time.
- `golangci-lint@v1.54.2` (this branch's pin) doesn't build against a modern Go 1.26 toolchain — a pre-existing, unrelated `x/tools` incompatibility; CI pins its own Go version and isn't affected. Bumping to the latest `v1.x` (`v1.64.8`, avoiding `v2`'s config/default-linter overhaul) does fix the build, but its updated `staticcheck`/`ineffassign`/`gosimple` linters immediately surface ~20 pre-existing findings across unrelated files. Left the pin as-is — real scope growth this PR shouldn't absorb.
- Unversioned tool symlinks (`bin/<tool>` → last-branch-wins, pre-existing behavior), a lower-priority observation, also worth a follow-up.

## Testing

Verified against **GNU Make 4.4.1** specifically (installed via Homebrew), not just the macOS-default Make 3.81 — the latter silently ignores `.SHELLFLAGS`, so it can't exercise `set -e` recipe behavior at all.

- `rm -rf bin/oadp-1.4` / `rm -f bin/setup-envtest`, then `gmake controller-gen` / `gmake kustomize` / `gmake envtest` individually — each installs fresh.
- Re-running each immediately after → "already installed", no reinstall, no network call.
- Simulated a wrong-arch binary (cross-compiled `linux/amd64`) for controller-gen, kustomize, and envtest → each correctly detected via `go version -m`'s `GOARCH`/`GOOS` fields, removed, reinstalled with a valid native binary.
- `gmake generate manifests bundle` → zero diff against a clean checkout.
- `gmake test` → exit 0, all packages pass, `Go code is formatted`, `api is up to date`, `bundle is up to date`.

> [!Note]
> Responses generated with Claude
