### PR TITLE
[OADP-8700] Guard NodeAgent.ExtraArgs access against nil when using restic config

### DIFF
--- a/controllers/nodeagent.go
+++ b/controllers/nodeagent.go
@@ -417,7 +417,7 @@ func (r *DPAReconciler) customizeNodeAgentDaemonset(dpa *oadpv1alpha1.DataProtec
 			nodeAgentContainer.ImagePullPolicy = imagePullPolicy
 			setContainerDefaults(nodeAgentContainer)
 
-			if len(dpa.Spec.Configuration.NodeAgent.ExtraArgs) > 0 {
+			if !useResticConf && len(dpa.Spec.Configuration.NodeAgent.ExtraArgs) > 0 {
 				nodeAgentContainer.Args = common.MergeExtraArgs(nodeAgentContainer.Args, dpa.Spec.Configuration.NodeAgent.ExtraArgs)
 			}
 


### PR DESCRIPTION
## Why the changes were made

Fixes: [OADP-8700](https://redhat.atlassian.net/browse/OADP-8700)
## How to test the changes made

<!-- Explain how the changes introduced by this PR can be tested and verified, with commands and pictures -->
