### PR TITLE
Deprecate config.credentialsFile; translate to spec.credential

### DIFF
--- a/api/v1alpha1/dataprotectionapplication_types.go
+++ b/api/v1alpha1/dataprotectionapplication_types.go
@@ -43,6 +43,10 @@ const (
 	ConditionKubevirtDatamoverReady = "KubevirtDatamoverReady"
 )
 
+// ConditionCredentialsFileDeprecated warns when a BackupLocation or SnapshotLocation
+// uses the deprecated config.credentialsFile instead of spec.credential.
+const ConditionCredentialsFileDeprecated = "CredentialsFileDeprecated"
+
 // Readiness condition reasons
 const (
 	ReasonDeploymentReady    = "DeploymentReady"

--- a/internal/controller/dataprotectionapplication_controller.go
+++ b/internal/controller/dataprotectionapplication_controller.go
@@ -146,6 +146,19 @@ func (r *DataProtectionApplicationReconciler) Reconcile(ctx context.Context, req
 		)
 	}
 
+	if dpaUsesCredentialsFile(r.dpa) {
+		apimeta.SetStatusCondition(&r.dpa.Status.Conditions,
+			metav1.Condition{
+				Type:    oadpv1alpha1.ConditionCredentialsFileDeprecated,
+				Status:  metav1.ConditionTrue,
+				Reason:  "CredentialsFileDeprecated",
+				Message: "config.credentialsFile is deprecated and will be removed in a future release. Please migrate to spec.credential.",
+			},
+		)
+	} else {
+		apimeta.RemoveStatusCondition(&r.dpa.Status.Conditions, oadpv1alpha1.ConditionCredentialsFileDeprecated)
+	}
+
 	// Update readiness conditions for all components
 	allReady, readinessErr := r.updateReadinessConditions()
 	if readinessErr != nil {
@@ -166,6 +179,26 @@ func (r *DataProtectionApplicationReconciler) Reconcile(ctx context.Context, req
 	}
 
 	return ctrl.Result{}, err
+}
+
+// dpaUsesCredentialsFile reports whether any BackupLocation or SnapshotLocation in the
+// DPA still configures the deprecated config.credentialsFile instead of spec.credential.
+func dpaUsesCredentialsFile(dpa *oadpv1alpha1.DataProtectionApplication) bool {
+	for _, bsl := range dpa.Spec.BackupLocations {
+		if bsl.Velero != nil {
+			if _, ok := bsl.Velero.Config["credentialsFile"]; ok {
+				return true
+			}
+		}
+	}
+	for _, vsl := range dpa.Spec.SnapshotLocations {
+		if vsl.Velero != nil {
+			if _, ok := vsl.Velero.Config["credentialsFile"]; ok {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/registry.go
+++ b/internal/controller/registry.go
@@ -268,11 +268,18 @@ func (r *DataProtectionApplicationReconciler) getSecretNameAndKey(config map[str
 	// Assume default values unless user has overriden them
 	secretName := credentials.PluginSpecificFields[plugin].SecretName
 	secretKey := credentials.PluginSpecificFields[plugin].PluginSecretKey
-	if _, ok := config["credentialsFile"]; ok {
-		if secretName, secretKey, err :=
-			credentials.GetSecretNameKeyFromCredentialsFileConfigString(config["credentialsFile"]); err == nil {
-			r.Log.Info(fmt.Sprintf("credentialsFile secret: %s, key: %s", secretName, secretKey))
-			return secretName, secretKey, nil
+	if credFile, ok := config["credentialsFile"]; ok {
+		if credential != nil {
+			if cfSecretName, cfSecretKey, parseErr := credentials.GetSecretNameKeyFromCredentialsFileConfigString(credFile); parseErr == nil &&
+				(cfSecretName != credential.Name || cfSecretKey != credential.Key) {
+				r.Log.Info("config.credentialsFile and spec.credential point to different secrets; plugin behavior will change when credentialsFile support is removed",
+					"credentialsFile", credFile, "spec.credential.name", credential.Name, "spec.credential.key", credential.Key, "plugin", plugin)
+			}
+			r.Log.Info("config.credentialsFile is deprecated and ignored because spec.credential is set; remove config.credentialsFile", "plugin", plugin)
+		} else if cfSecretName, cfSecretKey, err := credentials.GetSecretNameKeyFromCredentialsFileConfigString(credFile); err == nil {
+			secretName = cfSecretName
+			secretKey = cfSecretKey
+			r.Log.Info("config.credentialsFile is deprecated; translating to secret reference, please migrate to spec.credential", "plugin", plugin, "secretName", secretName, "secretKey", secretKey)
 		}
 	}
 	// check if user specified the Credential Name and Key

--- a/internal/controller/registry_test.go
+++ b/internal/controller/registry_test.go
@@ -214,6 +214,81 @@ func TestDPAReconciler_getSecretNameAndKey(t *testing.T) {
 
 			wantProfile: "aws-provider-no-cred",
 		},
+		{
+			name: "given only credentialsFile config, it is translated to secret name and key",
+			bsl: &oadpv1alpha1.BackupLocation{
+				Velero: &velerov1.BackupStorageLocationSpec{
+					Provider: AWSProvider,
+					Config: map[string]string{
+						Region:            "aws-region",
+						"credentialsFile": "legacy-secret/legacy-key",
+					},
+				},
+			},
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "legacy-secret",
+					Namespace: "test-ns",
+				},
+				Data: secretData,
+			},
+			wantSecretName: "legacy-secret",
+			wantSecretKey:  "legacy-key",
+		},
+		{
+			name: "given both credentialsFile config and spec.credential, spec.credential wins",
+			bsl: &oadpv1alpha1.BackupLocation{
+				Velero: &velerov1.BackupStorageLocationSpec{
+					Provider: AWSProvider,
+					Credential: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "cloud-credentials-aws",
+						},
+						Key: "cloud",
+					},
+					Config: map[string]string{
+						Region:            "aws-region",
+						"credentialsFile": "legacy-secret/legacy-key",
+					},
+				},
+			},
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cloud-credentials-aws",
+					Namespace: "test-ns",
+				},
+				Data: secretData,
+			},
+			wantSecretName: "cloud-credentials-aws",
+			wantSecretKey:  "cloud",
+		},
+		{
+			name: "given mismatched credentialsFile and spec.credential, spec.credential wins and mismatch is logged",
+			bsl: &oadpv1alpha1.BackupLocation{
+				Velero: &velerov1.BackupStorageLocationSpec{
+					Provider: AWSProvider,
+					Credential: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "cloud-credentials-aws",
+						},
+						Key: "cloud",
+					},
+					Config: map[string]string{
+						Region:            "aws-region",
+						"credentialsFile": "different-secret/different-key",
+					},
+				},
+			},
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cloud-credentials-aws",
+					Namespace: "test-ns",
+				},
+				Data: secretData,
+			},
+			wantSecretName: "cloud-credentials-aws",
+			wantSecretKey:  "cloud",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/controller/vsl.go
+++ b/internal/controller/vsl.go
@@ -304,10 +304,6 @@ func (r *DataProtectionApplicationReconciler) ensureVslSecretDataExists(vsl *oad
 		}
 		// Check if the VSL secret key configured in the DPA exists with a secret data
 		if vsl.Velero != nil {
-			// if using credentialsFile return nil, don't check default secret data key
-			if vsl.Velero.Config[CredentialsFileKey] != "" {
-				return nil
-			}
 			_, _, err := r.getSecretNameAndKey(vsl.Velero.Config, vsl.Velero.Credential, oadpv1alpha1.DefaultPlugin(vsl.Velero.Provider))
 			if err != nil {
 				return err

--- a/internal/controller/vsl_test.go
+++ b/internal/controller/vsl_test.go
@@ -259,6 +259,82 @@ func TestDPAReconciler_ValidateVolumeSnapshotLocation(t *testing.T) {
 				Data: map[string][]byte{"cloud": []byte("dummy_data")},
 			},
 		},
+		{
+			name: "test AWS VSL with credentialsFile config and matching secret is allowed",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-Velero-VSL",
+					Namespace: "test-ns",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{
+							DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
+								oadpv1alpha1.DefaultPluginAWS,
+							},
+						},
+					},
+					SnapshotLocations: []oadpv1alpha1.SnapshotLocation{
+						{
+							Velero: &velerov1.VolumeSnapshotLocationSpec{
+								Provider: AWSProvider,
+								Config: map[string]string{
+									Region:            "us-east-1",
+									"credentialsFile": "legacy-vsl-secret/legacy-key",
+								},
+							},
+						},
+					},
+				},
+			},
+			want:    true,
+			wantErr: false,
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "legacy-vsl-secret",
+					Namespace: "test-ns",
+				},
+				Data: map[string][]byte{"legacy-key": []byte("dummy_data")},
+			},
+		},
+		{
+			name: "test AWS VSL with credentialsFile config pointing at missing secret is rejected",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-Velero-VSL",
+					Namespace: "test-ns",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{
+							DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
+								oadpv1alpha1.DefaultPluginAWS,
+							},
+						},
+					},
+					SnapshotLocations: []oadpv1alpha1.SnapshotLocation{
+						{
+							Velero: &velerov1.VolumeSnapshotLocationSpec{
+								Provider: AWSProvider,
+								Config: map[string]string{
+									Region:            "us-east-1",
+									"credentialsFile": "nonexistent-secret/legacy-key",
+								},
+							},
+						},
+					},
+				},
+			},
+			want:    false,
+			wantErr: true,
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cloud-credentials",
+					Namespace: "test-ns",
+				},
+				Data: map[string][]byte{"cloud": []byte("dummy_data")},
+			},
+		},
 
 		// GCP tests
 		{

--- a/pkg/credentials/credentials.go
+++ b/pkg/credentials/credentials.go
@@ -300,14 +300,16 @@ func GetSecretNameAndKey(bslSpec *velerov1.BackupStorageLocationSpec, plugin oad
 	// Assume default values unless user has overriden them
 	secretName := PluginSpecificFields[plugin].SecretName
 	secretKey := PluginSpecificFields[plugin].PluginSecretKey
-	if _, ok := bslSpec.Config["credentialsFile"]; ok {
-		if secretName, secretKey, err :=
-			GetSecretNameKeyFromCredentialsFileConfigString(bslSpec.Config["credentialsFile"]); err == nil {
-			return secretName, secretKey
+	credential := bslSpec.Credential
+	if credential == nil {
+		if credFile, ok := bslSpec.Config["credentialsFile"]; ok {
+			if cfSecretName, cfSecretKey, err := GetSecretNameKeyFromCredentialsFileConfigString(credFile); err == nil {
+				secretName = cfSecretName
+				secretKey = cfSecretKey
+			}
 		}
 	}
 	// check if user specified the Credential Name and Key
-	credential := bslSpec.Credential
 	if credential != nil {
 		if len(credential.Name) > 0 {
 			secretName = credential.Name


### PR DESCRIPTION
## What

Deprecates `config.credentialsFile` on BSL/VSL and translates it to `spec.credential` as a fallback, keeping OADP credential resolution aligned with Velero's upcoming behavior.

Also sets/clears a `CredentialsFileDeprecated` status condition on DPA each reconcile so operators get a visible warning and can track migration progress.

Closes #2383

## Why

Velero upstream ([velero-io/velero#10254](https://github.com/velero-io/velero/pull/10254)) will strip `config.credentialsFile` before passing BSL/VSL config to plugins. Without this change, OADP and Velero would silently resolve different secrets for the same BSL/VSL — a hard-to-diagnose mismatch.

Secondary fix: `ensureVslSecretDataExists` previously skipped `verifySecretContent` for VSLs using `credentialsFile`. That bypass is removed so both code paths are validated equally.

## How to test

- Deploy a DPA with a BSL/VSL using `config.credentialsFile: "my-secret/cloud"` — verify OADP resolves the secret and backups work.
- Confirm `kubectl get dpa -o yaml` shows a `CredentialsFileDeprecated` condition (`status: "True"`) pointing to `spec.credential`.
- Add `spec.credential` alongside `credentialsFile` — verify `spec.credential` wins (check operator logs for the "ignored" message).
- Migrate to `spec.credential` only — verify the condition disappears.
- Unit tests: `go test ./internal/controller/... ./pkg/credentials/...`

*Posted via [Claude Code](https://claude.ai/code)*