### PR TITLE
OADP-7895 CRD changes for the non admin describe command issue

### DIFF
--- a/bundle/manifests/oadp.openshift.io_nonadminbackups.yaml
+++ b/bundle/manifests/oadp.openshift.io_nonadminbackups.yaml
@@ -666,6 +666,10 @@ spec:
                     description: number of PodVolumeBackups related to this NonAdminBackup's
                       Backup
                     type: integer
+                  uploaderType:
+                    description: type of uploader used for pod volume backups (e.g.,
+                      kopia, restic)
+                    type: string
                 type: object
               phase:
                 description: phase is a simple one high-level summary of the lifecycle

--- a/config/crd/bases/oadp.openshift.io_nonadminbackups.yaml
+++ b/config/crd/bases/oadp.openshift.io_nonadminbackups.yaml
@@ -666,6 +666,10 @@ spec:
                     description: number of PodVolumeBackups related to this NonAdminBackup's
                       Backup
                     type: integer
+                  uploaderType:
+                    description: type of uploader used for pod volume backups (e.g.,
+                      kopia, restic)
+                    type: string
                 type: object
               phase:
                 description: phase is a simple one high-level summary of the lifecycle


### PR DESCRIPTION
## Why the changes were made

After merging this non admin repo PR : https://github.com/migtools/oadp-non-admin/pull/377, the CRD in the oadp operator needs to be updated.

## How to test the changes made

Try to run oadp nonadmin cli commands

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an `uploaderType` status field to non-admin backup records, indicating which uploader is used for pod volume backups, such as Kopia or Restic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->