### PR TITLE
fix(e2e): TEST_VIRT excludes kdm specs, enable split-job e2e (issue #2413 option B)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1003,9 +1003,11 @@ TEST_VIRT ?= false
 # TEST_VIRT_KDM runs only the kubevirt-datamover-specific specs (ginkgo label
 # "kdm", a subset of "virt") -- for CI jobs that build/test against the
 # kubevirt-datamover-controller/-plugin repos specifically and don't need the
-# full TEST_VIRT suite's runtime. TEST_VIRT=true already covers these specs
-# too, since they carry both labels -- this only matters when TEST_VIRT_KDM
-# is set WITHOUT TEST_VIRT.
+# full TEST_VIRT suite's runtime. TEST_VIRT=true excludes kdm specs (see
+# TEST_FILTER below) so the two suites can run as separate, parallel CI jobs
+# without overlap -- see https://github.com/openshift/oadp-operator/issues/2413
+# option B. Set TEST_VIRT_KDM=true (with or without TEST_VIRT) to run kdm
+# specs only.
 TEST_VIRT_KDM ?= false
 HCO_INDEX_TAG ?= 1.18.0
 # hcp
@@ -1027,12 +1029,15 @@ FAIL_FAST ?= true
 TEST_FILTER = (($(shell echo '! aws && ! gcp && ! azure && ! ibmcloud' | \
 $(SED) -r "s/[&]* [!] $(CLUSTER_TYPE)|[!] $(CLUSTER_TYPE) [&]*//")) || $(CLUSTER_TYPE))
 #TEST_FILTER := $(shell echo '! aws && ! gcp && ! azure' | $(SED) -r "s/[&]* [!] $(CLUSTER_TYPE)|[!] $(CLUSTER_TYPE) [&]*//")
-ifeq ($(TEST_VIRT),true)
-	TEST_FILTER += && (virt)
+# TEST_VIRT_KDM takes precedence: it isolates the kdm job regardless of
+# TEST_VIRT/TEST_VIRT_GA. Otherwise TEST_VIRT excludes kdm specs (they run as
+# their own job via TEST_VIRT_KDM=true) -- option B of issue #2413.
+ifeq ($(TEST_VIRT_KDM),true)
+	TEST_FILTER += && (kdm)
+else ifeq ($(TEST_VIRT),true)
+	TEST_FILTER += && (virt) && (! kdm)
 else ifeq ($(TEST_VIRT_GA),true)
 	TEST_FILTER += && (virt)
-else ifeq ($(TEST_VIRT_KDM),true)
-	TEST_FILTER += && (kdm)
 else
 	TEST_FILTER += && (! virt)
 endif

--- a/Makefile
+++ b/Makefile
@@ -1003,11 +1003,17 @@ TEST_VIRT ?= false
 # TEST_VIRT_KDM runs only the kubevirt-datamover-specific specs (ginkgo label
 # "kdm", a subset of "virt") -- for CI jobs that build/test against the
 # kubevirt-datamover-controller/-plugin repos specifically and don't need the
-# full TEST_VIRT suite's runtime. TEST_VIRT=true excludes kdm specs (see
-# TEST_FILTER below) so the two suites can run as separate, parallel CI jobs
-# without overlap -- see https://github.com/openshift/oadp-operator/issues/2413
-# option B. Set TEST_VIRT_KDM=true (with or without TEST_VIRT) to run kdm
-# specs only.
+# full TEST_VIRT suite's runtime. Tri-state, distinguished via $(origin):
+#   unset          -> TEST_VIRT=true includes kdm specs too (legacy behavior,
+#                      what existing openshift/release jobs rely on today)
+#   explicit false -> TEST_VIRT=true excludes kdm specs, for a split non-kdm
+#                      CI job
+#   explicit true  -> kdm specs only, regardless of TEST_VIRT/TEST_VIRT_GA
+# This lets a new split kdm-only job opt in (TEST_VIRT_KDM=true) and a new
+# split non-kdm job opt out (TEST_VIRT_KDM=false) without changing what
+# existing jobs that don't set this var at all get today -- see
+# https://github.com/openshift/oadp-operator/issues/2413 option B.
+TEST_VIRT_KDM_ORIGIN := $(origin TEST_VIRT_KDM)
 TEST_VIRT_KDM ?= false
 HCO_INDEX_TAG ?= 1.18.0
 # hcp
@@ -1029,13 +1035,17 @@ FAIL_FAST ?= true
 TEST_FILTER = (($(shell echo '! aws && ! gcp && ! azure && ! ibmcloud' | \
 $(SED) -r "s/[&]* [!] $(CLUSTER_TYPE)|[!] $(CLUSTER_TYPE) [&]*//")) || $(CLUSTER_TYPE))
 #TEST_FILTER := $(shell echo '! aws && ! gcp && ! azure' | $(SED) -r "s/[&]* [!] $(CLUSTER_TYPE)|[!] $(CLUSTER_TYPE) [&]*//")
-# TEST_VIRT_KDM takes precedence: it isolates the kdm job regardless of
-# TEST_VIRT/TEST_VIRT_GA. Otherwise TEST_VIRT excludes kdm specs (they run as
-# their own job via TEST_VIRT_KDM=true) -- option B of issue #2413.
+# TEST_VIRT_KDM=true takes precedence: it isolates the kdm job regardless of
+# TEST_VIRT/TEST_VIRT_GA. Otherwise TEST_VIRT includes kdm specs unless
+# TEST_VIRT_KDM was explicitly set to false (see TEST_VIRT_KDM_ORIGIN above).
 ifeq ($(TEST_VIRT_KDM),true)
 	TEST_FILTER += && (kdm)
 else ifeq ($(TEST_VIRT),true)
-	TEST_FILTER += && (virt) && (! kdm)
+	ifeq ($(TEST_VIRT_KDM_ORIGIN),undefined)
+		TEST_FILTER += && (virt)
+	else
+		TEST_FILTER += && (virt) && (! kdm)
+	endif
 else ifeq ($(TEST_VIRT_GA),true)
 	TEST_FILTER += && (virt)
 else


### PR DESCRIPTION
## Summary
- `TEST_VIRT=true` now excludes `kdm`-labeled specs from `TEST_FILTER`
- `TEST_VIRT_KDM=true` still isolates kdm specs regardless of `TEST_VIRT`/`TEST_VIRT_GA`, and takes precedence

This enables option B from #2413: splitting `e2e-test-kubevirt-aws` into a non-kdm CSI job (`TEST_VIRT=true`) and a separate kdm-only job (`TEST_VIRT_KDM=true`), so each comfortably clears the 2h Prow step timeout instead of one job running both suites serially.

Fixes #2413

## Test plan
- [x] `TEST_VIRT_KDM=false TEST_VIRT=true` → filter resolves to `... && (virt) && (! kdm) && ...`
- [x] `TEST_VIRT_KDM=true TEST_VIRT=false` → filter resolves to `... && (kdm) && ...`
- [ ] openshift/release job config update to add the split kdm job (follow-up)

> [!Note]
> Responses generated with Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved virtualized test selection with clearer handling for KDM-specific coverage.
  * When the KDM option is enabled, only KDM tests run.
  * When disabled, KDM tests are excluded from general virtualized testing.
  * Leaving the option unset preserves the existing virtualized test selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->