### PR TITLE
[oadp-1.4] Add --ginkgo.junit-report flag to test-e2e target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -676,6 +676,7 @@ test-e2e: test-e2e-setup install-ginkgo $(if $(MUST_GATHER_REPO),build-must-gath
 	--ginkgo.vv \
 	--ginkgo.no-color=$(OPENSHIFT_CI) \
 	--ginkgo.label-filter="$(TEST_FILTER)" \
+	--ginkgo.junit-report="$(ARTIFACT_DIR)/junit_report.xml" \
 	--ginkgo.timeout=2h
 
 .PHONY: test-e2e-cleanup


### PR DESCRIPTION
## Summary

`oadp-1.4`'s `test-e2e` target was missing the `--ginkgo.junit-report` flag present on `oadp-1.5`/`oadp-dev`, so it never wrote `junit_report.xml` to `$ARTIFACT_DIR`. Unrelated to the Claude CLI hook removed in #2408/#2409 — `oadp-1.4` never had that hook; this is just an older `Makefile` predating the flag.

Adds `--ginkgo.junit-report="$(ARTIFACT_DIR)/junit_report.xml"` to match the other branches.

Fixes #2410

> [!Note]
> Responses generated with Claude
