### PR TITLE
Bump CSV metadata to v1.6.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # TOOL VERSIONS
 # All version-related variables are defined here for easy maintenance
-DEFAULT_VERSION := 1.6.1
+DEFAULT_VERSION := 1.6.2
 VERSION ?= $(DEFAULT_VERSION) # the version of the operator
 OPERATOR_SDK_VERSION ?= v1.35.0
 ENVTEST_K8S_VERSION = 1.35 #refers to the version of kubebuilder assets to be downloaded by envtest binary # Kubernetes version from OpenShift 4.22.x

--- a/bundle/manifests/oadp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/oadp-operator.clusterserviceversion.yaml
@@ -310,7 +310,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "true"
     features.operators.openshift.io/token-auth-azure: "true"
     features.operators.openshift.io/token-auth-gcp: "true"
-    olm.skipRange: '>=1.5.0 <1.6.1'
+    olm.skipRange: '>=1.5.0 <1.6.2'
     operatorframework.io/suggested-namespace: openshift-adp
     operators.openshift.io/infrastructure-features: '["Disconnected"]'
     operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine", "OpenShift
@@ -324,7 +324,7 @@ metadata:
     operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
-  name: oadp-operator.v1.6.1
+  name: oadp-operator.v1.6.2
   namespace: openshift-adp
 spec:
   apiservicedefinitions: {}
@@ -1739,5 +1739,5 @@ spec:
     name: kubevirt-datamover-controller
   - image: quay.io/konveyor/kubevirt-datamover-plugin:oadp-1.6
     name: kubevirt-datamover-plugin
-  replaces: oadp-operator.v1.6.0
-  version: 1.6.1
+  replaces: oadp-operator.v1.6.1
+  version: 1.6.2

--- a/bundle/oadp-operator.package.yaml
+++ b/bundle/oadp-operator.package.yaml
@@ -2,5 +2,5 @@
 packageName: redhat-oadp-operator
 channels:
 - name: stable
-  currentCSV: oadp-operator.v1.6.1
+  currentCSV: oadp-operator.v1.6.2
 defaultChannel: stable

--- a/config/manifests/bases/oadp-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/oadp-operator.clusterserviceversion.yaml
@@ -20,7 +20,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "true"
     features.operators.openshift.io/token-auth-azure: "true"
     features.operators.openshift.io/token-auth-gcp: "true"
-    olm.skipRange: '>=1.5.0 <1.6.1'
+    olm.skipRange: '>=1.5.0 <1.6.2'
     operatorframework.io/suggested-namespace: openshift-adp
     operators.openshift.io/infrastructure-features: '["Disconnected"]'
     operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine", "OpenShift
@@ -32,7 +32,7 @@ metadata:
     operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
-  name: oadp-operator.v1.6.1
+  name: oadp-operator.v1.6.2
   namespace: openshift-adp
 spec:
   apiservicedefinitions: {}
@@ -515,5 +515,5 @@ spec:
   maturity: stable
   provider:
     name: Red Hat
-  replaces: oadp-operator.v1.6.0
-  version: 1.6.1
+  replaces: oadp-operator.v1.6.1
+  version: 1.6.2

--- a/docs/version-update.md
+++ b/docs/version-update.md
@@ -4,14 +4,14 @@ This document outlines the files and fields that need to be updated for OADP ope
 
 ## Files to Update
 
-For a patch version update (e.g., 1.6.1 → 1.6.2), update these 4 files:
+For a patch version update (e.g., 1.6.2 → 1.6.3), update these 4 files:
 
 ### 1. Makefile
 
 Update `DEFAULT_VERSION` variable:
 
 ```makefile
-DEFAULT_VERSION := 1.6.1  # was 1.6.0
+DEFAULT_VERSION := 1.6.2  # was 1.6.1
 ```
 
 ### 2. config/manifests/bases/oadp-operator.clusterserviceversion.yaml
@@ -21,11 +21,11 @@ Update 4 fields:
 ```yaml
 metadata:
   annotations:
-    olm.skipRange: '>=1.5.0 <1.6.1'  # was <1.6.0
-  name: oadp-operator.v1.6.1  # was v1.6.0
+    olm.skipRange: '>=1.5.0 <1.6.2'  # was <1.6.1
+  name: oadp-operator.v1.6.2  # was v1.6.1
 spec:
-  replaces: oadp-operator.v1.6.0
-  version: 1.6.1  # was 1.6.0
+  replaces: oadp-operator.v1.6.1
+  version: 1.6.2  # was 1.6.1
 ```
 
 ### 3. bundle/manifests/oadp-operator.clusterserviceversion.yaml
@@ -35,11 +35,11 @@ Update 4 fields (same as above):
 ```yaml
 metadata:
   annotations:
-    olm.skipRange: '>=1.5.0 <1.6.1'  # was <1.6.0
-  name: oadp-operator.v1.6.1  # was v1.6.0
+    olm.skipRange: '>=1.5.0 <1.6.2'  # was <1.6.1
+  name: oadp-operator.v1.6.2  # was v1.6.1
 spec:
-  replaces: oadp-operator.v1.6.0
-  version: 1.6.1  # was 1.6.0
+  replaces: oadp-operator.v1.6.1
+  version: 1.6.2  # was 1.6.1
 ```
 
 ### 4. bundle/oadp-operator.package.yaml
@@ -49,7 +49,7 @@ Update 1 field:
 ```yaml
 channels:
 - name: stable
-  currentCSV: oadp-operator.v1.6.1  # was v1.6.0
+  currentCSV: oadp-operator.v1.6.2  # was v1.6.1
 ```
 
 ## Summary


### PR DESCRIPTION
## Why the changes were made

Bumps the OADP operator version from 1.6.1 to 1.6.2. Updates all version references across the OLM bundle metadata, including the `olm.skipRange`, CSV name, `replaces`, and `version` fields in both the base and generated bundle CSVs, the package channel's `currentCSV`, and the Makefile `DEFAULT_VERSION`.

## How to test the changes made

Run `make bundle-isupdated` — should output "bundle is up to date" with no diff. Verify the following values all read `1.6.2` / `v1.6.2`:

- `Makefile`: `DEFAULT_VERSION`
- `bundle/oadp-operator.package.yaml`: `currentCSV`
- `bundle/manifests/oadp-operator.clusterserviceversion.yaml`: `name`, `version`, `olm.skipRange`, `replaces`
- `config/manifests/bases/oadp-operator.clusterserviceversion.yaml`: same four fields

*Posted via [Claude Code](https://claude.ai/code)*