### PR TITLE
[oadp-1.5] fix: check errors.IsNotFound before failing DaemonSet delete in NodeAgent reconcile

### DIFF
--- a/internal/controller/nodeagent.go
+++ b/internal/controller/nodeagent.go
@@ -212,6 +212,9 @@ func (r *DataProtectionApplicationReconciler) ReconcileNodeAgentDaemonset(log lo
 		// no errors means there is already an existing DaemonSet.
 		// TODO: Check if NodeAgent is in use, a backup is running, so don't blindly delete NodeAgent.
 		if err := r.Delete(deleteContext, ds, &client.DeleteOptions{PropagationPolicy: ptr.To(metav1.DeletePropagationForeground)}); err != nil {
+			if errors.IsNotFound(err) {
+				return true, nil
+			}
 			// TODO: Come back and fix event recording to be consistent
 			r.EventRecorder.Event(ds, corev1.EventTypeNormal, "DeleteDaemonSetFailed", "Got DaemonSet to delete but could not delete err:"+err.Error())
 			return false, err


### PR DESCRIPTION
## Summary
The DaemonSet deletion path in `ReconcileNodeAgentDaemonset` didn't check `errors.IsNotFound(err)` before treating a delete failure as a real error — unlike the adjacent `Get()` call and the ConfigMap deletion path in the same file, which both handle this correctly.

```go
if err := r.Delete(deleteContext, ds, &client.DeleteOptions{...}); err != nil {
    if errors.IsNotFound(err) {
        return true, nil
    }
    r.EventRecorder.Event(ds, corev1.EventTypeNormal, "DeleteDaemonSetFailed", "...")
    return false, err
}
```

## How this was found
Surfaced by this repo's own e2e log-analysis tooling on `ci/prow/4.23-e2e-test-aws` for PR #2206 (`oadp-1.6`): the `AfterEach` cleanup of "Configuration testing for DPA Custom Resource" hit a `DeleteDaemonSetFailed` event while the velero pod was stuck `PodInitializing`. Confirmed to be a pre-existing bug present across `oadp-dev`/`oadp-1.6`/`oadp-1.5`/`oadp-1.4` (tracked via #2372 for all four branches; #2373/#2374 address `oadp-dev`/`oadp-1.6`, this PR addresses `oadp-1.5`).

## Test plan
- [x] `gofmt -l` clean
- [x] `go build ./internal/controller/...`
- [x] `go vet ./internal/controller/...`

Part of #2372

> [!Note]
> Responses generated with Claude