### PR TITLE
1.3: Fix ENVTESTPATH arch decided at Makefile-parse time on cold bin/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,10 +163,12 @@ vet: ## Run go vet against code.
 	go vet -mod=mod ./...
 
 ENVTEST := $(shell pwd)/bin/setup-envtest
-ENVTESTPATH = $(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)
-ifeq ($(shell $(ENVTEST) list | grep $(ENVTEST_K8S_VERSION)),)
-	ENVTESTPATH = $(shell $(ENVTEST) --arch=amd64 use $(ENVTEST_K8S_VERSION) -p path)
-endif
+# Native-arch resolution first, falling back to amd64 only if that fails (e.g. no
+# native-arch envtest assets published for this k8s version). Done as a single shell
+# expression (not a make ifeq) so it's decided when ENVTESTPATH is actually referenced
+# in a recipe, after $(ENVTEST) is guaranteed installed for the host's real arch --
+# not at Makefile-parse time against a possibly-cold bin/ (see issue #2377).
+ENVTESTPATH = $(shell out=$$($(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path 2>/dev/null); if [ -z "$$out" ]; then out=$$($(ENVTEST) --arch=amd64 use $(ENVTEST_K8S_VERSION) -p path 2>/dev/null); fi; echo "$$out")
 $(ENVTEST): ## Download envtest-setup locally if necessary.
 	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20250308055145-5fe7bb3edc86)
 


### PR DESCRIPTION
Fixes #2377

`ifeq` evaluates its `$(shell ...)` condition at Makefile-parse time, before any target's prerequisites run. On a cold `bin/` (`setup-envtest` not yet installed), `$(ENVTEST) list` fails silently, the grep finds nothing, and `ENVTESTPATH` gets permanently redefined to force `--arch=amd64` — regardless of host arch — even though `setup-envtest` is correctly installed for the host's native arch by the time the `test` recipe actually runs.

Moves the fallback entirely into the shell expression itself (still a recursively-expanded variable, so it's only evaluated when referenced in the `test` recipe, after `envtest` has installed the right arch).

Direct fix for oadp-1.3 — doesn't cherry-pick cleanly from the oadp-1.4 fix (oadp-1.3 predates the `go-install-tool-versioned` refactor), so opened separately rather than via cherry-pick bot.

> [!Note]
> Responses generated with Claude