### PR TITLE
Design: per-item backup outcomes and resource rollup (OADP-8697)

### DIFF
--- a/docs/design/backup_outcomes-design.md
+++ b/docs/design/backup_outcomes-design.md
@@ -1,0 +1,187 @@
+# Backup outcomes design
+
+_First-principles design for **per-item backup outcomes**: what happened to each resource in a single Velero backup run._
+
+**Upstream:** [velero-io/velero#10503](https://github.com/velero-io/velero/issues/10503)
+
+Related: [backup resource rollup](backup_resource_rollup-design.md) (downstream grouping), [vm backup status](vm_backup_status-design.md) (VM case study).
+
+## Problem
+
+After a Velero backup finishes — especially `PartiallyFailed` — operators need to know:
+
+**For this backup, which resources failed, warned, or were skipped, and why?**
+
+Today Velero only answers at job level:
+
+```yaml
+status:
+  phase: PartiallyFailed
+  errors: 2
+```
+
+There is no single, machine-readable **outcome per resource** for one backup.
+
+## What exists today
+
+**Machine-readable** = explicit `{GVR, namespace, name, outcome, message}` — not regex on `results.gz`.
+
+Before adding a new file or log line, map what each backup artifact already records:
+
+### In-cluster: `Backup.status`
+
+| Field | Per-item? | Use |
+|-------|-----------|-----|
+| `phase`, `failureReason` | Job | Whole backup failed |
+| `errors`, `warnings` | Count only | Points to BSL logs/results |
+| `validationErrors` | Pre-run strings | Not backup outcomes |
+| `hookStatus` | Count only | No per-hook detail |
+| `backupItemOperations*` | Counts | Points to `itemoperations` |
+
+### Object storage: `backups/<name>/`
+
+| File | Per-item? | Outcome signal | Limitation |
+|------|-----------|----------------|------------|
+| `resource-list.json.gz` | Yes (inventory) | Denominator only | No pass/fail |
+| `results.gz` | Errors only | Sync fail/warn strings | Unstructured; `name:` ambiguous; async gaps ([#9377](https://github.com/vmware-tanzu/velero/issues/9377)) |
+| `volumeinfo.json.gz` | PVC | Structured succeeded/failed | PVC-only; can be stale |
+| `itemoperations.json.gz` | Async ops | Structured async status | Partial coverage; may disagree with `results` |
+| `<backup>.tar.gz` | Yes (manifests) | Content only | No outcome; large |
+| `velero-backup.json` | Job | Status snapshot | May predate async finalize |
+| `logs.gz` | No | Debug | Not structured |
+| `volumesnapshots.json.gz`, `podvolumebackups.json.gz` | Volume path | Snapshot/PVB metadata | Not generic item outcomes |
+
+### Merge vs new capture
+
+| Approach | When |
+|----------|------|
+| **Merge at finalize** | Data already exists in `results` + `volumeinfo` + `itemoperations` + `resource-list` — unify after async completes ([#9377](https://github.com/vmware-tanzu/velero/issues/9377)) |
+| **Structure at write time** | Velero records a failure — store GVR/ns/name as fields, not only inside a string |
+| **New capture** | No file records it today — e.g. per-hook outcome, explicit `skipped` with reason |
+
+**#10503 is mostly merge + structure**, not more `logs.gz` text. Success = in resource-list, absent from failure sets, volumeinfo OK for PVCs.
+
+### Next step
+
+Walk one real `PartiallyFailed` backup: for each failed object, note which file(s) hold truth. That matrix drives the finalize merge rules and the short list of gaps that need new fields at backup time.
+
+
+## Scope
+
+**In scope:** one backup run → one outcome view.
+
+**Out of scope (for this document):**
+
+- Restore outcomes
+- Rollup to logical units (VM, StatefulSet, Helm app) — see [backup resource rollup](backup_resource_rollup-design.md)
+- Cross-backup history (“what failed across last week’s dailies”)
+- Changing Velero backup phase semantics or retry behavior
+
+## Model
+
+### One backup, one snapshot
+
+Each `velero backup create` (or schedule tick) produces a **new** `Backup` CR and a new object-storage prefix. Outcomes describe **that run only**. They are written once at finalize and are not updated by later backups.
+
+### Per-item outcome
+
+An outcome is the result for one Kubernetes object that was part of this backup:
+
+```
+{ group, resource, version, namespace, name, outcome, message? }
+```
+
+`outcome` is one of:
+
+| Value | Meaning |
+|-------|---------|
+| `succeeded` | Backed up without error |
+| `failed` | Error prevented successful backup of this item |
+| `warning` | Backed up with a non-fatal issue |
+| `skipped` | Explicitly not backed up (selector, hook, policy) — semantics TBD |
+
+A single object may accumulate messages from multiple steps (e.g. metadata OK, volume async fail). The outcome is `failed` if any step failed; messages should be deduplicated or listed.
+
+### Sparse storage, implicit success
+
+At scale (thousands of objects, few failures), persist **only non-success items** plus a **summary**:
+
+```json
+{
+  "backup": "daily-2026-09-08",
+  "summary": {
+    "totalItems": 8420,
+    "succeeded": 8408,
+    "failed": 10,
+    "warnings": 2,
+    "skipped": 0
+  },
+  "items": [
+    {
+      "group": "kubevirt.io",
+      "resource": "virtualmachines",
+      "version": "v1",
+      "namespace": "app-ns",
+      "name": "vm-broken",
+      "outcome": "failed",
+      "message": "persistentvolumeclaims \"vm-broken-disk\" not found"
+    }
+  ]
+}
+```
+
+**Rule:** if an object is in the backup’s resource list (and `volumeinfo` is OK for PVCs) and does not appear in `items` → treat as `succeeded`.
+
+Do not store one row per succeeded object. Do not put the full list on the `Backup` CR.
+
+### Where outcomes come from
+
+Finalize merge (after async work):
+
+1. `resource-list` — what was in scope
+2. `results` — sync errors (parse or prefer structured fields if written at failure time)
+3. `volumeinfo` — PVC results
+4. `itemoperations` — async failures (wins over stale `results`/`volumeinfo` when they disagree)
+
+Output = sparse non-success rows + summary. Do not duplicate `resource-list` with one success row per object.
+
+### Error string parsing (interim)
+
+Two common shapes in `results.gz`:
+
+- `error executing custom action (groupResource=..., namespace=..., name=...): ...` → structured fields present
+- `name: /X message: /...` → resolve kind by cross-reference to resource list, not by assuming `name`’s type
+
+Unrecognized patterns → keep as unstructured message; never drop.
+
+## Open questions
+
+1. **Skipped vs succeeded** — when does Velero omit an item vs mark it skipped with a reason?
+2. **PVC vs parent object** — one outcome row per API object, or collapse volume failure onto a parent? (Recommendation: per API object; rollup is downstream.)
+3. **Warnings** — separate outcome or modifier on `succeeded`?
+4. **Artifact vs API only** — persist `<backup>-item-outcomes.json.gz`, or expose only via `pkg/` and let callers persist if needed?
+5. **Summary on `Backup.status`** — counts only (no per-item rows)?
+
+## Consumers
+
+| Consumer | Uses outcomes for |
+|----------|-------------------|
+| `velero backup describe` | Human-readable failure list |
+| oadp-cli `backup resource-status` | Input to owner/label rollup |
+| Portals / automation | Selective retry, ticketing, reports |
+
+Consumers that need “did VM X succeed?” combine sparse outcomes + resource list + optional owner graph — that is rollup, not part of this layer.
+
+## Success criteria
+
+- [ ] For a named backup, list every **failed** and **warned** item with explicit GVR, namespace, name, and message
+- [ ] Async failures included in the same view as sync failures
+- [ ] Size bounded by failure count, not total object count
+- [ ] Stable enough for integrators to depend on without parsing `results.gz` ad hoc
+
+## Non-goals
+
+- Per-VM or per-app status (downstream)
+- Reason-code taxonomy (`MissingPVC`, etc.) — downstream
+- Restore outcomes
+- Mutating or amending outcomes after finalize

--- a/docs/design/backup_resource_rollup-design.md
+++ b/docs/design/backup_resource_rollup-design.md
@@ -1,0 +1,135 @@
+# Generalized backup resource rollup design
+
+_A generalization of `docs/design/vm_backup_status-design.md` (tracking [OADP-8697](https://redhat.atlassian.net/browse/OADP-8697)), after finding the underlying mechanism is not KubeVirt-specific._
+
+## Abstract
+Velero reports backup outcomes per raw Kubernetes object, as a flat list plus an unstructured error string, with no concept of the logical or composite unit (a VM, a database cluster, a Helm release) that object belongs to.
+This proposal describes a general mechanism, structured error parsing plus `ownerReference` graph walking, that rolls per-item results up to whatever logical unit a user cares about, so that a namespace with thousands of such units stays legible when a backup partially fails.
+VM support (the original motivation, see `vm_backup_status-design.md`) becomes one built-in convenience on top of this generic engine rather than bespoke logic.
+
+## Background
+`docs/design/vm_backup_status-design.md` set out to solve per-VM backup visibility specifically, and validated the problem against a real cluster: a `PartiallyFailed` backup's only detail is an unstructured string (`<backup>-results.gz`) where the same `name:` field holds a VM name in one failure and a PVC name in another, with no `kind` field to tell them apart.
+
+While designing the correlation logic for that document, we checked whether the VM-to-PVC link required KubeVirt-specific knowledge (parsing `VirtualMachine.spec.template.spec.volumes[]`) or whether it was already expressed through standard Kubernetes mechanisms.
+It's the latter.
+Inspecting the actual backed-up manifests from our test namespace:
+
+```json
+// DataVolume vm-good-1-disk
+"ownerReferences": [{"kind": "VirtualMachine", "name": "vm-good-1", "controller": true}]
+```
+```json
+// PVC vm-good-1-disk
+"ownerReferences": [{"kind": "DataVolume", "name": "vm-good-1-disk", "controller": true}]
+```
+
+`VirtualMachine → DataVolume → PVC` is a standard `controller: true` ownership chain, the same mechanism used by `Deployment → ReplicaSet → Pod`, `StatefulSet → Pod`, `Job → Pod`, or any CRD written with controller-runtime's `SetControllerReference` (which covers most operators, including most database operators).
+Walking that chain to find "which logical unit does this failed item belong to" requires no VM-specific code at all.
+
+Separately, re-examining our two reproduced failures, both were already attributed by Velero directly to the VM item itself:
+```
+error executing custom action (groupResource=virtualmachines.kubevirt.io, namespace=oadp-8697-multi-vm,
+  name=vm-broken-orphan-pvc): rpc error: code = Unknown desc = persistentvolumeclaims "..." not found
+```
+This string already contains a structured `groupResource=`, `namespace=`, `name=` triple, it is simply serialized as free text rather than as fields.
+The only failure mode from our testing that actually required walking up from a child item was the original single-VM repro, where the error landed on the PVC item (`PVC ... has no volume backing this claim`), and that case is exactly what `ownerReferences` walking solves generically.
+
+So the two things that make the VM case work are both workload-agnostic:
+1. Parse Velero's own error/warning text into structured `{groupResource, namespace, name, message}` tuples.
+2. Walk `ownerReferences` from a failed item up to whatever unit the user considers "the thing they care about."
+
+## Goals
+- Provide one general mechanism to roll up raw per-item backup results to a logical/composite unit, for any workload that uses standard Kubernetes ownership or labeling, not only VMs.
+- Make VM support (and any other grouping) a thin configuration of this engine, not a separate implementation, so future groupings (StatefulSet, a specific operator's CR, Helm releases) cost close to nothing to add.
+- Preserve the failures-first, summary-line-first CLI presentation already validated for the VM case, now parameterized by grouping key instead of hardcoded to VirtualMachine.
+
+## Non Goals
+- Full semantic modeling of every possible spec-level reference (e.g. a Pod mounting a ConfigMap by name, which has no `ownerReference`) as a first-class grouping mechanism in v1. Our evidence shows Velero already attributes these failures to the referencing item directly, so structured error parsing alone covers the cases that motivated OADP-8697; a "well-known reference path" table is a possible v2 enrichment, not a launch requirement.
+- Replacing Velero's own resource list or error reporting. This stays a derived, read-only enrichment view.
+- Cross-namespace or cross-backup grouping in v1. Scope is one backup's included namespace(s) at a time.
+
+## High-Level Design
+A small generic engine with two building blocks:
+
+1. **Error/warning structurer**: parses Velero's `results.gz` (and any similarly formatted plugin errors) into `{groupResource, namespace, name, message}` tuples wherever the format allows, and falls back to an `Unstructured` bucket (never silently dropped) otherwise.
+2. **Ownership graph walker**: builds an item graph for the backup from the resource list plus each item's `ownerReferences` (read live from cluster when the source namespace still exists, or from the backup tarball otherwise), and walks `controller: true` references upward from any failed/warned item to a target.
+
+A **grouping strategy** decides what "target" means:
+- `owner:<Kind>` — stop walking when a `Kind` match is reached (e.g. `owner:VirtualMachine`, `owner:StatefulSet`).
+- `owner` (no kind) — walk all the way to the topmost object with no further owner.
+- `label:<key>` — skip the graph walk, group flatly by a label value (for Helm-style apps that share `app.kubernetes.io/instance` without using `ownerReferences`).
+
+VM support becomes `--group-by=owner:VirtualMachine` shipped as a default preset; nothing about the engine itself knows what a VM is.
+
+## Detailed Design
+
+### Command shape
+```
+kubectl oadp backup resource-status <backup> --group-by=owner:VirtualMachine
+kubectl oadp backup resource-status <backup> --group-by=owner:StatefulSet
+kubectl oadp backup resource-status <backup> --group-by=owner              # walk to topmost owner
+kubectl oadp backup resource-status <backup> --group-by=label:app.kubernetes.io/instance
+```
+Shared flags across all grouping strategies (same as the VM-specific design): `--status=succeeded|failed|skipped`, `--group-by-reason`, `-o table|wide|json|yaml`, with `table` defaulting to a failures-first view plus a one-line summary count, so the output size tracks the failure count, not the namespace's total object count.
+
+### Error structuring rules
+Two known Velero error shapes observed in practice:
+- `error executing custom action (groupResource=X, namespace=Y, name=Z): <message>` → parses directly into `{groupResource: X, namespace: Y, name: Z, message}`.
+- `name: /Z message: /<message>` (the older item-backup-error shape, seen when a PVC's own backup step fails rather than a plugin custom action) → `Z` is the failing item's name but its `kind` is not present in the string; the structurer resolves `kind` by cross-referencing `Z` against the backup's resource list (which kind's name list contains `Z`) rather than guessing from field order, which is what made naive `name:` grepping unreliable in the first place.
+- Anything that matches neither pattern is kept as `{message, groupResource: Unstructured}` and always surfaced, never hidden, since silently dropping unrecognized errors would recreate the exact visibility gap this proposal fixes.
+
+### Ownership graph walk
+Given the resource list for the backup, fetch each object's `metadata.ownerReferences` (live cluster lookup preferred; tarball fallback for backups whose source namespace no longer exists, exactly as in the VM-specific design).
+For a structured error tuple `{groupResource, namespace, name}`, look up that object, and if it has a `controller: true` owner reference, follow it, repeating until the grouping strategy's stop condition is met or no further owner exists.
+This is a small, generic, iterative graph walk, bounded by the depth of real ownership chains (rarely more than 2-3 hops in practice: `PVC → DataVolume → VirtualMachine`, `Pod → ReplicaSet → Deployment`).
+
+### Rollup semantics
+A group (e.g. one VM, one StatefulSet, one label value) is:
+- `Failed` if any item under it produced a structured or unstructured error, carrying the (deduplicated) set of reasons up.
+- `Succeeded` if every item under it backed up cleanly.
+- `Skipped` if explicitly excluded (selector/filter), a case that needs further definition, see Open Issues.
+
+### Relationship to the VM-specific design
+`vm_backup_status-design.md`'s Phase 1 CLI and Phase 2 CRD both become thin instances of this engine:
+- Its correlation algorithm (steps 1-4) is superseded by the generic structurer + graph walker described here; notably, the VM-specific design's step 2 ("read `spec.template.spec.volumes[]`") turns out to be unnecessary for the failure modes we tested, since ownership chains already carry that information.
+- Its reason-code taxonomy (`MissingPVC`, `MissingDataSource`, etc.) still applies, now as an optional classification layer applied to the generic `{groupResource, namespace, name, message}` tuples, rather than being VM-specific parsing logic.
+- Its Phase 2 CRD sketch (`VirtualMachineBackupStatus`) would generalize to something like `BackupResourceRollup` with a `spec.groupBy` field, if a persisted, in-cluster version is pursued later.
+
+## Alternatives Considered
+
+**Ship the VM-specific version first, generalize afterward.**
+This was the original plan. Deprioritized once we found the generic mechanism (structured errors + ownerRef walk) is not meaningfully more work than the VM-specific version would have been, and is simpler, since it avoids writing and maintaining bespoke `VirtualMachine.spec` parsing at all.
+
+**Structured error parsing without the ownership graph walk.**
+Insufficient on its own: it correctly labels which raw item failed, but doesn't answer "which VM does this failed PVC belong to" for the failure mode where the error lands on a child item rather than the top-level object.
+
+**Ownership graph walk without structured error parsing.**
+Insufficient on its own: still need the message text for the human-readable "why," and the orphan-reference failure mode (referencing an object that was never created, so there's nothing to walk from) has no graph to walk at all, only structured error parsing catches it.
+
+**A full table of well-known spec-level reference paths (Pod→ConfigMap, VM→PVC-by-name, etc.) as a core v1 requirement.**
+Deferred. Higher effort and ongoing maintenance burden (one entry per Kind/field), and our evidence shows it is not needed for the failure modes that motivated OADP-8697, since Velero already attributes those to the referencing item directly. Worth revisiting as a v2 enrichment once real-world usage shows it's needed.
+
+## Security Considerations
+Read-only, same as the VM-specific design: no writes to Backups, VMs, or any other cluster resource.
+Needs read RBAC on whatever resource kinds appear in a given backup (broader than the VM-specific design, since the grouping target is now user-chosen), plus BSL object storage read access for historical backups whose source namespace no longer exists.
+
+## Compatibility
+Works retroactively against any existing backup, since `ownerReferences` and Velero's error text are already captured and stored today; no changes to Velero, the kubevirt-velero-plugin, or any other plugin are required to ship v1.
+
+## Implementation
+1. Implement the error structurer and ownership graph walker as a standalone, reusable library (not VM-aware), with unit tests built from the fixtures already captured while validating the VM-specific design (resource-list, results, and tarball files from the 5-VM repro).
+2. Implement `kubectl oadp backup resource-status` in `migtools/oadp-cli` on top of that library, with `owner:VirtualMachine` as the first shipped preset, directly superseding the VM-specific design's Phase 1 plan.
+3. Add `owner:StatefulSet` and `label:app.kubernetes.io/instance` presets to validate the engine generalizes beyond the motivating VM case before calling v1 done.
+4. Revisit `vm_backup_status-design.md`'s Phase 2 CRD idea, generalized to a `groupBy`-parameterized CRD, only if in-cluster persistence proves necessary after the CLI ships.
+
+## Open Issues
+- **Stop condition for `owner` grouping.** When walking to "the topmost owner" with no explicit Kind given, is the first Kind with no further owner always the right unit, or should some common Kinds (e.g. `ReplicaSet` between `Pod` and `Deployment`) be skipped by default since they're rarely what a user means by "the app"?
+- **Combining `owner` and `label` grouping.** Some workloads are partially expressed via ownership and partially via shared labels (e.g. a Helm release where only some resources have ownerRefs). Need to decide whether groupings can be combined or whether users must pick one strategy per invocation.
+- **Skip semantics**, carried over unresolved from the VM-specific design: Velero doesn't always explicitly mark an item "skipped," so we need a clear definition before that status value means something consistent.
+- **Command naming.** `resource-status` vs. `rollup` vs. `summary` vs. `grouped-status`, needs a decision before implementation.
+
+## References
+- `docs/design/vm_backup_status-design.md` (the VM-specific case this generalizes, including the original cluster evidence and reproduction steps)
+- [OADP-8697](https://redhat.atlassian.net/browse/OADP-8697)
+- `docs/design/kubectl-oadp.md` (existing kubectl-oadp plugin design, where this command would live)
+- [migtools/oadp-cli](https://github.com/migtools/oadp-cli)

--- a/docs/design/velero_upstream_issues-draft.md
+++ b/docs/design/velero_upstream_issues-draft.md
@@ -1,0 +1,7 @@
+# Velero upstream — backup outcomes
+
+**Issue:** [velero-io/velero#10503](https://github.com/velero-io/velero/issues/10503) — sparse per-item backup outcomes for observability
+
+Design: [backup_outcomes-design.md](backup_outcomes-design.md)
+
+Optional follow-up: comment on [#9377](https://github.com/vmware-tanzu/velero/issues/9377) linking #10503.

--- a/docs/design/vm_backup_status-design.md
+++ b/docs/design/vm_backup_status-design.md
@@ -1,0 +1,225 @@
+# Per-VM backup status visibility design
+
+_Tracks [OADP-8697](https://redhat.atlassian.net/browse/OADP-8697): Expose per-VM backup status in PartiallyFailed namespace backups._
+
+## Abstract
+When a namespace-scoped OADP/Velero backup of OpenShift Virtualization VMs finishes `PartiallyFailed`, there is no way to tell which individual VMs succeeded and which failed without manually correlating item-level errors back to their owning VM.
+This proposal makes that correlation visible, first through a `kubectl oadp` CLI command, and optionally later through an in-cluster status object, so the result stays legible even when a namespace has thousands of VMs.
+
+## Background
+Velero reports backup problems at the Kubernetes-resource level: PVC, DataVolume, VirtualMachine, VirtualMachineInstance, Pod.
+Nothing rolls those errors up to the VirtualMachine that owns the affected disk.
+Cohesity has reported this gap operating OADP-backed VM backups at scale, where a subset of VMs in large namespaces routinely have stale or broken configurations (missing DataVolume/PVC, orphaned VM/VMI, CSI mount issues, snapshot timeouts).
+
+To ground this proposal in real behavior rather than speculation, we reproduced the problem locally on a live OpenShift Virtualization cluster (CNV 4.22, OADP built from `oadp-dev`).
+Using the `cirros-test` DataVolume-clone pattern from `tests/e2e/sample-applications/virtual-machines/cirros-test/3-vms/`, we deployed 5 VMs in one namespace:
+
+- `vm-good-1`, `vm-good-2`, `vm-good-3`: normal clones of a `cirros` DataSource. All backed up successfully via CSI snapshot + `velero-fs` data movement.
+- `vm-broken-orphan-pvc`: disk volume references a PVC that was never created (stale/dangling reference).
+- `vm-broken-baddatasource`: `dataVolumeTemplate` clones from a nonexistent `DataSource` (broken config, the DataVolume/PVC never materializes).
+
+A real `velero.io/v1` Backup (`snapshotMoveData: true`, `kubevirt` + `csi` + `openshift` plugins) against that namespace produced `status.phase: PartiallyFailed`, `status.errors: 2`, with detail only available as:
+
+```
+name: /vm-broken-baddatasource message: /Error backing up item error: /error executing custom
+  action (groupResource=virtualmachines.kubevirt.io, namespace=oadp-8697-multi-vm,
+  name=vm-broken-baddatasource): rpc error: code = Unknown desc = persistentvolumeclaims
+  "vm-broken-baddatasource-disk" not found
+name: /vm-broken-orphan-pvc message: /Error backing up item error: /error executing custom
+  action (groupResource=virtualmachines.kubevirt.io, namespace=oadp-8697-multi-vm,
+  name=vm-broken-orphan-pvc): rpc error: code = Unknown desc = persistentvolumeclaims
+  "vm-broken-orphan-pvc-disk-does-not-exist" not found
+```
+
+This is the `Backup.status.errors` / `<backup>-results.gz` structure Velero already writes, and it is not a JSON error list, it is a flattened string with ad hoc `key: /value` segments.
+Critically, we found the `name:` field is not stable in what it names.
+In this run it happened to be the VM name (the failure occurred in the VM's custom backup action).
+In an earlier single-VM repro on the same cluster (`vmfr-test-backup-202608070835`, preserved in the backup storage from a prior session), the exact same field held a **PVC** name instead, because that failure happened one step later, during the PVC's own item backup:
+
+```
+name: /vmfr-test-vm-disk-1 message: /Error backing up item error: /PVC vmfr-test-ns/vmfr-test-vm-disk-1
+  has no volume backing this claim
+```
+
+So a naive grep for `name: /` cannot reliably tell you whether you are looking at a VM or a PVC, let alone which VM owns a failed PVC.
+At 5 VMs this is merely annoying.
+At 1,000+ VMs with a mix of failure modes it is not something an operator, or a script, can reliably act on.
+
+We also checked every other artifact Velero writes to object storage for this backup, to see what correlation data already exists:
+
+| File | Scope | Contents |
+|---|---|---|
+| `<backup>-resource-list.json.gz` | per-Kind | flat `namespace/name` lists per GVR, no cross-references between kinds |
+| `<backup>-results.gz` | backup-wide | unstructured error/warning strings (see above), no `kind` field |
+| `<backup>-volumeinfo.json.gz` | per-PVC | structured `result: succeeded/failed`, but keyed by PVC name only, no VM reference |
+| `<backup>-itemoperations.json.gz` | per-PVC datamover op | structured, PVC-scoped only |
+| VM manifest inside `<backup>.tar.gz` | per-VM | `spec.template.spec.volumes[]`, the only place that links a VM to the PVC/DataVolume names it owns |
+
+We also confirmed the kubevirt-velero-plugin already labels backed-up PVCs with `velero.kubevirt.io/pvc-uid` (used for VMFR's selective restore, see `docs/design/vm_file_restore-design.md`), but that label identifies the PVC, not the owning VM's name or namespace.
+So today, the only reliable VM-to-disk join key is the VM's own backed-up manifest, and nothing pre-computes that join for you.
+
+## Goals
+- Make per-VM backup outcome (succeeded / failed / skipped) and failure reason visible without manual cross-referencing, in a form that stays legible when a namespace has thousands of VMs.
+- Ship a first usable version quickly, without requiring new CRDs, webhooks, or changes to Velero or the kubevirt-velero-plugin release cycle.
+- Leave a clear path to a more integrated, cluster-native status object if the CLI proves the approach is worth persisting.
+
+## Non Goals
+- Changing Velero's core backup orchestration or phase semantics.
+- Automatic retry of failed VMs (separate RFE, per OADP-8697's acceptance criteria).
+- Automatic cleanup or remediation of stale VM configurations.
+- Per-VM status rollup for non-KubeVirt workloads.
+- Replacing Velero's own error reporting; this is a derived, read-only enrichment view on top of it.
+
+## High-Level Design
+Two phases, deliberately decoupled so the first phase can ship without waiting on the second.
+
+**Phase 1 (primary deliverable): `kubectl oadp backup vm-status <backup>`**
+A new subcommand in the existing `migtools/oadp-cli` plugin (which already ships `backup create/describe/logs/delete` using Velero's client libraries, see `docs/design/kubectl-oadp.md`).
+It reads the data sources listed above, resolves the VM-to-PVC/DataVolume join client-side, classifies failures into a small set of reason codes, and renders a table.
+Default output is failures-first: a one-line summary count plus a table of only the non-succeeded VMs, so a 4,000-VM namespace with 12 failures renders as 12 rows, not 4,000.
+
+**Phase 2 (optional follow-on): in-cluster status object**
+If Phase 1 proves useful, an OADP-operator controller (this repo) watches Backup completion and performs the same correlation server-side once, persisting the result as a small CRD (`VirtualMachineBackupStatus`, following the exact pattern already established by `VirtualMachineBackupsDiscovery`, see `docs/design/vm_file_restore-design.md`).
+This makes the result visible via `oc get`/`oc describe` without the CLI, computed once instead of on every query, and consumable by other automation (selective retry, selective data backup) mentioned in OADP-8697's business justification.
+
+## Detailed Design
+
+### Correlation algorithm
+For a given backup, build the per-VM view in four steps:
+
+1. **Enumerate VMs and PVCs in the backup.** From the live Backup's resource list (or `<backup>-resource-list.json.gz` for backups whose source namespace no longer exists), collect every `kubevirt.io/v1/VirtualMachine` and `v1/PersistentVolumeClaim` name.
+2. **Extract each VM's expected disks.** For every VM, read `spec.template.spec.volumes[]` (from the live cluster if the VM still exists there, otherwise from the VM manifest inside `<backup>.tar.gz`) and collect `persistentVolumeClaim.claimName` and `dataVolume.name` references, plus `dataVolumeTemplates[].metadata.name` for cloned disks. This is the VM's declared disk set, and it is present even for VMs whose backup ultimately failed.
+3. **Determine each disk's outcome.** Cross-reference the declared disk names against:
+   - the PVC resource list (was it backed up at all?),
+   - `<backup>-volumeinfo.json.gz` (`result: succeeded/failed/skipped` for CSI/datamover-backed disks),
+   - `<backup>-results.gz` error strings, matched against the declared disk names and the VM name (not just `name:`, since we proved that field is ambiguous) to attribute an error and classify it.
+4. **Roll up to VM status.** A VM is `Succeeded` if all its declared disks succeeded, `Failed` if any disk is missing or failed (carrying the first matched failure reason), `Skipped` if excluded by selector/filter. VMs with zero declared disks are `Succeeded` trivially (VM metadata backed up, nothing else expected).
+
+### Failure reason classification
+Raw error strings get mapped to a small, stable set of reason codes so that thousands of VMs collapse into a handful of buckets instead of thousands of free-text messages:
+
+| Reason code | Matches |
+|---|---|
+| `MissingPVC` | `persistentvolumeclaims "X" not found`, `PVC ... has no volume backing this claim` |
+| `MissingDataVolume` | `datavolumes.cdi.kubevirt.io "X" not found` |
+| `MissingDataSource` | `datasources.cdi.kubevirt.io "X" not found` |
+| `CSISnapshotTimeout` | timeout errors from `volumeinfo` / `itemoperations` |
+| `DataUploadFailed` | `snapshotDataMovementInfo.Phase: Failed` in `volumeinfo` |
+| `Unknown` | anything that doesn't match a known pattern (always shown verbatim, never silently dropped) |
+
+This taxonomy is a starting point based on the failure modes we could reproduce locally; it should be revisited once we have more real Cohesity-style stale-config samples (see Open Issues).
+
+### CLI shape and example output
+```
+$ kubectl oadp backup vm-status oadp-8697-multi-vm-backup
+Backup: oadp-8697-multi-vm-backup   Phase: PartiallyFailed
+VMs: 5 total   3 succeeded   2 failed   0 skipped
+
+FAILED:
+NAME                      NAMESPACE            REASON              DETAIL
+vm-broken-baddatasource   oadp-8697-multi-vm   MissingDataSource   dataVolumeTemplate "vm-broken-baddatasource-disk" clones from DataSource "does-not-exist" (not found)
+vm-broken-orphan-pvc      oadp-8697-multi-vm   MissingPVC          volume "rootdisk" references PVC "vm-broken-orphan-pvc-disk-does-not-exist" (not found)
+
+Use --status=succeeded|failed|skipped or -o wide to see all VMs.
+Use -o json / -o yaml for scripting.
+```
+
+At scale, `--group-by-reason` collapses the failure list further:
+```
+$ kubectl oadp backup vm-status ns-scale-backup --group-by-reason
+Backup: ns-scale-backup   Phase: PartiallyFailed
+VMs: 4000 total   3971 succeeded   29 failed   0 skipped
+
+REASON               COUNT   EXAMPLE VM
+MissingPVC             18    vm-4021
+CSISnapshotTimeout      7    vm-1187
+DataUploadFailed        4    vm-2755
+```
+
+Flags:
+- `--status=succeeded|failed|skipped` (repeatable) filters rows.
+- `--group-by-reason` clusters failed VMs by reason code with a count and one example, instead of one row per VM.
+- `-o table` (default, failures-first), `-o wide` (every VM regardless of status), `-o json`/`-o yaml` (full structured output for scripting, this is the actual "grep optimization": once the data is structured, `jq`/`grep` against it is reliable in a way that scraping `results.gz` is not).
+
+### Phase 2 CRD sketch
+```yaml
+apiVersion: oadp.openshift.io/v1alpha1
+kind: VirtualMachineBackupStatus
+metadata:
+  name: oadp-8697-multi-vm-backup
+  namespace: openshift-adp
+spec:
+  backupName: oadp-8697-multi-vm-backup
+status:
+  phase: Completed              # discovery/computation phase, distinct from the Backup's own phase
+  summary:
+    total: 5
+    succeeded: 3
+    failed: 2
+    skipped: 0
+  vms:
+  - name: vm-broken-baddatasource
+    namespace: oadp-8697-multi-vm
+    result: Failed
+    reason: MissingDataSource
+    detail: 'dataVolumeTemplate "vm-broken-baddatasource-disk" clones from DataSource "does-not-exist" (not found)'
+    disks:
+    - name: rootdisk
+      pvcName: vm-broken-baddatasource-disk
+      result: Failed
+  - name: vm-good-1
+    namespace: oadp-8697-multi-vm
+    result: Succeeded
+    disks:
+    - name: rootdisk
+      pvcName: vm-good-1-disk
+      result: Succeeded
+```
+A controller reconciling this CRD would watch Backups for completion (`Completed`/`PartiallyFailed`/`Failed`), run the same correlation algorithm as Phase 1, and write the result once. This is intentionally the same shape of design as `VirtualMachineBackupsDiscovery` (build candidate list, validate, incrementally update status), so it can reuse that controller's patterns directly.
+
+### Where the code lives
+- Phase 1: `migtools/oadp-cli`, alongside the existing `backup describe`/`backup logs` commands, using the same Velero client libraries.
+- Phase 2 (if pursued): this repo, `api/v1alpha1/` for the new CRD type and `internal/controller/` for the reconciler, mirroring `virtualmachinebackupsdiscovery_controller.go`.
+
+## Alternatives Considered
+
+**Extend Velero's own Backup CRD/status upstream.**
+Rejected as the primary approach: it is out of OADP's control, Velero is intentionally workload-agnostic and unlikely to accept KubeVirt-specific rollup logic in core, and the upstream release cycle is far slower than what this feature needs.
+
+**Push the correlation entirely into the kubevirt-velero-plugin (label PVCs with the owning VM's name/namespace at backup time, extending the existing `velero.kubevirt.io/pvc-uid` labeling).**
+This is a good complementary improvement: it would turn the VM-to-PVC join from "parse the VM manifest" into an O(1) label lookup, benefiting this feature and VMFR's existing discovery logic. But it lives in a separate repo with its own release cadence, and it does not retroactively help with backups already taken (like the ones we inspected in this session). Recommended as a fast-follow, not the initial fix.
+
+**Document a grep/jq recipe against `results.gz` instead of building tooling.**
+Rejected as the primary solution. We demonstrated directly that the same field (`name:`) can hold either a VM name or a PVC name depending on where in the pipeline a failure occurred, with no `kind` discriminator. A recipe built on that assumption will silently misattribute errors. A short-lived stopgap doc could still be written, but it should not be the answer to the acceptance criteria.
+
+**Ship the CRD/controller (Phase 2) as the only deliverable, skip the CLI.**
+Rejected as the starting point: it requires new API types, RBAC, and a bundle/CSV change before any user sees value, and it is slower to iterate on the reason-code taxonomy (see Open Issues) than a CLI command is. The CLI can ship, be used, and be refined immediately against real customer backups; the CRD is worth doing later once the correlation logic is validated.
+
+## Security Considerations
+Both phases are read-only with respect to cluster state; neither writes to or mutates Backups, VMs, PVCs, or DataVolumes.
+Phase 1 needs the same RBAC a user already needs for `velero backup describe`/`logs` (get/list Backups, DataUploads, PVCs, VirtualMachines in the target namespace), plus read access to the Backup Storage Location's object storage credentials when a backup's source namespace no longer exists and the tool must fall back to downloading the tarball.
+Phase 2 reuses the operator's own existing BSL access; the new CRD's status is read/list-only for regular users, and only the controller's service account gets write access to it.
+
+## Compatibility
+Phase 1 works against any existing or historical backup on this cluster without any cluster-side changes, we validated this directly against a real `PartiallyFailed` backup from a prior session as well as the fresh 5-VM repro; no version gating is needed beyond what the kubevirt-velero-plugin already emits today.
+Phase 2 introduces a new optional CRD and controller, which should be gated the same way `kubevirt-datamover` and VM File Restore are, an opt-in component enabled via the DPA, not installed by default.
+
+## Implementation
+1. Implement the correlation algorithm and reason-code classifier as a small, independently testable Go package, using the artifacts captured during this session (`resource-list.json.gz`, `results.gz`, `volumeinfo.json.gz`, and the 5-VM tarball) as recorded test fixtures.
+2. Wire it into `migtools/oadp-cli` as `kubectl oadp backup vm-status`.
+3. Validate against a larger synthetic namespace (dozens to low-hundreds of VMs, mixing more failure modes: CSI snapshot timeout, DataUpload failure, orphaned VMI) to stress-test the failures-first / group-by-reason output before calling Phase 1 done.
+4. Gather feedback (ideally against a real Cohesity-scale sample or a closer approximation) before committing to Phase 2.
+5. If Phase 2 is warranted, implement `VirtualMachineBackupStatus` and its controller in this repo, reusing the `VirtualMachineBackupsDiscovery` controller as a structural template.
+
+## Open Issues
+- **Live cluster vs. tarball for VM manifests.** Reading the VM's `spec.template.spec.volumes[]` from the live cluster is cheap and fast, but only works while the source VM still exists. Our own `vmfr-test-ns` repro namespace was deleted after its backups were taken, which is exactly the case where the tool must fall back to downloading and parsing `<backup>.tar.gz`. Phase 1 needs to support both paths, live-cluster first, tarball fallback.
+- **Reason-code taxonomy completeness.** The table above covers the failure modes we could reproduce locally (missing PVC, missing DataVolume, missing DataSource). Cohesity's reported stale-config cases at scale (orphan VM/VMI, CSI mount issues, snapshot timeouts) should be used to validate and extend this list before Phase 1 is considered done.
+- **Skip semantics.** Velero does not always explicitly mark an item as "skipped" the way it marks failures; we need to decide what counts as `Skipped` for a VM (e.g., excluded by backup label selector) versus simply absent from the backup's included namespaces.
+- **Ownership of Phase 1.** The command belongs in `migtools/oadp-cli`, a separate repository from this operator; this design doc lives here because the correlation logic and Phase 2 CRD are OADP-operator concerns, but Phase 1 implementation work needs to happen (or be coordinated) against that repo.
+
+## References
+- [OADP-8697](https://redhat.atlassian.net/browse/OADP-8697)
+- `docs/design/vm_file_restore-design.md` (VirtualMachineBackupsDiscovery/VirtualMachineFileRestore, the controller pattern Phase 2 would reuse)
+- `docs/design/kubectl-oadp.md` (existing kubectl-oadp plugin design, the CLI Phase 1 would extend)
+- [migtools/oadp-cli](https://github.com/migtools/oadp-cli)
+- [migtools/kubevirt-velero-plugin](https://github.com/migtools/kubevirt-velero-plugin)


### PR DESCRIPTION
## Why the changes were made

Design documentation for backup observability work tracked under [OADP-8697](https://redhat.atlassian.net/browse/OADP-8697):

- **`docs/design/backup_outcomes-design.md`** — per-item backup outcomes for a single Velero backup run (sparse failures + finalize merge model); upstream [velero-io/velero#10503](https://github.com/velero-io/velero/issues/10503)
- **`docs/design/backup_resource_rollup-design.md`** — generalized rollup via structured errors + `ownerReferences` (oadp-cli)
- **`docs/design/vm_backup_status-design.md`** — VM case study with cluster evidence
- **`docs/design/velero_upstream_issues-draft.md`** — pointer to upstream issue

No implementation in this PR — design only for review.

## How to test the changes made

- Read through the design docs for accuracy and scope
- Confirm links to Jira and velero-io/velero#10503
- Feedback welcome on sparse outcome model and merge-vs-capture split before oadp-cli / upstream implementation

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added design proposals for reporting per-item backup outcomes and resource-level rollups.
  * Documented approaches for classifying backup failures, associating failed items with logical resources, and supporting owner- or label-based grouping.
  * Added a proposal for VM-specific backup status reporting, including filtering, grouping, structured output, and optional future API support.
  * Added a draft upstream issue describing sparse per-item backup outcomes for improved observability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->