### PR TITLE
fix: vendor virtualmachineinstances RBAC from KDM PR #218

### DIFF
--- a/bundle/manifests/oadp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/oadp-operator.clusterserviceversion.yaml
@@ -1345,6 +1345,14 @@ spec:
         - apiGroups:
           - kubevirt.io
           resources:
+          - virtualmachineinstances
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - kubevirt.io
+          resources:
           - virtualmachines
           verbs:
           - get

--- a/config/kubevirt-datamover-controller_rbac/role.yaml
+++ b/config/kubevirt-datamover-controller_rbac/role.yaml
@@ -88,6 +88,14 @@ rules:
 - apiGroups:
   - kubevirt.io
   resources:
+  - virtualmachineinstances
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kubevirt.io
+  resources:
   - virtualmachines
   verbs:
   - get


### PR DESCRIPTION
## Why the changes were made

kubevirt-datamover-controller PR migtools/kubevirt-datamover-controller#218 adds a `virtualmachineinstances` get/list/watch permission needed for its guest-agent-based quiesce detection. This propagates that RBAC here so OADP-deployed controllers actually have it, instead of always falling back to skip-quiesce.

## How to test the changes made

- `make manifests && make bundle` remain clean (no drift) with this RBAC added.
- After deploying, verify the kubevirt-datamover-controller service account role includes `get/list/watch` on `virtualmachineinstances`:
  ```
  oc get role -n openshift-adp -o yaml | grep -A5 virtualmachineinstances
  ```

Depends-On: https://github.com/migtools/kubevirt-datamover-controller/pull/218

> [!Note]
> Responses generated with Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved KubeVirt integration by enabling discovery and monitoring of virtual machine instances.
  - Supports more complete data protection workflows for environments using KubeVirt virtual machines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->