### PR TITLE
[OADP-8716] Pin MCE to stable-2.8 only below OCP 4.19, matching HCP target env

### DIFF
--- a/tests/e2e/hcp_backup_restore_suite_test.go
+++ b/tests/e2e/hcp_backup_restore_suite_test.go
@@ -203,8 +203,30 @@ var _ = ginkgo.Describe("HCP Backup and Restore tests", ginkgo.Ordered, func() {
 
 		reqOperators := []libhcp.RequiredOperator{
 			{
-				Name:          libhcp.MCEName,
-				Namespace:     libhcp.MCENamespace,
+				Name:      libhcp.MCEName,
+				Namespace: libhcp.MCENamespace,
+				// Pinned to the ACM 2.13 / MCE 2.8 pairing our GovCloud HCP target
+				// environment actually runs on OCP 4.18 (ACM 2.13 -> ~2.15 planned, see
+				// ROSAENG-58373) -- not the 4.18 index's default channel (stable-2.11 as
+				// of this writing), which is a support-exception-only version for OCP
+				// 4.18 and can (and did) start enforcing an OCP floor the 4.18 cluster
+				// doesn't meet. Check with the OADP/HCP team from time to time
+				// (Brae Troutman, as of this writing) for updated ACM/MCE version
+				// requirements before bumping this -- see OADP-7564.
+				//
+				// Production also pins the HyperShift operator image itself to a
+				// specific SHA (passed to the MCE hypershift addon), rather than relying
+				// on whatever image ships bundled with this MCE version. That's done via
+				// an admin-controlled ConfigMap named "hypershift-override-images" in
+				// this namespace (keyed by image-stream name -- see
+				// stolostron/hypershift-addon-operator's pkg/util/constant.go,
+				// HypershiftOverrideImagesCM/ImageStreamHypershiftOperator), separate
+				// from the tenant-writable hypershift-operator-install-flags ConfigMap
+				// the CVE-2026-66808 fix locked down. Not replicated here yet -- if a
+				// SHA pin becomes necessary for this test too, source the value from an
+				// env var at runtime rather than hardcoding it (the real pinned image
+				// used in production isn't something to commit to a public repo).
+				Channel:       "stable-2.8",
 				OperatorGroup: libhcp.MCEOperatorGroup,
 			},
 		}
@@ -213,19 +235,27 @@ var _ = ginkgo.Describe("HCP Backup and Restore tests", ginkgo.Ordered, func() {
 		h, err = libhcp.InstallRequiredOperators(ctx, runTimeClientForSuiteRun, reqOperators)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(h).ToNot(gomega.BeNil())
-		gomega.Eventually(lib.IsDeploymentReady(h.Client, libhcp.MCENamespace, libhcp.MCEOperatorName), libhcp.Wait10Min, time.Second*5).Should(gomega.BeTrue())
+		gomega.Eventually(lib.IsDeploymentReady(h.Client, libhcp.MCENamespace, libhcp.MCEOperatorName), libhcp.Wait10Min, time.Second*5).Should(gomega.BeTrue(), func() string {
+			libhcp.DumpHypershiftDiagnostics(ctx, h.Client, kubernetesClientForSuiteRun)
+			return "MCE operator deployment never became ready"
+		})
 
 		// Deploy the MCE manifest
 		err = h.DeployMCEManifest()
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 		// Deploy the MCE and wait for it to be ready
-		gomega.Eventually(lib.IsDeploymentReady(h.Client, libhcp.MCENamespace, libhcp.MCEOperatorName), libhcp.Wait10Min, time.Second*5).Should(gomega.BeTrue())
+		gomega.Eventually(lib.IsDeploymentReady(h.Client, libhcp.MCENamespace, libhcp.MCEOperatorName), libhcp.Wait10Min, time.Second*5).Should(gomega.BeTrue(), func() string {
+			libhcp.DumpHypershiftDiagnostics(ctx, h.Client, kubernetesClientForSuiteRun)
+			return "MCE operator deployment never became ready after applying MCE manifest"
+		})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-		// Validate the Hypershift operator
-		gomega.Eventually(lib.IsDeploymentReady(h.Client, libhcp.HONamespace, libhcp.HypershiftOperatorName), libhcp.Wait10Min, time.Second*5).Should(gomega.BeTrue())
-		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		// Validate the Hypershift operator.
+		gomega.Eventually(lib.IsDeploymentReady(h.Client, libhcp.HONamespace, libhcp.HypershiftOperatorName), libhcp.Wait10Min, time.Second*5).Should(gomega.BeTrue(), func() string {
+			libhcp.DumpHypershiftDiagnostics(ctx, h.Client, kubernetesClientForSuiteRun)
+			return "Hypershift operator deployment never became ready"
+		})
 	})
 
 	// After All

--- a/tests/e2e/hcp_backup_restore_suite_test.go
+++ b/tests/e2e/hcp_backup_restore_suite_test.go
@@ -201,32 +201,38 @@ var _ = ginkgo.Describe("HCP Backup and Restore tests", ginkgo.Ordered, func() {
 			return
 		}
 
+		// Below OCP 4.19, MCE's current default channel (stable-2.11) can't be used --
+		// MCE 2.11's backplane-operator refuses to reconcile there (a floor enforced in
+		// code, not visible via OLM/catalog metadata; see OADP-8716). SelectMCEChannel
+		// pins to stable-2.8 in that case, matching the ACM 2.13 / MCE 2.8 pairing the
+		// real GovCloud HCP target environment runs on OCP 4.18 (OADP-7564) -- and
+		// leaves the channel unset (floating on MCE's default) on OCP 4.19+, where HCP
+		// e2e also runs (4.22/4.23/5.0 periodics) and MCE 2.11 installs fine. Check with
+		// the OADP/HCP team from time to time (Brae Troutman, as of this writing) for
+		// updated ACM/MCE version requirements.
+		//
+		// Production also pins the HyperShift operator image itself to a specific SHA
+		// (passed to the MCE hypershift addon), rather than relying on whatever image
+		// ships bundled with this MCE version. That's done via an admin-controlled
+		// ConfigMap named "hypershift-override-images" in the multicluster-engine
+		// namespace (keyed by image-stream name -- see stolostron/hypershift-addon-operator's
+		// pkg/util/constant.go, HypershiftOverrideImagesCM/ImageStreamHypershiftOperator),
+		// separate from the tenant-writable hypershift-operator-install-flags ConfigMap
+		// the CVE-2026-66808 fix locked down. Not replicated here yet -- if a SHA pin
+		// becomes necessary for this test too, source the value from an env var at
+		// runtime rather than hardcoding it (the real pinned image used in production
+		// isn't something to commit to a public repo).
+		mceChannel, err := libhcp.SelectMCEChannel(ctx, runTimeClientForSuiteRun)
+		if err != nil {
+			ginkgo.Fail(fmt.Sprintf("HCP tests failed: could not determine MCE channel for this cluster's OCP version: %v", err))
+			return
+		}
+
 		reqOperators := []libhcp.RequiredOperator{
 			{
-				Name:      libhcp.MCEName,
-				Namespace: libhcp.MCENamespace,
-				// Pinned to the ACM 2.13 / MCE 2.8 pairing our GovCloud HCP target
-				// environment actually runs on OCP 4.18 (ACM 2.13 -> ~2.15 planned, see
-				// ROSAENG-58373) -- not the 4.18 index's default channel (stable-2.11 as
-				// of this writing), which is a support-exception-only version for OCP
-				// 4.18 and can (and did) start enforcing an OCP floor the 4.18 cluster
-				// doesn't meet. Check with the OADP/HCP team from time to time
-				// (Brae Troutman, as of this writing) for updated ACM/MCE version
-				// requirements before bumping this -- see OADP-7564.
-				//
-				// Production also pins the HyperShift operator image itself to a
-				// specific SHA (passed to the MCE hypershift addon), rather than relying
-				// on whatever image ships bundled with this MCE version. That's done via
-				// an admin-controlled ConfigMap named "hypershift-override-images" in
-				// this namespace (keyed by image-stream name -- see
-				// stolostron/hypershift-addon-operator's pkg/util/constant.go,
-				// HypershiftOverrideImagesCM/ImageStreamHypershiftOperator), separate
-				// from the tenant-writable hypershift-operator-install-flags ConfigMap
-				// the CVE-2026-66808 fix locked down. Not replicated here yet -- if a
-				// SHA pin becomes necessary for this test too, source the value from an
-				// env var at runtime rather than hardcoding it (the real pinned image
-				// used in production isn't something to commit to a public repo).
-				Channel:       "stable-2.8",
+				Name:          libhcp.MCEName,
+				Namespace:     libhcp.MCENamespace,
+				Channel:       mceChannel,
 				OperatorGroup: libhcp.MCEOperatorGroup,
 			},
 		}

--- a/tests/e2e/lib/hcp/mce.go
+++ b/tests/e2e/lib/hcp/mce.go
@@ -215,6 +215,38 @@ func filterLogLines(logs string, keywords []string) []string {
 	return matched
 }
 
+// sanitizeErrorForLog reduces an error to its structured Kubernetes status reason
+// (e.g. "NotFound", "Forbidden") rather than logging the full error text, which for
+// a client-go/controller-runtime transport error can embed the API server's URL or
+// other internal-hostname-shaped detail. apierrors.ReasonForError returns
+// metav1.StatusReasonUnknown for a non-API error, so this is safe to call
+// unconditionally.
+func sanitizeErrorForLog(err error) string {
+	return string(apierrors.ReasonForError(err))
+}
+
+// maxDiagnosticLineLength bounds how much of a single log line diagnostics will
+// print -- an operator log line is free-form text and could otherwise carry an
+// arbitrarily long embedded value.
+const maxDiagnosticLineLength = 200
+
+var urlPattern = regexp.MustCompile(`https?://\S+`)
+
+// redactDiagnosticLine bounds and lightly redacts a pod log line before it's
+// written to CI artifacts: strips embedded URLs (which can carry internal
+// hostnames) and truncates to maxDiagnosticLineLength. This is on top of, not a
+// replacement for, filterLogLines' keyword narrowing above -- the two together
+// keep this to "the few lines worth acting on, with obvious hostnames stripped and
+// length bounded" rather than either a full log dump or a blanket suppression that
+// would defeat the purpose of capturing these lines at all.
+func redactDiagnosticLine(line string) string {
+	redacted := urlPattern.ReplaceAllString(line, "[redacted-url]")
+	if len(redacted) > maxDiagnosticLineLength {
+		redacted = redacted[:maxDiagnosticLineLength] + "...[truncated]"
+	}
+	return redacted
+}
+
 // DumpHypershiftDiagnostics logs best-effort diagnostics for the MultiClusterEngine
 // operand and the hypershift/multicluster-engine namespaces. Intended to be called
 // right before failing an Eventually that waits on MCE/HyperShift operator readiness,
@@ -222,15 +254,27 @@ func filterLogLines(logs string, keywords []string) []string {
 // best-effort: a failure here must never panic or obscure the real test failure.
 // clientset may be nil, in which case pod log capture is skipped (conditions/components/
 // pods/events are still captured via c).
+//
+// Runs against a short-lived timeout derived from ctx rather than ctx directly --
+// this is called from a Ginkgo failure-message callback, which must return
+// promptly; an unbounded API call (or an unbounded pod-log stream -- see
+// getPodLogsWithTimeout below) here would otherwise be able to hang that callback,
+// and with it the whole suite, past any outer CI timeout.
 func DumpHypershiftDiagnostics(ctx context.Context, c client.Client, clientset *kubernetes.Clientset) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
 	log.Printf("=== HyperShift/MCE diagnostics dump ===")
 
 	mce := &unstructured.Unstructured{}
 	mce.SetGroupVersionKind(mceGVR.GroupVersion().WithKind("MultiClusterEngine"))
 	if err := c.Get(ctx, types.NamespacedName{Name: MCEOperandName, Namespace: MCENamespace}, mce); err != nil {
-		log.Printf("diagnostics: failed to get MultiClusterEngine %s/%s: %v", MCENamespace, MCEOperandName, err)
+		log.Printf("diagnostics: failed to get MultiClusterEngine %s/%s: %s", MCENamespace, MCEOperandName, sanitizeErrorForLog(err))
 	} else {
-		conditions, _, _ := unstructured.NestedSlice(mce.Object, "status", "conditions")
+		conditions, _, err := unstructured.NestedSlice(mce.Object, "status", "conditions")
+		if err != nil {
+			log.Printf("diagnostics: MultiClusterEngine %s/%s status.conditions is not a slice: %s", MCENamespace, MCEOperandName, sanitizeErrorForLog(err))
+		}
 		for _, condRaw := range conditions {
 			cond, ok := condRaw.(map[string]interface{})
 			if !ok {
@@ -239,7 +283,10 @@ func DumpHypershiftDiagnostics(ctx context.Context, c client.Client, clientset *
 			log.Printf("diagnostics: MultiClusterEngine %s/%s condition type=%v status=%v reason=%v",
 				MCENamespace, MCEOperandName, cond["type"], cond["status"], cond["reason"])
 		}
-		components, _, _ := unstructured.NestedSlice(mce.Object, "status", "components")
+		components, _, err := unstructured.NestedSlice(mce.Object, "status", "components")
+		if err != nil {
+			log.Printf("diagnostics: MultiClusterEngine %s/%s status.components is not a slice: %s", MCENamespace, MCEOperandName, sanitizeErrorForLog(err))
+		}
 		for _, compRaw := range components {
 			comp, ok := compRaw.(map[string]interface{})
 			if !ok {
@@ -253,7 +300,7 @@ func DumpHypershiftDiagnostics(ctx context.Context, c client.Client, clientset *
 	for _, ns := range []string{HONamespace, MCENamespace} {
 		pods := &corev1.PodList{}
 		if err := c.List(ctx, pods, client.InNamespace(ns)); err != nil {
-			log.Printf("diagnostics: failed to list pods in %s: %v", ns, err)
+			log.Printf("diagnostics: failed to list pods in %s: %s", ns, sanitizeErrorForLog(err))
 		} else {
 			for _, pod := range pods.Items {
 				log.Printf("diagnostics: pod %s/%s phase=%s", ns, pod.Name, pod.Status.Phase)
@@ -267,13 +314,13 @@ func DumpHypershiftDiagnostics(ctx context.Context, c client.Client, clientset *
 					continue
 				}
 				for _, container := range pod.Spec.Containers {
-					logs, err := lib.GetPodContainerLogs(clientset, ns, pod.Name, container.Name)
+					logs, err := getPodLogsWithTimeout(ctx, clientset, ns, pod.Name, container.Name)
 					if err != nil {
-						log.Printf("diagnostics: failed to get logs for %s/%s container %s: %v", ns, pod.Name, container.Name, err)
+						log.Printf("diagnostics: failed to get logs for %s/%s container %s: %s", ns, pod.Name, container.Name, sanitizeErrorForLog(err))
 						continue
 					}
 					for _, line := range filterLogLines(logs, diagnosticLogKeywords) {
-						log.Printf("diagnostics: pod %s/%s container %s log: %s", ns, pod.Name, container.Name, line)
+						log.Printf("diagnostics: pod %s/%s container %s log: %s", ns, pod.Name, container.Name, redactDiagnosticLine(line))
 					}
 				}
 			}
@@ -281,7 +328,7 @@ func DumpHypershiftDiagnostics(ctx context.Context, c client.Client, clientset *
 
 		events := &corev1.EventList{}
 		if err := c.List(ctx, events, client.InNamespace(ns)); err != nil {
-			log.Printf("diagnostics: failed to list events in %s: %v", ns, err)
+			log.Printf("diagnostics: failed to list events in %s: %s", ns, sanitizeErrorForLog(err))
 		} else {
 			for _, event := range events.Items {
 				log.Printf("diagnostics: event %s/%s reason=%s type=%s count=%d", ns, event.InvolvedObject.Name, event.Reason, event.Type, event.Count)
@@ -290,6 +337,31 @@ func DumpHypershiftDiagnostics(ctx context.Context, c client.Client, clientset *
 	}
 
 	log.Printf("=== end HyperShift/MCE diagnostics dump ===")
+}
+
+// getPodLogsWithTimeout wraps lib.GetPodContainerLogs, which ignores any context
+// and streams via its own internal context.Background() with no deadline, in a
+// goroutine bounded by ctx -- so a stalled log stream can't hang the caller past
+// ctx's own deadline. Returns ctx.Err() if that deadline is reached first; the
+// underlying GetPodContainerLogs call is abandoned (not cancelled -- it has no
+// context to cancel), which is an acceptable one-shot best-effort leak in a
+// diagnostics-only path that runs at most a handful of times per suite.
+func getPodLogsWithTimeout(ctx context.Context, clientset *kubernetes.Clientset, namespace, podName, container string) (string, error) {
+	type result struct {
+		logs string
+		err  error
+	}
+	done := make(chan result, 1)
+	go func() {
+		logs, err := lib.GetPodContainerLogs(clientset, namespace, podName, container)
+		done <- result{logs, err}
+	}()
+	select {
+	case r := <-done:
+		return r.logs, r.err
+	case <-ctx.Done():
+		return "", ctx.Err()
+	}
 }
 
 func (h *HCHandler) IsMCEDeployed() bool {

--- a/tests/e2e/lib/hcp/mce.go
+++ b/tests/e2e/lib/hcp/mce.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
@@ -15,7 +16,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openshift/oadp-operator/tests/e2e/lib"
 )
 
 const (
@@ -130,6 +134,103 @@ func (op *HCHandler) DeployMCEManifest() error {
 	}
 
 	return nil
+}
+
+// diagnosticLogKeywords are matched case-insensitively against MCE operator pod log
+// lines. Deliberately narrow rather than dumping full logs: these are operator-authored
+// diagnostic lines, not free-text user/backup content, but still worth filtering down
+// to only the lines an investigator would act on.
+var diagnosticLogKeywords = []string{"error", "denied", "forbidden", "minimum version", "reconcil"}
+
+func filterLogLines(logs string, keywords []string) []string {
+	var matched []string
+	for _, line := range strings.Split(logs, "\n") {
+		lower := strings.ToLower(line)
+		for _, kw := range keywords {
+			if strings.Contains(lower, kw) {
+				matched = append(matched, line)
+				break
+			}
+		}
+	}
+	return matched
+}
+
+// DumpHypershiftDiagnostics logs best-effort diagnostics for the MultiClusterEngine
+// operand and the hypershift/multicluster-engine namespaces. Intended to be called
+// right before failing an Eventually that waits on MCE/HyperShift operator readiness,
+// since none of this state is otherwise captured by CI artifacts. Every step is
+// best-effort: a failure here must never panic or obscure the real test failure.
+// clientset may be nil, in which case pod log capture is skipped (conditions/components/
+// pods/events are still captured via c).
+func DumpHypershiftDiagnostics(ctx context.Context, c client.Client, clientset *kubernetes.Clientset) {
+	log.Printf("=== HyperShift/MCE diagnostics dump ===")
+
+	mce := &unstructured.Unstructured{}
+	mce.SetGroupVersionKind(mceGVR.GroupVersion().WithKind("MultiClusterEngine"))
+	if err := c.Get(ctx, types.NamespacedName{Name: MCEOperandName, Namespace: MCENamespace}, mce); err != nil {
+		log.Printf("diagnostics: failed to get MultiClusterEngine %s/%s: %v", MCENamespace, MCEOperandName, err)
+	} else {
+		conditions, _, _ := unstructured.NestedSlice(mce.Object, "status", "conditions")
+		for _, condRaw := range conditions {
+			cond, ok := condRaw.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			log.Printf("diagnostics: MultiClusterEngine %s/%s condition type=%v status=%v reason=%v",
+				MCENamespace, MCEOperandName, cond["type"], cond["status"], cond["reason"])
+		}
+		components, _, _ := unstructured.NestedSlice(mce.Object, "status", "components")
+		for _, compRaw := range components {
+			comp, ok := compRaw.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			log.Printf("diagnostics: MultiClusterEngine %s/%s component name=%v type=%v status=%v reason=%v",
+				MCENamespace, MCEOperandName, comp["name"], comp["type"], comp["status"], comp["reason"])
+		}
+	}
+
+	for _, ns := range []string{HONamespace, MCENamespace} {
+		pods := &corev1.PodList{}
+		if err := c.List(ctx, pods, client.InNamespace(ns)); err != nil {
+			log.Printf("diagnostics: failed to list pods in %s: %v", ns, err)
+		} else {
+			for _, pod := range pods.Items {
+				log.Printf("diagnostics: pod %s/%s phase=%s", ns, pod.Name, pod.Status.Phase)
+
+				// Capture logs from the MCE operator pod specifically -- its reconciler
+				// can reject the MultiClusterEngine CR outright (e.g. an OCP-version
+				// floor check) before any managed component, including the HyperShift
+				// operator Deployment, is ever created. That failure mode is otherwise
+				// invisible: MCE's own Deployment/CSV still report Ready/Succeeded.
+				if clientset == nil || ns != MCENamespace || !strings.HasPrefix(pod.Name, MCEOperatorName) {
+					continue
+				}
+				for _, container := range pod.Spec.Containers {
+					logs, err := lib.GetPodContainerLogs(clientset, ns, pod.Name, container.Name)
+					if err != nil {
+						log.Printf("diagnostics: failed to get logs for %s/%s container %s: %v", ns, pod.Name, container.Name, err)
+						continue
+					}
+					for _, line := range filterLogLines(logs, diagnosticLogKeywords) {
+						log.Printf("diagnostics: pod %s/%s container %s log: %s", ns, pod.Name, container.Name, line)
+					}
+				}
+			}
+		}
+
+		events := &corev1.EventList{}
+		if err := c.List(ctx, events, client.InNamespace(ns)); err != nil {
+			log.Printf("diagnostics: failed to list events in %s: %v", ns, err)
+		} else {
+			for _, event := range events.Items {
+				log.Printf("diagnostics: event %s/%s reason=%s type=%s count=%d", ns, event.InvolvedObject.Name, event.Reason, event.Type, event.Count)
+			}
+		}
+	}
+
+	log.Printf("=== end HyperShift/MCE diagnostics dump ===")
 }
 
 func (h *HCHandler) IsMCEDeployed() bool {

--- a/tests/e2e/lib/hcp/mce.go
+++ b/tests/e2e/lib/hcp/mce.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
+	configv1 "github.com/openshift/api/config/v1"
 	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
@@ -27,7 +30,63 @@ const (
 	MCEOperatorNamespace = "multicluster-engine"
 	MCEOperatorGroupName = "multicluster-engine"
 	MCESubscriptionName  = "multicluster-engine"
+
+	// mceStableChannelOCPVersionThresholdMajor/Minor: below this OCP version, MCE's
+	// current default channel (stable-2.11 as of this writing) can't be used --
+	// MCE 2.11's backplane-operator refuses to reconcile on OCP < 4.19 (a floor
+	// enforced in code, not visible via OLM/catalog metadata; see OADP-8716). Below
+	// the threshold, pin to stable-2.8 instead, matching the ACM 2.13/MCE 2.8 pairing
+	// the real GovCloud HCP target environment runs on OCP 4.18 (OADP-7564).
+	mceStableChannelOCPVersionThresholdMajor = 4
+	mceStableChannelOCPVersionThresholdMinor = 19
+
+	// mceLegacyChannel is used on clusters below the threshold above.
+	mceLegacyChannel = "stable-2.8"
 )
+
+// SelectMCEChannel picks the MCE subscription channel appropriate for the cluster's
+// OCP version. Returns "" for OCP versions at or above
+// mceStableChannelOCPVersionThresholdMajor.Minor, signaling the caller to float on
+// MCE's default channel as usual; returns mceLegacyChannel below that threshold.
+func SelectMCEChannel(ctx context.Context, c client.Client) (string, error) {
+	clusterVersion := &configv1.ClusterVersion{}
+	if err := c.Get(ctx, types.NamespacedName{Name: "version"}, clusterVersion); err != nil {
+		return "", fmt.Errorf("failed to get cluster version: %v", err)
+	}
+
+	version := clusterVersion.Status.Desired.Version
+	if version == "" && len(clusterVersion.Status.History) > 0 {
+		version = clusterVersion.Status.History[0].Version
+	}
+	if version == "" {
+		return "", fmt.Errorf("cluster version status has no desired or history version")
+	}
+
+	re := regexp.MustCompile(`^(\d+)\.(\d+)`)
+	m := re.FindStringSubmatch(version)
+	if m == nil {
+		return "", fmt.Errorf("could not parse major.minor from cluster version %q", version)
+	}
+	major, err := strconv.Atoi(m[1])
+	if err != nil {
+		return "", fmt.Errorf("failed to parse major version from %q: %v", version, err)
+	}
+	minor, err := strconv.Atoi(m[2])
+	if err != nil {
+		return "", fmt.Errorf("failed to parse minor version from %q: %v", version, err)
+	}
+
+	if major < mceStableChannelOCPVersionThresholdMajor ||
+		(major == mceStableChannelOCPVersionThresholdMajor && minor < mceStableChannelOCPVersionThresholdMinor) {
+		log.Printf("Cluster OCP version %s is below %d.%d; pinning MCE to channel %s", version,
+			mceStableChannelOCPVersionThresholdMajor, mceStableChannelOCPVersionThresholdMinor, mceLegacyChannel)
+		return mceLegacyChannel, nil
+	}
+
+	log.Printf("Cluster OCP version %s is at or above %d.%d; using MCE's default channel", version,
+		mceStableChannelOCPVersionThresholdMajor, mceStableChannelOCPVersionThresholdMinor)
+	return "", nil
+}
 
 // DeleteMCEOperand deletes the MCE operand
 func (h *HCHandler) DeleteMCEOperand() error {


### PR DESCRIPTION
Fixes: [OADP-8716](https://redhat.atlassian.net/browse/OADP-8716)

## Summary

`periodic-ci-openshift-oadp-operator-oadp-1.6-4.18-e2e-test-hcp-aws-periodic` fails in the HCP suite's `BeforeAll`:

```
Timed out after 600.003s.
Eventually returned error: deployments.apps "operator" not found
```

MCE (multicluster-engine) v2.11.5's `backplane-operator` reconciler hard-rejects the `MultiClusterEngine` CR with a hardcoded minimum-OpenShift-version check (`OCP version ... did not meet minimum version requirement of 4.19.0`), introduced in [stolostron/backplane-operator#3784](https://github.com/stolostron/backplane-operator/pull/3784). This fires before any managed component — including the HyperShift operator `Deployment` — is created, while MCE's own operator Deployment/CSV report `Ready`/`Succeeded` normally, so the failure is otherwise invisible.

MCE 2.11 (ACM 2.16) doesn't officially support OCP 4.18 — only via an unsupported support-exception path. Our actual GovCloud HCP target environment doesn't run MCE 2.11 at all: it's ACM 2.13 / MCE 2.8, moving to ACM ~2.15 later ([ROSAENG-58373](https://redhat.atlassian.net/browse/ROSAENG-58373)). The MCE `Subscription` had no `Channel` set, so it floated onto whatever the 4.18 catalog's default channel resolved to (`stable-2.11`) rather than the version this test actually needs to validate against. Tracked in [OADP-7564](https://redhat.atlassian.net/browse/OADP-7564) (OADP 1.6 HCP support on OCP 4.18 for ROSA GovCloud).

**HCP e2e isn't 4.18-only.** `ci-operator/config` in `openshift/release` has `TEST_HCP` set for `oadp-1.6` on OCP 4.18, 4.22, 4.23, and 5.0 — all running the same test binary off the same branch. `stable-2.8`'s head bundle declares `olm.maxOpenShiftVersion: 4.19`, an OLM-enforced cap, so a channel pin can't be a single hardcoded value without breaking the newer-OCP jobs.

## Design

- **`tests/e2e/lib/hcp/mce.go`**: `SelectMCEChannel` reads the cluster's `ClusterVersion` and returns `stable-2.8` below OCP 4.19 (matching the ACM 2.13/MCE 2.8 pairing the real GovCloud target runs), or `""` at 4.19 and above, signaling the caller to float on MCE's default channel as before — where MCE 2.11 installs fine and the other HCP periodics already run.
- **`tests/e2e/hcp_backup_restore_suite_test.go`**: the MCE `Subscription`'s `Channel` is set from `SelectMCEChannel`'s result instead of a hardcoded value.
- **`DumpHypershiftDiagnostics`** (`tests/e2e/lib/hcp/mce.go`) captures MCE operator pod logs (filtered to a small keyword allowlist — error/denied/forbidden/minimum version/reconcile — then further redacted: embedded URLs stripped, lines length-bounded), `MultiClusterEngine` CR conditions/components, and pod/event listings in the `hypershift`/`multicluster-engine` namespaces. None of this was previously captured by CI artifacts, which otherwise leave a `BeforeAll` timeout undiagnosable from the artifacts alone. Runs against a 30s-bounded context derived internally (it's called from a Ginkgo failure-message callback, which must return promptly), including the pod-log fetch — which goes through a shared helper that ignores any context and streams via its own unbounded one internally, so that one call is wrapped in a goroutine raced against the bound instead. Logged Kubernetes errors are reduced to their structured status reason (e.g. `NotFound`) rather than full error text, which for a transport-level error can embed the API server's URL.

Production additionally pins the HyperShift operator image itself to a specific SHA via an admin-controlled `hypershift-override-images` ConfigMap (distinct from the tenant-writable install-flags ConfigMap `stolostron/hypershift-addon-operator` locks down for CVE-2026-66808) — not replicated here since the real pinned image reference is internal, but noted as a code comment at the channel-selection call site as a future extension point (would be sourced from an env var, not hardcoded, if needed).

## Known limitations

- Check with the OADP/HCP team from time to time for updated ACM/MCE version requirements before assuming the 4.19 threshold and `stable-2.8` stay correct indefinitely — see the code comments at `SelectMCEChannel` and its call site, [OADP-7564](https://redhat.atlassian.net/browse/OADP-7564), and [ROSAENG-58373](https://redhat.atlassian.net/browse/ROSAENG-58373).
- `SelectMCEChannel` hasn't been exercised against a live 4.22/4.23/5.0 cluster to confirm the "leave Channel unset" branch behaves identically to today's pre-fix code path there — the logic is equivalent (empty `Channel` was always the existing behavior), but only the 4.18 branch has been reasoned through against real failure data.

## Testing

- `go build ./tests/e2e/...` and `go vet ./tests/e2e/...` — clean.
- `make lint` — 0 issues.
- Can't run the live HCP suite locally (needs a 4.18+HCP-capable AWS cluster).

## Test plan

- [x] `go vet ./tests/e2e/...` passes
- [ ] Next periodic run on 4.18 (or manual rerun) confirms `stable-2.8` installs cleanly and the HyperShift operator becomes ready
- [ ] Next periodic run on 4.22/4.23/5.0 confirms no regression (channel stays unset, behavior unchanged)
- [ ] Cherry-pick to `oadp-1.6` after merge (release branch, not targeted directly per repo convention)

> [!Note]
> Responses generated with Claude
