### PR TITLE
Fix VMFR NetworkPolicy egress to BSL endpoints

### DIFF
--- a/internal/controller/networkpolicy.go
+++ b/internal/controller/networkpolicy.go
@@ -777,9 +777,9 @@ func (r *DataProtectionApplicationReconciler) reconcileVMFileRestoreNetworkPolic
 					},
 				},
 			},
-			// Egress: this controller only orchestrates via CRs (no cloud/BSL credentials
-			// referenced in its code) and needs no direct cloud storage access.
-			Egress: scopedEgressRules(),
+			// Egress: VMFR downloads backup contents directly from the configured
+			// BackupStorageLocation, which may be an arbitrary S3-compatible endpoint.
+			Egress: unrestrictedEgressRule(),
 		}
 
 		return nil

--- a/internal/controller/networkpolicy_test.go
+++ b/internal/controller/networkpolicy_test.go
@@ -316,9 +316,10 @@ var _ = ginkgo.Describe("ReconcileNetworkPolicies", func() {
 			gomega.Expect(*port.Protocol).To(gomega.Equal(corev1.ProtocolTCP))
 		}
 
-		// Verify scoped egress (DNS + API-server only)
+		// Verify unrestricted egress: VMFR downloads backup contents directly from
+		// arbitrary, admin-configured S3-compatible BackupStorageLocation endpoints.
 		gomega.Expect(np.Spec.PolicyTypes).To(gomega.ContainElement(networkingv1.PolicyTypeEgress))
-		gomega.Expect(np.Spec.Egress).To(gomega.Equal(scopedEgressRules()))
+		gomega.Expect(np.Spec.Egress).To(gomega.Equal(unrestrictedEgressRule()))
 	})
 
 	ginkgo.It("should create KubeVirt datamover NetworkPolicy when enabled", func() {


### PR DESCRIPTION
## Why the changes were made

VM file restore downloads backup contents directly from configured BackupStorageLocation endpoints. The VMFR NetworkPolicy previously allowed only DNS and Kubernetes API egress, which blocked S3-compatible BSL access when OADP NetworkPolicies were enabled.

Fixes: #2429

## How to test the changes made

- `go test ./internal/controller`
- Verified the VMFR NetworkPolicy test expects unrestricted egress.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * VM file restores can now connect directly to configured backup storage endpoints, improving compatibility with storage locations that require unrestricted outbound access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->