### PR TITLE
Remove unused GetSecretNameAndKey and GetSecretNameKeyConfigProviderForBackupLocation

### DIFF
--- a/api/v1alpha1/dataprotectionapplication_types.go
+++ b/api/v1alpha1/dataprotectionapplication_types.go
@@ -43,6 +43,10 @@ const (
 	ConditionKubevirtDatamoverReady = "KubevirtDatamoverReady"
 )
 
+// ConditionCredentialsFileDeprecated warns when a BackupLocation or SnapshotLocation
+// uses the deprecated config.credentialsFile instead of spec.credential.
+const ConditionCredentialsFileDeprecated = "CredentialsFileDeprecated"
+
 // Readiness condition reasons
 const (
 	ReasonDeploymentReady    = "DeploymentReady"

--- a/internal/controller/dataprotectionapplication_controller.go
+++ b/internal/controller/dataprotectionapplication_controller.go
@@ -146,6 +146,19 @@ func (r *DataProtectionApplicationReconciler) Reconcile(ctx context.Context, req
 		)
 	}
 
+	if dpaUsesCredentialsFile(r.dpa) {
+		apimeta.SetStatusCondition(&r.dpa.Status.Conditions,
+			metav1.Condition{
+				Type:    oadpv1alpha1.ConditionCredentialsFileDeprecated,
+				Status:  metav1.ConditionTrue,
+				Reason:  "CredentialsFileDeprecated",
+				Message: "config.credentialsFile is deprecated and will be removed in a future release. Please migrate to spec.credential.",
+			},
+		)
+	} else {
+		apimeta.RemoveStatusCondition(&r.dpa.Status.Conditions, oadpv1alpha1.ConditionCredentialsFileDeprecated)
+	}
+
 	// Update readiness conditions for all components
 	allReady, readinessErr := r.updateReadinessConditions()
 	if readinessErr != nil {
@@ -166,6 +179,26 @@ func (r *DataProtectionApplicationReconciler) Reconcile(ctx context.Context, req
 	}
 
 	return ctrl.Result{}, err
+}
+
+// dpaUsesCredentialsFile reports whether any BackupLocation or SnapshotLocation in the
+// DPA still configures the deprecated config.credentialsFile instead of spec.credential.
+func dpaUsesCredentialsFile(dpa *oadpv1alpha1.DataProtectionApplication) bool {
+	for _, bsl := range dpa.Spec.BackupLocations {
+		if bsl.Velero != nil {
+			if _, ok := bsl.Velero.Config["credentialsFile"]; ok {
+				return true
+			}
+		}
+	}
+	for _, vsl := range dpa.Spec.SnapshotLocations {
+		if vsl.Velero != nil {
+			if _, ok := vsl.Velero.Config["credentialsFile"]; ok {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/registry.go
+++ b/internal/controller/registry.go
@@ -268,11 +268,18 @@ func (r *DataProtectionApplicationReconciler) getSecretNameAndKey(config map[str
 	// Assume default values unless user has overriden them
 	secretName := credentials.PluginSpecificFields[plugin].SecretName
 	secretKey := credentials.PluginSpecificFields[plugin].PluginSecretKey
-	if _, ok := config["credentialsFile"]; ok {
-		if secretName, secretKey, err :=
-			credentials.GetSecretNameKeyFromCredentialsFileConfigString(config["credentialsFile"]); err == nil {
-			r.Log.Info(fmt.Sprintf("credentialsFile secret: %s, key: %s", secretName, secretKey))
-			return secretName, secretKey, nil
+	if credFile, ok := config["credentialsFile"]; ok {
+		if credential != nil {
+			if cfSecretName, cfSecretKey, parseErr := credentials.GetSecretNameKeyFromCredentialsFileConfigString(credFile); parseErr == nil &&
+				(cfSecretName != credential.Name || cfSecretKey != credential.Key) {
+				r.Log.Info("config.credentialsFile and spec.credential point to different secrets; plugin behavior will change when credentialsFile support is removed",
+					"credentialsFile", credFile, "spec.credential.name", credential.Name, "spec.credential.key", credential.Key, "plugin", plugin)
+			}
+			r.Log.Info("config.credentialsFile is deprecated and ignored because spec.credential is set; remove config.credentialsFile", "plugin", plugin)
+		} else if cfSecretName, cfSecretKey, err := credentials.GetSecretNameKeyFromCredentialsFileConfigString(credFile); err == nil {
+			secretName = cfSecretName
+			secretKey = cfSecretKey
+			r.Log.Info("config.credentialsFile is deprecated; translating to secret reference, please migrate to spec.credential", "plugin", plugin, "secretName", secretName, "secretKey", secretKey)
 		}
 	}
 	// check if user specified the Credential Name and Key

--- a/internal/controller/registry_test.go
+++ b/internal/controller/registry_test.go
@@ -214,6 +214,81 @@ func TestDPAReconciler_getSecretNameAndKey(t *testing.T) {
 
 			wantProfile: "aws-provider-no-cred",
 		},
+		{
+			name: "given only credentialsFile config, it is translated to secret name and key",
+			bsl: &oadpv1alpha1.BackupLocation{
+				Velero: &velerov1.BackupStorageLocationSpec{
+					Provider: AWSProvider,
+					Config: map[string]string{
+						Region:            "aws-region",
+						"credentialsFile": "legacy-secret/legacy-key",
+					},
+				},
+			},
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "legacy-secret",
+					Namespace: "test-ns",
+				},
+				Data: secretData,
+			},
+			wantSecretName: "legacy-secret",
+			wantSecretKey:  "legacy-key",
+		},
+		{
+			name: "given both credentialsFile config and spec.credential, spec.credential wins",
+			bsl: &oadpv1alpha1.BackupLocation{
+				Velero: &velerov1.BackupStorageLocationSpec{
+					Provider: AWSProvider,
+					Credential: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "cloud-credentials-aws",
+						},
+						Key: "cloud",
+					},
+					Config: map[string]string{
+						Region:            "aws-region",
+						"credentialsFile": "legacy-secret/legacy-key",
+					},
+				},
+			},
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cloud-credentials-aws",
+					Namespace: "test-ns",
+				},
+				Data: secretData,
+			},
+			wantSecretName: "cloud-credentials-aws",
+			wantSecretKey:  "cloud",
+		},
+		{
+			name: "given mismatched credentialsFile and spec.credential, spec.credential wins and mismatch is logged",
+			bsl: &oadpv1alpha1.BackupLocation{
+				Velero: &velerov1.BackupStorageLocationSpec{
+					Provider: AWSProvider,
+					Credential: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "cloud-credentials-aws",
+						},
+						Key: "cloud",
+					},
+					Config: map[string]string{
+						Region:            "aws-region",
+						"credentialsFile": "different-secret/different-key",
+					},
+				},
+			},
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cloud-credentials-aws",
+					Namespace: "test-ns",
+				},
+				Data: secretData,
+			},
+			wantSecretName: "cloud-credentials-aws",
+			wantSecretKey:  "cloud",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/controller/vsl.go
+++ b/internal/controller/vsl.go
@@ -304,10 +304,6 @@ func (r *DataProtectionApplicationReconciler) ensureVslSecretDataExists(vsl *oad
 		}
 		// Check if the VSL secret key configured in the DPA exists with a secret data
 		if vsl.Velero != nil {
-			// if using credentialsFile return nil, don't check default secret data key
-			if vsl.Velero.Config[CredentialsFileKey] != "" {
-				return nil
-			}
 			_, _, err := r.getSecretNameAndKey(vsl.Velero.Config, vsl.Velero.Credential, oadpv1alpha1.DefaultPlugin(vsl.Velero.Provider))
 			if err != nil {
 				return err

--- a/internal/controller/vsl_test.go
+++ b/internal/controller/vsl_test.go
@@ -259,6 +259,82 @@ func TestDPAReconciler_ValidateVolumeSnapshotLocation(t *testing.T) {
 				Data: map[string][]byte{"cloud": []byte("dummy_data")},
 			},
 		},
+		{
+			name: "test AWS VSL with credentialsFile config and matching secret is allowed",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-Velero-VSL",
+					Namespace: "test-ns",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{
+							DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
+								oadpv1alpha1.DefaultPluginAWS,
+							},
+						},
+					},
+					SnapshotLocations: []oadpv1alpha1.SnapshotLocation{
+						{
+							Velero: &velerov1.VolumeSnapshotLocationSpec{
+								Provider: AWSProvider,
+								Config: map[string]string{
+									Region:            "us-east-1",
+									"credentialsFile": "legacy-vsl-secret/legacy-key",
+								},
+							},
+						},
+					},
+				},
+			},
+			want:    true,
+			wantErr: false,
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "legacy-vsl-secret",
+					Namespace: "test-ns",
+				},
+				Data: map[string][]byte{"legacy-key": []byte("dummy_data")},
+			},
+		},
+		{
+			name: "test AWS VSL with credentialsFile config pointing at missing secret is rejected",
+			dpa: &oadpv1alpha1.DataProtectionApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-Velero-VSL",
+					Namespace: "test-ns",
+				},
+				Spec: oadpv1alpha1.DataProtectionApplicationSpec{
+					Configuration: &oadpv1alpha1.ApplicationConfig{
+						Velero: &oadpv1alpha1.VeleroConfig{
+							DefaultPlugins: []oadpv1alpha1.DefaultPlugin{
+								oadpv1alpha1.DefaultPluginAWS,
+							},
+						},
+					},
+					SnapshotLocations: []oadpv1alpha1.SnapshotLocation{
+						{
+							Velero: &velerov1.VolumeSnapshotLocationSpec{
+								Provider: AWSProvider,
+								Config: map[string]string{
+									Region:            "us-east-1",
+									"credentialsFile": "nonexistent-secret/legacy-key",
+								},
+							},
+						},
+					},
+				},
+			},
+			want:    false,
+			wantErr: true,
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cloud-credentials",
+					Namespace: "test-ns",
+				},
+				Data: map[string][]byte{"cloud": []byte("dummy_data")},
+			},
+		},
 
 		// GCP tests
 		{

--- a/pkg/credentials/credentials.go
+++ b/pkg/credentials/credentials.go
@@ -6,10 +6,8 @@ import (
 	"os"
 	"strings"
 
-	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	oadpv1alpha1 "github.com/openshift/oadp-operator/api/v1alpha1"
@@ -295,63 +293,6 @@ func AppendCloudProviderVolumes(dpa *oadpv1alpha1.DataProtectionApplication, ds 
 	}
 }
 
-// TODO: remove duplicate func in registry.go - refactoring away registry.go later
-func GetSecretNameAndKey(bslSpec *velerov1.BackupStorageLocationSpec, plugin oadpv1alpha1.DefaultPlugin) (string, string) {
-	// Assume default values unless user has overriden them
-	secretName := PluginSpecificFields[plugin].SecretName
-	secretKey := PluginSpecificFields[plugin].PluginSecretKey
-	credential := bslSpec.Credential
-	if credential == nil {
-		if credFile, ok := bslSpec.Config["credentialsFile"]; ok {
-			if cfSecretName, cfSecretKey, err := GetSecretNameKeyFromCredentialsFileConfigString(credFile); err == nil {
-				secretName = cfSecretName
-				secretKey = cfSecretKey
-			}
-		}
-	}
-	// check if user specified the Credential Name and Key
-	if credential != nil {
-		if len(credential.Name) > 0 {
-			secretName = credential.Name
-		}
-		if len(credential.Key) > 0 {
-			secretKey = credential.Key
-		}
-	}
-
-	return secretName, secretKey
-}
-
-// TODO: remove duplicate func in registry.go - refactoring away registry.go later
-// Get for a given backup location
-// - secret name
-// - key
-// - bsl config
-// - provider
-// - error
-func GetSecretNameKeyConfigProviderForBackupLocation(blspec oadpv1alpha1.BackupLocation, namespace string) (string, string, string, map[string]string, error) {
-	if blspec.Velero != nil {
-		name, key := GetSecretNameAndKey(blspec.Velero, oadpv1alpha1.DefaultPlugin(blspec.Velero.Provider))
-		return name, key, blspec.Velero.Provider, blspec.Velero.Config, nil
-	}
-	if blspec.CloudStorage != nil {
-		if blspec.CloudStorage.Credential != nil {
-			// Get CloudStorageRef provider
-			cs := oadpv1alpha1.CloudStorage{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      blspec.CloudStorage.CloudStorageRef.Name,
-					Namespace: namespace,
-				},
-			}
-			err := client.GetClient().Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: blspec.CloudStorage.CloudStorageRef.Name}, &cs)
-			if err != nil {
-				return "", "", "", nil, err
-			}
-			return blspec.CloudStorage.Credential.Name, blspec.CloudStorage.Credential.Key, string(cs.Spec.Provider), blspec.CloudStorage.Config, nil
-		}
-	}
-	return "", "", "", nil, nil
-}
 
 func GetDecodedSecret(secretName, secretKey, namespace string) (s string, err error) {
 	bytes, err := GetDecodedSecretAsByte(secretName, secretKey, namespace)

--- a/pkg/credentials/credentials.go
+++ b/pkg/credentials/credentials.go
@@ -300,14 +300,16 @@ func GetSecretNameAndKey(bslSpec *velerov1.BackupStorageLocationSpec, plugin oad
 	// Assume default values unless user has overriden them
 	secretName := PluginSpecificFields[plugin].SecretName
 	secretKey := PluginSpecificFields[plugin].PluginSecretKey
-	if _, ok := bslSpec.Config["credentialsFile"]; ok {
-		if secretName, secretKey, err :=
-			GetSecretNameKeyFromCredentialsFileConfigString(bslSpec.Config["credentialsFile"]); err == nil {
-			return secretName, secretKey
+	credential := bslSpec.Credential
+	if credential == nil {
+		if credFile, ok := bslSpec.Config["credentialsFile"]; ok {
+			if cfSecretName, cfSecretKey, err := GetSecretNameKeyFromCredentialsFileConfigString(credFile); err == nil {
+				secretName = cfSecretName
+				secretKey = cfSecretKey
+			}
 		}
 	}
 	// check if user specified the Credential Name and Key
-	credential := bslSpec.Credential
 	if credential != nil {
 		if len(credential.Name) > 0 {
 			secretName = credential.Name


### PR DESCRIPTION
## Why the changes were made

`GetSecretNameAndKey` and `GetSecretNameKeyConfigProviderForBackupLocation` in `pkg/credentials/credentials.go` had no callers anywhere in the operator — only referencing each other within the same file. `GetSecretNameAndKey` was already marked with a TODO noting it duplicated the credential resolution logic in `internal/controller/registry.go`. Removing both functions and the now-unused `velerov1` and `metav1` imports.

Depends on #2390.

## How to test the changes made

- `go build ./...` — confirms no compilation errors
- `go test ./pkg/credentials/...` — confirms no test regressions

*Posted via [Claude Code](https://claude.ai/code)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added status warnings when the deprecated `config.credentialsFile` setting is used.
  * Added support for migrating credential references to `spec.credential`.

* **Bug Fixes**
  * `spec.credential` now takes precedence when both credential settings are configured.
  * Improved validation for credentials used by backup and snapshot locations, including missing-secret errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->