### PR TITLE
PodResources must be complete for Velero parser

### DIFF
--- a/internal/controller/defaults.go
+++ b/internal/controller/defaults.go
@@ -1,0 +1,39 @@
+package controller
+
+import (
+	"github.com/vmware-tanzu/velero/pkg/util/kube"
+)
+
+const unbounded = "0"
+
+// This module is for setting structure defaults where the default golang values for the type are not valid.
+// int -> 0
+// float -> 0.0
+// string -> ""
+
+// PodResources with emptystring will trigger parsing errors in Velero.
+// Replace empty string with unbounded so partial resource setting is accepted.
+func setPodResourcesDefaults(pr *kube.PodResources) {
+	if pr == nil {
+		return
+	}
+
+	if pr.CPURequest == "" {
+		pr.CPURequest = unbounded
+	}
+	if pr.CPULimit == "" {
+		pr.CPULimit = unbounded
+	}
+	if pr.MemoryRequest == "" {
+		pr.MemoryRequest = unbounded
+	}
+	if pr.MemoryLimit == "" {
+		pr.MemoryLimit = unbounded
+	}
+	if pr.EphemeralStorageRequest == "" {
+		pr.EphemeralStorageRequest = unbounded
+	}
+	if pr.EphemeralStorageLimit == "" {
+		pr.EphemeralStorageLimit = unbounded
+	}
+}

--- a/internal/controller/nodeagent.go
+++ b/internal/controller/nodeagent.go
@@ -182,6 +182,12 @@ func (r *DataProtectionApplicationReconciler) updateNodeAgentCM(cm *corev1.Confi
 		}
 	}
 
+	// If PodResources is set all fields must be filled for the Velero parser or it will be rejected.
+	// Fill unused fields with "0" as "" will cause parser rejection.
+	if configWithPrivileged.PodResources != nil {
+		setPodResourcesDefaults(configWithPrivileged.PodResources)
+	}
+
 	// Convert NodeAgentConfigMapSettings to a generic map
 	configNodeAgentJSON, err := json.Marshal(configWithPrivileged)
 	if err != nil {

--- a/internal/controller/nodeagent_test.go
+++ b/internal/controller/nodeagent_test.go
@@ -2047,7 +2047,9 @@ func TestDPAReconciler_updateNodeAgentCM(t *testing.T) {
 						"cpuRequest": "100m",
 						"memoryRequest": "100Mi",
 						"cpuLimit": "200m",
-						"memoryLimit": "200Mi"
+						"memoryLimit": "200Mi",
+						"ephemeralStorageRequest": "0",
+						"ephemeralStorageLimit": "0"
 					},
 					"restorePVC": {
 						"ignoreDelayBinding": true

--- a/internal/controller/repository_maintenance.go
+++ b/internal/controller/repository_maintenance.go
@@ -47,6 +47,10 @@ func (r *DataProtectionApplicationReconciler) updateRepositoryMaintenanceCM(cm *
 	// to to match the upstream implementation
 	// https://github.com/vmware-tanzu/velero/issues/9159
 	for key, config := range r.dpa.Spec.Configuration.RepositoryMaintenance {
+		// Velero parses a resource string of "" as invalid, replace with unbounded if unset
+		if config.PodResources != nil {
+			setPodResourcesDefaults(config.PodResources)
+		}
 		configJSON, err := json.Marshal(config)
 		if err != nil {
 			return fmt.Errorf("failed to serialize repository maintenance config for key %s: %w", key, err)

--- a/internal/controller/repository_maintenance_test.go
+++ b/internal/controller/repository_maintenance_test.go
@@ -84,7 +84,7 @@ func TestDataProtectionApplicationReconciler_updateRepositoryMaintenanceCM(t *te
 					},
 				},
 				Data: map[string]string{
-					"global":            `{"loadAffinity":[{"nodeSelector":{"matchLabels":{"app.kubernetes.io/name":"test-dpa"}}}],"podResources":{"cpuRequest":"100m","memoryRequest":"128Mi","cpuLimit":"200m","memoryLimit":"256Mi"}}`,
+					"global":            `{"loadAffinity":[{"nodeSelector":{"matchLabels":{"app.kubernetes.io/name":"test-dpa"}}}],"podResources":{"cpuRequest":"100m","memoryRequest":"128Mi","cpuLimit":"200m","memoryLimit":"256Mi","ephemeralStorageRequest":"0","ephemeralStorageLimit":"0"}}`,
 					"maintenance-job-1": `{"loadAffinity":[{"nodeSelector":{"matchLabels":{"app.kubernetes.io/name":"test-dpa"}}}]}`,
 				},
 			},
@@ -192,7 +192,7 @@ func TestDataProtectionApplicationReconciler_updateRepositoryMaintenanceCM(t *te
 					},
 				},
 				Data: map[string]string{
-					"global": `{"podResources":{"cpuRequest":"100m","memoryRequest":"128Mi"},"podAnnotations":{"sidecar.istio.io/inject":"false"},"podLabels":{"network-access":"allowed"}}`,
+					"global": `{"podResources":{"cpuRequest":"100m","memoryRequest":"128Mi","cpuLimit":"0","memoryLimit":"0","ephemeralStorageRequest":"0","ephemeralStorageLimit":"0"},"podAnnotations":{"sidecar.istio.io/inject":"false"},"podLabels":{"network-access":"allowed"}}`,
 				},
 			},
 		},


### PR DESCRIPTION
## Why the changes were made

https://redhat.atlassian.net/browse/OADP-8548

Velero datamover and maintenance Pod config the default values of "" causes parser errors. The default value has to be "0" for unbounded. If PodResources is only partially set, despite all values are optional, the result is Velero ignores them all.

As a result, a Pod with `memoryLimit` or `ephemeralStorageLimit` will not be evicted when violated unless all values: `cpuRequest`, `cpuLimit`, `memoryRequest`, `memoryLimit`, `ephemeralStorageRequest`, `ephemeralStorageLimit` are set.

This issue also applies to OADP-1.5 without the `ephemeralStorageRequest` and `ephemeralStorageLimit` fields.

```
time="2026-08-07T17:02:41Z" level=info msg="Setting log-level to INFO"
time="2026-08-07T17:02:41Z" level=info msg="Starting Velero node-agent server v1.18.2-rc.2-OADP (-)" logSource="/workspace/pkg/cmd/cli/nodeagent/server.go:110"
time="2026-08-07T17:02:41Z" level=info msg="Concurrency configs are not found, use the default number 1" logSource="/workspace/pkg/cmd/cli/nodeagent/server.go:688"
time="2026-08-07T17:02:41Z" level=info msg="Starting controllers" logSource="/workspace/pkg/cmd/cli/nodeagent/server.go:293"
time="2026-08-07T17:02:41Z" level=info msg="Starting metric server for node agent at address [:8085]" logSource="/workspace/pkg/cmd/cli/nodeagent/server.go:279"
time="2026-08-07T17:02:41Z" level=warning msg="Pod resource requirements are invalid, ignore" error="couldn't parse CPU request \"\": quantities must match the regular expression '^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'" error.file="/workspace/pkg/util/kube/resource_requirements.go:58" error.function=github.com/vmware-tanzu/velero/pkg/util/kube.ParseResourceRequirements logSource="/workspace/pkg/cmd/cli/nodeagent/server.go:345"
time="2026-08-07T17:02:41Z" level=info msg="Using backup repo config map[kopia:{\"fullMaintenanceInterval\":\"eagerGC\"}]" logSource="/workspace/pkg/cmd/cli/nodeagent/server.go:384"
time="2026-08-07T17:02:41Z" level=info msg="Controllers starting..." logSource="/workspace/pkg/cmd/cli/nodeagent/server.go:516"
```

## How to test the changes made

Modified unit tests to account for the change that the values must be "0" on output if unset.

Built the container and tested the following DPA in OCP 4.22.

```yaml
apiVersion: oadp.openshift.io/v1alpha1
kind: DataProtectionApplication
metadata:
  name: velero-sample
  namespace: openshift-adp
spec:
  backupImages: false
  configuration:
    nodeAgent:
      dataMoverPrepareTimeout: 10m
      enable: true
      fullMaintenanceInterval: eagerGC
      podResources:
        memoryLimit: 100Mi
      uploaderType: kopia
    velero:
      defaultPlugins:
        - openshift
        - aws
        - kubevirt
        - hypershift
      defaultSnapshotMoveData: true
      disableFsBackup: false
      featureFlags:
        - EnableCSI
      noDefaultBackupLocation: true
  logFormat: text
```

Node-agent logs

```
time="2026-08-12T23:28:32Z" level=info msg="Setting log-level to INFO"
time="2026-08-12T23:28:32Z" level=info msg="Starting Velero node-agent server v1.18.2-rc.2-OADP (-)" logSource="/workspace/pkg/cmd/cli/nodeagent/server.go:110"
time="2026-08-12T23:28:32Z" level=info msg="Concurrency configs are not found, use the default number 1" logSource="/workspace/pkg/cmd/cli/nodeagent/server.go:688"
time="2026-08-12T23:28:32Z" level=info msg="Starting controllers" logSource="/workspace/pkg/cmd/cli/nodeagent/server.go:293"
time="2026-08-12T23:28:32Z" level=info msg="Using customized pod resource requirements &{0 0 0 100Mi 0 0}" logSource="/workspace/pkg/cmd/cli/nodeagent/server.go:348"
time="2026-08-12T23:28:32Z" level=info msg="Using backup repo config map[kopia:{\"fullMaintenanceInterval\":\"eagerGC\"}]" logSource="/workspace/pkg/cmd/cli/nodeagent/server.go:384"
time="2026-08-12T23:28:32Z" level=info msg="Starting metric server for node agent at address [:8085]" logSource="/workspace/pkg/cmd/cli/nodeagent/server.go:279"
time="2026-08-12T23:28:32Z" level=info msg="Controllers starting..." logSource="/workspace/pkg/cmd/cli/nodeagent/server.go:516"
```

Node-agent configmap output:

```yaml
kind: ConfigMap
apiVersion: v1
metadata:
  name: node-agent-velero-sample
  namespace: openshift-adp
  uid: 69ff5cec-ec44-4fa1-8e1f-50ec84b36591
  resourceVersion: '33695705'
  creationTimestamp: '2026-08-07T16:18:49Z'
  labels:
    app.kubernetes.io/component: node-agent-config
    app.kubernetes.io/instance: velero-sample
    app.kubernetes.io/managed-by: oadp-operator
    openshift.io/oadp: 'True'
  ownerReferences:
    - apiVersion: oadp.openshift.io/v1alpha1
      kind: DataProtectionApplication
      name: velero-sample
      uid: 1f263902-6e64-4a75-93f8-cd8dcaa12efd
      controller: true
      blockOwnerDeletion: true
data:
  node-agent-config: '{"podResources":{"cpuRequest":"0","cpuLimit":"0","memoryRequest":"0","memoryLimit":"100Mi","ephemeralStorageRequest":"0","ephemeralStorageLimit":"0"},"privilegedFsBackup":true}'
```

.metadata.managedFields from output shown have been removed because they are annoying to read.