### PR TITLE
[oadp-1.4] fix: check errors.IsNotFound before failing DaemonSet delete in NodeAgent reconcile

### DIFF
--- a/controllers/nodeagent.go
+++ b/controllers/nodeagent.go
@@ -150,6 +150,9 @@ func (r *DPAReconciler) ReconcileNodeAgentDaemonset(log logr.Logger) (bool, erro
 		// If dpa.Spec.Configuration.NodeAgent enable exists and is false, attempt to delete.
 		deleteOptionPropagationForeground := metav1.DeletePropagationForeground
 		if err := r.Delete(deleteContext, ds, &client.DeleteOptions{PropagationPolicy: &deleteOptionPropagationForeground}); err != nil {
+			if errors.IsNotFound(err) {
+				return true, nil
+			}
 			// TODO: Come back and fix event recording to be consistent
 			r.EventRecorder.Event(ds, corev1.EventTypeNormal, "DeleteDaemonSetFailed", "Got DaemonSet to delete but could not delete err:"+err.Error())
 			return false, err


### PR DESCRIPTION
## Summary
The DaemonSet deletion path in `ReconcileNodeAgentDaemonset` didn't check `errors.IsNotFound(err)` before treating a delete failure as a real error — unlike the adjacent `Get()` call in the same function, which already handles this correctly.

```go
if err := r.Delete(deleteContext, ds, &client.DeleteOptions{...}); err != nil {
    if errors.IsNotFound(err) {
        return true, nil
    }
    r.EventRecorder.Event(ds, corev1.EventTypeNormal, "DeleteDaemonSetFailed", "...")
    return false, err
}
```

## How this was found
Surfaced by this repo's own e2e log-analysis tooling on `ci/prow/4.23-e2e-test-aws` for PR #2206 (`oadp-1.6`): the `AfterEach` cleanup of "Configuration testing for DPA Custom Resource" hit a `DeleteDaemonSetFailed` event while the velero pod was stuck `PodInitializing`. Confirmed to be a pre-existing bug present across `oadp-dev`/`oadp-1.6`/`oadp-1.5`/`oadp-1.4` (tracked via #2372 for all four branches; #2373/#2374/#2375 address `oadp-dev`/`oadp-1.6`/`oadp-1.5`, this PR addresses `oadp-1.4`).

## Test plan
- [x] `gofmt -l` clean
- [x] `go build ./controllers/...`
- [x] `go vet ./controllers/...`

Part of #2372

> [!Note]
> Responses generated with Claude