### PR TITLE
[OADP-8704] fix: only set region in BSL config for AWS CloudStorage

### DIFF
--- a/internal/controller/bsl.go
+++ b/internal/controller/bsl.go
@@ -258,11 +258,12 @@ func (r *DataProtectionApplicationReconciler) ReconcileBackupStorageLocations(lo
 					}
 				}
 
-				// Add region from CloudStorage CR if specified
-				if bucket.Spec.Region != "" && bsl.Spec.Config == nil {
-					bsl.Spec.Config = make(map[string]string)
-				}
-				if bucket.Spec.Region != "" {
+				// Add region from CloudStorage CR only for AWS provider.
+				// Currently only AWS supports region in BSL config.
+				if bucket.Spec.Provider == oadpv1alpha1.AWSBucketProvider && bucket.Spec.Region != "" {
+					if bsl.Spec.Config == nil {
+						bsl.Spec.Config = make(map[string]string)
+					}
 					bsl.Spec.Config["region"] = bucket.Spec.Region
 				}
 

--- a/internal/controller/bsl.go
+++ b/internal/controller/bsl.go
@@ -275,6 +275,12 @@ func (r *DataProtectionApplicationReconciler) ReconcileBackupStorageLocations(lo
 					bsl.Spec.Config[k] = v
 				}
 
+				// Defensive cleanup: region is only supported in BSL config for AWS.
+				// Remove stale region values that might remain from prior reconciliations
+				if bucket.Spec.Provider != oadpv1alpha1.AWSBucketProvider {
+					delete(bsl.Spec.Config, "region")
+				}
+
 				// Handle enableSharedConfig from CloudStorage CR
 				if bucket.Spec.EnableSharedConfig != nil && *bucket.Spec.EnableSharedConfig {
 					if bsl.Spec.Config == nil {
@@ -479,7 +485,7 @@ func (r *DataProtectionApplicationReconciler) populateBSLFromCloudStorage(bslSpe
 	}
 
 	// Add region if specified in CloudStorage
-	if cloudStorage.Spec.Region != "" {
+	if cloudStorage.Spec.Provider == oadpv1alpha1.AWSBucketProvider && cloudStorage.Spec.Region != "" {
 		bslSpec.Velero.Config["region"] = cloudStorage.Spec.Region
 	}
 

--- a/internal/controller/bsl_test.go
+++ b/internal/controller/bsl_test.go
@@ -4674,7 +4674,6 @@ func TestDPAReconciler_populateBSLFromCloudStorage(t *testing.T) {
 						},
 					},
 					Config: map[string]string{
-						"region":         "eastus",
 						"storageAccount": "mystorageaccount",
 					},
 					Credential: &corev1.SecretKeySelector{

--- a/internal/controller/bsl_test.go
+++ b/internal/controller/bsl_test.go
@@ -3336,7 +3336,6 @@ func TestDPAReconciler_ReconcileBackupStorageLocations(t *testing.T) {
 					Config: map[string]string{
 						"storageAccount": "mystorageaccount",
 						"resourceGroup":  "myresourcegroup",
-						"region":         "eastus",
 					},
 					StorageType: velerov1.StorageType{
 						ObjectStorage: &velerov1.ObjectStorageLocation{

--- a/internal/controller/cloudstorage_providers_integration_test.go
+++ b/internal/controller/cloudstorage_providers_integration_test.go
@@ -351,7 +351,6 @@ func TestCloudStorageRefIntegrationGCP(t *testing.T) {
 			expectedBucket:   "my-gcp-backup-bucket",
 			expectedConfig: map[string]string{
 				"project": "my-gcp-project",
-				"region":  "us-central1",
 			},
 		},
 		{
@@ -427,7 +426,6 @@ func TestCloudStorageRefIntegrationGCP(t *testing.T) {
 			expectedBucket:   "legacy-backup-bucket",
 			expectedConfig: map[string]string{
 				"project":          "legacy-project",
-				"region":           "us-west1",
 				"snapshotLocation": "us-west1",
 			},
 		},


### PR DESCRIPTION
Limit region propagation from CloudStorage to BackupStorageLocation config to AWS provider only, since region in BSL config is not supported for GCP/Azure in this path.

## Why the changes were made

Fixes: [OADP-8704](https://redhat.atlassian.net/browse/OADP-8704)

## How to test the changes made

<!-- Explain how the changes introduced by this PR can be tested and verified, with commands and pictures -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated cloud storage backup configuration to apply region settings only to AWS providers.
  * Removed unsupported automatic region settings from Google Cloud and Azure configurations.
  * Preserved other provider-specific configuration settings, such as project and snapshot location.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->